### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.10-beta.1, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 29048054d08950d668ffaa893d9e27550bd24948
+GitCommit: 61bde14964280981fb12890d4614befc902da79a
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.10-beta.1-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.10-beta.1-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 29048054d08950d668ffaa893d9e27550bd24948
+GitCommit: 61bde14964280981fb12890d4614befc902da79a
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.10-beta.1-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7222c28f0957530d7746a10fb67a75920c0e6d1
+GitCommit: 093344023cb30eb36f05adaab3ae51bb939ee1ae
 Directory: 3.8/ubuntu
 
 Tags: 3.8.9-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.9-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7222c28f0957530d7746a10fb67a75920c0e6d1
+GitCommit: 093344023cb30eb36f05adaab3ae51bb939ee1ae
 Directory: 3.8/alpine
 
 Tags: 3.8.9-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/61bde14: Update to 3.8.10-beta.1, Erlang/OTP 23.1.5, OpenSSL 1.1.1i
- https://github.com/docker-library/rabbitmq/commit/0933440: Update to 3.8.9, Erlang/OTP 23.1.5, OpenSSL 1.1.1i