### PR TITLE
[update] Update Oracle Linux 7 images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0ea52ec02766faf5863ac51e86adecb74af134e4
+amd64-GitCommit: f71dbcc736321d1ece62680b655ba0d83007a593
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 378d013708b8ae351cc9b603d2f90e058726acdd
+arm64v8-GitCommit: 27ca376c37963f43180e5bc81b79745fdffdbd35
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Fix [CVE-2016-5766](https://linux.oracle.com/cve/CVE-2016-5766.html) via [ELSA-2020-5443 - gd security update](https://linux.oracle.com/errata/ELSA-2020-5443.html).

Signed-off-by: Avi Miller <avi.miller@oracle.com>