### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev6, 2.3-dev
+Tags: 2.3-dev7, 2.3-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3136139767f5ee652493820868b7c0c19344069
+GitCommit: a83ae777c7466d0da4e23b9398f5d9d9340876b0
 Directory: 2.3-rc
 
-Tags: 2.3-dev6-alpine, 2.3-dev-alpine
+Tags: 2.3-dev7-alpine, 2.3-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a3136139767f5ee652493820868b7c0c19344069
+GitCommit: a83ae777c7466d0da4e23b9398f5d9d9340876b0
 Directory: 2.3-rc/alpine
 
 Tags: 2.2.4, 2.2, latest, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a83ae77: Update to 2.3-dev7