### PR TITLE
Bump Traefik to v2.3.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,14 +3,14 @@ Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vin
 Tags: v2.3.2-windowsservercore-1809, 2.3.2-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: 613b06ccf8a14c086ea92802c68cc4e394135ce7
+GitCommit: 3f8ca2ac908290de94d21362956aa8ff219e7419
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.3.2, 2.3.2, v2.3, 2.3, picodon, latest
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 613b06ccf8a14c086ea92802c68cc4e394135ce7
+GitCommit: 3f8ca2ac908290de94d21362956aa8ff219e7419
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,13 +1,13 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.1-windowsservercore-1809, 2.3.1-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.3.2-windowsservercore-1809, 2.3.2-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
 GitCommit: 613b06ccf8a14c086ea92802c68cc4e394135ce7
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.1, 2.3.1, v2.3, 2.3, picodon, latest
+Tags: v2.3.2, 2.3.2, v2.3, 2.3, picodon, latest
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 613b06ccf8a14c086ea92802c68cc4e394135ce7


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.2](https://github.com/traefik/traefik/releases/tag/v2.3.2).

/cc @SantoDE @jbdoumenjou @rtribotte

Cheers
