### PR TITLE
Bump Traefik to v2.3.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e3a11c7578f6cbc690f64a964f794f604840a4bf
 Directory: alpine
 
-Tags: v2.3.5-windowsservercore-1809, 2.3.5-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.3.6-windowsservercore-1809, 2.3.6-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: d1233fc2eb8fa09950515598dfa34c70c69b260b
+GitCommit: 52997b0fdb3c358e0eb73ff1f999e0359e15909e
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.5, 2.3.5, v2.3, 2.3, picodon, latest
+Tags: v2.3.6, 2.3.6, v2.3, 2.3, picodon, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: d1233fc2eb8fa09950515598dfa34c70c69b260b
+GitCommit: 52997b0fdb3c358e0eb73ff1f999e0359e15909e
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.3.6](https://github.com/traefik/traefik/releases/tag/v2.3.6).

/cc @ldez @jbdoumenjou @SantoDE

Cheers
