### PR TITLE
archlinux: Release 20201123.0.9844

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://github.com/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201115.0.9067
-GitCommit: df41327a935821867c51fde75bb82c488bf606fc
-GitFetch: refs/tags/v20201115.0.9067
+Tags: latest, base, base-20201123.0.9844
+GitCommit: cd2db9c68a43b280fd08aeb1b2b70fc9d4ccc37b
+GitFetch: refs/tags/v20201123.0.9844
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201115.0.9067
-GitCommit: df41327a935821867c51fde75bb82c488bf606fc
-GitFetch: refs/tags/v20201115.0.9067
+Tags: base-devel, base-devel-20201123.0.9844
+GitCommit: cd2db9c68a43b280fd08aeb1b2b70fc9d4ccc37b
+GitFetch: refs/tags/v20201123.0.9844
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
