### PR TITLE
Update Clear Linux OS to 33820

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 39aaceb6d07d1df68a6aa5aa19c5dcef83310d04
-GitFetch: refs/tags/clear-linux-33810
+GitCommit: 8afa9392880e3531844754c1ccd2611fa4ba691c
+GitFetch: refs/tags/clear-linux-33820


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 33820

@bryteise @alexjch