### PR TITLE
update jetty to use jdk15 and jetty-9.4.34

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -64,55 +64,55 @@ Architectures: amd64
 Directory: 10.0-jdk11
 GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
 
-Tags: 9.4.33-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.34-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.34-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 9.4.34-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64
 Directory: 9.4-jre8-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.34-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
+Tags: 9.4.34-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
 Architectures: amd64
 Directory: 9.4-jdk14-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33, 9.4, 9, 9.4.33-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
+Tags: 9.4.34, 9.4, 9, 9.4.34-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
 Architectures: amd64
 Directory: 9.4-jdk14
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 9.4.34-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64
 Directory: 9.4-jdk11-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 9.4.34-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64
 Directory: 9.4-jdk11
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 9.4.34-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64
 Directory: 9.4-jdk8-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.33-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 9.4.34-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64
 Directory: 9.4-jdk8
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
 Tags: 9.3.29-jre8, 9.3-jre8
 Architectures: amd64

--- a/library/jetty
+++ b/library/jetty
@@ -14,15 +14,15 @@ Architectures: amd64
 Directory: 11.0-jre11
 GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
 
-Tags: 11.0.0.beta3-jdk14-slim
+Tags: 11.0.0.beta3-jdk15-slim
 Architectures: amd64
-Directory: 11.0-jdk14-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+Directory: 11.0-jdk15-slim
+GitCommit: 6fadad42db862f7770939dce377cab06d2d234fe
 
-Tags: 11.0.0.beta3, 11.0.0.beta3-jdk14
+Tags: 11.0.0.beta3, 11.0.0.beta3-jdk15
 Architectures: amd64
-Directory: 11.0-jdk14
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+Directory: 11.0-jdk15
+GitCommit: 6fadad42db862f7770939dce377cab06d2d234fe
 
 Tags: 11.0.0.beta3-jdk11-slim
 Architectures: amd64
@@ -44,15 +44,15 @@ Architectures: amd64
 Directory: 10.0-jre11
 GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
 
-Tags: 10.0.0.beta3-jdk14-slim
+Tags: 10.0.0.beta3-jdk15-slim
 Architectures: amd64
-Directory: 10.0-jdk14-slim
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+Directory: 10.0-jdk15-slim
+GitCommit: 6fadad42db862f7770939dce377cab06d2d234fe
 
-Tags: 10.0.0.beta3, 10.0.0.beta3-jdk14
+Tags: 10.0.0.beta3, 10.0.0.beta3-jdk15
 Architectures: amd64
-Directory: 10.0-jdk14
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+Directory: 10.0-jdk15
+GitCommit: 6fadad42db862f7770939dce377cab06d2d234fe
 
 Tags: 10.0.0.beta3-jdk11-slim
 Architectures: amd64
@@ -84,15 +84,15 @@ Architectures: amd64
 Directory: 9.4-jre8
 GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
 
-Tags: 9.4.34-jdk14-slim, 9.4-jdk14-slim, 9-jdk14-slim
+Tags: 9.4.34-jdk15-slim, 9.4-jdk15-slim, 9-jdk15-slim
 Architectures: amd64
-Directory: 9.4-jdk14-slim
-GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
+Directory: 9.4-jdk15-slim
+GitCommit: 6fadad42db862f7770939dce377cab06d2d234fe
 
-Tags: 9.4.34, 9.4, 9, 9.4.34-jdk14, 9.4-jdk14, 9-jdk14, latest, jdk14
+Tags: 9.4.34, 9.4, 9, 9.4.34-jdk15, 9.4-jdk15, 9-jdk15, latest, jdk15
 Architectures: amd64
-Directory: 9.4-jdk14
-GitCommit: 25315061fa0ab82505aaffac204ca55d72ad3295
+Directory: 9.4-jdk15
+GitCommit: 6fadad42db862f7770939dce377cab06d2d234fe
 
 Tags: 9.4.34-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64


### PR DESCRIPTION
- Update Jetty version from `9.4.33` to `9.4.34` .
- Update the images based off `openjdk:14-jdk` to instead use `openjdk:15-jdk`.