### PR TITLE
Fedora Update 2020-10-26

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -10,20 +10,20 @@ arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 
-Tags: latest, 32
+Tags: 32
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/32
-GitCommit: d011eb05bd6855b2e2fa4393117d1cdadc575b16
+GitCommit: e120e2507c0cf4303b49957bc3e4289e48c54021
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
-Tags: 33
+Tags: latest, 33
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/33
-GitCommit: 31676f13b9cf08f51ab74bba2988ca21d13725c7
+GitCommit: 866c1fb990191c11be58832164e7a93136a66e80
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
@@ -31,11 +31,10 @@ s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
 Tags: rawhide, 34
-Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
+Architectures: amd64, arm64v8, s390x, arm32v7
 GitFetch: refs/heads/34
-GitCommit: da3adfaa3a64b02bfc6a78199964ac2f8d777f1c
+GitCommit: 08247fdb107a76a0394e2a6dc2c9ca5b2e660d73
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
-ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/


### PR DESCRIPTION
Fedora 33 is now the latest Fedora release.

Signed-off-by: Clement Verna <cverna@tutanota.com>