### PR TITLE
Update Solr to 8.6.3

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,14 +6,14 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.6.2, 8.6, 8, latest
+Tags: 8.6.3, 8.6, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: e544db9616b5c9a7bf7663c510c90d138bce6ae9
+GitCommit: 0a9474015d0fe6dd9e29388a0f733f2ef1848523
 Directory: 8.6
 
-Tags: 8.6.2-slim, 8.6-slim, 8-slim, slim
+Tags: 8.6.3-slim, 8.6-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: e544db9616b5c9a7bf7663c510c90d138bce6ae9
+GitCommit: 0a9474015d0fe6dd9e29388a0f733f2ef1848523
 Directory: 8.6/slim
 
 Tags: 8.5.2, 8.5


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/r9fcceed40d9da7d6ed69ce818241e18294c106c1e437d4040e12e199%40%3Cdev.lucene.apache.org%3E) which links to the [release notes](https://lucene.apache.org/solr/8_6_3/changes/Changes.html).

Copy-pasting the release highlights:

 * SOLR-14898: Prevent duplicate header accumulation on internally
forwarded requests
 * SOLR-14768: Fix HTTP multipart POST requests to Solr (8.6.0 regression)
 * SOLR-14859: PrefixTree-based fields now reject invalid schema
properties instead of quietly failing certain queries
 * SOLR-14663: CREATE ConfigSet action now copies base node content