### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -34,21 +34,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/buster
 
-Tags: jessie-curl, oldoldstable-curl
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: debian/jessie/curl
-
-Tags: jessie-scm, oldoldstable-scm
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: debian/jessie/scm
-
-Tags: jessie, oldoldstable
-Architectures: amd64, arm32v5, arm32v7, i386
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: debian/jessie
-
 Tags: sid-curl, unstable-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/92c215e: Merge pull request https://github.com/docker-library/buildpack-deps/pull/118 from infosiftr/jessie-eol
- https://github.com/docker-library/buildpack-deps/commit/aa985ad: Remove Debian Jessie (EOL)
- https://github.com/docker-library/buildpack-deps/commit/743fd8c: Update put-shared link/badge