### PR TITLE
arangodb 3.6.9

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -5,9 +5,9 @@ Tags: 3.5, 3.5.6
 GitCommit: 0d0cc55233e8abb08f42e07cd82be9795b75c7c6
 Directory: alpine/3.5.6
 
-Tags: 3.6, 3.6.8
-GitCommit: 0f59992ab9fcbb9486feb27edfe1aa20a6376745
-Directory: alpine/3.6.8
+Tags: 3.6, 3.6.9
+GitCommit: dd22fb0b6c3e356edd6e722551ab79515898aa55
+Directory: alpine/3.6.9
 
 Tags: 3.7, 3.7.3, latest
 GitCommit: d65e5fd722b6e3263aa0379216e5871c3a3e77d3


### PR DESCRIPTION
Updated ArangoDB 3.6 to 3.6.9.