### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-18-jdk-oraclelinux8, 16-ea-18-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-18-jdk-oracle, 16-ea-18-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-18-jdk, 16-ea-18, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-19-jdk-oraclelinux8, 16-ea-19-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-19-jdk-oracle, 16-ea-19-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-19-jdk, 16-ea-19, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-18-jdk-oraclelinux7, 16-ea-18-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-19-jdk-oraclelinux7, 16-ea-19-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-18-jdk-buster, 16-ea-18-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-19-jdk-buster, 16-ea-19-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/buster
 
-Tags: 16-ea-18-jdk-slim-buster, 16-ea-18-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-18-jdk-slim, 16-ea-18-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-19-jdk-slim-buster, 16-ea-19-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-19-jdk-slim, 16-ea-19-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-14-jdk-alpine3.12, 16-ea-14-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-14-jdk-alpine, 16-ea-14-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -30,24 +30,24 @@ Architectures: amd64
 GitCommit: 2d4433f9d8a458f239429751fc2ae96c032cbfb3
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-18-jdk-windowsservercore-1809, 16-ea-18-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-18-jdk-windowsservercore, 16-ea-18-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-18-jdk, 16-ea-18, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-19-jdk-windowsservercore-1809, 16-ea-19-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-19-jdk-windowsservercore, 16-ea-19-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-19-jdk, 16-ea-19, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-18-jdk-windowsservercore-ltsc2016, 16-ea-18-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-18-jdk-windowsservercore, 16-ea-18-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-18-jdk, 16-ea-18, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-19-jdk-windowsservercore-ltsc2016, 16-ea-19-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-19-jdk-windowsservercore, 16-ea-19-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-19-jdk, 16-ea-19, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-18-jdk-nanoserver-1809, 16-ea-18-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-18-jdk-nanoserver, 16-ea-18-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-19-jdk-nanoserver-1809, 16-ea-19-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-19-jdk-nanoserver, 16-ea-19-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 10bca823483103ea973acf1317972909ecaaedff
+GitCommit: 7a529734f91150e8ced49e0691d041ad7b8c9f1f
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/7a52973: Update to 16-ea+19