### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.39.3, 3.39, 3, latest
+Tags: 3.40.0, 3.40, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c87e92c8021a6ba40815cbbe855c9031cde4a72f
+GitCommit: 7f2cc223f2173b9dfdbfe5d6b5113ff457ad926a
 Directory: 3/debian
 
-Tags: 3.39.3-alpine, 3.39-alpine, 3-alpine, alpine
+Tags: 3.40.0-alpine, 3.40-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: c87e92c8021a6ba40815cbbe855c9031cde4a72f
+GitCommit: 7f2cc223f2173b9dfdbfe5d6b5113ff457ad926a
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 705e1d8724e478a93fbb76b6cfdf670d86f01d9e
+GitCommit: 3eeb98378c4664f4f7813c3d45bfeee26d51ce58
 Directory: 2/debian
 
 Tags: 2.38.2-alpine, 2.38-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386
-GitCommit: 705e1d8724e478a93fbb76b6cfdf670d86f01d9e
+GitCommit: 3eeb98378c4664f4f7813c3d45bfeee26d51ce58
 Directory: 2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/34a95e7: Update to 3.39.3, ghost-cli 1.15.3
- https://github.com/docker-library/ghost/commit/3eeb983: Update to 2.38.2, ghost-cli 1.15.3