### PR TITLE
Updating Oracle Linux images for tzdata-2020b

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d17fc9867a6769bd5707b86179d71dc0740fbdae
+amd64-GitCommit: 6d8a0ddd6c2f36761853dfdc303a1d8309f69252
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4ca3119b88b326ff3e2a1fa91852305a2599a34b
+arm64v8-GitCommit: 67d1a557e35e5e579899c13cf9257e97ec8bc7c0
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This is a full matrix update, i.e. both `amd64` and `arm64v8` builds of `oraclelinux:7`, `oraclelinux:7-slim`, `oraclelinux:8` and `oraclelinux:8-slim` for the latest `tzdata-2020b` update.

* See [ELBA-2020-4282 for details](https://linux.oracle.com/errata/ELBA-2020-4282.html)

Signed-off-by: Avi Miller <avi.miller@oracle.com>