### PR TITLE
[Haskell] Set LANG=C.UTF-8 by default.

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -3,17 +3,17 @@ Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
 GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 8.10.2-buster, 8.10-buster, 8-buster, buster, 8.10.2, 8.10, 8, latest
-GitCommit: 1abd4be882ad4a87394244baaeee6aa08cb0b13f
+GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
 Directory: 8.10/buster
 
 Tags: 8.10.2-stretch, 8.10-stretch, 8-stretch, stretch
-GitCommit: 1abd4be882ad4a87394244baaeee6aa08cb0b13f
+GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
 Directory: 8.10/stretch
 
 Tags: 8.8.4-buster, 8.8-buster, 8.8.4, 8.8
-GitCommit: 1abd4be882ad4a87394244baaeee6aa08cb0b13f
+GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
 Directory: 8.8/buster
 
 Tags: 8.8.4-stretch, 8.8-stretch
-GitCommit: 1abd4be882ad4a87394244baaeee6aa08cb0b13f
+GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
 Directory: 8.8/stretch


### PR DESCRIPTION
Minor change to improve compatibility for when users don't specify an encoding. They'll now default to UTF-8 instead of ASCII.