### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,21 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.6.0-php7.2-apache, 5.6-php7.2-apache, 5-php7.2-apache, php7.2-apache, 5.6.0-php7.2, 5.6-php7.2, 5-php7.2, php7.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
-Directory: php7.2/apache
-
-Tags: 5.6.0-php7.2-fpm, 5.6-php7.2-fpm, 5-php7.2-fpm, php7.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
-Directory: php7.2/fpm
-
-Tags: 5.6.0-php7.2-fpm-alpine, 5.6-php7.2-fpm-alpine, 5-php7.2-fpm-alpine, php7.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
-Directory: php7.2/fpm-alpine
-
 Tags: 5.6.0-php7.3-apache, 5.6-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.6.0-php7.3, 5.6-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
@@ -50,11 +35,6 @@ GitCommit: 5b53a06ca346a2396f2e0373959314c5c9c73e04
 Directory: php7.4/fpm-alpine
 
 # Now, wp-cli variants (which do _not_ include WordPress, so no WordPress version number -- only wp-cli version)
-
-Tags: cli-2.4.0-php7.2, cli-2.4-php7.2, cli-2-php7.2, cli-php7.2
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0d11ed412fef07e748a5463041b7be0b5755dd6
-Directory: php7.2/cli
 
 Tags: cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/c3460db: Remove PHP 7.2 (EOL)