### PR TITLE
Update Clear Linux OS to 33980

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c2963445171336a0f8277d322e7a0dc46af9b9c7
-GitFetch: refs/tags/clear-linux-33970
+GitCommit: 1e7a59d6eb1c318a2b13cf09eb5795443568b923
+GitFetch: refs/tags/clear-linux-33980


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 33980

@bryteise @mdhorn @karthikprabhu17