### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev0, 2.4-dev
+Tags: 2.4-dev1, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: efd86caa8356759e9462325302e949c83d82a820
+GitCommit: 2352794b88adcac2c859d2afde832db50aeb2182
 Directory: 2.4-rc
 
-Tags: 2.4-dev0-alpine, 2.4-dev-alpine
+Tags: 2.4-dev1-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efd86caa8356759e9462325302e949c83d82a820
+GitCommit: 2352794b88adcac2c859d2afde832db50aeb2182
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.1, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2352794: Update to 2.4-dev1