### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.37.1, 3.37, 3, latest
+Tags: 3.38.0, 3.38, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 705e1d8724e478a93fbb76b6cfdf670d86f01d9e
+GitCommit: 1ab4a679faa41050f3e8a0f25f19eb8c3de2cabc
 Directory: 3/debian
 
-Tags: 3.37.1-alpine, 3.37-alpine, 3-alpine, alpine
+Tags: 3.38.0-alpine, 3.38-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 705e1d8724e478a93fbb76b6cfdf670d86f01d9e
+GitCommit: 1ab4a679faa41050f3e8a0f25f19eb8c3de2cabc
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1ab4a67: Update to 3.38.0, ghost-cli 1.15.2