### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev7, 2.3-dev
+Tags: 2.3-dev8, 2.3-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83ae777c7466d0da4e23b9398f5d9d9340876b0
+GitCommit: 16ed3f73b635be4133919035459834af72affc36
 Directory: 2.3-rc
 
-Tags: 2.3-dev7-alpine, 2.3-dev-alpine
+Tags: 2.3-dev8-alpine, 2.3-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83ae777c7466d0da4e23b9398f5d9d9340876b0
+GitCommit: 16ed3f73b635be4133919035459834af72affc36
 Directory: 2.3-rc/alpine
 
 Tags: 2.2.4, 2.2, latest, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/16ed3f7: Update to 2.3-dev8