### PR TITLE
Add bzip2 for diff-pr.sh

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -11,6 +11,8 @@ RUN set -eux; \
 		git \
 # gawk for diff-pr.sh
 		gawk \
+# tar -tf in diff-pr.sh
+		bzip2 \
 	; \
 	rm -rf /var/lib/apt/lists/*
 


### PR DESCRIPTION
Should fix build failures happening on https://github.com/docker-library/official-images/pull/9224