### PR TITLE
Update mediawiki to 1.35.1 and 1.31.12

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,16 +2,16 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 7fb7a88b3dd745fdd1115ad701a1e5f5c6236420
+GitCommit: 13b8f2e3b19f04c2bf40b29786f605e918954b76
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.35.0, 1.35, lts, stable, latest
+Tags: 1.35.1, 1.35, lts, stable, latest
 Directory: 1.35/apache
 
-Tags: 1.35.0-fpm, 1.35-fpm, lts-fpm, stable-fpm
+Tags: 1.35.1-fpm, 1.35-fpm, lts-fpm, stable-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.0-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, stable-fpm-alpine
+Tags: 1.35.1-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 
@@ -25,12 +25,12 @@ Tags: 1.34.4-fpm-alpine, 1.34-fpm-alpine, legacy-fpm-alpline
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.34/fpm-alpine
 
-Tags: 1.31.10, 1.31, legacylts
+Tags: 1.31.12, 1.31, legacylts
 Directory: 1.31/apache
 
-Tags: 1.31.10-fpm, 1.31-fpm, legacylts-fpm
+Tags: 1.31.12-fpm, 1.31-fpm, legacylts-fpm
 Directory: 1.31/fpm
 
-Tags: 1.31.10-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.31.12-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.31/fpm-alpine

--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,7 +2,7 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 13b8f2e3b19f04c2bf40b29786f605e918954b76
+GitCommit: 38d4e7f77f8b5b4efda91f969ccba2475fc2c597
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 Tags: 1.35.1, 1.35, lts, stable, latest


### PR DESCRIPTION
Update Mediawiki to the latest releases:
https://lists.wikimedia.org/pipermail/mediawiki-announce/2020-December/000268.html
https://lists.wikimedia.org/pipermail/mediawiki-announce/2020-December/000269.html﻿

Closes wikimedia/mediawiki-docker#89
