### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -6,82 +6,82 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 8.0.0RC5-cli-buster, 8.0-rc-cli-buster, rc-cli-buster, 8.0.0RC5-buster, 8.0-rc-buster, rc-buster, 8.0.0RC5-cli, 8.0-rc-cli, rc-cli, 8.0.0RC5, 8.0-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 018051197461ec51475a740d26816975bb6b5278
+GitCommit: 0fdd2f0fc4cc55b70bced7ce77f97a3b70f10b3f
 Directory: 8.0-rc/buster/cli
 
 Tags: 8.0.0RC5-apache-buster, 8.0-rc-apache-buster, rc-apache-buster, 8.0.0RC5-apache, 8.0-rc-apache, rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 018051197461ec51475a740d26816975bb6b5278
+GitCommit: 0fdd2f0fc4cc55b70bced7ce77f97a3b70f10b3f
 Directory: 8.0-rc/buster/apache
 
 Tags: 8.0.0RC5-fpm-buster, 8.0-rc-fpm-buster, rc-fpm-buster, 8.0.0RC5-fpm, 8.0-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 018051197461ec51475a740d26816975bb6b5278
+GitCommit: 0fdd2f0fc4cc55b70bced7ce77f97a3b70f10b3f
 Directory: 8.0-rc/buster/fpm
 
 Tags: 8.0.0RC5-zts-buster, 8.0-rc-zts-buster, rc-zts-buster, 8.0.0RC5-zts, 8.0-rc-zts, rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 018051197461ec51475a740d26816975bb6b5278
+GitCommit: 0fdd2f0fc4cc55b70bced7ce77f97a3b70f10b3f
 Directory: 8.0-rc/buster/zts
 
 Tags: 8.0.0RC5-cli-alpine3.12, 8.0-rc-cli-alpine3.12, rc-cli-alpine3.12, 8.0.0RC5-alpine3.12, 8.0-rc-alpine3.12, rc-alpine3.12, 8.0.0RC5-cli-alpine, 8.0-rc-cli-alpine, rc-cli-alpine, 8.0.0RC5-alpine, 8.0-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 018051197461ec51475a740d26816975bb6b5278
+GitCommit: 0fdd2f0fc4cc55b70bced7ce77f97a3b70f10b3f
 Directory: 8.0-rc/alpine3.12/cli
 
 Tags: 8.0.0RC5-fpm-alpine3.12, 8.0-rc-fpm-alpine3.12, rc-fpm-alpine3.12, 8.0.0RC5-fpm-alpine, 8.0-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 018051197461ec51475a740d26816975bb6b5278
+GitCommit: 0fdd2f0fc4cc55b70bced7ce77f97a3b70f10b3f
 Directory: 8.0-rc/alpine3.12/fpm
 
 Tags: 7.4.12-cli-buster, 7.4-cli-buster, 7-cli-buster, cli-buster, 7.4.12-buster, 7.4-buster, 7-buster, buster, 7.4.12-cli, 7.4-cli, 7-cli, cli, 7.4.12, 7.4, 7, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/buster/cli
 
 Tags: 7.4.12-apache-buster, 7.4-apache-buster, 7-apache-buster, apache-buster, 7.4.12-apache, 7.4-apache, 7-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/buster/apache
 
 Tags: 7.4.12-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, fpm-buster, 7.4.12-fpm, 7.4-fpm, 7-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/buster/fpm
 
 Tags: 7.4.12-zts-buster, 7.4-zts-buster, 7-zts-buster, zts-buster, 7.4.12-zts, 7.4-zts, 7-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/buster/zts
 
 Tags: 7.4.12-cli-alpine3.12, 7.4-cli-alpine3.12, 7-cli-alpine3.12, cli-alpine3.12, 7.4.12-alpine3.12, 7.4-alpine3.12, 7-alpine3.12, alpine3.12, 7.4.12-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, cli-alpine, 7.4.12-alpine, 7.4-alpine, 7-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/alpine3.12/cli
 
 Tags: 7.4.12-fpm-alpine3.12, 7.4-fpm-alpine3.12, 7-fpm-alpine3.12, fpm-alpine3.12, 7.4.12-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/alpine3.12/fpm
 
 Tags: 7.4.12-zts-alpine3.12, 7.4-zts-alpine3.12, 7-zts-alpine3.12, zts-alpine3.12, 7.4.12-zts-alpine, 7.4-zts-alpine, 7-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/alpine3.12/zts
 
 Tags: 7.4.12-cli-alpine3.11, 7.4-cli-alpine3.11, 7-cli-alpine3.11, cli-alpine3.11, 7.4.12-alpine3.11, 7.4-alpine3.11, 7-alpine3.11, alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/alpine3.11/cli
 
 Tags: 7.4.12-fpm-alpine3.11, 7.4-fpm-alpine3.11, 7-fpm-alpine3.11, fpm-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/alpine3.11/fpm
 
 Tags: 7.4.12-zts-alpine3.11, 7.4-zts-alpine3.11, 7-zts-alpine3.11, zts-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dc9a6988d478fae0f0b8b871d10e611b50e3d0c
+GitCommit: fa268447c69a2ba855d4002e7b92a4a49ca3eae9
 Directory: 7.4/alpine3.11/zts
 
 Tags: 7.3.24-cli-buster, 7.3-cli-buster, 7.3.24-buster, 7.3-buster, 7.3.24-cli, 7.3-cli, 7.3.24, 7.3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/cf3943e: Merge pull request https://github.com/docker-library/php/pull/1088 from q0rban/1087-8.0-pear
- https://github.com/docker-library/php/commit/470ab97: Update put-shared link/badge
- https://github.com/docker-library/php/commit/03a9fae: Update templates.
- https://github.com/docker-library/php/commit/0fdd2f0: Configure PHP with pear/pecl installers for PHP 8.0 https://github.com/docker-library/php/pull/1087
- https://github.com/docker-library/php/commit/fa26844: Remove messages about pear being removed in PHP 8+.