### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.40.1, 3.40, 3, latest
+Tags: 3.40.2, 3.40, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25c66b1aa223707b6e23771593cc282e1428d0ab
+GitCommit: 88f1a1c6d990ebfa5a71c417613ea9b592aec321
 Directory: 3/debian
 
-Tags: 3.40.1-alpine, 3.40-alpine, 3-alpine, alpine
+Tags: 3.40.2-alpine, 3.40-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 25c66b1aa223707b6e23771593cc282e1428d0ab
+GitCommit: 88f1a1c6d990ebfa5a71c417613ea9b592aec321
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/88f1a1c: Update to 3.40.2, ghost-cli 1.15.3