### PR TITLE
Add arm64v8 support to clojure:latest

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -5,6 +5,7 @@ GitRepo: https://github.com/Quantisan/docker-clojure.git
 GitCommit: 418a20e619eac56a317997aa5b8f975c154e44b6
 
 Tags: latest
+Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/latest
 
 Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.5, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.5-buster

--- a/library/clojure
+++ b/library/clojure
@@ -51,46 +51,61 @@ Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/tools-deps
 
 Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.5, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.5-slim-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-15-slim-buster/lein
 
 Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.5-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-15-buster/lein
 
 Tags: openjdk-15-boot, openjdk-15-boot-2.8.3, openjdk-15-boot-slim-buster, openjdk-15-boot-2.8.3-slim-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-15-slim-buster/boot
 
 Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-15-buster/boot
 
 Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.763, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.763-slim-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-15-slim-buster/tools-deps
 
 Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.763-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-15-buster/tools-deps
 
 Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.5, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.5-slim-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-slim-buster/lein
 
 Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.5-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/lein
 
 Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-slim-buster/boot
 
 Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/boot
 
 Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.763, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.763-slim-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-slim-buster/tools-deps
 
 Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.763-buster
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/tools-deps
 
 Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.5-alpine
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-alpine/lein
 
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-alpine/boot
 
 Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.763-alpine
+Architectures: amd64, arm64v8
 Directory: target/openjdk-16-alpine/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -99,13 +99,10 @@ Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/tools-deps
 
 Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.5-alpine
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-alpine/lein
 
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-alpine/boot
 
 Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.763-alpine
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-alpine/tools-deps


### PR DESCRIPTION
This should support arm64v8 now that it's based on openjdk-11 upstream. I think only the openjdk-8 images don't at this point.