### PR TITLE
Updated nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,42 +3,42 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.19.3, mainline, 1, 1.19, latest
+Tags: 1.19.4, mainline, 1, 1.19, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
+GitCommit: deff8fbe9d3e8613de110265aa932d84d1827acf
 Directory: mainline/buster
 
-Tags: 1.19.3-perl, mainline-perl, 1-perl, 1.19-perl, perl
+Tags: 1.19.4-perl, mainline-perl, 1-perl, 1.19-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
+GitCommit: deff8fbe9d3e8613de110265aa932d84d1827acf
 Directory: mainline/buster-perl
 
-Tags: 1.19.3-alpine, mainline-alpine, 1-alpine, 1.19-alpine, alpine
+Tags: 1.19.4-alpine, mainline-alpine, 1-alpine, 1.19-alpine, alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
+GitCommit: aebdace36df83690ca283405efd283bc750ff41e
 Directory: mainline/alpine
 
-Tags: 1.19.3-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.19-alpine-perl, alpine-perl
+Tags: 1.19.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.19-alpine-perl, alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 0dc809fa606828a78087cd0a824bed06268d73e0
+GitCommit: aebdace36df83690ca283405efd283bc750ff41e
 Directory: mainline/alpine-perl
 
 Tags: 1.18.0, stable, 1.18
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
+GitCommit: a4208f853fa3fcb73a146a268fb2d5f0eee7733b
 Directory: stable/buster
 
 Tags: 1.18.0-perl, stable-perl, 1.18-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
+GitCommit: a4208f853fa3fcb73a146a268fb2d5f0eee7733b
 Directory: stable/buster-perl
 
 Tags: 1.18.0-alpine, stable-alpine, 1.18-alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
+GitCommit: a4208f853fa3fcb73a146a268fb2d5f0eee7733b
 Directory: stable/alpine
 
 Tags: 1.18.0-alpine-perl, stable-alpine-perl, 1.18-alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 5488180ebdd45b12b45107694dfa92dc878a2795
+GitCommit: a4208f853fa3fcb73a146a268fb2d5f0eee7733b
 Directory: stable/alpine-perl


### PR DESCRIPTION
Mainline is bumped to 1.19.4
Stable is updated without version bump to fix minor issues in entrypoint
scripts