### PR TITLE
Update for the release of 20.0.0.12 of websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -11,6 +11,7 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: kernel-java11-openj9
 Directory: ga/latest/kernel
+Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: full, latest
@@ -19,6 +20,7 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: full-java11-openj9
 Directory: ga/latest/full
+Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 20.0.0.12-kernel-java8-ibmjava
@@ -27,6 +29,7 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 20.0.0.12-kernel-java11-openj9
 Directory: ga/20.0.0.12/kernel
+Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 20.0.0.12-full-java8-ibmjava
@@ -35,6 +38,7 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 20.0.0.12-full-java11-openj9
 Directory: ga/20.0.0.12/full
+Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 20.0.0.9-kernel-java8-ibmjava

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 4ecc2d2a325b03a89bd87179bf483773793da6fe
+GitCommit: 0444a92b55552917b418245496d980f1d508ae6d
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -12,17 +12,33 @@ Tags: kernel
 Directory: ga/latest/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
+Tags: kernel-java11-openj9
+Directory: ga/latest/kernel
+File: Dockerfile.ubuntu.adoptopenjdk11
+
 Tags: full, latest
 Directory: ga/latest/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 20.0.0.11-kernel-java8-ibmjava
-Directory: ga/20.0.0.11/kernel
+Tags: full-java11-openj9
+Directory: ga/latest/full
+File: Dockerfile.ubuntu.adoptopenjdk11
+
+Tags: 20.0.0.12-kernel-java8-ibmjava
+Directory: ga/20.0.0.12/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 20.0.0.11-full-java8-ibmjava
-Directory: ga/20.0.0.11/full
+Tags: 20.0.0.12-kernel-java11-openj9
+Directory: ga/20.0.0.12/kernel
+File: Dockerfile.ubuntu.adoptopenjdk11
+
+Tags: 20.0.0.12-full-java8-ibmjava
+Directory: ga/20.0.0.12/full
 File: Dockerfile.ubuntu.ibmjava8
+
+Tags: 20.0.0.12-full-java11-openj9
+Directory: ga/20.0.0.12/full
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 20.0.0.9-kernel-java8-ibmjava
 Directory: ga/20.0.0.9/kernel
@@ -30,12 +46,4 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 20.0.0.9-full-java8-ibmjava
 Directory: ga/20.0.0.9/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 20.0.0.6-kernel-java8-ibmjava
-Directory: ga/20.0.0.6/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 20.0.0.6-full-java8-ibmjava
-Directory: ga/20.0.0.6/full
 File: Dockerfile.ubuntu.ibmjava8

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -5,9 +5,6 @@ GitRepo: https://github.com/WASdev/ci.docker.git
 GitCommit: 0444a92b55552917b418245496d980f1d508ae6d
 Architectures: amd64, i386, ppc64le, s390x
 
-Tags: beta
-Directory: beta
-
 Tags: kernel
 Directory: ga/latest/kernel
 File: Dockerfile.ubuntu.ibmjava8


### PR DESCRIPTION
Updates for the 20.0.0.12 release of websphere-liberty. This removes 20.0.0.6, and adds in new kernel-slim and full images for both latest and 20.0.0.12.