### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/132a93b20fcae6a9ef82425ae491262c975003f4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/e21089424490fd2151f252e584429af3a45da9c0/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 132a93b20fcae6a9ef82425ae491262c975003f4
+GitCommit: e21089424490fd2151f252e584429af3a45da9c0
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e33ce41cb5b911f50a58c0e42af2bcc04181f621
+amd64-GitCommit: ce0c6e451f3a01c556b2275d71b2d2b812378f17
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 274bd72e185d24fdaed0f7d4703362882508397b
+arm32v5-GitCommit: 3ba76ff43bf193f601f9ae06f1c2c52eb9509672
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: ea4bd11471573e18afd506704695f99e1950bc11
+arm32v6-GitCommit: 8a9279b9232e3ca11896e15b2bdf8475485bc9a7
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7482732605f01ef23691e8e8b42c0f5517e65cd9
+arm32v7-GitCommit: ed2d438aeca0385aa2464469d3d2b6ee742ca028
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0cd82e1da438a44317bdf0d7ec9ff0b08b4bcffb
+arm64v8-GitCommit: 06434871c89cc0fc03881d51b9b01def7c89dacc
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 304948cb5a18bd05d15a387ecd465c4a3644d5ca
+i386-GitCommit: ff4a349c08f9f2104c8dc633e3c3e10f1099182b
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: cadee917dc6539000e76ea202700c339fdff2d90
+mips64le-GitCommit: 342f1960ca66efc3c2d8a62c03b8e5a848de21fb
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 9b3ea0bcd3ae0f13f3ba4ed54794cbab184dbd26
+ppc64le-GitCommit: aa71cb3e53d8795c47840535042f8a0fad4cb76c
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ad6c168ad28240181eba5b319f8a92966e40a3a4
+s390x-GitCommit: 2b3dc07b0714b8e380e0824b3ad30cb9801c9745
 
 Tags: 1.32.0-uclibc, 1.32-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/e210894: Update Buildroot to 2020.08.2