### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,76 +5,76 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.15.4-buster, 1.15-buster, 1-buster, buster
-SharedTags: 1.15.4, 1.15, 1, latest
+Tags: 1.15.5-buster, 1.15-buster, 1-buster, buster
+SharedTags: 1.15.5, 1.15, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4f7e163eab39e600cc211db615d8406ba3651e81
+GitCommit: 071e264f53e89ea75f1a38f6c1c33641685d8560
 Directory: 1.15/buster
 
-Tags: 1.15.4-alpine3.12, 1.15-alpine3.12, 1-alpine3.12, alpine3.12, 1.15.4-alpine, 1.15-alpine, 1-alpine, alpine
+Tags: 1.15.5-alpine3.12, 1.15-alpine3.12, 1-alpine3.12, alpine3.12, 1.15.5-alpine, 1.15-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4f7e163eab39e600cc211db615d8406ba3651e81
+GitCommit: 071e264f53e89ea75f1a38f6c1c33641685d8560
 Directory: 1.15/alpine3.12
 
-Tags: 1.15.4-windowsservercore-1809, 1.15-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.15.4-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.4, 1.15, 1, latest
+Tags: 1.15.5-windowsservercore-1809, 1.15-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.15.5-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.5, 1.15, 1, latest
 Architectures: windows-amd64
-GitCommit: 4f7e163eab39e600cc211db615d8406ba3651e81
+GitCommit: 071e264f53e89ea75f1a38f6c1c33641685d8560
 Directory: 1.15/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.15.4-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.15.4-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.4, 1.15, 1, latest
+Tags: 1.15.5-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.15.5-windowsservercore, 1.15-windowsservercore, 1-windowsservercore, windowsservercore, 1.15.5, 1.15, 1, latest
 Architectures: windows-amd64
-GitCommit: 4f7e163eab39e600cc211db615d8406ba3651e81
+GitCommit: 071e264f53e89ea75f1a38f6c1c33641685d8560
 Directory: 1.15/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.15.4-nanoserver-1809, 1.15-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.15.4-nanoserver, 1.15-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.15.5-nanoserver-1809, 1.15-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.15.5-nanoserver, 1.15-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 4f7e163eab39e600cc211db615d8406ba3651e81
+GitCommit: 071e264f53e89ea75f1a38f6c1c33641685d8560
 Directory: 1.15/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.14.11-buster, 1.14-buster
-SharedTags: 1.14.11, 1.14
+Tags: 1.14.12-buster, 1.14-buster
+SharedTags: 1.14.12, 1.14
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/buster
 
-Tags: 1.14.11-stretch, 1.14-stretch
+Tags: 1.14.12-stretch, 1.14-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/stretch
 
-Tags: 1.14.11-alpine3.12, 1.14-alpine3.12, 1.14.11-alpine, 1.14-alpine
+Tags: 1.14.12-alpine3.12, 1.14-alpine3.12, 1.14.12-alpine, 1.14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/alpine3.12
 
-Tags: 1.14.11-alpine3.11, 1.14-alpine3.11
+Tags: 1.14.12-alpine3.11, 1.14-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/alpine3.11
 
-Tags: 1.14.11-windowsservercore-1809, 1.14-windowsservercore-1809
-SharedTags: 1.14.11-windowsservercore, 1.14-windowsservercore, 1.14.11, 1.14
+Tags: 1.14.12-windowsservercore-1809, 1.14-windowsservercore-1809
+SharedTags: 1.14.12-windowsservercore, 1.14-windowsservercore, 1.14.12, 1.14
 Architectures: windows-amd64
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.14.11-windowsservercore-ltsc2016, 1.14-windowsservercore-ltsc2016
-SharedTags: 1.14.11-windowsservercore, 1.14-windowsservercore, 1.14.11, 1.14
+Tags: 1.14.12-windowsservercore-ltsc2016, 1.14-windowsservercore-ltsc2016
+SharedTags: 1.14.12-windowsservercore, 1.14-windowsservercore, 1.14.12, 1.14
 Architectures: windows-amd64
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.14.11-nanoserver-1809, 1.14-nanoserver-1809
-SharedTags: 1.14.11-nanoserver, 1.14-nanoserver
+Tags: 1.14.12-nanoserver-1809, 1.14-nanoserver-1809
+SharedTags: 1.14.12-nanoserver, 1.14-nanoserver
 Architectures: windows-amd64
-GitCommit: 487f890a006c1e8c9956b9c46588712094256186
+GitCommit: fd9176ce75ea25302b4d66fba029b197e442e77a
 Directory: 1.14/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/071e264: Update 1.15 to 1.15.5
- https://github.com/docker-library/golang/commit/fd9176c: Update 1.14 to 1.14.12