### PR TITLE
Updating oraclelinux:7 and oraclelinux:7-slim for ELSA-2020-4076

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 52339856c3cf67775e37b128952ba43c19507ab2
+amd64-GitCommit: d17fc9867a6769bd5707b86179d71dc0740fbdae
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4a17af9c6111f19751a5dba3f558bc84a2a11028
+arm64v8-GitCommit: 4ca3119b88b326ff3e2a1fa91852305a2599a34b
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See https://linux.oracle.com/errata/ELSA-2020-4076.html for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>