### PR TITLE
update jetty versions to 9.4.32 and 10 & 11 beta2

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,122 +4,122 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.0.beta1-jre11-slim
+Tags: 11.0.0.beta2-jre11-slim
 Architectures: amd64
 Directory: 11.0-jre11-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 11.0.0.beta1-jre11
+Tags: 11.0.0.beta2-jre11
 Architectures: amd64
 Directory: 11.0-jre11
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 11.0.0.beta1-jdk14-slim
+Tags: 11.0.0.beta2-jdk14-slim
 Architectures: amd64
 Directory: 11.0-jdk14-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 11.0.0.beta1, 11.0.0.beta1-jdk14
+Tags: 11.0.0.beta2, 11.0.0.beta2-jdk14
 Architectures: amd64
 Directory: 11.0-jdk14
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 11.0.0.beta1-jdk11-slim
+Tags: 11.0.0.beta2-jdk11-slim
 Architectures: amd64
 Directory: 11.0-jdk11-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 11.0.0.beta1-jdk11
+Tags: 11.0.0.beta2-jdk11
 Architectures: amd64
 Directory: 11.0-jdk11
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 10.0.0.beta1-jre11-slim
+Tags: 10.0.0.beta2-jre11-slim
 Architectures: amd64
 Directory: 10.0-jre11-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 10.0.0.beta1-jre11
+Tags: 10.0.0.beta2-jre11
 Architectures: amd64
 Directory: 10.0-jre11
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 10.0.0.beta1-jdk14-slim
+Tags: 10.0.0.beta2-jdk14-slim
 Architectures: amd64
 Directory: 10.0-jdk14-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 10.0.0.beta1, 10.0.0.beta1-jdk14
+Tags: 10.0.0.beta2, 10.0.0.beta2-jdk14
 Architectures: amd64
 Directory: 10.0-jdk14
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 10.0.0.beta1-jdk11-slim
+Tags: 10.0.0.beta2-jdk11-slim
 Architectures: amd64
 Directory: 10.0-jdk11-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 10.0.0.beta1-jdk11
+Tags: 10.0.0.beta2-jdk11
 Architectures: amd64
 Directory: 10.0-jdk11
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.32-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.32-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 9.4.32-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64
 Directory: 9.4-jre8-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.32-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
+Tags: 9.4.32-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
 Architectures: amd64
 Directory: 9.4-jdk14-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31, 9.4, 9, 9.4.31-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
+Tags: 9.4.32, 9.4, 9, 9.4.32-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
 Architectures: amd64
 Directory: 9.4-jdk14
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 9.4.32-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64
 Directory: 9.4-jdk11-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 9.4.32-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64
 Directory: 9.4-jdk11
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 9.4.32-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64
 Directory: 9.4-jdk8-slim
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
-Tags: 9.4.31-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 9.4.32-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64
 Directory: 9.4-jdk8
-GitCommit: 0e8423f9c1f03dd2c9bcfe196d5ba487cc116c9c
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
 Tags: 9.3.28-jre8, 9.3-jre8
 Architectures: amd64
 Directory: 9.3-jre8
-GitCommit: f4b8a22e641c5673498e21a4a8a1e0f506d61aa4
+GitCommit: 4bdfabe5bfc49baa24fc53990d1626e39ac4ab92
 
 Tags: 9.2.30-jre8, 9.2-jre8
 Architectures: amd64
 Directory: 9.2-jre8
-GitCommit: 9c6c5560976c7e2bf71ee67b77c409ac4b21fd74
+GitCommit: 481a3bcb16a8bf0ee11a4b67a4710050e5403064


### PR DESCRIPTION
Update to latest versions of Jetty, `9.4.32`,  `10.0.0.beta2` and `11.0.0.beta2`.

Fixed some issues on [eclipse/jetty.docker](https://github.com/eclipse/jetty.docker) including:
- define jetty user home directory as $JETTY_BASE
- fix failed startup when JAVA_OPTIONS causes additional output