### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/6dae271348d2d16047c39527fc25f9b06ee67367/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/132a93b20fcae6a9ef82425ae491262c975003f4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 6dae271348d2d16047c39527fc25f9b06ee67367
+GitCommit: 132a93b20fcae6a9ef82425ae491262c975003f4
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9f35d71493d683567e30f45b1cda4a0f1f11ae3f
+amd64-GitCommit: e33ce41cb5b911f50a58c0e42af2bcc04181f621
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: fa0ab3f4a9198c64f249d45ce2027f077eecf0e4
+arm32v5-GitCommit: 274bd72e185d24fdaed0f7d4703362882508397b
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 10716777c5b134b42476a3d2108398690b261e83
+arm32v6-GitCommit: ea4bd11471573e18afd506704695f99e1950bc11
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7d617c90637444953eca3bc3d3755f392ff7de7d
+arm32v7-GitCommit: 7482732605f01ef23691e8e8b42c0f5517e65cd9
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7ad4fc59b8cbbf2758052c0ef960326004d503f2
+arm64v8-GitCommit: 0cd82e1da438a44317bdf0d7ec9ff0b08b4bcffb
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 88d369a04164726d329389b68ccc01401aca6d07
+i386-GitCommit: 304948cb5a18bd05d15a387ecd465c4a3644d5ca
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: ca750041b66692d5704dcecad5abd79829aac1db
+mips64le-GitCommit: cadee917dc6539000e76ea202700c339fdff2d90
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 93da82c93d7e80ae7402343fc2c01a56f20f0c4b
+ppc64le-GitCommit: 9b3ea0bcd3ae0f13f3ba4ed54794cbab184dbd26
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 83e290048298c38b02d689975caf54978c3de2cb
+s390x-GitCommit: ad6c168ad28240181eba5b319f8a92966e40a3a4
 
 Tags: 1.32.0-uclibc, 1.32-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/132a93b: Update Buildroot to 2020.08.1
- https://github.com/docker-library/busybox/commit/f240d2c: fix: override filetype (https://github.com/docker-library/busybox/pull/88)