### PR TITLE
[nats-streaming] Release v0.19.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,30 +1,30 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 49cdc0a64cf8d1c0d4ac46e25f195d717020dd29
+GitCommit: a66231ba810d884b8548fa74ca04e79173216aeb
 
-Tags: 0.18.0-alpine3.12, 0.18-alpine3.12, alpine3.12, 0.18.0-alpine, 0.18-alpine, alpine
+Tags: 0.19.0-alpine3.12, 0.19-alpine3.12, alpine3.12, 0.19.0-alpine, 0.19-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.18.0/alpine3.12
+Directory: 0.19.0/alpine3.12
 
-Tags: 0.18.0-scratch, 0.18-scratch, scratch, 0.18.0-linux, 0.18-linux, linux
-SharedTags: 0.18.0, 0.18, latest
+Tags: 0.19.0-scratch, 0.19-scratch, scratch, 0.19.0-linux, 0.19-linux, linux
+SharedTags: 0.19.0, 0.19, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.18.0/scratch
+Directory: 0.19.0/scratch
 
-Tags: 0.18.0-windowsservercore-1809, 0.18-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.18.0-windowsservercore, 0.18-windowsservercore, windowsservercore
+Tags: 0.19.0-windowsservercore-1809, 0.19-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.19.0-windowsservercore, 0.19-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.18.0/windowsservercore-1809
+Directory: 0.19.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 0.18.0-nanoserver-1809, 0.18-nanoserver-1809, nanoserver-1809
-SharedTags: 0.18.0-nanoserver, 0.18-nanoserver, nanoserver, 0.18.0, 0.18, latest
+Tags: 0.19.0-nanoserver-1809, 0.19-nanoserver-1809, nanoserver-1809
+SharedTags: 0.19.0-nanoserver, 0.19-nanoserver, nanoserver, 0.19.0, 0.19, latest
 Architectures: windows-amd64
-Directory: 0.18.0/nanoserver-1809
+Directory: 0.19.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 0.18.0-windowsservercore-ltsc2016, 0.18-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 0.18.0-windowsservercore, 0.18-windowsservercore, windowsservercore
+Tags: 0.19.0-windowsservercore-ltsc2016, 0.19-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 0.19.0-windowsservercore, 0.19-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.18.0/windowsservercore-ltsc2016
+Directory: 0.19.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.19.0)

Doc PR: https://github.com/docker-library/docs/pull/1826

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>