### PR TITLE
Updates for the 20.0.0.12 release of open-liberty

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,28 +2,58 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 3c0fb437b5de0d5ce976d6b118e7feec697900fa
+GitCommit: cd35776e84f4b91bf44c02ab891494451f0590e0
 Architectures: amd64, i386, ppc64le, s390x
+
+Tags: beta
+Directory: releases/latest/beta
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk8
+
+Tags: beta-java11
+Directory: releases/latest/beta
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: kernel-slim, kernel-slim-java8-openj9
 Directory: releases/latest/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
+Tags: kernel-slim-java11-openj9
+Directory: releases/latest/kernel-slim
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
+
 Tags: full, full-java8-openj9, latest
 Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 20.0.0.11-kernel-slim-java8-openj9
-Directory: releases/20.0.0.11/kernel-slim
+Tags: full-java11-openj9
+Directory: releases/latest/full
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
+
+Tags: 20.0.0.12-kernel-slim-java8-openj9
+Directory: releases/20.0.0.12/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 20.0.0.11-full-java8-openj9
-Directory: releases/20.0.0.11/full
+Tags: 20.0.0.12-kernel-slim-java11-openj9
+Directory: releases/20.0.0.12/kernel-slim
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
+
+Tags: 20.0.0.12-full-java8-openj9
+Directory: releases/20.0.0.12/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
+
+Tags: 20.0.0.12-full-java11-openj9
+Directory: releases/20.0.0.12/full
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.adoptopenjdk11
 
 Tags: 20.0.0.9-kernel-java8-openj9
 Directory: releases/20.0.0.9/kernel
@@ -32,15 +62,5 @@ File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 20.0.0.9-full-java8-openj9
 Directory: releases/20.0.0.9/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 20.0.0.6-kernel-java8-openj9
-Directory: releases/20.0.0.6/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 20.0.0.6-full-java8-openj9
-Directory: releases/20.0.0.6/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: cd35776e84f4b91bf44c02ab891494451f0590e0
+GitCommit: 51ff2606fcecbcb70c35fd69f3adcb214eb34c7b
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta


### PR DESCRIPTION
Updates for the release of open-liberty version 20.0.0.12. This adds beta images, java11 versions of the most recent images, removes 20.0.0.6, and adds 20.0.0.12.