### PR TITLE
arangodb 3.7.5

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -9,6 +9,6 @@ Tags: 3.6, 3.6.9
 GitCommit: dd22fb0b6c3e356edd6e722551ab79515898aa55
 Directory: alpine/3.6.9
 
-Tags: 3.7, 3.7.3, latest
-GitCommit: d65e5fd722b6e3263aa0379216e5871c3a3e77d3
-Directory: alpine/3.7.3
+Tags: 3.7, 3.7.5, latest
+GitCommit: 69b34f38c24fe43521a7f265a9110396d869cfec
+Directory: alpine/3.7.5


### PR DESCRIPTION
Updated ArangoDB 3.7 to 3.7.5.