### PR TITLE
[oraclelinux] Update Oracle Linux 8 images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f71dbcc736321d1ece62680b655ba0d83007a593
+amd64-GitCommit: f15fb4a80ab23978c9e641e0f2de692538d31c9f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 27ca376c37963f43180e5bc81b79745fdffdbd35
+arm64v8-GitCommit: 671abb4c8e184c554df5997ae4d2cc28680cc0d1
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Fix [CVE-2020-1971](https://linux.oracle.com/cve/CVE-2020-1971.html) via [ELSA-2020-5476 - openssl security and bug fix update](https://linux.oracle.com/errata/ELSA-2020-5476.html)

Signed-off-by: Avi Miller <avi.miller@oracle.com>