### PR TITLE
Update Solr to 8.7.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,12 +6,22 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.6.3, 8.6, 8, latest
+Tags: 8.7.0, 8.7, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: 5ca83ea788711fb540d2073d95da115af53d1319
+Directory: 8.7
+
+Tags: 8.7.0-slim, 8.7-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 5ca83ea788711fb540d2073d95da115af53d1319
+Directory: 8.7/slim
+
+Tags: 8.6.3, 8.6
 Architectures: amd64, arm64v8
 GitCommit: 0a9474015d0fe6dd9e29388a0f733f2ef1848523
 Directory: 8.6
 
-Tags: 8.6.3-slim, 8.6-slim, 8-slim, slim
+Tags: 8.6.3-slim, 8.6-slim
 Architectures: amd64, arm64v8
 GitCommit: 0a9474015d0fe6dd9e29388a0f733f2ef1848523
 Directory: 8.6/slim


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/r05f081aa744b84decb3149b70682c70c2b593c69e1beb92c6d7cd72f%40%3Csolr-user.lucene.apache.org%3E) which links to the [release notes](https://lucene.apache.org/solr/8_7_0/changes/Changes.html).

Copy-pasting the release highlights:
* SOLR-14588 -- Circuit Breakers Infrastructure and Real JVM Based Circuit Breaker
* SOLR-14615 –- CPU Based Circuit Breaker
* SOLR-14537 -- Improve performance of ExportWriter
* SOLR-14651 -- The MetricsHistoryHandler Can Be Disabled