### PR TITLE
Bump Traefik to v2.4.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,33 +1,46 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.3.5-windowsservercore-1809, 2.3.5-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
-GitRepo: https://github.com/traefik/traefik-library-image.git
+Tags: v2.4.0-rc1-windowsservercore-1809, 2.4.0-rc1-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809
 Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: e3a11c7578f6cbc690f64a964f794f604840a4bf
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.4.0-rc1, 2.4.0-rc1, v2.4, 2.4, livarot
+Architectures: amd64, arm32v6, arm64v8
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: e3a11c7578f6cbc690f64a964f794f604840a4bf
+Directory: alpine
+
+Tags: v2.3.5-windowsservercore-1809, 2.3.5-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: d1233fc2eb8fa09950515598dfa34c70c69b260b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.3.5, 2.3.5, v2.3, 2.3, picodon, latest
-GitRepo: https://github.com/traefik/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
+GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: d1233fc2eb8fa09950515598dfa34c70c69b260b
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
-GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: windows-amd64
+GitRepo: https://github.com/containous/traefik-library-image.git
 GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v1.7.26-alpine, 1.7.26-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
-GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
+GitRepo: https://github.com/containous/traefik-library-image.git
 GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: alpine
 
 Tags: v1.7.26, 1.7.26, v1.7, 1.7, maroilles
-GitRepo: https://github.com/containous/traefik-library-image.git
 Architectures: amd64, arm32v6, arm64v8
+GitRepo: https://github.com/containous/traefik-library-image.git
 GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
 Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.0-rc1](https://github.com/traefik/traefik/releases/tag/v2.4.0-rc1).

/cc @rtribotte @SantoDE @jbdoumenjou

Cheers
