### PR TITLE
Odoo: update 12.0-14.0 to release 20201112

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: b5260037cb051a032ff505eba408996d6783a8cc
+GitCommit: 867c2ae68426b3fe32481ff8a6216e1a989e86b7
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

This PR brings the latest updates of Odoo 12.0, 13.0 and  14.0