### PR TITLE
Odoo: update 12.0-14.0 to release 20201123

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 867c2ae68426b3fe32481ff8a6216e1a989e86b7
+GitCommit: 920582ed7794c142ef888f3142c1afa7013b4f38
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo images 12.0 up to 14.0.

Thanks.