### PR TITLE
Update Rakudo Star

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -1,11 +1,11 @@
 Maintainers: Moritz Lenz <moritz.lenz@gmail.com> (@moritz)
 GitRepo: https://github.com/raku/docker
 
-Tags: latest, 2020.01
+Tags: latest, 2020.10
 Architectures: amd64, arm64v8
-GitCommit: d893fa621e755045c80fb4d0615c2810812d98f7
+GitCommit: 41361d587e7356ff57d4b09f48694f483bfbbd5c
 
-Tags: alpine, 2020.01-alpine
+Tags: alpine, 2020.10-alpine
 Architectures: amd64, arm64v8
-GitCommit: d893fa621e755045c80fb4d0615c2810812d98f7
+GitCommit: 41361d587e7356ff57d4b09f48694f483bfbbd5c
 Directory: alpine


### PR DESCRIPTION
Also, update base image of alpine.

* Alpine Linux: 3.10 → 3.12
* Rakudo Star: 2020.01 → 2020.10