### PR TITLE
AdoptOpenJDK: Oct 2020 release of 8u272-b10, 11.0.9+11 and 15.0.1+9.

### DIFF
--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -7,14 +7,14 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 Tags: 8u272-b10-jdk-hotspot-focal, 8-jdk-hotspot-focal, 8-hotspot-focal
 SharedTags: 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u272-b10-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
 SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +22,7 @@ Constraints: windowsservercore-1809
 Tags: 8u272-b10-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
 SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -30,14 +30,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u272-b10-jre-hotspot-focal, 8-jre-hotspot-focal
 SharedTags: 8u272-b10-jre-hotspot, 8-jre-hotspot
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u272-b10-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
 SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -45,7 +45,7 @@ Constraints: windowsservercore-1809
 Tags: 8u272-b10-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -55,14 +55,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.9_11-jdk-hotspot-focal, 11-jdk-hotspot-focal, 11-hotspot-focal
 SharedTags: 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.9_11-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
 SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -70,7 +70,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.9_11-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
 SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -78,14 +78,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.9_11-jre-hotspot-focal, 11-jre-hotspot-focal
 SharedTags: 11.0.9_11-jre-hotspot, 11-jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.9_11-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
 SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -93,7 +93,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.9_11-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -103,14 +103,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 14.0.2_12-jdk-hotspot-focal, 14-jdk-hotspot-focal, 14-hotspot-focal
 SharedTags: 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 14.0.2_12-jdk-hotspot-windowsservercore-1809, 14-jdk-hotspot-windowsservercore-1809, 14-hotspot-windowsservercore-1809
 SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -118,7 +118,7 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jdk-hotspot-windowsservercore-ltsc2016, 14-jdk-hotspot-windowsservercore-ltsc2016, 14-hotspot-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -126,14 +126,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 14.0.2_12-jre-hotspot-focal, 14-jre-hotspot-focal
 SharedTags: 14.0.2_12-jre-hotspot, 14-jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 14.0.2_12-jre-hotspot-windowsservercore-1809, 14-jre-hotspot-windowsservercore-1809
 SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -141,7 +141,7 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jre-hotspot-windowsservercore-ltsc2016, 14-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -151,14 +151,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.1_9-jdk-hotspot-focal, 15-jdk-hotspot-focal, 15-hotspot-focal, hotspot-focal
 SharedTags: 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.1_9-jdk-hotspot-windowsservercore-1809, 15-jdk-hotspot-windowsservercore-1809, 15-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
 SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -166,7 +166,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.1_9-jdk-hotspot-windowsservercore-ltsc2016, 15-jdk-hotspot-windowsservercore-ltsc2016, 15-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
 SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -174,14 +174,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.1_9-jre-hotspot-focal, 15-jre-hotspot-focal
 SharedTags: 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.1_9-jre-hotspot-windowsservercore-1809, 15-jre-hotspot-windowsservercore-1809
 SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -189,7 +189,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.1_9-jre-hotspot-windowsservercore-ltsc2016, 15-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -199,14 +199,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u272-b10-jdk-openj9-0.23.0-focal, 8-jdk-openj9-focal, 8-openj9-focal
 SharedTags: 8u272-b10-jdk-openj9-0.23.0, 8-jdk-openj9, 8-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
 SharedTags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u272-b10-jdk-openj9-0.23.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -214,7 +214,7 @@ Constraints: windowsservercore-1809
 Tags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
 SharedTags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u272-b10-jdk-openj9-0.23.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -222,14 +222,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u272-b10-jre-openj9-0.23.0-focal, 8-jre-openj9-focal
 SharedTags: 8u272-b10-jre-openj9-0.23.0, 8-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 8u272-b10-jre-openj9-0.23.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
 SharedTags: 8u272-b10-jre-openj9-0.23.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u272-b10-jre-openj9-0.23.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -237,7 +237,7 @@ Constraints: windowsservercore-1809
 Tags: 8u272-b10-jre-openj9-0.23.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 8u272-b10-jre-openj9-0.23.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u272-b10-jre-openj9-0.23.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -247,14 +247,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.9_11-jdk-openj9-0.23.0-focal, 11-jdk-openj9-focal, 11-openj9-focal
 SharedTags: 11.0.9_11-jdk-openj9-0.23.0, 11-jdk-openj9, 11-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
 SharedTags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.9_11-jdk-openj9-0.23.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -262,7 +262,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
 SharedTags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.9_11-jdk-openj9-0.23.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -270,14 +270,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.9_11-jre-openj9-0.23.0-focal, 11-jre-openj9-focal
 SharedTags: 11.0.9_11-jre-openj9-0.23.0, 11-jre-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
 SharedTags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.9_11-jre-openj9-0.23.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -285,7 +285,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.9_11-jre-openj9-0.23.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -295,14 +295,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 14.0.2_12-jdk-openj9-0.21.0-focal, 14-jdk-openj9-focal, 14-openj9-focal
 SharedTags: 14.0.2_12-jdk-openj9-0.21.0, 14-jdk-openj9, 14-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore-1809, 14-jdk-openj9-windowsservercore-1809, 14-openj9-windowsservercore-1809
 SharedTags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, 14.0.2_12-jdk-openj9-0.21.0, 14-jdk-openj9, 14-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -310,7 +310,7 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore-ltsc2016, 14-jdk-openj9-windowsservercore-ltsc2016, 14-openj9-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, 14.0.2_12-jdk-openj9-0.21.0, 14-jdk-openj9, 14-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -318,14 +318,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 14.0.2_12-jre-openj9-0.21.0-focal, 14-jre-openj9-focal
 SharedTags: 14.0.2_12-jre-openj9-0.21.0, 14-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore-1809, 14-jre-openj9-windowsservercore-1809
 SharedTags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.2_12-jre-openj9-0.21.0, 14-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -333,7 +333,7 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore-ltsc2016, 14-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.2_12-jre-openj9-0.21.0, 14-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -343,14 +343,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.1_9-jdk-openj9-0.23.0-focal, 15-jdk-openj9-focal, 15-openj9-focal, openj9-focal
 SharedTags: 15.0.1_9-jdk-openj9-0.23.0, 15-jdk-openj9, 15-openj9, openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore-1809, 15-jdk-openj9-windowsservercore-1809, 15-openj9-windowsservercore-1809, openj9-windowsservercore-1809
 SharedTags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, openj9-windowsservercore, 15.0.1_9-jdk-openj9-0.23.0, 15-jdk-openj9, 15-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -358,7 +358,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore-ltsc2016, 15-jdk-openj9-windowsservercore-ltsc2016, 15-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
 SharedTags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, openj9-windowsservercore, 15.0.1_9-jdk-openj9-0.23.0, 15-jdk-openj9, 15-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -366,14 +366,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.1_9-jre-openj9-0.23.0-focal, 15-jre-openj9-focal
 SharedTags: 15.0.1_9-jre-openj9-0.23.0, 15-jre-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore-1809, 15-jre-openj9-windowsservercore-1809
 SharedTags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.1_9-jre-openj9-0.23.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -381,7 +381,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore-ltsc2016, 15-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.1_9-jre-openj9-0.23.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
+GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -5,14 +5,14 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 #-----------------------------hotspot v8 images---------------------------------
 Tags: 8u272-b10-jdk-hotspot-focal, 8-jdk-hotspot-focal, 8-hotspot-focal
-SharedTags: 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+SharedTags: 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u272-b10-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
-SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/windows/windowsservercore-1809
@@ -20,7 +20,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 8u272-b10-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
-SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
@@ -28,14 +28,14 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u272-b10-jre-hotspot-focal, 8-jre-hotspot-focal
-SharedTags: 8u272-b10-jre-hotspot, 8-jre-hotspot
+SharedTags: 8u272-b10-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u272-b10-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
-SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot
+SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/windows/windowsservercore-1809
@@ -43,7 +43,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 8u272-b10-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot
+SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 8/jre/windows/windowsservercore-ltsc2016
@@ -53,14 +53,14 @@ Constraints: windowsservercore-ltsc2016
 
 #-----------------------------hotspot v11 images---------------------------------
 Tags: 11.0.9_11-jdk-hotspot-focal, 11-jdk-hotspot-focal, 11-hotspot-focal
-SharedTags: 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+SharedTags: 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.9_11-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
-SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/windows/windowsservercore-1809
@@ -68,7 +68,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 11.0.9_11-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
-SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
@@ -76,14 +76,14 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.9_11-jre-hotspot-focal, 11-jre-hotspot-focal
-SharedTags: 11.0.9_11-jre-hotspot, 11-jre-hotspot
+SharedTags: 11.0.9_11-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.9_11-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
-SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot
+SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/windows/windowsservercore-1809
@@ -91,7 +91,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 11.0.9_11-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot
+SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 11/jre/windows/windowsservercore-ltsc2016
@@ -101,14 +101,14 @@ Constraints: windowsservercore-ltsc2016
 
 #-----------------------------hotspot v14 images---------------------------------
 Tags: 14.0.2_12-jdk-hotspot-focal, 14-jdk-hotspot-focal, 14-hotspot-focal
-SharedTags: 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
+SharedTags: 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, 14-jdk, 14
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 14.0.2_12-jdk-hotspot-windowsservercore-1809, 14-jdk-hotspot-windowsservercore-1809, 14-hotspot-windowsservercore-1809
-SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
+SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, 14-jdk, 14
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/windows/windowsservercore-1809
@@ -116,7 +116,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 14.0.2_12-jdk-hotspot-windowsservercore-ltsc2016, 14-jdk-hotspot-windowsservercore-ltsc2016, 14-hotspot-windowsservercore-ltsc2016
-SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
+SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot, 14-jdk, 14
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
@@ -124,14 +124,14 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 14.0.2_12-jre-hotspot-focal, 14-jre-hotspot-focal
-SharedTags: 14.0.2_12-jre-hotspot, 14-jre-hotspot
+SharedTags: 14.0.2_12-jre-hotspot, 14-jre-hotspot, 14-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 14.0.2_12-jre-hotspot-windowsservercore-1809, 14-jre-hotspot-windowsservercore-1809
-SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot
+SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot, 14-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/windows/windowsservercore-1809
@@ -139,7 +139,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 14.0.2_12-jre-hotspot-windowsservercore-ltsc2016, 14-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot
+SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot, 14-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 14/jre/windows/windowsservercore-ltsc2016
@@ -149,14 +149,14 @@ Constraints: windowsservercore-ltsc2016
 
 #-----------------------------hotspot v15 images---------------------------------
 Tags: 15.0.1_9-jdk-hotspot-focal, 15-jdk-hotspot-focal, 15-hotspot-focal, hotspot-focal
-SharedTags: 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
+SharedTags: 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, hotspot, jdk, 15, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.1_9-jdk-hotspot-windowsservercore-1809, 15-jdk-hotspot-windowsservercore-1809, 15-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
-SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
+SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, hotspot, jdk, 15, latest
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/windows/windowsservercore-1809
@@ -164,7 +164,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 15.0.1_9-jdk-hotspot-windowsservercore-ltsc2016, 15-jdk-hotspot-windowsservercore-ltsc2016, 15-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
-SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
+SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, hotspot, jdk, 15, latest
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
@@ -172,14 +172,14 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 15.0.1_9-jre-hotspot-focal, 15-jre-hotspot-focal
-SharedTags: 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
+SharedTags: 15.0.1_9-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.1_9-jre-hotspot-windowsservercore-1809, 15-jre-hotspot-windowsservercore-1809
-SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
+SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/windows/windowsservercore-1809
@@ -187,7 +187,7 @@ File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
 Tags: 15.0.1_9-jre-hotspot-windowsservercore-ltsc2016, 15-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
+SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: windows-amd64
 GitCommit: 9b88ff88450a006bb669e4def8dab866e56baad9
 Directory: 15/jre/windows/windowsservercore-ltsc2016

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -4,161 +4,113 @@ Maintainers: Dinakar Guniguntala <dinakar.g@in.ibm.com> (@dinogun)
 GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 
 #-----------------------------hotspot v8 images---------------------------------
-Tags: 8u265-b01-jdk-hotspot-bionic, 8-jdk-hotspot-bionic, 8-hotspot-bionic
-SharedTags: 8u265-b01-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+Tags: 8u272-b10-jdk-hotspot-focal, 8-jdk-hotspot-focal, 8-hotspot-focal
+SharedTags: 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8u265-b01-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
-SharedTags: 8u265-b01-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u265-b01-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+Tags: 8u272-b10-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
+SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u265-b01-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
-SharedTags: 8u265-b01-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u265-b01-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
+Tags: 8u272-b10-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
+SharedTags: 8u272-b10-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u272-b10-jdk-hotspot, 8-jdk-hotspot, 8-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u265-b01-jre-hotspot-bionic, 8-jre-hotspot-bionic
-SharedTags: 8u265-b01-jre-hotspot, 8-jre-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+Tags: 8u272-b10-jre-hotspot-focal, 8-jre-hotspot-focal
+SharedTags: 8u272-b10-jre-hotspot, 8-jre-hotspot
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 8u265-b01-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
-SharedTags: 8u265-b01-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u265-b01-jre-hotspot, 8-jre-hotspot
+Tags: 8u272-b10-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
+SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u265-b01-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 8u265-b01-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u265-b01-jre-hotspot, 8-jre-hotspot
+Tags: 8u272-b10-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
+SharedTags: 8u272-b10-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u272-b10-jre-hotspot, 8-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
 #-----------------------------hotspot v11 images---------------------------------
-Tags: 11.0.8_10-jdk-hotspot-bionic, 11-jdk-hotspot-bionic, 11-hotspot-bionic
-SharedTags: 11.0.8_10-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+Tags: 11.0.9_11-jdk-hotspot-focal, 11-jdk-hotspot-focal, 11-hotspot-focal
+SharedTags: 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11.0.8_10-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
-SharedTags: 11.0.8_10-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.8_10-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+Tags: 11.0.9_11-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
+SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.8_10-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
-SharedTags: 11.0.8_10-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.8_10-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
+Tags: 11.0.9_11-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
+SharedTags: 11.0.9_11-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.9_11-jdk-hotspot, 11-jdk-hotspot, 11-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.8_10-jre-hotspot-bionic, 11-jre-hotspot-bionic
-SharedTags: 11.0.8_10-jre-hotspot, 11-jre-hotspot
+Tags: 11.0.9_11-jre-hotspot-focal, 11-jre-hotspot-focal
+SharedTags: 11.0.9_11-jre-hotspot, 11-jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 11.0.8_10-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
-SharedTags: 11.0.8_10-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.8_10-jre-hotspot, 11-jre-hotspot
+Tags: 11.0.9_11-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
+SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.8_10-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 11.0.8_10-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.8_10-jre-hotspot, 11-jre-hotspot
+Tags: 11.0.9_11-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
+SharedTags: 11.0.9_11-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.9_11-jre-hotspot, 11-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
-#-----------------------------hotspot v13 images---------------------------------
-Tags: 13.0.2_8-jdk-hotspot-bionic, 13-jdk-hotspot-bionic, 13-hotspot-bionic
-SharedTags: 13.0.2_8-jdk-hotspot, 13-jdk-hotspot, 13-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jdk/ubuntu
-File: Dockerfile.hotspot.releases.full
-
-Tags: 13.0.2_8-jdk-hotspot-windowsservercore-1809, 13-jdk-hotspot-windowsservercore-1809, 13-hotspot-windowsservercore-1809
-SharedTags: 13.0.2_8-jdk-hotspot-windowsservercore, 13-jdk-hotspot-windowsservercore, 13-hotspot-windowsservercore, 13.0.2_8-jdk-hotspot, 13-jdk-hotspot, 13-hotspot
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jdk/windows/windowsservercore-1809
-File: Dockerfile.hotspot.releases.full
-Constraints: windowsservercore-1809
-
-Tags: 13.0.2_8-jdk-hotspot-windowsservercore-ltsc2016, 13-jdk-hotspot-windowsservercore-ltsc2016, 13-hotspot-windowsservercore-ltsc2016
-SharedTags: 13.0.2_8-jdk-hotspot-windowsservercore, 13-jdk-hotspot-windowsservercore, 13-hotspot-windowsservercore, 13.0.2_8-jdk-hotspot, 13-jdk-hotspot, 13-hotspot
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jdk/windows/windowsservercore-ltsc2016
-File: Dockerfile.hotspot.releases.full
-Constraints: windowsservercore-ltsc2016
-
-Tags: 13.0.2_8-jre-hotspot-bionic, 13-jre-hotspot-bionic
-SharedTags: 13.0.2_8-jre-hotspot, 13-jre-hotspot
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jre/ubuntu
-File: Dockerfile.hotspot.releases.full
-
-Tags: 13.0.2_8-jre-hotspot-windowsservercore-1809, 13-jre-hotspot-windowsservercore-1809
-SharedTags: 13.0.2_8-jre-hotspot-windowsservercore, 13-jre-hotspot-windowsservercore, 13.0.2_8-jre-hotspot, 13-jre-hotspot
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jre/windows/windowsservercore-1809
-File: Dockerfile.hotspot.releases.full
-Constraints: windowsservercore-1809
-
-Tags: 13.0.2_8-jre-hotspot-windowsservercore-ltsc2016, 13-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 13.0.2_8-jre-hotspot-windowsservercore, 13-jre-hotspot-windowsservercore, 13.0.2_8-jre-hotspot, 13-jre-hotspot
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jre/windows/windowsservercore-ltsc2016
-File: Dockerfile.hotspot.releases.full
-Constraints: windowsservercore-ltsc2016
-
-
 #-----------------------------hotspot v14 images---------------------------------
-Tags: 14.0.2_12-jdk-hotspot-bionic, 14-jdk-hotspot-bionic, 14-hotspot-bionic
+Tags: 14.0.2_12-jdk-hotspot-focal, 14-jdk-hotspot-focal, 14-hotspot-focal
 SharedTags: 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 14.0.2_12-jdk-hotspot-windowsservercore-1809, 14-jdk-hotspot-windowsservercore-1809, 14-hotspot-windowsservercore-1809
 SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -166,22 +118,22 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jdk-hotspot-windowsservercore-ltsc2016, 14-jdk-hotspot-windowsservercore-ltsc2016, 14-hotspot-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jdk-hotspot-windowsservercore, 14-jdk-hotspot-windowsservercore, 14-hotspot-windowsservercore, 14.0.2_12-jdk-hotspot, 14-jdk-hotspot, 14-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.2_12-jre-hotspot-bionic, 14-jre-hotspot-bionic
+Tags: 14.0.2_12-jre-hotspot-focal, 14-jre-hotspot-focal
 SharedTags: 14.0.2_12-jre-hotspot, 14-jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 14.0.2_12-jre-hotspot-windowsservercore-1809, 14-jre-hotspot-windowsservercore-1809
 SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -189,216 +141,168 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jre-hotspot-windowsservercore-ltsc2016, 14-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jre-hotspot-windowsservercore, 14-jre-hotspot-windowsservercore, 14.0.2_12-jre-hotspot, 14-jre-hotspot
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
 #-----------------------------hotspot v15 images---------------------------------
-Tags: 15_36-jdk-hotspot-bionic, 15-jdk-hotspot-bionic, 15-hotspot-bionic, hotspot-bionic
-SharedTags: 15_36-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
+Tags: 15.0.1_9-jdk-hotspot-focal, 15-jdk-hotspot-focal, 15-hotspot-focal, hotspot-focal
+SharedTags: 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 15_36-jdk-hotspot-windowsservercore-1809, 15-jdk-hotspot-windowsservercore-1809, 15-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
-SharedTags: 15_36-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15_36-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
+Tags: 15.0.1_9-jdk-hotspot-windowsservercore-1809, 15-jdk-hotspot-windowsservercore-1809, 15-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
+SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 15_36-jdk-hotspot-windowsservercore-ltsc2016, 15-jdk-hotspot-windowsservercore-ltsc2016, 15-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
-SharedTags: 15_36-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15_36-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
+Tags: 15.0.1_9-jdk-hotspot-windowsservercore-ltsc2016, 15-jdk-hotspot-windowsservercore-ltsc2016, 15-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
+SharedTags: 15.0.1_9-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, hotspot-windowsservercore, 15.0.1_9-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15_36-jre-hotspot-bionic, 15-jre-hotspot-bionic
-SharedTags: 15_36-jre-hotspot, 15-jre-hotspot, latest
+Tags: 15.0.1_9-jre-hotspot-focal, 15-jre-hotspot-focal
+SharedTags: 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
-Tags: 15_36-jre-hotspot-windowsservercore-1809, 15-jre-hotspot-windowsservercore-1809
-SharedTags: 15_36-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15_36-jre-hotspot, 15-jre-hotspot, latest
+Tags: 15.0.1_9-jre-hotspot-windowsservercore-1809, 15-jre-hotspot-windowsservercore-1809
+SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 15_36-jre-hotspot-windowsservercore-ltsc2016, 15-jre-hotspot-windowsservercore-ltsc2016
-SharedTags: 15_36-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15_36-jre-hotspot, 15-jre-hotspot, latest
+Tags: 15.0.1_9-jre-hotspot-windowsservercore-ltsc2016, 15-jre-hotspot-windowsservercore-ltsc2016
+SharedTags: 15.0.1_9-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.1_9-jre-hotspot, 15-jre-hotspot, latest
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
 #-----------------------------openj9 v8 images---------------------------------
-Tags: 8u265-b01-jdk-openj9-0.21.0-bionic, 8-jdk-openj9-bionic, 8-openj9-bionic
-SharedTags: 8u265-b01-jdk-openj9-0.21.0, 8-jdk-openj9, 8-openj9
+Tags: 8u272-b10-jdk-openj9-0.23.0-focal, 8-jdk-openj9-focal, 8-openj9-focal
+SharedTags: 8u272-b10-jdk-openj9-0.23.0, 8-jdk-openj9, 8-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8u265-b01-jdk-openj9-0.21.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
-SharedTags: 8u265-b01-jdk-openj9-0.21.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u265-b01-jdk-openj9-0.21.0, 8-jdk-openj9, 8-openj9
+Tags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
+SharedTags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u272-b10-jdk-openj9-0.23.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u265-b01-jdk-openj9-0.21.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
-SharedTags: 8u265-b01-jdk-openj9-0.21.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u265-b01-jdk-openj9-0.21.0, 8-jdk-openj9, 8-openj9
+Tags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
+SharedTags: 8u272-b10-jdk-openj9-0.23.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u272-b10-jdk-openj9-0.23.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u265-b01-jre-openj9-0.21.0-bionic, 8-jre-openj9-bionic
-SharedTags: 8u265-b01-jre-openj9-0.21.0, 8-jre-openj9
+Tags: 8u272-b10-jre-openj9-0.23.0-focal, 8-jre-openj9-focal
+SharedTags: 8u272-b10-jre-openj9-0.23.0, 8-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 8u265-b01-jre-openj9-0.21.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
-SharedTags: 8u265-b01-jre-openj9-0.21.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u265-b01-jre-openj9-0.21.0, 8-jre-openj9
+Tags: 8u272-b10-jre-openj9-0.23.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
+SharedTags: 8u272-b10-jre-openj9-0.23.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u272-b10-jre-openj9-0.23.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u265-b01-jre-openj9-0.21.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 8u265-b01-jre-openj9-0.21.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u265-b01-jre-openj9-0.21.0, 8-jre-openj9
+Tags: 8u272-b10-jre-openj9-0.23.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
+SharedTags: 8u272-b10-jre-openj9-0.23.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u272-b10-jre-openj9-0.23.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
 #-----------------------------openj9 v11 images---------------------------------
-Tags: 11.0.8_10-jdk-openj9-0.21.0-bionic, 11-jdk-openj9-bionic, 11-openj9-bionic
-SharedTags: 11.0.8_10-jdk-openj9-0.21.0, 11-jdk-openj9, 11-openj9
+Tags: 11.0.9_11-jdk-openj9-0.23.0-focal, 11-jdk-openj9-focal, 11-openj9-focal
+SharedTags: 11.0.9_11-jdk-openj9-0.23.0, 11-jdk-openj9, 11-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11.0.8_10-jdk-openj9-0.21.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
-SharedTags: 11.0.8_10-jdk-openj9-0.21.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.8_10-jdk-openj9-0.21.0, 11-jdk-openj9, 11-openj9
+Tags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
+SharedTags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.9_11-jdk-openj9-0.23.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.8_10-jdk-openj9-0.21.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
-SharedTags: 11.0.8_10-jdk-openj9-0.21.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.8_10-jdk-openj9-0.21.0, 11-jdk-openj9, 11-openj9
+Tags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
+SharedTags: 11.0.9_11-jdk-openj9-0.23.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.9_11-jdk-openj9-0.23.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.8_10-jre-openj9-0.21.0-bionic, 11-jre-openj9-bionic
-SharedTags: 11.0.8_10-jre-openj9-0.21.0, 11-jre-openj9
+Tags: 11.0.9_11-jre-openj9-0.23.0-focal, 11-jre-openj9-focal
+SharedTags: 11.0.9_11-jre-openj9-0.23.0, 11-jre-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 11.0.8_10-jre-openj9-0.21.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
-SharedTags: 11.0.8_10-jre-openj9-0.21.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.8_10-jre-openj9-0.21.0, 11-jre-openj9
+Tags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
+SharedTags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.9_11-jre-openj9-0.23.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.8_10-jre-openj9-0.21.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 11.0.8_10-jre-openj9-0.21.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.8_10-jre-openj9-0.21.0, 11-jre-openj9
+Tags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
+SharedTags: 11.0.9_11-jre-openj9-0.23.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.9_11-jre-openj9-0.23.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
-#-----------------------------openj9 v13 images---------------------------------
-Tags: 13.0.2_8-jdk-openj9-0.18.0-bionic, 13-jdk-openj9-bionic, 13-openj9-bionic
-SharedTags: 13.0.2_8-jdk-openj9-0.18.0, 13-jdk-openj9, 13-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jdk/ubuntu
-File: Dockerfile.openj9.releases.full
-
-Tags: 13.0.2_8-jdk-openj9-0.18.0-windowsservercore-1809, 13-jdk-openj9-windowsservercore-1809, 13-openj9-windowsservercore-1809
-SharedTags: 13.0.2_8-jdk-openj9-0.18.0-windowsservercore, 13-jdk-openj9-windowsservercore, 13-openj9-windowsservercore, 13.0.2_8-jdk-openj9-0.18.0, 13-jdk-openj9, 13-openj9
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jdk/windows/windowsservercore-1809
-File: Dockerfile.openj9.releases.full
-Constraints: windowsservercore-1809
-
-Tags: 13.0.2_8-jdk-openj9-0.18.0-windowsservercore-ltsc2016, 13-jdk-openj9-windowsservercore-ltsc2016, 13-openj9-windowsservercore-ltsc2016
-SharedTags: 13.0.2_8-jdk-openj9-0.18.0-windowsservercore, 13-jdk-openj9-windowsservercore, 13-openj9-windowsservercore, 13.0.2_8-jdk-openj9-0.18.0, 13-jdk-openj9, 13-openj9
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jdk/windows/windowsservercore-ltsc2016
-File: Dockerfile.openj9.releases.full
-Constraints: windowsservercore-ltsc2016
-
-Tags: 13.0.2_8-jre-openj9-0.18.0-bionic, 13-jre-openj9-bionic
-SharedTags: 13.0.2_8-jre-openj9-0.18.0, 13-jre-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jre/ubuntu
-File: Dockerfile.openj9.releases.full
-
-Tags: 13.0.2_8-jre-openj9-0.18.0-windowsservercore-1809, 13-jre-openj9-windowsservercore-1809
-SharedTags: 13.0.2_8-jre-openj9-0.18.0-windowsservercore, 13-jre-openj9-windowsservercore, 13.0.2_8-jre-openj9-0.18.0, 13-jre-openj9
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jre/windows/windowsservercore-1809
-File: Dockerfile.openj9.releases.full
-Constraints: windowsservercore-1809
-
-Tags: 13.0.2_8-jre-openj9-0.18.0-windowsservercore-ltsc2016, 13-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 13.0.2_8-jre-openj9-0.18.0-windowsservercore, 13-jre-openj9-windowsservercore, 13.0.2_8-jre-openj9-0.18.0, 13-jre-openj9
-Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
-Directory: 13/jre/windows/windowsservercore-ltsc2016
-File: Dockerfile.openj9.releases.full
-Constraints: windowsservercore-ltsc2016
-
-
 #-----------------------------openj9 v14 images---------------------------------
-Tags: 14.0.2_12-jdk-openj9-0.21.0-bionic, 14-jdk-openj9-bionic, 14-openj9-bionic
+Tags: 14.0.2_12-jdk-openj9-0.21.0-focal, 14-jdk-openj9-focal, 14-openj9-focal
 SharedTags: 14.0.2_12-jdk-openj9-0.21.0, 14-jdk-openj9, 14-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore-1809, 14-jdk-openj9-windowsservercore-1809, 14-openj9-windowsservercore-1809
 SharedTags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, 14.0.2_12-jdk-openj9-0.21.0, 14-jdk-openj9, 14-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -406,22 +310,22 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore-ltsc2016, 14-jdk-openj9-windowsservercore-ltsc2016, 14-openj9-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jdk-openj9-0.21.0-windowsservercore, 14-jdk-openj9-windowsservercore, 14-openj9-windowsservercore, 14.0.2_12-jdk-openj9-0.21.0, 14-jdk-openj9, 14-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 14.0.2_12-jre-openj9-0.21.0-bionic, 14-jre-openj9-bionic
+Tags: 14.0.2_12-jre-openj9-0.21.0-focal, 14-jre-openj9-focal
 SharedTags: 14.0.2_12-jre-openj9-0.21.0, 14-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore-1809, 14-jre-openj9-windowsservercore-1809
 SharedTags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.2_12-jre-openj9-0.21.0, 14-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -429,55 +333,55 @@ Constraints: windowsservercore-1809
 Tags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore-ltsc2016, 14-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 14.0.2_12-jre-openj9-0.21.0-windowsservercore, 14-jre-openj9-windowsservercore, 14.0.2_12-jre-openj9-0.21.0, 14-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 14/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 
 #-----------------------------openj9 v15 images---------------------------------
-Tags: 15_36-jdk-openj9-0.22.0-bionic, 15-jdk-openj9-bionic, 15-openj9-bionic, openj9-bionic
-SharedTags: 15_36-jdk-openj9-0.22.0, 15-jdk-openj9, 15-openj9, openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+Tags: 15.0.1_9-jdk-openj9-0.23.0-focal, 15-jdk-openj9-focal, 15-openj9-focal, openj9-focal
+SharedTags: 15.0.1_9-jdk-openj9-0.23.0, 15-jdk-openj9, 15-openj9, openj9
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 15_36-jdk-openj9-0.22.0-windowsservercore-1809, 15-jdk-openj9-windowsservercore-1809, 15-openj9-windowsservercore-1809, openj9-windowsservercore-1809
-SharedTags: 15_36-jdk-openj9-0.22.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, openj9-windowsservercore, 15_36-jdk-openj9-0.22.0, 15-jdk-openj9, 15-openj9, openj9
+Tags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore-1809, 15-jdk-openj9-windowsservercore-1809, 15-openj9-windowsservercore-1809, openj9-windowsservercore-1809
+SharedTags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, openj9-windowsservercore, 15.0.1_9-jdk-openj9-0.23.0, 15-jdk-openj9, 15-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 15_36-jdk-openj9-0.22.0-windowsservercore-ltsc2016, 15-jdk-openj9-windowsservercore-ltsc2016, 15-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
-SharedTags: 15_36-jdk-openj9-0.22.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, openj9-windowsservercore, 15_36-jdk-openj9-0.22.0, 15-jdk-openj9, 15-openj9, openj9
+Tags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore-ltsc2016, 15-jdk-openj9-windowsservercore-ltsc2016, 15-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
+SharedTags: 15.0.1_9-jdk-openj9-0.23.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, openj9-windowsservercore, 15.0.1_9-jdk-openj9-0.23.0, 15-jdk-openj9, 15-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15_36-jre-openj9-0.22.0-bionic, 15-jre-openj9-bionic
-SharedTags: 15_36-jre-openj9-0.22.0, 15-jre-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+Tags: 15.0.1_9-jre-openj9-0.23.0-focal, 15-jre-openj9-focal
+SharedTags: 15.0.1_9-jre-openj9-0.23.0, 15-jre-openj9
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
-Tags: 15_36-jre-openj9-0.22.0-windowsservercore-1809, 15-jre-openj9-windowsservercore-1809
-SharedTags: 15_36-jre-openj9-0.22.0-windowsservercore, 15-jre-openj9-windowsservercore, 15_36-jre-openj9-0.22.0, 15-jre-openj9
+Tags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore-1809, 15-jre-openj9-windowsservercore-1809
+SharedTags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.1_9-jre-openj9-0.23.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 15_36-jre-openj9-0.22.0-windowsservercore-ltsc2016, 15-jre-openj9-windowsservercore-ltsc2016
-SharedTags: 15_36-jre-openj9-0.22.0-windowsservercore, 15-jre-openj9-windowsservercore, 15_36-jre-openj9-0.22.0, 15-jre-openj9
+Tags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore-ltsc2016, 15-jre-openj9-windowsservercore-ltsc2016
+SharedTags: 15.0.1_9-jre-openj9-0.23.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.1_9-jre-openj9-0.23.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 6b25b910101cc3772d688d7aea0755ee3db51e2e
+GitCommit: 51c60f2382db67fc0b4e21c1f3f21b2217a911e8
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Remove Java 13 images as they are no longer supported.