### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,40 +1,40 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/27938afac28fcb1fc167ddf6ee15520e88d90259/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/f5aa18521c3b73f92ae340d14dc9d24555d02f43/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.0.0-rc1-buster, 3.0-rc-buster, 3.0.0-rc1, 3.0-rc
+Tags: 3.0.0-buster, 3.0-buster, 3-buster, buster, 3.0.0, 3.0, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cb97d24839bb1b446f55fac5e14573e62a94d6b2
-Directory: 3.0-rc/buster
+GitCommit: 921f2e68671461785e822aa437b68433278263b9
+Directory: 3.0/buster
 
-Tags: 3.0.0-rc1-slim-buster, 3.0-rc-slim-buster, 3.0.0-rc1-slim, 3.0-rc-slim
+Tags: 3.0.0-slim-buster, 3.0-slim-buster, 3-slim-buster, slim-buster, 3.0.0-slim, 3.0-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cb97d24839bb1b446f55fac5e14573e62a94d6b2
-Directory: 3.0-rc/buster/slim
+GitCommit: 921f2e68671461785e822aa437b68433278263b9
+Directory: 3.0/buster/slim
 
-Tags: 3.0.0-rc1-alpine3.12, 3.0-rc-alpine3.12, 3.0.0-rc1-alpine, 3.0-rc-alpine
+Tags: 3.0.0-alpine3.12, 3.0-alpine3.12, 3-alpine3.12, alpine3.12, 3.0.0-alpine, 3.0-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cb97d24839bb1b446f55fac5e14573e62a94d6b2
-Directory: 3.0-rc/alpine3.12
+GitCommit: 921f2e68671461785e822aa437b68433278263b9
+Directory: 3.0/alpine3.12
 
-Tags: 2.7.2-buster, 2.7-buster, 2-buster, buster, 2.7.2, 2.7, 2, latest
+Tags: 2.7.2-buster, 2.7-buster, 2-buster, 2.7.2, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/buster
 
-Tags: 2.7.2-slim-buster, 2.7-slim-buster, 2-slim-buster, slim-buster, 2.7.2-slim, 2.7-slim, 2-slim, slim
+Tags: 2.7.2-slim-buster, 2.7-slim-buster, 2-slim-buster, 2.7.2-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/buster/slim
 
-Tags: 2.7.2-alpine3.12, 2.7-alpine3.12, 2-alpine3.12, alpine3.12, 2.7.2-alpine, 2.7-alpine, 2-alpine, alpine
+Tags: 2.7.2-alpine3.12, 2.7-alpine3.12, 2-alpine3.12, 2.7.2-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/alpine3.12
 
-Tags: 2.7.2-alpine3.11, 2.7-alpine3.11, 2-alpine3.11, alpine3.11
+Tags: 2.7.2-alpine3.11, 2.7-alpine3.11, 2-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5a4e2d8d9fae6681ac3e2344eac547f0e2cdc598
 Directory: 2.7/alpine3.11


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/cf2a6f3: Merge pull request https://github.com/docker-library/ruby/pull/333 from mtsmfm/3-0-stackbrew
- https://github.com/docker-library/ruby/commit/f5aa185: Update generate-stackbrew-library.sh for Ruby 3.0
- https://github.com/docker-library/ruby/commit/eceb2e6: Merge pull request https://github.com/docker-library/ruby/pull/332 from mtsmfm/3-0
- https://github.com/docker-library/ruby/commit/921f2e6: Ruby 3.0.0 is released