### PR TITLE
Update Clear Linux OS to 33840

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 39aaceb6d07d1df68a6aa5aa19c5dcef83310d04
-GitFetch: refs/tags/clear-linux-33810
+GitCommit: 61360d7245ea776649eaea02b10c8c31705daff7
+GitFetch: refs/tags/clear-linux-33840


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 33840

@bryteise @alexjch