### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.38.2, 3.38, 3, latest
+Tags: 3.38.3, 3.38, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 986e41b6d2e0b238181805f016c893343f530102
+GitCommit: d12d0cb7e452661f43aea1a6bd5554e028b6b5f4
 Directory: 3/debian
 
-Tags: 3.38.2-alpine, 3.38-alpine, 3-alpine, alpine
+Tags: 3.38.3-alpine, 3.38-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 986e41b6d2e0b238181805f016c893343f530102
+GitCommit: d12d0cb7e452661f43aea1a6bd5554e028b6b5f4
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/d12d0cb: Update to 3.38.3, ghost-cli 1.15.2