### PR TITLE
Update CentOS Linux images for the 8.3.2011 release

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -2,13 +2,13 @@ Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
 GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
 Directory: docker
 
-Tags: latest, centos8, 8
+Tags: latest, centos8, 8, centos8.3.2011, 8.3.2011
 GitFetch: refs/heads/CentOS-8-x86_64
-GitCommit: 12a4f1c0d78e257ce3d33fe89092eee07e6574da
+GitCommit: ccd17799397027acf9ee6d660e75b8fce4c852e8
 arm64v8-GitFetch: refs/heads/CentOS-8-aarch64
-arm64v8-GitCommit: 72306c7451107d95c82368e6faf9a58ae0a9c39b
+arm64v8-GitCommit: 88b3ec90d3e01f637cab87ad124e8917f60839af
 ppc64le-GitFetch: refs/heads/CentOS-8-ppc64le
-ppc64le-GitCommit: 35604e16d4d1c2c9195abdf39787508feb34c456
+ppc64le-GitCommit: cf1c88f0b706f6c6192e4e80ec8ec5be5c499eaa
 Architectures: amd64, arm64v8, ppc64le
 
 Tags: centos7, 7, centos7.9.2009, 7.9.2009


### PR DESCRIPTION
We have a new CentOS Linux Release today:
https://lists.centos.org/pipermail/centos-announce/2020-December/035874.html

Here are the latest images.

Signed-off-by: Brian Stinson <bstinson@centosproject.org>