### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -25,9 +25,9 @@ Architectures: amd64, arm64v8
 GitCommit: 117c598294e093ef5674542d8462c582daa946e4
 Directory: 16/jdk/slim-buster
 
-Tags: 16-ea-14-jdk-alpine3.12, 16-ea-14-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-14-jdk-alpine, 16-ea-14-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
+Tags: 16-ea-23-jdk-alpine3.12, 16-ea-23-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-23-jdk-alpine, 16-ea-23-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
 Architectures: amd64
-GitCommit: 2d4433f9d8a458f239429751fc2ae96c032cbfb3
+GitCommit: 66c01fe9c251c5e5f1fae75291af93270842c178
 Directory: 16/jdk/alpine3.12
 
 Tags: 16-ea-23-jdk-windowsservercore-1809, 16-ea-23-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/66c01fe: Update to 16-ea+23