### PR TITLE
Update SonarQube to 8.5.1

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,16 +4,16 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
              Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: e612cf000910bfec4cf0d3d08b89d25c61cfcbf7
+GitCommit: 03ce69f589c5b6a3f731d5c941fcb049bb55064c
 
 Tags: 7.9.4-community, 7.9-community, lts
 Directory: 7/community
 
-Tags: 8.5.0-community, 8.5-community, 8-community, community, latest
+Tags: 8.5.1-community, 8.5-community, 8-community, community, latest
 Directory: 8/community
 
-Tags: 8.5.0-developer, 8.5-developer, 8-developer, developer
+Tags: 8.5.1-developer, 8.5-developer, 8-developer, developer
 Directory: 8/developer
 
-Tags: 8.5.0-enterprise, 8.5-enterprise, 8-enterprise, enterprise
+Tags: 8.5.1-enterprise, 8.5-enterprise, 8-enterprise, enterprise
 Directory: 8/enterprise


### PR DESCRIPTION
This is a patch release of SonarQube 8.5