### PR TITLE
Updating Couchbase Server EE to 6.6.1

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -9,9 +9,9 @@ Tags: community-7.0.0-beta
 GitCommit: de4d4fe41f6ac64a8640d4b7942808d959da1484
 Directory: community/couchbase-server/7.0.0-beta
 
-Tags: latest, enterprise, 6.6.0, enterprise-6.6.0
-GitCommit: f0ab8e5c7fc1091465097dc231cd5586f3eb7355
-Directory: enterprise/couchbase-server/6.6.0
+Tags: latest, enterprise, 6.6.1, enterprise-6.6.1
+GitCommit: 323dcfd696fd3b64aa92697c86f58c2e30cb8f82
+Directory: enterprise/couchbase-server/6.6.1
 
 Tags: community, community-6.6.0
 GitCommit: 78cbcaa2c90ce4c975299e7cbfdce146a7bab081


### PR DESCRIPTION
I'm afraid this PR will still likely fail validation as it has in the past. Something about our image doesn't like GitHub Actions. :(