### PR TITLE
Bump Traefik to v2.3.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.3-windowsservercore-1809, 2.3.3-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.3.4-windowsservercore-1809, 2.3.4-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: windows-amd64
-GitCommit: 725891b0d6f7bca7ae760b6dc62e6da19a837222
+GitCommit: 99db7b16a149cc0ad91b3a28e5bddfaf5a2cae78
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.3, 2.3.3, v2.3, 2.3, picodon, latest
+Tags: v2.3.4, 2.3.4, v2.3, 2.3, picodon, latest
 GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: 725891b0d6f7bca7ae760b6dc62e6da19a837222
+GitCommit: 99db7b16a149cc0ad91b3a28e5bddfaf5a2cae78
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.3.4](https://github.com/traefik/traefik/releases/tag/v2.3.4).

/cc @SantoDE @jbdoumenjou @kevinpollet

Cheers
