### PR TITLE
Add Official GridDB Image

### DIFF
--- a/library/griddb
+++ b/library/griddb
@@ -1,0 +1,7 @@
+Maintainers: Katsuhiko Nonomura <katsuhiko.nonomura@griddb.org> (@knonomura)
+GitRepo: https://github.com/griddb/griddb-docker.git
+
+Tags: latest, 4.5.2-bionic, 4.5.2-centos7
+Architectures: amd64
+GitCommit: 0840c3334a1166bfe5618b512ddf2e6164d5a923
+Directory: griddb


### PR DESCRIPTION
> Hello,
> We would like to add an official image for our GridDB.
>
> * [x] associated with or contacted upstream? Yes https://github.com/griddb/griddb-docker
> * [x] does it fit into one of the common categories? ("service", "language stack", "base distribution") (yes, "service")
> * [x] is it reasonably popular, or does it solve a particular use case well? (yes, griddb solve about database)
> * [ ]  does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
> * [x] dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
> * [ ]  2+ dockerization review?
> * [x]  existing official images have been considered as a base? (yes, we use `FROM ubuntu:18.04` and `FROM centos7.8.2003` for the base)
> * [x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
> * [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
