### PR TITLE
node: November 2020 Security Releases for Debian base images

### DIFF
--- a/library/node
+++ b/library/node
@@ -18,24 +18,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
 Directory: 15/alpine3.12
 
-Tags: 15.2.0-buster, 15.2-buster, 15-buster, buster, current-buster
+Tags: 15.2.1-buster, 15.2-buster, 15-buster, buster, current-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 15/buster
 
-Tags: 15.2.0-buster-slim, 15.2-buster-slim, 15-buster-slim, buster-slim, current-buster-slim
+Tags: 15.2.1-buster-slim, 15.2-buster-slim, 15-buster-slim, buster-slim, current-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 15/buster-slim
 
-Tags: 15.2.0-stretch, 15.2-stretch, 15-stretch, stretch, current-stretch, 15.2.0, 15.2, 15, latest, current
+Tags: 15.2.1-stretch, 15.2-stretch, 15-stretch, stretch, current-stretch, 15.2.1, 15.2, 15, latest, current
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 15/stretch
 
-Tags: 15.2.0-stretch-slim, 15.2-stretch-slim, 15-stretch-slim, stretch-slim, current-stretch-slim, 15.2.0-slim, 15.2-slim, 15-slim, slim, current-slim
+Tags: 15.2.1-stretch-slim, 15.2-stretch-slim, 15-stretch-slim, stretch-slim, current-stretch-slim, 15.2.1-slim, 15.2-slim, 15-slim, slim, current-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 15/stretch-slim
 
 Tags: 14.15.0-alpine3.10, 14.15-alpine3.10, 14-alpine3.10, fermium-alpine3.10, lts-alpine3.10
@@ -53,24 +53,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
 Directory: 14/alpine3.12
 
-Tags: 14.15.0-buster, 14.15-buster, 14-buster, fermium-buster, lts-buster
+Tags: 14.15.1-buster, 14.15-buster, 14-buster, fermium-buster, lts-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 14/buster
 
-Tags: 14.15.0-buster-slim, 14.15-buster-slim, 14-buster-slim, fermium-buster-slim, lts-buster-slim
+Tags: 14.15.1-buster-slim, 14.15-buster-slim, 14-buster-slim, fermium-buster-slim, lts-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 14/buster-slim
 
-Tags: 14.15.0-stretch, 14.15-stretch, 14-stretch, fermium-stretch, lts-stretch, 14.15.0, 14.15, 14, fermium, lts
+Tags: 14.15.1-stretch, 14.15-stretch, 14-stretch, fermium-stretch, lts-stretch, 14.15.1, 14.15, 14, fermium, lts
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 14/stretch
 
-Tags: 14.15.0-stretch-slim, 14.15-stretch-slim, 14-stretch-slim, fermium-stretch-slim, lts-stretch-slim, 14.15.0-slim, 14.15-slim, 14-slim, fermium-slim, lts-slim
+Tags: 14.15.1-stretch-slim, 14.15-stretch-slim, 14-stretch-slim, fermium-stretch-slim, lts-stretch-slim, 14.15.1-slim, 14.15-slim, 14-slim, fermium-slim, lts-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 14/stretch-slim
 
 Tags: 12.19.0-alpine3.10, 12.19-alpine3.10, 12-alpine3.10, erbium-alpine3.10
@@ -93,24 +93,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
 Directory: 12/alpine3.9
 
-Tags: 12.19.0-buster, 12.19-buster, 12-buster, erbium-buster
+Tags: 12.19.1-buster, 12.19-buster, 12-buster, erbium-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 12/buster
 
-Tags: 12.19.0-buster-slim, 12.19-buster-slim, 12-buster-slim, erbium-buster-slim
+Tags: 12.19.1-buster-slim, 12.19-buster-slim, 12-buster-slim, erbium-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 12/buster-slim
 
-Tags: 12.19.0-stretch, 12.19-stretch, 12-stretch, erbium-stretch, 12.19.0, 12.19, 12, erbium
+Tags: 12.19.1-stretch, 12.19-stretch, 12-stretch, erbium-stretch, 12.19.1, 12.19, 12, erbium
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 12/stretch
 
-Tags: 12.19.0-stretch-slim, 12.19-stretch-slim, 12-stretch-slim, erbium-stretch-slim, 12.19.0-slim, 12.19-slim, 12-slim, erbium-slim
+Tags: 12.19.1-stretch-slim, 12.19-stretch-slim, 12-stretch-slim, erbium-stretch-slim, 12.19.1-slim, 12.19-slim, 12-slim, erbium-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 12/stretch-slim
 
 Tags: 10.23.0-alpine3.10, 10.23-alpine3.10, 10-alpine3.10, dubnium-alpine3.10


### PR DESCRIPTION
- https://nodejs.org/en/blog/release/v12.19.1
- https://nodejs.org/en/blog/release/v14.15.1
- https://nodejs.org/en/blog/release/v15.2.1
- https://nodejs.org/en/blog/vulnerability/november-2020-security-releases/

Supersedes #9096