### PR TITLE
Fedora Update 2020-10-08

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -11,26 +11,31 @@ ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 
 Tags: latest, 32
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/32
-GitCommit: 858623325e7131ebb26e4c59b77a41817c1226d3
+GitCommit: d011eb05bd6855b2e2fa4393117d1cdadc575b16
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
+arm32v7-Directory: armhfp/
 
 Tags: 33
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/33
-GitCommit: ca4fa870a01789a777d5ebd0d7af855ee585a50d
+GitCommit: 31676f13b9cf08f51ab74bba2988ca21d13725c7
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
+s390x-Directory: s390x/
+arm32v7-Directory: armhfp/
 
 Tags: rawhide, 34
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/34
-GitCommit: 8e8f37ceb92fcc3ae14944d10146cb47a9a02aba
+GitCommit: da3adfaa3a64b02bfc6a78199964ac2f8d777f1c
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
+s390x-Directory: s390x/
+arm32v7-Directory: armhfp/


### PR DESCRIPTION
Update the content for Fedora 32, 33 and 34. Also
adds back support for arm32v7 and s390x.

Signed-off-by: Clement Verna <cverna@tutanota.com>