### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: efd86caa8356759e9462325302e949c83d82a820
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.0, 2.3, latest
+Tags: 2.3.1, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: efd86caa8356759e9462325302e949c83d82a820
+GitCommit: f14d7fcdf03e79e106af443b947418ca0a1ad1f4
 Directory: 2.3
 
-Tags: 2.3.0-alpine, 2.3-alpine, alpine
+Tags: 2.3.1-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efd86caa8356759e9462325302e949c83d82a820
+GitCommit: f14d7fcdf03e79e106af443b947418ca0a1ad1f4
 Directory: 2.3/alpine
 
 Tags: 2.2.5, 2.2, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/f14d7fc: Update to 2.3.1