### PR TITLE
Update Oracle Linux 7 images for ELSA-2020-5011

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d9cac66f4f7c97d94992b07b20c15669327edabe
+amd64-GitCommit: 0ea52ec02766faf5863ac51e86adecb74af134e4
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 196568c88ef37661d04cd6df99b53ff143738dca
+arm64v8-GitCommit: 378d013708b8ae351cc9b603d2f90e058726acdd
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This includes fixes for CVE-2020-8622, CVE-2020-8623 and CVE-2020-8624. 

See https://linux.oracle.com/errata/ELSA-2020-5011.html for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>