### PR TITLE
Update Backdrop to 1.17.3

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -5,12 +5,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.13.2, 1.13, 1, 1.13.2-apache, 1.13-apache, 1-apache, apache, latest
+Tags: 1.17.3, 1.17, 1, 1.17.3-apache, 1.17-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f
+GitCommit: b760ba970a67f3dcdc975ed8b77f915895184577
 Directory: 1/apache
 
-Tags: 1.13.2-fpm, 1.13-fpm, 1-fpm, fpm
+Tags: 1.17.3-fpm, 1.17-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 1c82e369b6bf1b8ab45becda7f9f9777fe7f6a7f
+GitCommit: b760ba970a67f3dcdc975ed8b77f915895184577
 Directory: 1/fpm


### PR DESCRIPTION
Updates to https://github.com/backdrop/backdrop/releases/tag/1.17.3

Docker image commits: the latest: https://github.com/backdrop-ops/backdrop-docker/commit/b760ba970a67f3dcdc975ed8b77f915895184577
(also https://github.com/backdrop-ops/backdrop-docker/commit/acc5ac5d4fbce952e72219de370ad82bd4e17683 and https://github.com/backdrop-ops/backdrop-docker/commit/b4104ce33507eb61421144274678c57525c14766)

Thank you!