### PR TITLE
Fix for sonarqube:7.9.4

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,7 +4,7 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
              Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 03ce69f589c5b6a3f731d5c941fcb049bb55064c
+GitCommit: 080756681fa616580101c685dd08f6cb0d328bb6
 
 Tags: 7.9.4-community, 7.9-community, lts
 Directory: 7/community


### PR DESCRIPTION
Hello,

there was a small regression with the last merge of a public PR for our LTS image (see https://github.com/SonarSource/docker-sonarqube/issues/440 ) . 
The fix was not in the application but in the `run.sh` script, so a new tag is not needed but the LTS image needs to be rebuild using the new commit  