### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-20-jdk-oraclelinux8, 16-ea-20-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-20-jdk-oracle, 16-ea-20-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-20-jdk, 16-ea-20, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-21-jdk-oraclelinux8, 16-ea-21-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-21-jdk-oracle, 16-ea-21-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-21-jdk, 16-ea-21, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-20-jdk-oraclelinux7, 16-ea-20-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-21-jdk-oraclelinux7, 16-ea-21-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-20-jdk-buster, 16-ea-20-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-21-jdk-buster, 16-ea-21-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/buster
 
-Tags: 16-ea-20-jdk-slim-buster, 16-ea-20-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-20-jdk-slim, 16-ea-20-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-21-jdk-slim-buster, 16-ea-21-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-21-jdk-slim, 16-ea-21-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-14-jdk-alpine3.12, 16-ea-14-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-14-jdk-alpine, 16-ea-14-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -30,24 +30,24 @@ Architectures: amd64
 GitCommit: 2d4433f9d8a458f239429751fc2ae96c032cbfb3
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-20-jdk-windowsservercore-1809, 16-ea-20-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-20-jdk-windowsservercore, 16-ea-20-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-20-jdk, 16-ea-20, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-21-jdk-windowsservercore-1809, 16-ea-21-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-21-jdk-windowsservercore, 16-ea-21-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-21-jdk, 16-ea-21, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-20-jdk-windowsservercore-ltsc2016, 16-ea-20-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-20-jdk-windowsservercore, 16-ea-20-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-20-jdk, 16-ea-20, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-21-jdk-windowsservercore-ltsc2016, 16-ea-21-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-21-jdk-windowsservercore, 16-ea-21-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-21-jdk, 16-ea-21, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-20-jdk-nanoserver-1809, 16-ea-20-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-20-jdk-nanoserver, 16-ea-20-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-21-jdk-nanoserver-1809, 16-ea-21-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-21-jdk-nanoserver, 16-ea-21-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: befe4f8b639495e5881781b366af682f1a0a1d39
+GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -135,67 +135,67 @@ GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
 Directory: 14/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.8-jdk-buster, 11.0.8-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
-SharedTags: 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.9-jdk-buster, 11.0.9-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
+SharedTags: 11.0.9-jdk, 11.0.9, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jdk/buster
 
-Tags: 11.0.8-jdk-slim-buster, 11.0.8-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.8-jdk-slim, 11.0.8-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.9-jdk-slim-buster, 11.0.9-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.9-jdk-slim, 11.0.9-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 52cb2ce3bda94b1c0229f11bfa176035ad41c9b8
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jdk/slim-buster
 
-Tags: 11.0.8-jdk-windowsservercore-1809, 11.0.8-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.8-jdk-windowsservercore, 11.0.8-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.9-jdk-windowsservercore-1809, 11.0.9-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.9-jdk-windowsservercore, 11.0.9-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.9-jdk, 11.0.9, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.8-jdk-windowsservercore-ltsc2016, 11.0.8-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.8-jdk-windowsservercore, 11.0.8-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.8-jdk, 11.0.8, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.9-jdk-windowsservercore-ltsc2016, 11.0.9-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.9-jdk-windowsservercore, 11.0.9-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.9-jdk, 11.0.9, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.8-jdk-nanoserver-1809, 11.0.8-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.8-jdk-nanoserver, 11.0.8-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.9-jdk-nanoserver-1809, 11.0.9-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.9-jdk-nanoserver, 11.0.9-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.8-jre-buster, 11.0-jre-buster, 11-jre-buster
-SharedTags: 11.0.8-jre, 11.0-jre, 11-jre
+Tags: 11.0.9-jre-buster, 11.0-jre-buster, 11-jre-buster
+SharedTags: 11.0.9-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: 67f8b1afea57091472229c49f6b112b0d8af1fee
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jre/buster
 
-Tags: 11.0.8-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.8-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.9-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.9-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: 67f8b1afea57091472229c49f6b112b0d8af1fee
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jre/slim-buster
 
-Tags: 11.0.8-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.8-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.8-jre, 11.0-jre, 11-jre
+Tags: 11.0.9-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.9-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.9-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.8-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.8-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.8-jre, 11.0-jre, 11-jre
+Tags: 11.0.9-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.9-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.9-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 83fbf16d99f4094df192b4f07909b473ad1d8392
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.8-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.8-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.9-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.9-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 601cc5f946f8ada75d8b8eaa1eb3f4c4b821ac23
+GitCommit: a1056a406c11909319b95a9631933cdc2035005a
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/bd88879: Update to 16-ea+21
- https://github.com/docker-library/openjdk/commit/a1056a4: Update to 11.0.9