### PR TITLE
Update mariadb

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,25 +6,25 @@ GitRepo: https://github.com/docker-library/mariadb.git
 
 Tags: 10.5.6-focal, 10.5-focal, 10-focal, focal, 10.5.6, 10.5, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 33058df3907bf6daaa51db8fd01105226506122a
+GitCommit: 0081e91ebc00c8e77f0e610de965b1d284f13135
 Directory: 10.5
 
 Tags: 10.4.15-focal, 10.4-focal, 10.4.15, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b5c414408d9fea9d4cab9370bdf6716aa2e9c648
+GitCommit: 0081e91ebc00c8e77f0e610de965b1d284f13135
 Directory: 10.4
 
 Tags: 10.3.25-focal, 10.3-focal, 10.3.25, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: affe478a1811a7abeb76fd623c29c24777e6f07a
+GitCommit: 0081e91ebc00c8e77f0e610de965b1d284f13135
 Directory: 10.3
 
 Tags: 10.2.34-bionic, 10.2-bionic, 10.2.34, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3ad38c77d29010ecb82231c15651e1b425af925d
+GitCommit: 0081e91ebc00c8e77f0e610de965b1d284f13135
 Directory: 10.2
 
 Tags: 10.1.47-bionic, 10.1-bionic, 10.1.47, 10.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0bd0a2eaecf32990656d0b66bd89ebf47ecb44ad
+GitCommit: 0081e91ebc00c8e77f0e610de965b1d284f13135
 Directory: 10.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mariadb/commit/0081e91: Use auth-root-authentication-method available 10.1+ --skip-test-db 10.3+ (https://github.com/docker-library/mariadb/pull/297)
- https://github.com/docker-library/mariadb/commit/257cce8: Merge pull request https://github.com/docker-library/mariadb/pull/296 from grooverdan/no-flush-privs2