### PR TITLE
Update clojure tools-deps variants to 1.10.1.708

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 09d4fb43b6053be4bccb31f058dee7d6d0e50be3
+GitCommit: 9970bc67c75f08280d390e3cd40d2267a9f918e8
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
@@ -19,10 +19,10 @@ Directory: target/openjdk-8-buster/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.697, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.697-buster
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.708, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.708-buster
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.697-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.708-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
 Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.3, lein, lein-2.9.3, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.3-buster, lein-buster, lein-2.9.3-buster
@@ -41,11 +41,11 @@ Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.697, tools-deps, tools-deps-1.10.1.697, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.697-buster, tools-deps-buster, tools-deps-1.10.1.697-buster
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.708, tools-deps, tools-deps-1.10.1.708, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.708-buster, tools-deps-buster, tools-deps-1.10.1.708-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.697-slim-buster, tools-deps-1.10.1.697-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.708-slim-buster, tools-deps-1.10.1.708-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
@@ -61,10 +61,10 @@ Directory: target/openjdk-14-slim-buster/boot
 Tags: openjdk-14-boot-buster, openjdk-14-boot-2.8.3-buster
 Directory: target/openjdk-14-buster/boot
 
-Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.697, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.697-slim-buster
+Tags: openjdk-14-tools-deps, openjdk-14-tools-deps-1.10.1.708, openjdk-14-tools-deps-slim-buster, openjdk-14-tools-deps-1.10.1.708-slim-buster
 Directory: target/openjdk-14-slim-buster/tools-deps
 
-Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.697-buster
+Tags: openjdk-14-tools-deps-buster, openjdk-14-tools-deps-1.10.1.708-buster
 Directory: target/openjdk-14-buster/tools-deps
 
 Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.3, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.3-slim-buster
@@ -79,10 +79,10 @@ Directory: target/openjdk-15-slim-buster/boot
 Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
 Directory: target/openjdk-15-buster/boot
 
-Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.697, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.697-slim-buster
+Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.708, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.708-slim-buster
 Directory: target/openjdk-15-slim-buster/tools-deps
 
-Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.697-buster
+Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.708-buster
 Directory: target/openjdk-15-buster/tools-deps
 
 Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.3, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.3-slim-buster
@@ -97,10 +97,10 @@ Directory: target/openjdk-16-slim-buster/boot
 Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
 Directory: target/openjdk-16-buster/boot
 
-Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.697, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.697-slim-buster
+Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.708, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.708-slim-buster
 Directory: target/openjdk-16-slim-buster/tools-deps
 
-Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.697-buster
+Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.708-buster
 Directory: target/openjdk-16-buster/tools-deps
 
 Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.3-alpine
@@ -109,5 +109,5 @@ Directory: target/openjdk-16-alpine/lein
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
 Directory: target/openjdk-16-alpine/boot
 
-Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.697-alpine
+Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.708-alpine
 Directory: target/openjdk-16-alpine/tools-deps


### PR DESCRIPTION
Hot on the heels of clojure tools-deps 1.10.1.697 here comes 1.10.1.708.