### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.9.3
+Tags: 7.10.1
 Architectures: amd64, arm64v8
-GitCommit: e12af6f82a22521626db075a939962d065e07850
+GitCommit: 38f3a55628528582a5a951e2fab6c01878af163c
 Directory: 7
 
 Tags: 6.8.13

--- a/library/kibana
+++ b/library/kibana
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.9.3
-GitCommit: dc886f4cae5864081e35ef1fa019930604a50418
+Tags: 7.10.1
+GitCommit: 87f688d33b13dfb010749eae424f273e7a10ec95
 Directory: 7
 
 Tags: 6.8.13

--- a/library/logstash
+++ b/library/logstash
@@ -4,8 +4,8 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.9.3
-GitCommit: 86c1d9316ae7f8a89bcdf57e1fc7382689310e14
+Tags: 7.10.1
+GitCommit: 8178ceb29afa653f2ee0e4e4cf8c99d76e97a7b3
 Directory: 7
 
 Tags: 6.8.13


### PR DESCRIPTION
elasticsearch:
- docker-library/elasticsearch@38f3a55: Update to 7.10.1
- docker-library/elasticsearch@b6bd4e8: Replace "::set-env" with "$GITHUB_ENV"
- docker-library/elasticsearch@c075da8: Update to 7.10.0

logstash:
- docker-library/logstash@8178ceb: Update to 7.10.1
- docker-library/logstash@5d23272: Replace "::set-env" with "$GITHUB_ENV"
- docker-library/logstash@b680245: Update to 7.10.0

kibana:
- docker-library/kibana@87f688d: Update to 7.10.1
- docker-library/kibana@1ebc7ca: Replace "::set-env" with "$GITHUB_ENV"
- docker-library/kibana@a3a2ee7: Update to 7.10.0