### PR TITLE
Add OpenJ9 images

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -1,27 +1,57 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
-GitCommit: 391db05e9a4c9aad68979d7df2eb42f2ada5e303
+GitCommit: c9b33882bc9877c1102d00e3f65e5c8ad04fe01a
 
-Tags: 6.6.1-jdk8, 6.6-jdk8, jdk8, 6.6.1-jdk, 6.6-jdk, jdk, 6.6.1, 6.6, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: jdk8
 
-Tags: 6.6.1-jre8, 6.6-jre8, jre8, 6.6.1-jre, 6.6-jre, jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: jre8
+# Hotspot
 
-Tags: 6.6.1-jdk11, 6.6-jdk11, jdk11
+Tags: 6.6.1-jdk8, 6.6.1-jdk8-hotspot, 6.6-jdk8, 6.6-jdk8-hotspot, jdk8, jdk8-hotspot, 6.6.1-jdk, 6.6.1-jdk-hotspot, 6.6-jdk, 6.6-jdk-hotspot, jdk, jdk-hotspot, 6.6.1, 6.6.1-hotspot, 6.6, 6.6-hotspot, latest, hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: jdk11
+Directory: hotspot/jdk8
 
-Tags: 6.6.1-jre11, 6.6-jre11, jre11
+Tags: 6.6.1-jre8, 6.6.1-jre8-hotspot, 6.6-jre8, 6.6-jre8-hotspot, jre8, jre8-hotspot, 6.6.1-jre, 6.6.1-jre-hotspot, 6.6-jre, 6.6-jre-hotspot, jre, jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: jre11
+Directory: hotspot/jre8
 
-Tags: 6.6.1-jdk14, 6.6-jdk14, jdk14
+Tags: 6.6.1-jdk11, 6.6.1-jdk11-hotspot, 6.6-jdk11, 6.6-jdk11-hotspot, jdk11, jdk11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: jdk14
+Directory: hotspot/jdk11
 
-Tags: 6.6.1-jre14, 6.6-jre14, jre14
+Tags: 6.6.1-jre11, 6.6.1-jre11-hotspot, 6.6-jre11, 6.6-jre11-hotspot, jre11, jre11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: jre14
+Directory: hotspot/jre11
+
+Tags: 6.6.1-jdk14, 6.6.1-jdk14-hotspot, 6.6-jdk14, 6.6-jdk14-hotspot, jdk14, jdk14-hotspot
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Directory: hotspot/jdk14
+
+Tags: 6.6.1-jre14, 6.6.1-jre14-hotspot, 6.6-jre14, 6.6-jre14-hotspot, jre14, jre14-hotspot
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Directory: hotspot/jre14
+
+
+# OpenJ9
+
+Tags: 6.6.1-jdk8-openj9, 6.6-jdk8-openj9, jdk8-openj9, 6.6.1-jdk-openj9, 6.6-jdk-openj9, jdk-openj9, 6.6.1-openj9, 6.6-openj9, openj9
+Architectures: amd64, ppc64le, s390x
+Directory: openj9/jdk8
+
+Tags: 6.6.1-jre8-openj9, 6.6-jre8-openj9, jre8-openj9, 6.6.1-jre-openj9, 6.6-jre-openj9, jre-openj9
+Architectures: amd64, ppc64le, s390x
+Directory: openj9/jre8
+
+Tags: 6.6.1-jdk11-openj9, 6.6-jdk11-openj9, jdk11-openj9
+Architectures: amd64, ppc64le, s390x
+Directory: openj9/jdk11
+
+Tags: 6.6.1-jre11-openj9, 6.6-jre11-openj9, jre11-openj9
+Architectures: amd64, ppc64le, s390x
+Directory: openj9/jre11
+
+Tags: 6.6.1-jdk14-openj9, 6.6-jdk14-openj9, jdk14-openj9
+Architectures: amd64, ppc64le, s390x
+Directory: openj9/jdk14
+
+Tags: 6.6.1-jre14-openj9, 6.6-jre14-openj9, jre14-openj9
+Architectures: amd64, ppc64le, s390x
+Directory: openj9/jre14


### PR DESCRIPTION
A user [requested](https://github.com/keeganwitt/docker-gradle/issues/155) OpenJ9 based images.  Since these are already provided by AdoptOpenJDK, it didn't seem unreasonable.