### PR TITLE
upgrade r-base to R 4.0.3 released yesterday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.0.2, latest
+Tags: 4.0.3, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 206d35749495c5309183bfabaea90091eaff5cf4
-Directory: r-base/latest
+GitCommit: f710db09bce5ed4670f80ff4bf5a6cc8f022b76b
+Directory: r-base/4.0.3
 


### PR DESCRIPTION
Standard upgrade to R 4.0.3 released October 10 (yesterday)

Minor tweak in in library/r-base to actually point to the named release (4.0.3) here
Minor change in Dockerfile adding another softlink, and defaulting to not installing recommended packages