### PR TITLE
archlinux: Release 20201129.0.10056

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://github.com/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201123.0.9844
-GitCommit: cd2db9c68a43b280fd08aeb1b2b70fc9d4ccc37b
-GitFetch: refs/tags/v20201123.0.9844
+Tags: latest, base, base-20201129.0.10056
+GitCommit: bb88ba0ee69048511de789fa87a191ae4c176ff2
+GitFetch: refs/tags/v20201129.0.10056
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201123.0.9844
-GitCommit: cd2db9c68a43b280fd08aeb1b2b70fc9d4ccc37b
-GitFetch: refs/tags/v20201123.0.9844
+Tags: base-devel, base-devel-20201129.0.10056
+GitCommit: bb88ba0ee69048511de789fa87a191ae4c176ff2
+GitFetch: refs/tags/v20201129.0.10056
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
