### PR TITLE
Fix rakudo-star $PATH

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -3,10 +3,10 @@ GitRepo: https://github.com/Raku/docker
 
 Tags: latest, 2020.10
 Architectures: amd64, arm64v8
-GitCommit: 0d86b9c4575d22574c43356fb5773c33ae96c6eb
+GitCommit: 9101edf7704759d30c6fd180f3f9646109e1327d
 Directory: 2020.10/buster
 
 Tags: alpine, 2020.10-alpine
 Architectures: amd64, arm64v8
-GitCommit: 0d86b9c4575d22574c43356fb5773c33ae96c6eb
+GitCommit: 9101edf7704759d30c6fd180f3f9646109e1327d
 Directory: 2020.10/alpine3.12


### PR DESCRIPTION
The paths for some key binaries are currently missing from $PATH. The PR https://github.com/Raku/docker/pull/36 was created and merged to address this issue.

Closes https://github.com/Raku/docker/issues/37.