### PR TITLE
archlinux: Release 20201220.0.11678

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://github.com/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201213.0.11146
-GitCommit: f70853f3a094e3c17b37c5d5aabda2ac713deb95
-GitFetch: refs/tags/v20201213.0.11146
+Tags: latest, base, base-20201220.0.11678
+GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc
+GitFetch: refs/tags/v20201220.0.11678
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201213.0.11146
-GitCommit: f70853f3a094e3c17b37c5d5aabda2ac713deb95
-GitFetch: refs/tags/v20201213.0.11146
+Tags: base-devel, base-devel-20201220.0.11678
+GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc
+GitFetch: refs/tags/v20201220.0.11678
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
