### PR TITLE
[security] Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.7, 1.6, 1, latest
+Tags: 1.6.8, 1.6, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9854471a384e40b8eaf96851dd5a02637fba367a
+GitCommit: dcaec15d8dcdf7ae6929b6c81e7bcc7c95a5fc75
 Directory: debian
 
-Tags: 1.6.7-alpine, 1.6-alpine, 1-alpine, alpine
+Tags: 1.6.8-alpine, 1.6-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9854471a384e40b8eaf96851dd5a02637fba367a
+GitCommit: dcaec15d8dcdf7ae6929b6c81e7bcc7c95a5fc75
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/dcaec15: Update to 1.6.8

https://github.com/memcached/memcached/wiki/ReleaseNotes168