### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev2, 2.4-dev
+Tags: 2.4-dev3, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ad7662656f2d2dc3218d2e3616c141956cb4a8d0
+GitCommit: 71238cd04e38aad1f218e9b24ec2517f5d11f825
 Directory: 2.4-rc
 
-Tags: 2.4-dev2-alpine, 2.4-dev-alpine
+Tags: 2.4-dev3-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad7662656f2d2dc3218d2e3616c141956cb4a8d0
+GitCommit: 71238cd04e38aad1f218e9b24ec2517f5d11f825
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.2, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/71238cd: Update to 2.4-dev3