### PR TITLE
Update mariadb

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mariadb.git
 
-Tags: 10.5.7-focal, 10.5-focal, 10-focal, focal, 10.5.7, 10.5, 10, latest
+Tags: 10.5.8-focal, 10.5-focal, 10-focal, focal, 10.5.8, 10.5, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 5aa55c25db15da23bcc75afdc1b4da0b61099dff
+GitCommit: 58bef417cbeea4eb6b15c46b6097c3cbb99beb32
 Directory: 10.5
 
-Tags: 10.4.16-focal, 10.4-focal, 10.4.16, 10.4
+Tags: 10.4.17-focal, 10.4-focal, 10.4.17, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: e47d8430989ab4a61291e3b08466f9a5fb2d2663
+GitCommit: 8ef8085a9b9a24c440292d7e854fb2158f967210
 Directory: 10.4
 
-Tags: 10.3.26-focal, 10.3-focal, 10.3.26, 10.3
+Tags: 10.3.27-focal, 10.3-focal, 10.3.27, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6cfc9b1b49fdf1ef8e17273c9460ba21e7052a1c
+GitCommit: 36c34c3de9f4018d5153b531d754c5ae6805f723
 Directory: 10.3
 
-Tags: 10.2.35-bionic, 10.2-bionic, 10.2.35, 10.2
+Tags: 10.2.36-bionic, 10.2-bionic, 10.2.36, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f382d0526c1daf63069ece2a96c4610807d63a7c
+GitCommit: a6f3e998fbe25b027bbc168f8c8948be461aa127
 Directory: 10.2
 
 Tags: 10.1.48-bionic, 10.1-bionic, 10.1.48, 10.1


### PR DESCRIPTION
"Emergency Release of MariaDB 10.5.8, 10.4.17, 10.3.27, and 10.2.36 is now available"

https://mariadb.org/mariadb-10-5-8-10-4-17-10-3-27-and-10-2-36-now-available/

Changes:

- https://github.com/docker-library/mariadb/commit/58bef41: Update to 1:10.5.8+maria~focal
- https://github.com/docker-library/mariadb/commit/a6f3e99: Update to 1:10.2.36+maria~bionic
- https://github.com/docker-library/mariadb/commit/36c34c3: Update to 1:10.3.27+maria~focal
- https://github.com/docker-library/mariadb/commit/8ef8085: Update to 1:10.4.17+maria~focal