### PR TITLE
[oraclelinux] Update Oracle Linux 7 images for CVE-2020-1971

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f15fb4a80ab23978c9e641e0f2de692538d31c9f
+amd64-GitCommit: fbf2fbd291036ba1cc2b407f287bec9f547863c7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 671abb4c8e184c554df5997ae4d2cc28680cc0d1
+arm64v8-GitCommit: 7daf0e74bd152f07663479136d40b6ab26828f1e
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See https://linux.oracle.com/errata/ELSA-2020-5566-1.html for details. 

It seems the images pushed via https://github.com/docker-library/official-images/pull/9301 didn't have the updated `openssl-libs` packages.

Signed-off-by: Avi Miller <avi.miller@oracle.com>