### PR TITLE
Add back s390x

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -6,56 +6,46 @@ GitCommit: fa9021708ab3315acbf4208125f6ca316e903ac6
 # Hotspot
 
 Tags: 6.7.1-jdk8, 6.7.1-jdk8-hotspot, 6.7-jdk8, 6.7-jdk8-hotspot, jdk8, jdk8-hotspot, 6.7.1-jdk, 6.7.1-jdk-hotspot, 6.7-jdk, 6.7-jdk-hotspot, jdk, jdk-hotspot, 6.7.1, 6.7.1-hotspot, 6.7, 6.7-hotspot, latest, hotspot
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk8
 
 Tags: 6.7.1-jre8, 6.7.1-jre8-hotspot, 6.7-jre8, 6.7-jre8-hotspot, jre8, jre8-hotspot, 6.7.1-jre, 6.7.1-jre-hotspot, 6.7-jre, 6.7-jre-hotspot, jre, jre-hotspot
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre8
 
 Tags: 6.7.1-jdk11, 6.7.1-jdk11-hotspot, 6.7-jdk11, 6.7-jdk11-hotspot, jdk11, jdk11-hotspot
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk11
 
 Tags: 6.7.1-jre11, 6.7.1-jre11-hotspot, 6.7-jre11, 6.7-jre11-hotspot, jre11, jre11-hotspot
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre11
 
 Tags: 6.7.1-jdk15, 6.7.1-jdk15-hotspot, 6.7-jdk15, 6.7-jdk15-hotspot, jdk15, jdk15-hotspot
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk15
 
 Tags: 6.7.1-jre15, 6.7.1-jre15-hotspot, 6.7-jre15, 6.7-jre15-hotspot, jre15, jre15-hotspot
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre15
 
 
 # OpenJ9
 
 Tags: 6.7.1-jdk8-openj9, 6.7-jdk8-openj9, jdk8-openj9, 6.7.1-jdk-openj9, 6.7-jdk-openj9, jdk-openj9, 6.7.1-openj9, 6.7-openj9, openj9
-#Architectures: amd64, ppc64le, s390x
-Architectures: amd64, ppc64le
+Architectures: amd64, ppc64le, s390x
 Directory: openj9/jdk8
 
 Tags: 6.7.1-jre8-openj9, 6.7-jre8-openj9, jre8-openj9, 6.7.1-jre-openj9, 6.7-jre-openj9, jre-openj9
-#Architectures: amd64, ppc64le, s390x
-Architectures: amd64, ppc64le
+Architectures: amd64, ppc64le, s390x
 Directory: openj9/jre8
 
 Tags: 6.7.1-jdk11-openj9, 6.7-jdk11-openj9, jdk11-openj9
-#Architectures: amd64, ppc64le, s390x
-Architectures: amd64, ppc64le
+Architectures: amd64, ppc64le, s390x
 Directory: openj9/jdk11
 
 Tags: 6.7.1-jre11-openj9, 6.7-jre11-openj9, jre11-openj9
-#Architectures: amd64, ppc64le, s390x
-Architectures: amd64, ppc64le
+Architectures: amd64, ppc64le, s390x
 Directory: openj9/jre11
 
 # temporarily commented out, due to OpenJ9 bug

--- a/library/groovy
+++ b/library/groovy
@@ -5,38 +5,32 @@ GitRepo: https://github.com/groovy/docker-groovy.git
 # Groovy 3
 
 Tags: 3.0.6-jdk8, 3.0-jdk8, 3.0.6-jdk, 3.0-jdk, jdk8, jdk
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk8
 
 Tags: 3.0.6-jre8, 3.0-jre8, 3.0.6-jre, 3.0-jre, 3.0.6, 3.0, jre8, jre, latest
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre8
 
 Tags: 3.0.6-jdk11, 3.0-jdk11, jdk11
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk11
 
 Tags: 3.0.6-jre11, 3.0-jre11, jre11
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre11
 
 Tags: 3.0.6-jdk15, 3.0-jdk15, jdk15
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk15
 
 Tags: 3.0.6-jre15, 3.0-jre15, jre15
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre15
 
@@ -45,42 +39,36 @@ Directory: jre15
 
 Tags: 4.0.0-alpha-1-jdk8, 4.0-jdk8, 4.0.0-alpha-1-jdk, 4.0-jdk
 GitFetch: refs/heads/4.0
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jdk8
 
 Tags: 4.0.0-alpha-1-jre8, 4.0-jre8, 4.0.0-alpha-1-jre, 4.0-jre, 4.0.0-alpha-1, 4.0
 GitFetch: refs/heads/4.0
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jre8
 
 Tags: 4.0.0-alpha-1-jdk11, 4.0-jdk11
 GitFetch: refs/heads/4.0
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jdk11
 
 Tags: 4.0.0-alpha-1-jre11, 4.0-jre11
 GitFetch: refs/heads/4.0
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jre11
 
 Tags: 4.0.0-alpha-1-jdk15, 4.0-jdk15
 GitFetch: refs/heads/4.0
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jdk15
 
 Tags: 4.0.0-alpha-1-jre15, 4.0-jre15
 GitFetch: refs/heads/4.0
-#Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8a5cb9daaf459b33713544c2557032c266ce1feb
 Directory: jre15


### PR DESCRIPTION
Now that !9128 added back s390x, we can add s390x back.

Reverts docker-library/official-images#9117