### PR TITLE
PHP 8.0.0rc2.

### DIFF
--- a/library/php
+++ b/library/php
@@ -4,32 +4,32 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 8.0.0rc2-cli-buster, 8.0-rc-cli-buster, rc-cli-buster, 8.0.0rc2-buster, 8.0-rc-buster, rc-buster, 8.0.0rc2-cli, 8.0-rc-cli, rc-cli, 8.0.0rc2, 8.0-rc, rc
+Tags: 8.0.0RC2-cli-buster, 8.0-rc-cli-buster, rc-cli-buster, 8.0.0RC2-buster, 8.0-rc-buster, rc-buster, 8.0.0RC2-cli, 8.0-rc-cli, rc-cli, 8.0.0RC2, 8.0-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/cli
 
-Tags: 8.0.0rc2-apache-buster, 8.0-rc-apache-buster, rc-apache-buster, 8.0.0rc2-apache, 8.0-rc-apache, rc-apache
+Tags: 8.0.0RC2-apache-buster, 8.0-rc-apache-buster, rc-apache-buster, 8.0.0RC2-apache, 8.0-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/apache
 
-Tags: 8.0.0rc2-fpm-buster, 8.0-rc-fpm-buster, rc-fpm-buster, 8.0.0rc2-fpm, 8.0-rc-fpm, rc-fpm
+Tags: 8.0.0RC2-fpm-buster, 8.0-rc-fpm-buster, rc-fpm-buster, 8.0.0RC2-fpm, 8.0-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/fpm
 
-Tags: 8.0.0rc2-zts-buster, 8.0-rc-zts-buster, rc-zts-buster, 8.0.0rc2-zts, 8.0-rc-zts, rc-zts
+Tags: 8.0.0RC2-zts-buster, 8.0-rc-zts-buster, rc-zts-buster, 8.0.0RC2-zts, 8.0-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/zts
 
-Tags: 8.0.0rc2-cli-alpine3.12, 8.0-rc-cli-alpine3.12, rc-cli-alpine3.12, 8.0.0rc2-alpine3.12, 8.0-rc-alpine3.12, rc-alpine3.12, 8.0.0rc2-cli-alpine, 8.0-rc-cli-alpine, rc-cli-alpine, 8.0.0rc2-alpine, 8.0-rc-alpine, rc-alpine
+Tags: 8.0.0RC2-cli-alpine3.12, 8.0-rc-cli-alpine3.12, rc-cli-alpine3.12, 8.0.0RC2-alpine3.12, 8.0-rc-alpine3.12, rc-alpine3.12, 8.0.0RC2-cli-alpine, 8.0-rc-cli-alpine, rc-cli-alpine, 8.0.0RC2-alpine, 8.0-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/alpine3.12/cli
 
-Tags: 8.0.0rc2-fpm-alpine3.12, 8.0-rc-fpm-alpine3.12, rc-fpm-alpine3.12, 8.0.0rc2-fpm-alpine, 8.0-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.0.0RC2-fpm-alpine3.12, 8.0-rc-fpm-alpine3.12, rc-fpm-alpine3.12, 8.0.0RC2-fpm-alpine, 8.0-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/alpine3.12/fpm

--- a/library/php
+++ b/library/php
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 8.0.0rc1-cli-buster, 8.0-rc-cli-buster, rc-cli-buster, 8.0.0rc1-buster, 8.0-rc-buster, rc-buster, 8.0.0rc1-cli, 8.0-rc-cli, rc-cli, 8.0.0rc1, 8.0-rc, rc
+Tags: 8.0.0rc2-cli-buster, 8.0-rc-cli-buster, rc-cli-buster, 8.0.0rc2-buster, 8.0-rc-buster, rc-buster, 8.0.0rc2-cli, 8.0-rc-cli, rc-cli, 8.0.0rc2, 8.0-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7ef129842e2620a30b45a1d9c003b1f290b0453d
+GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/cli
 
-Tags: 8.0.0rc1-apache-buster, 8.0-rc-apache-buster, rc-apache-buster, 8.0.0rc1-apache, 8.0-rc-apache, rc-apache
+Tags: 8.0.0rc2-apache-buster, 8.0-rc-apache-buster, rc-apache-buster, 8.0.0rc2-apache, 8.0-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7ef129842e2620a30b45a1d9c003b1f290b0453d
+GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/apache
 
-Tags: 8.0.0rc1-fpm-buster, 8.0-rc-fpm-buster, rc-fpm-buster, 8.0.0rc1-fpm, 8.0-rc-fpm, rc-fpm
+Tags: 8.0.0rc2-fpm-buster, 8.0-rc-fpm-buster, rc-fpm-buster, 8.0.0rc2-fpm, 8.0-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7ef129842e2620a30b45a1d9c003b1f290b0453d
+GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/fpm
 
-Tags: 8.0.0rc1-zts-buster, 8.0-rc-zts-buster, rc-zts-buster, 8.0.0rc1-zts, 8.0-rc-zts, rc-zts
+Tags: 8.0.0rc2-zts-buster, 8.0-rc-zts-buster, rc-zts-buster, 8.0.0rc2-zts, 8.0-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7ef129842e2620a30b45a1d9c003b1f290b0453d
+GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/buster/zts
 
-Tags: 8.0.0rc1-cli-alpine3.12, 8.0-rc-cli-alpine3.12, rc-cli-alpine3.12, 8.0.0rc1-alpine3.12, 8.0-rc-alpine3.12, rc-alpine3.12, 8.0.0rc1-cli-alpine, 8.0-rc-cli-alpine, rc-cli-alpine, 8.0.0rc1-alpine, 8.0-rc-alpine, rc-alpine
+Tags: 8.0.0rc2-cli-alpine3.12, 8.0-rc-cli-alpine3.12, rc-cli-alpine3.12, 8.0.0rc2-alpine3.12, 8.0-rc-alpine3.12, rc-alpine3.12, 8.0.0rc2-cli-alpine, 8.0-rc-cli-alpine, rc-cli-alpine, 8.0.0rc2-alpine, 8.0-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ef129842e2620a30b45a1d9c003b1f290b0453d
+GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/alpine3.12/cli
 
-Tags: 8.0.0rc1-fpm-alpine3.12, 8.0-rc-fpm-alpine3.12, rc-fpm-alpine3.12, 8.0.0rc1-fpm-alpine, 8.0-rc-fpm-alpine, rc-fpm-alpine
+Tags: 8.0.0rc2-fpm-alpine3.12, 8.0-rc-fpm-alpine3.12, rc-fpm-alpine3.12, 8.0.0rc2-fpm-alpine, 8.0-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ef129842e2620a30b45a1d9c003b1f290b0453d
+GitCommit: 13c031bd1d4c24112b4e8ea5237a95ab0f9ed9e1
 Directory: 8.0-rc/alpine3.12/fpm
 
 Tags: 7.4.11-cli-buster, 7.4-cli-buster, 7-cli-buster, cli-buster, 7.4.11-buster, 7.4-buster, 7-buster, buster, 7.4.11-cli, 7.4-cli, 7-cli, cli, 7.4.11, 7.4, 7, latest


### PR DESCRIPTION
Changes:
- docker-library/php@13c031b: Update 8.0-rc to 8.0.0RC2 