### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.39.0, 3.39, 3, latest
+Tags: 3.39.2, 3.39, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 66240c5a203c7882417c133c923f7ad26d8a6f4f
+GitCommit: 4e13f4573c049eff193bf7f8fb61b9f1da483b9b
 Directory: 3/debian
 
-Tags: 3.39.0-alpine, 3.39-alpine, 3-alpine, alpine
+Tags: 3.39.2-alpine, 3.39-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 66240c5a203c7882417c133c923f7ad26d8a6f4f
+GitCommit: 4e13f4573c049eff193bf7f8fb61b9f1da483b9b
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4e13f45: Update to 3.39.2, ghost-cli 1.15.2