### PR TITLE
arangodb 3.6.7.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -6,8 +6,8 @@ GitCommit: 0d0cc55233e8abb08f42e07cd82be9795b75c7c6
 Directory: alpine/3.5.6
 
 Tags: 3.6, 3.6.7
-GitCommit: fd8fbcde85c9d0605bb614a801589c0033049a7a
-Directory: alpine/3.6.7
+GitCommit: 08a18dbce08b25b6f353d77686a242e5f0693b46
+Directory: alpine/3.6.7.1
 
 Tags: 3.7, 3.7.2, latest
 GitCommit: 4845b146318913d7ebb71e73db9e04bf9c024348


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.7.1 (3.6.7 with Hotfix 1).