### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev3, 2.4-dev
+Tags: 2.4-dev4, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71238cd04e38aad1f218e9b24ec2517f5d11f825
+GitCommit: 1c9d1b10168462a3aeaa6a8b8d56ea160302b745
 Directory: 2.4-rc
 
-Tags: 2.4-dev3-alpine, 2.4-dev-alpine
+Tags: 2.4-dev4-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71238cd04e38aad1f218e9b24ec2517f5d11f825
+GitCommit: 1c9d1b10168462a3aeaa6a8b8d56ea160302b745
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.2, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/1c9d1b1: Update to 2.4-dev4