### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,62 +1,72 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/66992739524afb5ef874199da3ba3d0aec9740b5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/efd86caa8356759e9462325302e949c83d82a820/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.3-dev9, 2.3-dev
+Tags: 2.4-dev0, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fc3fea5028529a12980f390658dfdffe993d9f74
-Directory: 2.3-rc
+GitCommit: efd86caa8356759e9462325302e949c83d82a820
+Directory: 2.4-rc
 
-Tags: 2.3-dev9-alpine, 2.3-dev-alpine
+Tags: 2.4-dev0-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fc3fea5028529a12980f390658dfdffe993d9f74
-Directory: 2.3-rc/alpine
+GitCommit: efd86caa8356759e9462325302e949c83d82a820
+Directory: 2.4-rc/alpine
 
-Tags: 2.2.4, 2.2, latest, lts
+Tags: 2.3.0, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 34f7b69c09fa0f16a0834641aa6556523c67b1ed
+GitCommit: efd86caa8356759e9462325302e949c83d82a820
+Directory: 2.3
+
+Tags: 2.3.0-alpine, 2.3-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: efd86caa8356759e9462325302e949c83d82a820
+Directory: 2.3/alpine
+
+Tags: 2.2.5, 2.2, lts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: b808ca775382ae59e9ed3a43308fcbe62c1389c5
 Directory: 2.2
 
-Tags: 2.2.4-alpine, 2.2-alpine, alpine, lts-alpine
+Tags: 2.2.5-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34f7b69c09fa0f16a0834641aa6556523c67b1ed
+GitCommit: 1678bf37370bac8e3dc7a6b03d62c734bb7d58dc
 Directory: 2.2/alpine
 
-Tags: 2.1.9, 2.1
+Tags: 2.1.10, 2.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c447fe1188126dd86d04bebbf7f026d18ed18930
+GitCommit: b808ca775382ae59e9ed3a43308fcbe62c1389c5
 Directory: 2.1
 
-Tags: 2.1.9-alpine, 2.1-alpine
+Tags: 2.1.10-alpine, 2.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c447fe1188126dd86d04bebbf7f026d18ed18930
+GitCommit: 45fa7611660c5017326eaa9db671c439dc12262d
 Directory: 2.1/alpine
 
-Tags: 2.0.18, 2.0
+Tags: 2.0.19, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e12ed145d747d8d2cee989d746112bbeb515ac75
+GitCommit: c395a5c7bcc9d7bc04aaaf028a591cbad7afd9f7
 Directory: 2.0
 
-Tags: 2.0.18-alpine, 2.0-alpine
+Tags: 2.0.19-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e12ed145d747d8d2cee989d746112bbeb515ac75
+GitCommit: c395a5c7bcc9d7bc04aaaf028a591cbad7afd9f7
 Directory: 2.0/alpine
 
-Tags: 1.8.26, 1.8
+Tags: 1.8.27, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 947eebe116d8256622545d804982620ceb18f88b
+GitCommit: c3371e83f9c47c4c25cfc731f5765703b514890e
 Directory: 1.8
 
-Tags: 1.8.26-alpine, 1.8-alpine
+Tags: 1.8.27-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 947eebe116d8256622545d804982620ceb18f88b
+GitCommit: c3371e83f9c47c4c25cfc731f5765703b514890e
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 14431e31ab981456585021f7dca35626c5e060c1
+GitCommit: b808ca775382ae59e9ed3a43308fcbe62c1389c5
 Directory: 1.7
 
 Tags: 1.7.12-alpine, 1.7-alpine


### PR DESCRIPTION
Changes:

- docker-library/haproxy@35444fc: Merge pull request docker-library/haproxy#133 from TimWolla/haproxy-2.3
- docker-library/haproxy@c3371e8: Update to 1.8.27
- docker-library/haproxy@c395a5c: Update to 2.0.19
- docker-library/haproxy@efd86ca: Add HAProxy 2.3 / 2.4-dev
- docker-library/haproxy@9f793ab: Merge pull request docker-library/haproxy#132 from infosiftr/fix-arm32v5
- docker-library/haproxy@b808ca7: Add extra flag to fix arm32v5 build
- docker-library/haproxy@45fa761: Update to 2.1.10
- docker-library/haproxy@1678bf3: Update to 2.2.5