### PR TITLE
Replace Java 14 with Java 15

### DIFF
--- a/library/groovy
+++ b/library/groovy
@@ -6,33 +6,33 @@ GitRepo: https://github.com/groovy/docker-groovy.git
 
 Tags: 3.0.6-jdk8, 3.0-jdk8, 3.0.6-jdk, 3.0-jdk, jdk8, jdk
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk8
 
 Tags: 3.0.6-jre8, 3.0-jre8, 3.0.6-jre, 3.0-jre, 3.0.6, 3.0, jre8, jre, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre8
 
 Tags: 3.0.6-jdk11, 3.0-jdk11, jdk11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk11
 
 Tags: 3.0.6-jre11, 3.0-jre11, jre11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre11
 
-Tags: 3.0.6-jdk14, 3.0-jdk14, jdk14
+Tags: 3.0.6-jdk15, 3.0-jdk15, jdk15
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
-Directory: jdk14
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
+Directory: jdk15
 
-Tags: 3.0.6-jre14, 3.0-jre14, jre14
+Tags: 3.0.6-jre15, 3.0-jre15, jre15
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
-Directory: jre14
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
+Directory: jre15
 
 
 # Groovy 4
@@ -40,35 +40,35 @@ Directory: jre14
 Tags: 4.0.0-alpha-1-jdk8, 4.0-jdk8, 4.0.0-alpha-1-jdk, 4.0-jdk
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f427b874110293f40682002b2c860ad1f040830
+GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jdk8
 
 Tags: 4.0.0-alpha-1-jre8, 4.0-jre8, 4.0.0-alpha-1-jre, 4.0-jre, 4.0.0-alpha-1, 4.0
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f427b874110293f40682002b2c860ad1f040830
+GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jre8
 
 Tags: 4.0.0-alpha-1-jdk11, 4.0-jdk11
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f427b874110293f40682002b2c860ad1f040830
+GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jdk11
 
 Tags: 4.0.0-alpha-1-jre11, 4.0-jre11
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f427b874110293f40682002b2c860ad1f040830
+GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jre11
 
-Tags: 4.0.0-alpha-1-jdk14, 4.0-jdk14
+Tags: 4.0.0-alpha-1-jdk15, 4.0-jdk15
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f427b874110293f40682002b2c860ad1f040830
-Directory: jdk14
+GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
+Directory: jdk15
 
-Tags: 4.0.0-alpha-1-jre14, 4.0-jre14
+Tags: 4.0.0-alpha-1-jre15, 4.0-jre15
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f427b874110293f40682002b2c860ad1f040830
-Directory: jre14
+GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
+Directory: jre15

--- a/library/groovy
+++ b/library/groovy
@@ -1,6 +1,9 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/groovy/docker-groovy.git
 
+
+# Groovy 3
+
 Tags: 3.0.6-jdk8, 3.0-jdk8, 3.0.6-jdk, 3.0-jdk, jdk8, jdk
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
@@ -31,6 +34,8 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: bead178965ad50c71ab4f7603b258021c5356c38
 Directory: jre14
 
+
+# Groovy 4
 
 Tags: 4.0.0-alpha-1-jdk8, 4.0-jdk8, 4.0.0-alpha-1-jdk, 4.0-jdk
 GitFetch: refs/heads/4.0


### PR DESCRIPTION
Given the current base tags for Java 15 images are now 20.04, but will be flipped to 18.04, then back to 20.04 (AdoptOpenJDK/openjdk-docker#445), I'm not sure when it'd be best to merge this.