### PR TITLE
Update Rocket.Chat 3.9 and add 3.8 and 3.7

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,13 +1,21 @@
-# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/9d6297118afd4a6b494b1b82cb4dc7f58e83e45d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/7adc64d3cf133ef950b8904083714452dd3e4458/generate-stackbrew-library.sh
 
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 3.9.1, 3.9, 3, latest
-GitCommit: 6abd2f7d579284e227198262859ac54ea75e24ec
-Directory: 3
+Tags: 3.9.2, 3.9, 3, latest
+GitCommit: 6991e8547c95e61235f351facb0c1f4ad727ec52
+Directory: 3.9
+
+Tags: 3.8.3, 3.8
+GitCommit: 648c6d66da0421a344368c8861285bbf83590c7a
+Directory: 3.8
+
+Tags: 3.7.3, 3.7
+GitCommit: 648c6d66da0421a344368c8861285bbf83590c7a
+Directory: 3.7
 
 Tags: 2.4.13, 2.4, 2
-GitCommit: 6abd2f7d579284e227198262859ac54ea75e24ec
-Directory: 2
+GitCommit: 648c6d66da0421a344368c8861285bbf83590c7a
+Directory: 2.4
 


### PR DESCRIPTION
We decided to build Docker images for all our current supported versions (the last 3 minor according to https://docs.rocket.chat/getting-support) so I've create other folders and Dockerfiles to support that.