### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-26-jdk-oraclelinux8, 16-ea-26-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-26-jdk-oracle, 16-ea-26-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-26-jdk, 16-ea-26, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-27-jdk-oraclelinux8, 16-ea-27-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-27-jdk-oracle, 16-ea-27-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-27-jdk, 16-ea-27, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 8107dd6c8a2f42c91fd37904fdfe7d4c434ca5fc
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-26-jdk-oraclelinux7, 16-ea-26-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-27-jdk-oraclelinux7, 16-ea-27-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 8107dd6c8a2f42c91fd37904fdfe7d4c434ca5fc
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-26-jdk-buster, 16-ea-26-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-27-jdk-buster, 16-ea-27-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 8107dd6c8a2f42c91fd37904fdfe7d4c434ca5fc
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/buster
 
-Tags: 16-ea-26-jdk-slim-buster, 16-ea-26-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-26-jdk-slim, 16-ea-26-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-27-jdk-slim-buster, 16-ea-27-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-27-jdk-slim, 16-ea-27-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 8107dd6c8a2f42c91fd37904fdfe7d4c434ca5fc
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-23-jdk-alpine3.12, 16-ea-23-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-23-jdk-alpine, 16-ea-23-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -30,46 +30,46 @@ Architectures: amd64
 GitCommit: 66c01fe9c251c5e5f1fae75291af93270842c178
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-26-jdk-windowsservercore-1809, 16-ea-26-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-26-jdk-windowsservercore, 16-ea-26-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-26-jdk, 16-ea-26, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-27-jdk-windowsservercore-1809, 16-ea-27-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-27-jdk-windowsservercore, 16-ea-27-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-27-jdk, 16-ea-27, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: e619736ef49b4c836b468cd7dce184b76839bd0d
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-26-jdk-windowsservercore-ltsc2016, 16-ea-26-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-26-jdk-windowsservercore, 16-ea-26-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-26-jdk, 16-ea-26, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-27-jdk-windowsservercore-ltsc2016, 16-ea-27-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-27-jdk-windowsservercore, 16-ea-27-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-27-jdk, 16-ea-27, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: e619736ef49b4c836b468cd7dce184b76839bd0d
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-26-jdk-nanoserver-1809, 16-ea-26-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-26-jdk-nanoserver, 16-ea-26-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-27-jdk-nanoserver-1809, 16-ea-27-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-27-jdk-nanoserver, 16-ea-27-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: e619736ef49b4c836b468cd7dce184b76839bd0d
+GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 15.0.1-jdk-oraclelinux8, 15.0.1-oraclelinux8, 15.0-jdk-oraclelinux8, 15.0-oraclelinux8, 15-jdk-oraclelinux8, 15-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 15.0.1-jdk-oracle, 15.0.1-oracle, 15.0-jdk-oracle, 15.0-oracle, 15-jdk-oracle, 15-oracle, jdk-oracle, oracle
 SharedTags: 15.0.1-jdk, 15.0.1, 15.0-jdk, 15.0, 15-jdk, 15, jdk, latest
 Architectures: amd64, arm64v8
-GitCommit: 62e712df78c49e4a2e46cec127f2abba8506c715
+GitCommit: 4ae4d4e71b94eaec4887aa0f8a3273611dec5359
 Directory: 15/jdk/oraclelinux8
 
 Tags: 15.0.1-jdk-oraclelinux7, 15.0.1-oraclelinux7, 15.0-jdk-oraclelinux7, 15.0-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 62e712df78c49e4a2e46cec127f2abba8506c715
+GitCommit: 4ae4d4e71b94eaec4887aa0f8a3273611dec5359
 Directory: 15/jdk/oraclelinux7
 
 Tags: 15.0.1-jdk-buster, 15.0.1-buster, 15.0-jdk-buster, 15.0-buster, 15-jdk-buster, 15-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
-GitCommit: 62e712df78c49e4a2e46cec127f2abba8506c715
+GitCommit: 4ae4d4e71b94eaec4887aa0f8a3273611dec5359
 Directory: 15/jdk/buster
 
 Tags: 15.0.1-jdk-slim-buster, 15.0.1-slim-buster, 15.0-jdk-slim-buster, 15.0-slim-buster, 15-jdk-slim-buster, 15-slim-buster, jdk-slim-buster, slim-buster, 15.0.1-jdk-slim, 15.0.1-slim, 15.0-jdk-slim, 15.0-slim, 15-jdk-slim, 15-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 62e712df78c49e4a2e46cec127f2abba8506c715
+GitCommit: 4ae4d4e71b94eaec4887aa0f8a3273611dec5359
 Directory: 15/jdk/slim-buster
 
 Tags: 15.0.1-jdk-windowsservercore-1809, 15.0.1-windowsservercore-1809, 15.0-jdk-windowsservercore-1809, 15.0-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/c36d9b4: Update to 16-ea+27
- https://github.com/docker-library/openjdk/commit/e99679c: Update to 16-ea+26
- https://github.com/docker-library/openjdk/commit/4ae4d4e: Update to 15.0.1
- https://github.com/docker-library/openjdk/commit/3ac51aa: Update to 16-ea+26
- https://github.com/docker-library/openjdk/commit/01bbc86: Update to 15.0.1