### PR TITLE
node: update to 12.20.0 and 15.3.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,39 +3,39 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 15.2.1-alpine3.10, 15.2-alpine3.10, 15-alpine3.10, alpine3.10, current-alpine3.10
+Tags: 15.3.0-alpine3.10, 15.3-alpine3.10, 15-alpine3.10, alpine3.10, current-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/alpine3.10
 
-Tags: 15.2.1-alpine3.11, 15.2-alpine3.11, 15-alpine3.11, alpine3.11, current-alpine3.11, 15.2.1-alpine, 15.2-alpine, 15-alpine, alpine, current-alpine
+Tags: 15.3.0-alpine3.11, 15.3-alpine3.11, 15-alpine3.11, alpine3.11, current-alpine3.11, 15.3.0-alpine, 15.3-alpine, 15-alpine, alpine, current-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/alpine3.11
 
-Tags: 15.2.1-alpine3.12, 15.2-alpine3.12, 15-alpine3.12, alpine3.12, current-alpine3.12
+Tags: 15.3.0-alpine3.12, 15.3-alpine3.12, 15-alpine3.12, alpine3.12, current-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/alpine3.12
 
-Tags: 15.2.1-buster, 15.2-buster, 15-buster, buster, current-buster
+Tags: 15.3.0-buster, 15.3-buster, 15-buster, buster, current-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/buster
 
-Tags: 15.2.1-buster-slim, 15.2-buster-slim, 15-buster-slim, buster-slim, current-buster-slim
+Tags: 15.3.0-buster-slim, 15.3-buster-slim, 15-buster-slim, buster-slim, current-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/buster-slim
 
-Tags: 15.2.1-stretch, 15.2-stretch, 15-stretch, stretch, current-stretch, 15.2.1, 15.2, 15, latest, current
+Tags: 15.3.0-stretch, 15.3-stretch, 15-stretch, stretch, current-stretch, 15.3.0, 15.3, 15, latest, current
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/stretch
 
-Tags: 15.2.1-stretch-slim, 15.2-stretch-slim, 15-stretch-slim, stretch-slim, current-stretch-slim, 15.2.1-slim, 15.2-slim, 15-slim, slim, current-slim
+Tags: 15.3.0-stretch-slim, 15.3-stretch-slim, 15-stretch-slim, stretch-slim, current-stretch-slim, 15.3.0-slim, 15.3-slim, 15-slim, slim, current-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
 Directory: 15/stretch-slim
 
 Tags: 14.15.1-alpine3.10, 14.15-alpine3.10, 14-alpine3.10, fermium-alpine3.10, lts-alpine3.10
@@ -73,44 +73,44 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
 Directory: 14/stretch-slim
 
-Tags: 12.19.1-alpine3.10, 12.19-alpine3.10, 12-alpine3.10, erbium-alpine3.10
+Tags: 12.20.0-alpine3.10, 12.20-alpine3.10, 12-alpine3.10, erbium-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/alpine3.10
 
-Tags: 12.19.1-alpine3.11, 12.19-alpine3.11, 12-alpine3.11, erbium-alpine3.11, 12.19.1-alpine, 12.19-alpine, 12-alpine, erbium-alpine
+Tags: 12.20.0-alpine3.11, 12.20-alpine3.11, 12-alpine3.11, erbium-alpine3.11, 12.20.0-alpine, 12.20-alpine, 12-alpine, erbium-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/alpine3.11
 
-Tags: 12.19.1-alpine3.12, 12.19-alpine3.12, 12-alpine3.12, erbium-alpine3.12
+Tags: 12.20.0-alpine3.12, 12.20-alpine3.12, 12-alpine3.12, erbium-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/alpine3.12
 
-Tags: 12.19.1-alpine3.9, 12.19-alpine3.9, 12-alpine3.9, erbium-alpine3.9
+Tags: 12.20.0-alpine3.9, 12.20-alpine3.9, 12-alpine3.9, erbium-alpine3.9
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41ea0562287bbf98693572c9228edc1beb7fd709
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/alpine3.9
 
-Tags: 12.19.1-buster, 12.19-buster, 12-buster, erbium-buster
+Tags: 12.20.0-buster, 12.20-buster, 12-buster, erbium-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/buster
 
-Tags: 12.19.1-buster-slim, 12.19-buster-slim, 12-buster-slim, erbium-buster-slim
+Tags: 12.20.0-buster-slim, 12.20-buster-slim, 12-buster-slim, erbium-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/buster-slim
 
-Tags: 12.19.1-stretch, 12.19-stretch, 12-stretch, erbium-stretch, 12.19.1, 12.19, 12, erbium
+Tags: 12.20.0-stretch, 12.20-stretch, 12-stretch, erbium-stretch, 12.20.0, 12.20, 12, erbium
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/stretch
 
-Tags: 12.19.1-stretch-slim, 12.19-stretch-slim, 12-stretch-slim, erbium-stretch-slim, 12.19.1-slim, 12.19-slim, 12-slim, erbium-slim
+Tags: 12.20.0-stretch-slim, 12.20-stretch-slim, 12-stretch-slim, erbium-stretch-slim, 12.20.0-slim, 12.20-slim, 12-slim, erbium-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ba99d6d8dfa58fa4595ad3b23693d17fad05c44e
+GitCommit: ecab21f67543ce370cca404b925b21fdc35ea0b2
 Directory: 12/stretch-slim
 
 Tags: 10.23.0-alpine3.10, 10.23-alpine3.10, 10-alpine3.10, dubnium-alpine3.10


### PR DESCRIPTION
- https://nodejs.org/en/blog/release/v12.20.0/
- https://nodejs.org/en/blog/release/v15.3.0/

https://github.com/nodejs/docker-node/pull/1403