### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.38.1, 3.38, 3, latest
+Tags: 3.38.2, 3.38, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 31ebf85ff8b550d7584a2d7c50c8245a68a0a898
+GitCommit: 986e41b6d2e0b238181805f016c893343f530102
 Directory: 3/debian
 
-Tags: 3.38.1-alpine, 3.38-alpine, 3-alpine, alpine
+Tags: 3.38.2-alpine, 3.38-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 31ebf85ff8b550d7584a2d7c50c8245a68a0a898
+GitCommit: 986e41b6d2e0b238181805f016c893343f530102
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/986e41b: Update to 3.38.2, ghost-cli 1.15.2