### PR TITLE
Update Clear Linux OS to 33940

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 7a36ca821927a53e8ca70eb748ca8cd0a3cb7443
-GitFetch: refs/tags/clear-linux-33930
+GitCommit: 77b6645fc878640a9b7262aa2ea84bcc6182394b
+GitFetch: refs/tags/clear-linux-33940


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 33940

@bryteise @mdhorn @karthikprabhu17