### PR TITLE
Update clojure for latest leiningen & tools-deps releases

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,15 +2,15 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 1f877fe5d1b0638ba5e2b6a1d2f3b06b2c33b114
+GitCommit: 4b6fed5bb0506719213e7e09aaa17168940c9334
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.3, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.3-buster
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.5, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.5-buster
 Directory: target/openjdk-8-buster/lein
 
-Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.3-slim-buster
+Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.5-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
@@ -19,17 +19,17 @@ Directory: target/openjdk-8-buster/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.739, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.739-buster
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.754, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.754-buster
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.739-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.754-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.3, lein, lein-2.9.3, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.3-buster, lein-buster, lein-2.9.3-buster
+Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.5, lein, lein-2.9.5, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.5-buster, lein-buster, lein-2.9.5-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/lein
 
-Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.3-slim-buster, slim-buster, lein-slim-buster, lein-2.9.3-slim-buster
+Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.5-slim-buster, slim-buster, lein-slim-buster, lein-2.9.5-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/lein
 
@@ -41,18 +41,18 @@ Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.739, tools-deps, tools-deps-1.10.1.739, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.739-buster, tools-deps-buster, tools-deps-1.10.1.739-buster
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.754, tools-deps, tools-deps-1.10.1.754, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.754-buster, tools-deps-buster, tools-deps-1.10.1.754-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.739-slim-buster, tools-deps-1.10.1.739-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.754-slim-buster, tools-deps-1.10.1.754-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.3, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.3-slim-buster
+Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.5, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.5-slim-buster
 Directory: target/openjdk-15-slim-buster/lein
 
-Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.3-buster
+Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.5-buster
 Directory: target/openjdk-15-buster/lein
 
 Tags: openjdk-15-boot, openjdk-15-boot-2.8.3, openjdk-15-boot-slim-buster, openjdk-15-boot-2.8.3-slim-buster
@@ -61,16 +61,16 @@ Directory: target/openjdk-15-slim-buster/boot
 Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
 Directory: target/openjdk-15-buster/boot
 
-Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.739, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.739-slim-buster
+Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.754, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.754-slim-buster
 Directory: target/openjdk-15-slim-buster/tools-deps
 
-Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.739-buster
+Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.754-buster
 Directory: target/openjdk-15-buster/tools-deps
 
-Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.3, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.3-slim-buster
+Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.5, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.5-slim-buster
 Directory: target/openjdk-16-slim-buster/lein
 
-Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.3-buster
+Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.5-buster
 Directory: target/openjdk-16-buster/lein
 
 Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
@@ -79,17 +79,17 @@ Directory: target/openjdk-16-slim-buster/boot
 Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
 Directory: target/openjdk-16-buster/boot
 
-Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.739, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.739-slim-buster
+Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.754, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.754-slim-buster
 Directory: target/openjdk-16-slim-buster/tools-deps
 
-Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.739-buster
+Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.754-buster
 Directory: target/openjdk-16-buster/tools-deps
 
-Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.3-alpine
+Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.5-alpine
 Directory: target/openjdk-16-alpine/lein
 
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
 Directory: target/openjdk-16-alpine/boot
 
-Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.739-alpine
+Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.754-alpine
 Directory: target/openjdk-16-alpine/tools-deps


### PR DESCRIPTION
Two upstream clojure tooling releases:

- Leiningen 2.9.5
- tools-deps 1.10.1.754