### PR TITLE
archlinux: Release 20201115.0.9067

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://github.com/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201108.0.8567
-GitCommit: 5caaec704006713993f245ee2fb7fc1a2dc86272
-GitFetch: refs/tags/v20201108.0.8567
+Tags: latest, base, base-20201115.0.9067
+GitCommit: df41327a935821867c51fde75bb82c488bf606fc
+GitFetch: refs/tags/v20201115.0.9067
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201108.0.8567
-GitCommit: 5caaec704006713993f245ee2fb7fc1a2dc86272
-GitFetch: refs/tags/v20201108.0.8567
+Tags: base-devel, base-devel-20201115.0.9067
+GitCommit: df41327a935821867c51fde75bb82c488bf606fc
+GitFetch: refs/tags/v20201115.0.9067
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
