### PR TITLE
arangodb 3.7.6

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,14 +1,10 @@
 Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart), Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
 GitRepo: https://github.com/arangodb/arangodb-docker
 
-Tags: 3.5, 3.5.7
-GitCommit: 6c63af96b4393a7849a85053717de7151aeee0b7
-Directory: alpine/3.5.7
-
 Tags: 3.6, 3.6.10
 GitCommit: 3e5f79a09a5f4ba9a677e1164e87eef19bb388c1
 Directory: alpine/3.6.10
 
-Tags: 3.7, 3.7.5, latest
-GitCommit: 69b34f38c24fe43521a7f265a9110396d869cfec
-Directory: alpine/3.7.5
+Tags: 3.7, 3.7.6, latest
+GitCommit: 9cc734449144648a9d1b5b029fd3a72e635897b7
+Directory: alpine/3.7.6


### PR DESCRIPTION
Updated ArangoDB 3.7 to 3.7.6 and removed 3.5 (EoL).