### PR TITLE
elixir 1.11.1, and change to the new repo url

### DIFF
--- a/library/elixir
+++ b/library/elixir
@@ -1,19 +1,35 @@
-# this file is generated via https://github.com/c0b/docker-elixir/blob/e2d20313fefcd13b8d3b1bcd94df60bd4f02a0b3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/erlef/docker-elixir/blob/4d889a2a5bc2611ac6b354ec4a9392c085cd7f0c/generate-stackbrew-library.sh
 
-Maintainers: . <c0b@users.noreply.github.com> (@c0b)
-GitRepo: https://github.com/c0b/docker-elixir.git
+Maintainers: . <c0b@users.noreply.github.com> (@c0b),
+             Tristan Sloughter <t@crashfast.com> (@tsloughter)
+GitRepo: https://github.com/erlef/docker-elixir.git
 
-Tags: 1.10.4, 1.10, latest
+Tags: 1.11.1, 1.11, latest
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 5d25131693118e23795b4605f5473cb548311403
+Directory: 1.11
+
+Tags: 1.11.1-slim, 1.11-slim, slim
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 5d25131693118e23795b4605f5473cb548311403
+Directory: 1.11/slim
+
+Tags: 1.11.1-alpine, 1.11-alpine, alpine
+Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+GitCommit: 5d25131693118e23795b4605f5473cb548311403
+Directory: 1.11/alpine
+
+Tags: 1.10.4, 1.10
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: a8d582c328db5864a4e8e5f869900e3a52265f38
 Directory: 1.10
 
-Tags: 1.10.4-slim, 1.10-slim, slim
+Tags: 1.10.4-slim, 1.10-slim
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: a8d582c328db5864a4e8e5f869900e3a52265f38
 Directory: 1.10/slim
 
-Tags: 1.10.4-alpine, 1.10-alpine, alpine
+Tags: 1.10.4-alpine, 1.10-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
 GitCommit: a8d582c328db5864a4e8e5f869900e3a52265f38
 Directory: 1.10/alpine
@@ -34,91 +50,91 @@ GitCommit: 0d9f47458468a8bf1407374731cbec077ab6f895
 Directory: 1.9/alpine
 
 Tags: 1.8.2, 1.8
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 4122b4840bd762d1434424e1ec693929b0198c98
 Directory: 1.8
 
 Tags: 1.8.2-slim, 1.8-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 4122b4840bd762d1434424e1ec693929b0198c98
 Directory: 1.8/slim
 
 Tags: 1.8.2-alpine, 1.8-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 4122b4840bd762d1434424e1ec693929b0198c98
 Directory: 1.8/alpine
 
 Tags: 1.8.2-otp-22, 1.8-otp-22
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 6dc5ffd3b4c2915096887b45ba8e71d391ce2398
 Directory: 1.8/otp-22
 
 Tags: 1.8.2-otp-22-alpine, 1.8-otp-22-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 6dc5ffd3b4c2915096887b45ba8e71d391ce2398
 Directory: 1.8/otp-22-alpine
 
 Tags: 1.7.4, 1.7
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 2b7dd2845d27a6dad57bf0047b305375d6182402
 Directory: 1.7
 
 Tags: 1.7.4-slim, 1.7-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 7c1f05ca3fd47bdc86cab3f0310068646a31dcac
 Directory: 1.7/slim
 
 Tags: 1.7.4-alpine, 1.7-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 2b7dd2845d27a6dad57bf0047b305375d6182402
 Directory: 1.7/alpine
 
 Tags: 1.6.6, 1.6
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6
 
 Tags: 1.6.6-slim, 1.6-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/slim
 
 Tags: 1.6.6-alpine, 1.6-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 0936291249c7e11d4618a17a2b452045c9e6233a
 Directory: 1.6/alpine
 
 Tags: 1.6.6-otp-21, 1.6-otp-21
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: b57a72d04ddd1f1b4e2e3f5b70e44e37def4db31
 Directory: 1.6/otp-21
 
 Tags: 1.6.6-otp-21-alpine, 1.6-otp-21-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
-GitCommit: 084efbdda747411b3a41c231deaff03c437e5aad
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 373b3a8017bd774b7d193818a326de0fde7f6733
 Directory: 1.6/otp-21-alpine
 
 Tags: 1.5.3, 1.5
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5
 
 Tags: 1.5.3-slim, 1.5-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5/slim
 
 Tags: 1.5.3-alpine, 1.5-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, s390x, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: f2528c0158d465f96f311faa19aff3cffb4e7f25
 Directory: 1.5/alpine
 
 Tags: 1.4.5, 1.4
-Architectures: amd64, arm32v7, arm64v8, i386, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 8f1888ae05506b9ad12e1b97f084a15e7588f442
 Directory: 1.4
 
 Tags: 1.4.5-slim, 1.4-slim
-Architectures: amd64, arm32v7, arm64v8, i386, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 8f1888ae05506b9ad12e1b97f084a15e7588f442
 Directory: 1.4/slim


### PR DESCRIPTION
As the c0b/docker-elixir#145 does not merge for a long time, we decide to move to new repo, https://github.com/erlef/docker-elixir/ 