### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,6 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.10-beta.1, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e254cc0c254ba4e9e4cf1608b01ae271ee381a37
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.10-beta.1-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 888638927482f86af6e88bebb67423926cb1112f
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.10-beta.1-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e254cc0c254ba4e9e4cf1608b01ae271ee381a37
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.10-beta.1-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 888638927482f86af6e88bebb67423926cb1112f
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b553555982b7d699b6033595e8351d8479db627e


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e254cc0: Update to 3.8.10-beta.1, Erlang/OTP 23.1.2, OpenSSL 1.1.1h