### PR TITLE
caddy: v2.3.0-rc.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/66905660327fd16a9d95c95da1e59a3302493dc8/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/253a295b9dde0448fb447ef6802efc7d4474a500/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.1.1-alpine
@@ -92,6 +92,52 @@ SharedTags: 2.2.1-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.2/windows-builder/ltsc2016
 GitCommit: 66905660327fd16a9d95c95da1e59a3302493dc8
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2016
+
+Tags: 2.3.0-rc.1-alpine
+SharedTags: 2.3.0-rc.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.3/alpine
+GitCommit: 253a295b9dde0448fb447ef6802efc7d4474a500
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.3.0-rc.1-builder-alpine
+SharedTags: 2.3.0-rc.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.3/builder
+GitCommit: 253a295b9dde0448fb447ef6802efc7d4474a500
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.3.0-rc.1-windowsservercore-1809
+SharedTags: 2.3.0-rc.1-windowsservercore, 2.3.0-rc.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.3/windows/1809
+GitCommit: 253a295b9dde0448fb447ef6802efc7d4474a500
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.3.0-rc.1-windowsservercore-ltsc2016
+SharedTags: 2.3.0-rc.1-windowsservercore, 2.3.0-rc.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.3/windows/ltsc2016
+GitCommit: 253a295b9dde0448fb447ef6802efc7d4474a500
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2016
+
+Tags: 2.3.0-rc.1-builder-windowsservercore-1809
+SharedTags: 2.3.0-rc.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.3/windows-builder/1809
+GitCommit: 253a295b9dde0448fb447ef6802efc7d4474a500
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.3.0-rc.1-builder-windowsservercore-ltsc2016
+SharedTags: 2.3.0-rc.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.3/windows-builder/ltsc2016
+GitCommit: 253a295b9dde0448fb447ef6802efc7d4474a500
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
This is the first RC for Caddy v2.3.0.

Release notes: https://github.com/caddyserver/caddy/releases/tag/v2.3.0-rc.1
Upstream PR: https://github.com/caddyserver/caddy-docker/pull/134

When v2.3.0 releases, I'll remove the v2.1 tags from the manifest.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>