### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev4, 2.4-dev
+Tags: 2.4-dev5, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 2b1ab821252292159f7caa2fb03ce90a120074ab
 Directory: 2.4-rc
 
-Tags: 2.4-dev4-alpine, 2.4-dev-alpine
+Tags: 2.4-dev5-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 2b1ab821252292159f7caa2fb03ce90a120074ab
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.2, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2b1ab82: Update to 2.4-dev5