### PR TITLE
archlinux: Release 20201206.0.10501

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://github.com/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201129.0.10056
-GitCommit: bb88ba0ee69048511de789fa87a191ae4c176ff2
-GitFetch: refs/tags/v20201129.0.10056
+Tags: latest, base, base-20201206.0.10501
+GitCommit: 68b39814a97dba78c3bc5b64d7b97211a13076c7
+GitFetch: refs/tags/v20201206.0.10501
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201129.0.10056
-GitCommit: bb88ba0ee69048511de789fa87a191ae4c176ff2
-GitFetch: refs/tags/v20201129.0.10056
+Tags: base-devel, base-devel-20201206.0.10501
+GitCommit: 68b39814a97dba78c3bc5b64d7b97211a13076c7
+GitFetch: refs/tags/v20201206.0.10501
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
