### PR TITLE
Update Git

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -1,6 +1,6 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
-GitCommit: f6e27a40b3c8b6dcc8dc07a278f7a9f0c2a808cb
+GitCommit: 391db05e9a4c9aad68979d7df2eb42f2ada5e303
 
 Tags: 6.6.1-jdk8, 6.6-jdk8, jdk8, 6.6.1-jdk, 6.6-jdk, jdk, 6.6.1, 6.6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x


### PR DESCRIPTION
Temporarily using PPA for Git until https://github.com/AdoptOpenJDK/openjdk-docker/pull/397 gets merged.