### PR TITLE
Update node.js v15 from v15.3.0 to v15.4.0

### DIFF
--- a/library/node
+++ b/library/node
@@ -3,39 +3,39 @@
 Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@nodejs)
 GitRepo: https://github.com/nodejs/docker-node.git
 
-Tags: 15.3.0-alpine3.10, 15.3-alpine3.10, 15-alpine3.10, alpine3.10, current-alpine3.10
+Tags: 15.4.0-alpine3.10, 15.4-alpine3.10, 15-alpine3.10, alpine3.10, current-alpine3.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/alpine3.10
 
-Tags: 15.3.0-alpine3.11, 15.3-alpine3.11, 15-alpine3.11, alpine3.11, current-alpine3.11, 15.3.0-alpine, 15.3-alpine, 15-alpine, alpine, current-alpine
+Tags: 15.4.0-alpine3.11, 15.4-alpine3.11, 15-alpine3.11, alpine3.11, current-alpine3.11, 15.4.0-alpine, 15.4-alpine, 15-alpine, alpine, current-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/alpine3.11
 
-Tags: 15.3.0-alpine3.12, 15.3-alpine3.12, 15-alpine3.12, alpine3.12, current-alpine3.12
+Tags: 15.4.0-alpine3.12, 15.4-alpine3.12, 15-alpine3.12, alpine3.12, current-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/alpine3.12
 
-Tags: 15.3.0-buster, 15.3-buster, 15-buster, buster, current-buster
+Tags: 15.4.0-buster, 15.4-buster, 15-buster, buster, current-buster
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/buster
 
-Tags: 15.3.0-buster-slim, 15.3-buster-slim, 15-buster-slim, buster-slim, current-buster-slim
+Tags: 15.4.0-buster-slim, 15.4-buster-slim, 15-buster-slim, buster-slim, current-buster-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/buster-slim
 
-Tags: 15.3.0-stretch, 15.3-stretch, 15-stretch, stretch, current-stretch, 15.3.0, 15.3, 15, latest, current
+Tags: 15.4.0-stretch, 15.4-stretch, 15-stretch, stretch, current-stretch, 15.4.0, 15.4, 15, latest, current
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/stretch
 
-Tags: 15.3.0-stretch-slim, 15.3-stretch-slim, 15-stretch-slim, stretch-slim, current-stretch-slim, 15.3.0-slim, 15.3-slim, 15-slim, slim, current-slim
+Tags: 15.4.0-stretch-slim, 15.4-stretch-slim, 15-stretch-slim, stretch-slim, current-stretch-slim, 15.4.0-slim, 15.4-slim, 15-slim, slim, current-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 36c93521a25730e203a55b18c4ad73f980874a0a
+GitCommit: dd05dd89c6e158a4893109e42d51cd0f5065d631
 Directory: 15/stretch-slim
 
 Tags: 14.15.1-alpine3.10, 14.15-alpine3.10, 14-alpine3.10, fermium-alpine3.10, lts-alpine3.10


### PR DESCRIPTION
Reference:

- https://github.com/nodejs/docker-node/pull/1406
- https://nodejs.org/en/blog/release/v15.4.0/
- https://github.com/nodejs/node/releases/tag/v15.4.0
- https://github.com/nodejs/node/blob/master/doc/changelogs/CHANGELOG_V15.md#15.4.0