### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.36.0, 3.36, 3, latest
+Tags: 3.37.1, 3.37, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 585880b8606f9e461284f668bf2f46884d409a96
+GitCommit: 7b4f549f37c511bcb4b8dbaea57e4252387c6048
 Directory: 3/debian
 
-Tags: 3.36.0-alpine, 3.36-alpine, 3-alpine, alpine
+Tags: 3.37.1-alpine, 3.37-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 585880b8606f9e461284f668bf2f46884d409a96
+GitCommit: 7b4f549f37c511bcb4b8dbaea57e4252387c6048
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 585880b8606f9e461284f668bf2f46884d409a96
+GitCommit: 81b731ad0423b00117f18be784323f3878388e3d
 Directory: 2/debian
 
 Tags: 2.38.2-alpine, 2.38-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 585880b8606f9e461284f668bf2f46884d409a96
+GitCommit: 81b731ad0423b00117f18be784323f3878388e3d
 Directory: 2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/7b4f549: Update to 3.37.1, ghost-cli 1.15.1
- https://github.com/docker-library/ghost/commit/81b731a: Update to 2.38.2, ghost-cli 1.15.1