### PR TITLE
Add Amazon Corretto 15 images

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -14,6 +14,10 @@ Tags: 11, 11.0.8, 11.0.8-al2, 11-al2-jdk, 11-al2-full
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
+Tags: 15, 15-al2-jdk, 15-al2-full
+Architectures: amd64, arm64v8
+Directory: 15/jdk/al2
+
 Tags: 8-alpine, 8u262-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine
@@ -25,3 +29,7 @@ Directory: 8/jre/alpine
 Tags: 11-alpine, 11.0.8-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine
+
+Tags: 15-alpine, 15-alpine-full, 15-alpine-jdk
+Architectures: amd64
+Directory: 15/jdk/alpine


### PR DESCRIPTION
Add tags of Amazon Corretto 15 images:

- Amazon Linux 2: 
  - Tags: 15, 15-al2-jdk, 15-al2-full
  - [Dockerfile](https://github.com/corretto/corretto-docker/blob/master/15/jdk/al2/Dockerfile)
- Alpine: 
  - 15-alpine, 15-alpine-full, 15-alpine-jdk
  - [Dockerfile](https://github.com/corretto/corretto-docker/blob/master/15/jdk/alpine/Dockerfile)