### PR TITLE
Update CentOS Images for the 7.9.2009 release

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -11,17 +11,17 @@ ppc64le-GitFetch: refs/heads/CentOS-8-ppc64le
 ppc64le-GitCommit: 35604e16d4d1c2c9195abdf39787508feb34c456
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: centos7, 7
+Tags: centos7, 7, centos7.9.2009, 7.9.2009
 GitFetch: refs/heads/CentOS-7-x86_64
-GitCommit: f2788ce41161326a18420913b0195d1c6cfa1581
+GitCommit: b2d195220e1c5b181427c3172829c23ab9cd27eb
 arm32v7-GitFetch: refs/heads/CentOS-7armhfp
 arm32v7-GitCommit: 8022ae6d18ddf031b1b3a80549eeb46d1deb6dcd
 arm64v8-GitFetch: refs/heads/CentOS-7-aarch64
-arm64v8-GitCommit: e5273e922411fcacdf0eb3d27e925199da4ad2dc
+arm64v8-GitCommit: 02ea5808a8a155bad28677dd5857c8d382027e14
 ppc64le-GitFetch: refs/heads/CentOS-7-ppc64le
-ppc64le-GitCommit: a7c33c6ee61c033b8047cdd3f63f26dd200dc4d5
+ppc64le-GitCommit: 35604e16d4d1c2c9195abdf39787508feb34c456
 i386-GitFetch: refs/heads/CentOS-7-i386
-i386-GitCommit: f28507d5d256d5ddc2816148f4e2242057a28673
+i386-GitCommit: 206003c215684a869a686cf9ea5f9697e577c546
 Architectures: amd64, arm64v8, arm32v7, ppc64le, i386
 
 Tags: centos6, 6


### PR DESCRIPTION
We released CentOS Linux 7.9.2009 yesterday:
https://lists.centos.org/pipermail/centos-announce/2020-November/035820.html
https://lists.centos.org/pipermail/centos-announce/2020-November/035819.html

Here are the updated base images!

Signed-off-by: Brian Stinson <bstinson@centosproject.org>