### PR TITLE
Update swipl latest to 8.3.13 and stable to 8.2.2

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,4 +1,5 @@
-Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
+Maintainers: Jan Wielemaker <J.Wielemaker@vu.nl> (@JanWielemaker),
+             Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 GitCommit: 648de9790d5b9cd69a777bb23777b811f92c1609
 Architectures: amd64, arm32v7, arm64v8

--- a/library/swipl
+++ b/library/swipl
@@ -1,7 +1,10 @@
 Maintainers: Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: e890bf1885f30374ccb305a070aeeb19961d1972
-
-Tags: latest, stable, 8.2.2
+GitCommit: 648de9790d5b9cd69a777bb23777b811f92c1609
 Architectures: amd64, arm32v7, arm64v8
+
+Tags: latest, 8.3.13
+Directory: 8.3.13/stretch
+
+Tags: stable, 8.2.2
 Directory: 8.2.2/stretch


### PR DESCRIPTION
Bringing back separate images for `stable` (from the stable release) and `latest` (from the newer development release).