### PR TITLE
node: security update for alpine images

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,19 +3,19 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 15.2.0-alpine3.10, 15.2-alpine3.10, 15-alpine3.10, alpine3.10, current-alpine3.10
+Tags: 15.2.1-alpine3.10, 15.2-alpine3.10, 15-alpine3.10, alpine3.10, current-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 15/alpine3.10
 
-Tags: 15.2.0-alpine3.11, 15.2-alpine3.11, 15-alpine3.11, alpine3.11, current-alpine3.11, 15.2.0-alpine, 15.2-alpine, 15-alpine, alpine, current-alpine
+Tags: 15.2.1-alpine3.11, 15.2-alpine3.11, 15-alpine3.11, alpine3.11, current-alpine3.11, 15.2.1-alpine, 15.2-alpine, 15-alpine, alpine, current-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 15/alpine3.11
 
-Tags: 15.2.0-alpine3.12, 15.2-alpine3.12, 15-alpine3.12, alpine3.12, current-alpine3.12
+Tags: 15.2.1-alpine3.12, 15.2-alpine3.12, 15-alpine3.12, alpine3.12, current-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d5d4624b9fef82ae942f8de232c7bdca54b61fc7
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 15/alpine3.12
 
 Tags: 15.2.1-buster, 15.2-buster, 15-buster, buster, current-buster
@@ -38,19 +38,19 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 15/stretch-slim
 
-Tags: 14.15.0-alpine3.10, 14.15-alpine3.10, 14-alpine3.10, fermium-alpine3.10, lts-alpine3.10
+Tags: 14.15.1-alpine3.10, 14.15-alpine3.10, 14-alpine3.10, fermium-alpine3.10, lts-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 14/alpine3.10
 
-Tags: 14.15.0-alpine3.11, 14.15-alpine3.11, 14-alpine3.11, fermium-alpine3.11, lts-alpine3.11, 14.15.0-alpine, 14.15-alpine, 14-alpine, fermium-alpine, lts-alpine
+Tags: 14.15.1-alpine3.11, 14.15-alpine3.11, 14-alpine3.11, fermium-alpine3.11, lts-alpine3.11, 14.15.1-alpine, 14.15-alpine, 14-alpine, fermium-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 14/alpine3.11
 
-Tags: 14.15.0-alpine3.12, 14.15-alpine3.12, 14-alpine3.12, fermium-alpine3.12, lts-alpine3.12
+Tags: 14.15.1-alpine3.12, 14.15-alpine3.12, 14-alpine3.12, fermium-alpine3.12, lts-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c2604466d06ba562fd9040d18c57af16545c6a5b
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 14/alpine3.12
 
 Tags: 14.15.1-buster, 14.15-buster, 14-buster, fermium-buster, lts-buster
@@ -73,24 +73,24 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 14/stretch-slim
 
-Tags: 12.19.0-alpine3.10, 12.19-alpine3.10, 12-alpine3.10, erbium-alpine3.10
+Tags: 12.19.1-alpine3.10, 12.19-alpine3.10, 12-alpine3.10, erbium-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 12/alpine3.10
 
-Tags: 12.19.0-alpine3.11, 12.19-alpine3.11, 12-alpine3.11, erbium-alpine3.11, 12.19.0-alpine, 12.19-alpine, 12-alpine, erbium-alpine
+Tags: 12.19.1-alpine3.11, 12.19-alpine3.11, 12-alpine3.11, erbium-alpine3.11, 12.19.1-alpine, 12.19-alpine, 12-alpine, erbium-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 12/alpine3.11
 
-Tags: 12.19.0-alpine3.12, 12.19-alpine3.12, 12-alpine3.12, erbium-alpine3.12
+Tags: 12.19.1-alpine3.12, 12.19-alpine3.12, 12-alpine3.12, erbium-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 12/alpine3.12
 
-Tags: 12.19.0-alpine3.9, 12.19-alpine3.9, 12-alpine3.9, erbium-alpine3.9
+Tags: 12.19.1-alpine3.9, 12.19-alpine3.9, 12-alpine3.9, erbium-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a8494b1676216bfe274073993016da0c2e0bfcdd
+GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
 Directory: 12/alpine3.9
 
 Tags: 12.19.1-buster, 12.19-buster, 12-buster, erbium-buster


### PR DESCRIPTION
Following up #9098.

https://github.com/nodejs/docker-node/pull/1399#issuecomment-728347552