### PR TITLE
Update tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -35,7 +35,7 @@ GitCommit: 61a0c16a09b7716764c9bd4ee00b6ac40c4d9f4e
 Directory: 10.0/jdk11/adoptopenjdk-hotspot
 
 Tags: 10.0.0-M10-jdk11-adoptopenjdk-openj9, 10.0.0-jdk11-adoptopenjdk-openj9, 10.0-jdk11-adoptopenjdk-openj9, 10-jdk11-adoptopenjdk-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: 61a0c16a09b7716764c9bd4ee00b6ac40c4d9f4e
 Directory: 10.0/jdk11/adoptopenjdk-openj9
 
@@ -55,7 +55,7 @@ GitCommit: 61a0c16a09b7716764c9bd4ee00b6ac40c4d9f4e
 Directory: 10.0/jdk8/openjdk-slim-buster
 
 Tags: 10.0.0-M10-jdk8-adoptopenjdk-hotspot, 10.0.0-jdk8-adoptopenjdk-hotspot, 10.0-jdk8-adoptopenjdk-hotspot, 10-jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 61a0c16a09b7716764c9bd4ee00b6ac40c4d9f4e
 Directory: 10.0/jdk8/adoptopenjdk-hotspot
 
@@ -100,7 +100,7 @@ GitCommit: f284ec11dc580bff5adec3f4b0b1c9bf5f2d5b18
 Directory: 9.0/jdk11/adoptopenjdk-hotspot
 
 Tags: 9.0.40-jdk11-adoptopenjdk-openj9, 9.0-jdk11-adoptopenjdk-openj9, 9-jdk11-adoptopenjdk-openj9, jdk11-adoptopenjdk-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: f284ec11dc580bff5adec3f4b0b1c9bf5f2d5b18
 Directory: 9.0/jdk11/adoptopenjdk-openj9
 
@@ -120,7 +120,7 @@ GitCommit: f284ec11dc580bff5adec3f4b0b1c9bf5f2d5b18
 Directory: 9.0/jdk8/openjdk-slim-buster
 
 Tags: 9.0.40-jdk8-adoptopenjdk-hotspot, 9.0-jdk8-adoptopenjdk-hotspot, 9-jdk8-adoptopenjdk-hotspot, jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: f284ec11dc580bff5adec3f4b0b1c9bf5f2d5b18
 Directory: 9.0/jdk8/adoptopenjdk-hotspot
 
@@ -165,7 +165,7 @@ GitCommit: eec3cd9e3450b74c6ccfae193a1f5c65e488548c
 Directory: 8.5/jdk11/adoptopenjdk-hotspot
 
 Tags: 8.5.60-jdk11-adoptopenjdk-openj9, 8.5-jdk11-adoptopenjdk-openj9, 8-jdk11-adoptopenjdk-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: eec3cd9e3450b74c6ccfae193a1f5c65e488548c
 Directory: 8.5/jdk11/adoptopenjdk-openj9
 
@@ -185,7 +185,7 @@ GitCommit: eec3cd9e3450b74c6ccfae193a1f5c65e488548c
 Directory: 8.5/jdk8/openjdk-slim-buster
 
 Tags: 8.5.60-jdk8-adoptopenjdk-hotspot, 8.5-jdk8-adoptopenjdk-hotspot, 8-jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: eec3cd9e3450b74c6ccfae193a1f5c65e488548c
 Directory: 8.5/jdk8/adoptopenjdk-hotspot
 
@@ -210,7 +210,7 @@ GitCommit: f837bd06fb2796cd8d5b9063a87d4d330323803c
 Directory: 7/jdk8/openjdk-slim-buster
 
 Tags: 7.0.106-jdk8-adoptopenjdk-hotspot, 7.0-jdk8-adoptopenjdk-hotspot, 7-jdk8-adoptopenjdk-hotspot
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: f837bd06fb2796cd8d5b9063a87d4d330323803c
 Directory: 7/jdk8/adoptopenjdk-hotspot
 


### PR DESCRIPTION
I've verified that this does build successfully on s390x (at least, `10.0/jdk8/adoptopenjdk-hotspot`), so it does appear `adoptopenjdk` is indeed fixed. :partying_face: