### PR TITLE
Release of Oracle Linux 8 Update 3

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,14 +4,14 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 49445d41446a8c69780d960527829720897b895a
+amd64-GitCommit: d9cac66f4f7c97d94992b07b20c15669327edabe
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8a38d16b8e7e18886fabd64f977a315c4fc885e9
+arm64v8-GitCommit: 196568c88ef37661d04cd6df99b53ff143738dca
 
-Tags: 8.2, 8
+Tags: 8.3, 8
 Architectures: amd64, arm64v8
-Directory: 8.2
+Directory: 8.3
 
 Tags: 8-slim
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Release of [Oracle Linux 8 Update 3](https://blogs.oracle.com/linux/announcing-the-release-of-oracle-linux-8-update-3). This time without the merge conflicts.

Signed-off-by: Avi Miller <avi.miller@oracle.com>