### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.5.3-php7.2-apache, 5.5-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.5.3-php7.2, 5.5-php7.2, 5-php7.2, php7.2
+Tags: 5.6.0-php7.2-apache, 5.6-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.6.0-php7.2, 5.6-php7.2, 5-php7.2, php7.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.2/apache
 
-Tags: 5.5.3-php7.2-fpm, 5.5-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
+Tags: 5.6.0-php7.2-fpm, 5.6-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.2/fpm
 
-Tags: 5.5.3-php7.2-fpm-alpine, 5.5-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
+Tags: 5.6.0-php7.2-fpm-alpine, 5.6-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.2/fpm-alpine
 
-Tags: 5.5.3-php7.3-apache, 5.5-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.5.3-php7.3, 5.5-php7.3, 5-php7.3, php7.3
+Tags: 5.6.0-php7.3-apache, 5.6-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.6.0-php7.3, 5.6-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.3/apache
 
-Tags: 5.5.3-php7.3-fpm, 5.5-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.6.0-php7.3-fpm, 5.6-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.3/fpm
 
-Tags: 5.5.3-php7.3-fpm-alpine, 5.5-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.6.0-php7.3-fpm-alpine, 5.6-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.3/fpm-alpine
 
-Tags: 5.5.3-apache, 5.5-apache, 5-apache, apache, 5.5.3, 5.5, 5, latest, 5.5.3-php7.4-apache, 5.5-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.5.3-php7.4, 5.5-php7.4, 5-php7.4, php7.4
+Tags: 5.6.0-apache, 5.6-apache, 5-apache, apache, 5.6.0, 5.6, 5, latest, 5.6.0-php7.4-apache, 5.6-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.6.0-php7.4, 5.6-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.4/apache
 
-Tags: 5.5.3-fpm, 5.5-fpm, 5-fpm, fpm, 5.5.3-php7.4-fpm, 5.5-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.6.0-fpm, 5.6-fpm, 5-fpm, fpm, 5.6.0-php7.4-fpm, 5.6-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.4/fpm
 
-Tags: 5.5.3-fpm-alpine, 5.5-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.5.3-php7.4-fpm-alpine, 5.5-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.6.0-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.6.0-php7.4-fpm-alpine, 5.6-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5125491823651bcd691faf415d836f911fea09cd
+GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.4/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/5b53a06: Update to 5.6