### PR TITLE
[flink] add 1.12 ; remove 1.10

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/apache/flink-docker/blob/11221b1fc63ccacff701ad5b86be7f9063aacee7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/apache/flink-docker/blob/f47f4a2e257279c4c28667e3ceff12bc5eb70afb/generate-stackbrew-library.sh
 
 Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
@@ -24,12 +24,22 @@ Architectures: amd64
 GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
 Directory: ./1.11/scala_2.12-java8-debian
 
-Tags: 1.10.2-scala_2.12, 1.10-scala_2.12, 1.10.2, 1.10
+Tags: 1.12.0-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
 Architectures: amd64
-GitCommit: 58a29fca7c6ff05999fad4371638d16335f7e93e
-Directory: ./1.10/scala_2.12-debian
+GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+Directory: ./1.12/scala_2.11-java11-debian
 
-Tags: 1.10.2-scala_2.11, 1.10-scala_2.11
+Tags: 1.12.0-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.0-scala_2.11, 1.12-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 58a29fca7c6ff05999fad4371638d16335f7e93e
-Directory: ./1.10/scala_2.11-debian
+GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+Directory: ./1.12/scala_2.11-java8-debian
+
+Tags: 1.12.0-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.0-java11, 1.12-java11, java11
+Architectures: amd64
+GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+Directory: ./1.12/scala_2.12-java11-debian
+
+Tags: 1.12.0-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.0-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.0-java8, 1.12-java8, java8, 1.12.0, 1.12, latest
+Architectures: amd64
+GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+Directory: ./1.12/scala_2.12-java8-debian


### PR DESCRIPTION

This might be a replacement for https://github.com/docker-library/official-images/pull/9243