### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 16-ea-27-jdk-oraclelinux8, 16-ea-27-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-27-jdk-oracle, 16-ea-27-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-27-jdk, 16-ea-27, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-28-jdk-oraclelinux8, 16-ea-28-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-28-jdk-oracle, 16-ea-28-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-28-jdk, 16-ea-28, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-27-jdk-oraclelinux7, 16-ea-27-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-28-jdk-oraclelinux7, 16-ea-28-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-27-jdk-buster, 16-ea-27-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-28-jdk-buster, 16-ea-28-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/buster
 
-Tags: 16-ea-27-jdk-slim-buster, 16-ea-27-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-27-jdk-slim, 16-ea-27-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-28-jdk-slim-buster, 16-ea-28-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-28-jdk-slim, 16-ea-28-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-23-jdk-alpine3.12, 16-ea-23-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-23-jdk-alpine, 16-ea-23-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -30,24 +30,24 @@ Architectures: amd64
 GitCommit: 66c01fe9c251c5e5f1fae75291af93270842c178
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-27-jdk-windowsservercore-1809, 16-ea-27-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-27-jdk-windowsservercore, 16-ea-27-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-27-jdk, 16-ea-27, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-28-jdk-windowsservercore-1809, 16-ea-28-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-28-jdk-windowsservercore, 16-ea-28-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-28-jdk, 16-ea-28, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-27-jdk-windowsservercore-ltsc2016, 16-ea-27-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-27-jdk-windowsservercore, 16-ea-27-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-27-jdk, 16-ea-27, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-28-jdk-windowsservercore-ltsc2016, 16-ea-28-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-28-jdk-windowsservercore, 16-ea-28-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-28-jdk, 16-ea-28, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-27-jdk-nanoserver-1809, 16-ea-27-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-27-jdk-nanoserver, 16-ea-27-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-28-jdk-nanoserver-1809, 16-ea-28-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-28-jdk-nanoserver, 16-ea-28-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: c36d9b4503ac210755879d4ac85de4ec4143bc38
+GitCommit: d742dd354b3c6c59559d0544ced2cecbbc96ea7b
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/d742dd3: Update to 16-ea+28