### PR TITLE
[varnish] update lts image to 6.0.7

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,11 +1,11 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/f26947e3a1d7ab5e3e76114d58e54f0ddee13534/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/c0846f15b04cd499a1df1fb62f0693b41a84e636/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: 6.0, 6.0.6-1, 6.0.6, stable
+Tags: 6.0, 6.0.7-1, 6.0.7, stable
 Architectures: amd64
 Directory: stable/debian
-GitCommit: 2459369407fbf77df75d6948ee48de8c814fb3e4
+GitCommit: c0846f15b04cd499a1df1fb62f0693b41a84e636
 
 Tags: 6.5, 6.5.1-1, 6.5.1, 6, latest, fresh
 Architectures: amd64


### PR DESCRIPTION
This one is a bit more than the usual switch to a more recent package, it also trade `stretch` for `buster`, since the former is EOL.

I don't know if there are special announcements (I'll post on the Vanrish mailing list), tagging or something like that to do here, if so, please let me know!