### PR TITLE
Updating oraclelinux images for tzdata-2020d

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 10227d1a88809f983e79edde3f6c3875a6e3409a
+amd64-GitCommit: 49445d41446a8c69780d960527829720897b895a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 67d1a557e35e5e579899c13cf9257e97ec8bc7c0
+arm64v8-GitCommit: 8a38d16b8e7e18886fabd64f977a315c4fc885e9
 
 Tags: 8.2, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See https://linux.oracle.com/errata/ELBA-2020-4329.html for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>