### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.10-beta.1, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e254cc0c254ba4e9e4cf1608b01ae271ee381a37
+GitCommit: 7dd3fb201998f83a8ed039fab5399215fce02a5f
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.10-beta.1-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.10-beta.1-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e254cc0c254ba4e9e4cf1608b01ae271ee381a37
+GitCommit: 7dd3fb201998f83a8ed039fab5399215fce02a5f
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.10-beta.1-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b553555982b7d699b6033595e8351d8479db627e
+GitCommit: 308737ac982d754025e44ee4710c86182be50ae3
 Directory: 3.8/ubuntu
 
 Tags: 3.8.9-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.9-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b553555982b7d699b6033595e8351d8479db627e
+GitCommit: 308737ac982d754025e44ee4710c86182be50ae3
 Directory: 3.8/alpine
 
 Tags: 3.8.9-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/308737a: Update to 3.8.9, Erlang/OTP 23.1.3, OpenSSL 1.1.1h
- https://github.com/docker-library/rabbitmq/commit/7dd3fb2: Update to 3.8.10-beta.1, Erlang/OTP 23.1.3, OpenSSL 1.1.1h