### PR TITLE
Replace Java 14 with Java 15

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -1,6 +1,6 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
-GitCommit: 937b7d04a215482e506bd3a6fbcda638771e2dc1
+GitCommit: d1f217e41c055c31266b3d8d94dc896cdbe4f0a6
 
 
 # Hotspot
@@ -21,13 +21,13 @@ Tags: 6.7.0-jre11, 6.7.0-jre11-hotspot, 6.7-jre11, 6.7-jre11-hotspot, jre11, jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre11
 
-Tags: 6.7.0-jdk14, 6.7.0-jdk14-hotspot, 6.7-jdk14, 6.7-jdk14-hotspot, jdk14, jdk14-hotspot
+Tags: 6.7.0-jdk15, 6.7.0-jdk15-hotspot, 6.7-jdk15, 6.7-jdk15-hotspot, jdk15, jdk15-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: hotspot/jdk14
+Directory: hotspot/jdk15
 
-Tags: 6.7.0-jre14, 6.7.0-jre14-hotspot, 6.7-jre14, 6.7-jre14-hotspot, jre14, jre14-hotspot
+Tags: 6.7.0-jre15, 6.7.0-jre15-hotspot, 6.7-jre15, 6.7-jre15-hotspot, jre15, jre15-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Directory: hotspot/jre14
+Directory: hotspot/jre15
 
 
 # OpenJ9
@@ -48,10 +48,10 @@ Tags: 6.7.0-jre11-openj9, 6.7-jre11-openj9, jre11-openj9
 Architectures: amd64, ppc64le, s390x
 Directory: openj9/jre11
 
-Tags: 6.7.0-jdk14-openj9, 6.7-jdk14-openj9, jdk14-openj9
+Tags: 6.7.0-jdk15-openj9, 6.7-jdk15-openj9, jdk15-openj9
 Architectures: amd64, ppc64le, s390x
-Directory: openj9/jdk14
+Directory: openj9/jdk15
 
-Tags: 6.7.0-jre14-openj9, 6.7-jre14-openj9, jre14-openj9
+Tags: 6.7.0-jre15-openj9, 6.7-jre15-openj9, jre15-openj9
 Architectures: amd64, ppc64le, s390x
-Directory: openj9/jre14
+Directory: openj9/jre15


### PR DESCRIPTION
Given the current base tags for Java 15 images are now 20.04, but will be flipped to 18.04, then back to 20.04 (https://github.com/AdoptOpenJDK/openjdk-docker/issues/445), I'm not sure when it'd be best to merge this.