### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.38.3, 3.38, 3, latest
+Tags: 3.39.0, 3.39, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d12d0cb7e452661f43aea1a6bd5554e028b6b5f4
+GitCommit: 66240c5a203c7882417c133c923f7ad26d8a6f4f
 Directory: 3/debian
 
-Tags: 3.38.3-alpine, 3.38-alpine, 3-alpine, alpine
+Tags: 3.39.0-alpine, 3.39-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d12d0cb7e452661f43aea1a6bd5554e028b6b5f4
+GitCommit: 66240c5a203c7882417c133c923f7ad26d8a6f4f
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/66240c5: Update to 3.39.0, ghost-cli 1.15.2