### PR TITLE
Update wordpress (new beta "wp-config-docker.php"!)

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/fe3078d7544bd0bd77e30e1121988234f426dff9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -43,3 +43,33 @@ Tags: cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fe3078d7544bd0bd77e30e1121988234f426dff9
 Directory: cli/php7.3/alpine
+
+Tags: beta-5.6.0-apache, beta-5.6-apache, beta-5-apache, beta-apache, beta-5.6.0, beta-5.6, beta-5, beta, beta-5.6.0-php7.4-apache, beta-5.6-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.6.0-php7.4, beta-5.6-php7.4, beta-5-php7.4, beta-php7.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd
+Directory: beta/php7.4/apache
+
+Tags: beta-5.6.0-fpm, beta-5.6-fpm, beta-5-fpm, beta-fpm, beta-5.6.0-php7.4-fpm, beta-5.6-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd
+Directory: beta/php7.4/fpm
+
+Tags: beta-5.6.0-fpm-alpine, beta-5.6-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.6.0-php7.4-fpm-alpine, beta-5.6-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd
+Directory: beta/php7.4/fpm-alpine
+
+Tags: beta-5.6.0-php7.3-apache, beta-5.6-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.6.0-php7.3, beta-5.6-php7.3, beta-5-php7.3, beta-php7.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd
+Directory: beta/php7.3/apache
+
+Tags: beta-5.6.0-php7.3-fpm, beta-5.6-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd
+Directory: beta/php7.3/fpm
+
+Tags: beta-5.6.0-php7.3-fpm-alpine, beta-5.6-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd
+Directory: beta/php7.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/e7f2ca6: Merge pull request https://github.com/docker-library/wordpress/pull/557 from infosiftr/wp-config-docker.php
- https://github.com/docker-library/wordpress/commit/8f5bcc1: Add new "wp-config-docker.php" that uses "getenv" for configuration

> With this change, the "beta" tags are force-reenabled at the same version as the latest releases to allow users to test this before the next release of WordPress (where it is intended that this change will go live for all image variants).

> According to https://wordpress.org/about/roadmap/, WordPress 5.7 is scheduled for ~March 2021, so that would give a decent amount of time for folks to test this before it goes live (if we can get it to an acceptable state for merging soon).

> For users who are changing `WORDPRESS_*` variables and expecting our `docker-entrypoint.sh` to update them, the "migration" path is to remove your `wp-config.php` file and let the new entrypoint copy in the updated version, and everything will "just work" from then on.