### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-21-jdk-oraclelinux8, 16-ea-21-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-21-jdk-oracle, 16-ea-21-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-21-jdk, 16-ea-21, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-22-jdk-oraclelinux8, 16-ea-22-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-22-jdk-oracle, 16-ea-22-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-22-jdk, 16-ea-22, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-21-jdk-oraclelinux7, 16-ea-21-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-22-jdk-oraclelinux7, 16-ea-22-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-21-jdk-buster, 16-ea-21-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-22-jdk-buster, 16-ea-22-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/buster
 
-Tags: 16-ea-21-jdk-slim-buster, 16-ea-21-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-21-jdk-slim, 16-ea-21-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-22-jdk-slim-buster, 16-ea-22-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-22-jdk-slim, 16-ea-22-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-14-jdk-alpine3.12, 16-ea-14-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-14-jdk-alpine, 16-ea-14-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -30,24 +30,24 @@ Architectures: amd64
 GitCommit: 2d4433f9d8a458f239429751fc2ae96c032cbfb3
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-21-jdk-windowsservercore-1809, 16-ea-21-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-21-jdk-windowsservercore, 16-ea-21-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-21-jdk, 16-ea-21, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-22-jdk-windowsservercore-1809, 16-ea-22-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-22-jdk-windowsservercore, 16-ea-22-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-22-jdk, 16-ea-22, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-21-jdk-windowsservercore-ltsc2016, 16-ea-21-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-21-jdk-windowsservercore, 16-ea-21-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-21-jdk, 16-ea-21, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-22-jdk-windowsservercore-ltsc2016, 16-ea-22-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-22-jdk-windowsservercore, 16-ea-22-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-22-jdk, 16-ea-22, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-21-jdk-nanoserver-1809, 16-ea-21-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-21-jdk-nanoserver, 16-ea-21-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-22-jdk-nanoserver-1809, 16-ea-22-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-22-jdk-nanoserver, 16-ea-22-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: bd88879251ec7beecc41329326899d063d5abdd9
+GitCommit: 00fa9129c289ab704fe51541e23f37991c54a487
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/00fa912: Update to 16-ea+22