### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.35.5, 3.35, 3, latest
+Tags: 3.36.0, 3.36, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5e7c906938c20c1abe219cea185301418b8028ae
+GitCommit: 3332df18c9d6a11ba0d227b667ba27733a44fafe
 Directory: 3/debian
 
-Tags: 3.35.5-alpine, 3.35-alpine, 3-alpine, alpine
+Tags: 3.36.0-alpine, 3.36-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5e7c906938c20c1abe219cea185301418b8028ae
+GitCommit: 3332df18c9d6a11ba0d227b667ba27733a44fafe
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3332df1: Update to 3.36.0, ghost-cli 1.15.0