### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev1, 2.4-dev
+Tags: 2.4-dev2, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2352794b88adcac2c859d2afde832db50aeb2182
+GitCommit: ad7662656f2d2dc3218d2e3616c141956cb4a8d0
 Directory: 2.4-rc
 
-Tags: 2.4-dev1-alpine, 2.4-dev-alpine
+Tags: 2.4-dev2-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2352794b88adcac2c859d2afde832db50aeb2182
+GitCommit: ad7662656f2d2dc3218d2e3616c141956cb4a8d0
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.1, 2.3, latest
+Tags: 2.3.2, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f14d7fcdf03e79e106af443b947418ca0a1ad1f4
+GitCommit: ced45443a115fbcc9f170c5f71c19a2b227aeb1d
 Directory: 2.3
 
-Tags: 2.3.1-alpine, 2.3-alpine, alpine
+Tags: 2.3.2-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f14d7fcdf03e79e106af443b947418ca0a1ad1f4
+GitCommit: ced45443a115fbcc9f170c5f71c19a2b227aeb1d
 Directory: 2.3/alpine
 
-Tags: 2.2.5, 2.2, lts
+Tags: 2.2.6, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b808ca775382ae59e9ed3a43308fcbe62c1389c5
+GitCommit: acf4b709eac7a08c16ba7669ac76c46312033bb0
 Directory: 2.2
 
-Tags: 2.2.5-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.6-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1678bf37370bac8e3dc7a6b03d62c734bb7d58dc
+GitCommit: acf4b709eac7a08c16ba7669ac76c46312033bb0
 Directory: 2.2/alpine
 
 Tags: 2.1.10, 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/acf4b70: Update to 2.2.6
- https://github.com/docker-library/haproxy/commit/ced4544: Update to 2.3.2