### PR TITLE
Remove older oraclelinux tags.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -13,14 +13,6 @@ Tags: 8.2, 8
 Architectures: amd64, arm64v8
 Directory: 8.2
 
-Tags: 8.1
-Architectures: amd64, arm64v8
-Directory: 8.1
-
-Tags: 8.0
-Architectures: amd64, arm64v8
-Directory: 8.0
-
 Tags: 8-slim
 Architectures: amd64, arm64v8
 Directory: 8-slim
@@ -28,10 +20,6 @@ Directory: 8-slim
 Tags: 7.9, 7
 Architectures: amd64, arm64v8
 Directory: 7.9
-
-Tags: 7.8
-Architectures: amd64, arm64v8
-Directory: 7.8
 
 Tags: 7-slim
 Architectures: amd64, arm64v8


### PR DESCRIPTION
As pointed out by @tianon in #8858, these older tags are no longer required.

Signed-off-by: Avi Miller <avi.miller@oracle.com>
