### PR TITLE
Transfer jruby library maintenance to JRuby team

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -1,5 +1,7 @@
-Maintainers: Brian Goff <cpuguy83@gmail.com> (@cpuguy83)
-GitRepo: https://github.com/cpuguy83/docker-jruby.git
+Maintainers: JRuby Admin <admin@jruby.org> (@jruby),
+             Charles Oliver Nutter <headius@headius.com> (@headius),
+             Thomas E Enebo <tom.enebo@gmail.com> (@enebo)
+GitRepo: https://github.com/jruby/docker-jruby.git
 GitFetch: refs/heads/master
 GitCommit: 510284ff5ffbb257937d755a9d351e9df50ba31b
 


### PR DESCRIPTION
The JRuby team will be taking over maintenance of the official `jruby` image as per https://github.com/jruby/jruby/issues/5598

The admin@jruby.org email goes to the two co-leads of the project responsible for releases and administration, me (@headius) and Tom Enebo (@enebo).

This does not reflect the pending update of the images to JRuby 9.2.14.0 by the previous maintainer @cpuguy83: https://github.com/docker-library/official-images/pull/9318