### PR TITLE
eclipse-mosquitto 2.0.0

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,7 +1,13 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 3a13205e5e7635fab23bc26ca3898fbfdeec4836
+GitCommit: 122e6ecfd3ec31084a4d25c1412b3d615c617148
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+
+Tags: 2.0.0, 2.0
+Directory: docker/2.0
+
+Tags: 2.0.0-openssl, 2.0-openssl
+Directory: docker/2.0-openssl
 
 Tags: 1.6.12, 1.6, latest
 Directory: docker/1.6

--- a/test/tests/eclipse-mosquitto-basics/mosquitto.conf
+++ b/test/tests/eclipse-mosquitto-basics/mosquitto.conf
@@ -1,0 +1,2 @@
+listener 1883
+allow_anonymous true


### PR DESCRIPTION
This is a new version of Mosquitto with breaking behaviour changes, hence the major version number change.

I've left the `latest` tag where it is right now on purpose and will move it at some point in the future. I presume there are people out there using `latest` when they really should be using a fixed tag and want to give them the chance to migrate.