### PR TITLE
Update Clear Linux OS to 33970

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 77b6645fc878640a9b7262aa2ea84bcc6182394b
-GitFetch: refs/tags/clear-linux-33940
+GitCommit: c2963445171336a0f8277d322e7a0dc46af9b9c7
+GitFetch: refs/tags/clear-linux-33970


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 33970

@bryteise @mdhorn @karthikprabhu17