### PR TITLE
archlinux: Release 20201220.0.11678 with GitLab Repository

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -4,7 +4,7 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Christian Rebischke <Chris.Rebischke@archlinux.org> (@shibumi),
              Pierre Schmitz <pierre@archlinux.de> (@pierres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
-GitRepo: https://github.com/archlinux/archlinux-docker.git
+GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
 Tags: latest, base, base-20201220.0.11678
 GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc

--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://github.com/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201213.0.11146
-GitCommit: f70853f3a094e3c17b37c5d5aabda2ac713deb95
-GitFetch: refs/tags/v20201213.0.11146
+Tags: latest, base, base-20201220.0.11678
+GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc
+GitFetch: refs/tags/v20201220.0.11678
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201213.0.11146
-GitCommit: f70853f3a094e3c17b37c5d5aabda2ac713deb95
-GitFetch: refs/tags/v20201213.0.11146
+Tags: base-devel, base-devel-20201220.0.11678
+GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc
+GitFetch: refs/tags/v20201220.0.11678
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

The release was automatic [1], but the GitRepo change was done manually. This PR tests the possibility to change the `GitRepo` to a GitLab repository, see [2] and [3]. 

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
[2] https://github.com/docker-library/official-images/pull/9325#discussion_r546887606
[3] https://github.com/docker-library/docs/pull/1854

Closes #9325