### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.35.4, 3.35, 3, latest
+Tags: 3.35.5, 3.35, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 46627a4387ce51eff6634366095d9bc5d0e22b12
+GitCommit: 5e7c906938c20c1abe219cea185301418b8028ae
 Directory: 3/debian
 
-Tags: 3.35.4-alpine, 3.35-alpine, 3-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46627a4387ce51eff6634366095d9bc5d0e22b12
+Tags: 3.35.5-alpine, 3.35-alpine, 3-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 5e7c906938c20c1abe219cea185301418b8028ae
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d7c579647e33ca8c9ecac3a559c4a99a12cb73
+GitCommit: fb730ff1d89a2583a86ebc8d0fe4544f015921ac
 Directory: 2/debian
 
 Tags: 2.38.2-alpine, 2.38-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 30d7c579647e33ca8c9ecac3a559c4a99a12cb73
+GitCommit: fb730ff1d89a2583a86ebc8d0fe4544f015921ac
 Directory: 2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/61354a6: Update to 3.35.5, ghost-cli 1.14.1