### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/e21089424490fd2151f252e584429af3a45da9c0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/af5bd3dfba3b62f62d2dc133cfe9c47ae24ec18c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: e21089424490fd2151f252e584429af3a45da9c0
+GitCommit: af5bd3dfba3b62f62d2dc133cfe9c47ae24ec18c
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ce0c6e451f3a01c556b2275d71b2d2b812378f17
+amd64-GitCommit: 3a8b3f6d991fdce58339535827052b5ef2f0180e
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 3ba76ff43bf193f601f9ae06f1c2c52eb9509672
+arm32v5-GitCommit: 99e24443bc8ae215ecbb2fb1d97d71199ebbc7dc
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 8a9279b9232e3ca11896e15b2bdf8475485bc9a7
+arm32v6-GitCommit: 98baa8241c1011c4f8b1e1dbc57e9146feac2121
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: ed2d438aeca0385aa2464469d3d2b6ee742ca028
+arm32v7-GitCommit: 4b2e3e0cdf5e3c71579c0af5f4e9124b59437004
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 06434871c89cc0fc03881d51b9b01def7c89dacc
+arm64v8-GitCommit: 388459e808a2b5be8319afd0c7679cedfa17bffd
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: ff4a349c08f9f2104c8dc633e3c3e10f1099182b
+i386-GitCommit: 5c8368e98e2410059f21c4c68972b51013e6737d
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 342f1960ca66efc3c2d8a62c03b8e5a848de21fb
+mips64le-GitCommit: c13451376ff002bb28139ed07ae9ba84c18b84dd
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: aa71cb3e53d8795c47840535042f8a0fad4cb76c
+ppc64le-GitCommit: 74cba2d62d15243f77221afef46fef307d831743
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 2b3dc07b0714b8e380e0824b3ad30cb9801c9745
+s390x-GitCommit: c6b09b2b07ec49828c2c2d5dbb9d85642f02a195
 
 Tags: 1.32.0-uclibc, 1.32-uclibc, 1-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/af5bd3d: Update Buildroot to 2020.11