### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.10-beta.1, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 61bde14964280981fb12890d4614befc902da79a
+GitCommit: b16299d4f95aa18fd0b3a8ae45f788af9b029af8
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.10-beta.1-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.10-beta.1-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 61bde14964280981fb12890d4614befc902da79a
+GitCommit: b16299d4f95aa18fd0b3a8ae45f788af9b029af8
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.10-beta.1-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 093344023cb30eb36f05adaab3ae51bb939ee1ae
+GitCommit: 272329906f928c6431fff5c2c21b9ecccf75992d
 Directory: 3.8/ubuntu
 
 Tags: 3.8.9-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.9-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 093344023cb30eb36f05adaab3ae51bb939ee1ae
+GitCommit: 272329906f928c6431fff5c2c21b9ecccf75992d
 Directory: 3.8/alpine
 
 Tags: 3.8.9-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2723299: Update to 3.8.9, Erlang/OTP 23.2, OpenSSL 1.1.1i
- https://github.com/docker-library/rabbitmq/commit/b16299d: Update to 3.8.10-beta.1, Erlang/OTP 23.2, OpenSSL 1.1.1i