### PR TITLE
[oraclelinux] Update Oracle Linux images with new tzdata

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,14 +4,14 @@ GitCommit: 01a15ec99c7470a3391c691509db1759b41eaf66
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fbf2fbd291036ba1cc2b407f287bec9f547863c7
+amd64-GitCommit: 771e29f60d613a998545d5f2404e2f189f2722c5
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7daf0e74bd152f07663479136d40b6ab26828f1e
+arm64v8-GitCommit: b3619605fbd80be098075a973ba93452d0197361
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8
-Directory: 8.3
+Directory: 8
 
 Tags: 8-slim
 Architectures: amd64, arm64v8
@@ -19,7 +19,7 @@ Directory: 8-slim
 
 Tags: 7.9, 7
 Architectures: amd64, arm64v8
-Directory: 7.9
+Directory: 7
 
 Tags: 7-slim
 Architectures: amd64, arm64v8
@@ -27,7 +27,7 @@ Directory: 7-slim
 
 Tags: 6.10, 6
 Architectures: amd64
-Directory: 6.10
+Directory: 6
 
 Tags: 6-slim
 Architectures: amd64


### PR DESCRIPTION
See https://linux.oracle.com/errata/ELBA-2021-0013.html for details.

We've also done some minor housekeeping of the repo that holds the
archives.

Signed-off-by: Avi Miller <avi.miller@oracle.com>