### PR TITLE
Updating oraclelinux:6 and oraclelinux:6-slim for tzdata-2020b

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6d8a0ddd6c2f36761853dfdc303a1d8309f69252
+amd64-GitCommit: 10227d1a88809f983e79edde3f6c3875a6e3409a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 67d1a557e35e5e579899c13cf9257e97ec8bc7c0


### PR DESCRIPTION
This is the update for `oraclelinux:6` and `oraclelinux:6-slim` for the latest tzdata-2020b update. See [ELBA-2020-4282](https://linux.oracle.com/errata/ELBA-2020-4282.html) for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>