### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,67 +4,67 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-3-jdk-oraclelinux8, 17-ea-3-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-3-jdk-oracle, 17-ea-3-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-3-jdk, 17-ea-3, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-4-jdk-oraclelinux8, 17-ea-4-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-4-jdk-oracle, 17-ea-4-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-4-jdk, 17-ea-4, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-3-jdk-oraclelinux7, 17-ea-3-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-4-jdk-oraclelinux7, 17-ea-4-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-3-jdk-buster, 17-ea-3-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-4-jdk-buster, 17-ea-4-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/buster
 
-Tags: 17-ea-3-jdk-slim-buster, 17-ea-3-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-3-jdk-slim, 17-ea-3-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-4-jdk-slim-buster, 17-ea-4-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-4-jdk-slim, 17-ea-4-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/slim-buster
 
-Tags: 17-ea-3-jdk-windowsservercore-1809, 17-ea-3-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-3-jdk-windowsservercore, 17-ea-3-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-3-jdk, 17-ea-3, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-4-jdk-windowsservercore-1809, 17-ea-4-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-4-jdk-windowsservercore, 17-ea-4-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-4-jdk, 17-ea-4, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-3-jdk-windowsservercore-ltsc2016, 17-ea-3-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-3-jdk-windowsservercore, 17-ea-3-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-3-jdk, 17-ea-3, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-4-jdk-windowsservercore-ltsc2016, 17-ea-4-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-4-jdk-windowsservercore, 17-ea-4-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-4-jdk, 17-ea-4, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-3-jdk-nanoserver-1809, 17-ea-3-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-3-jdk-nanoserver, 17-ea-3-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-4-jdk-nanoserver-1809, 17-ea-4-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-4-jdk-nanoserver, 17-ea-4-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 23f461cd1ba13181f6d9fa6696b2b5f204d8c2d8
+GitCommit: c4a4511a69748ae5719383d184149d1db4bc9755
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16-ea-30-jdk-oraclelinux8, 16-ea-30-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-30-jdk-oracle, 16-ea-30-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-30-jdk, 16-ea-30, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-31-jdk-oraclelinux8, 16-ea-31-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-31-jdk-oracle, 16-ea-31-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-31-jdk, 16-ea-31, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-30-jdk-oraclelinux7, 16-ea-30-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-31-jdk-oraclelinux7, 16-ea-31-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-30-jdk-buster, 16-ea-30-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-31-jdk-buster, 16-ea-31-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/buster
 
-Tags: 16-ea-30-jdk-slim-buster, 16-ea-30-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-30-jdk-slim, 16-ea-30-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-31-jdk-slim-buster, 16-ea-31-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-31-jdk-slim, 16-ea-31-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-23-jdk-alpine3.12, 16-ea-23-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-23-jdk-alpine, 16-ea-23-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -72,24 +72,24 @@ Architectures: amd64
 GitCommit: 66c01fe9c251c5e5f1fae75291af93270842c178
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-30-jdk-windowsservercore-1809, 16-ea-30-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-30-jdk-windowsservercore, 16-ea-30-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-30-jdk, 16-ea-30, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-31-jdk-windowsservercore-1809, 16-ea-31-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-31-jdk-windowsservercore, 16-ea-31-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-31-jdk, 16-ea-31, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-30-jdk-windowsservercore-ltsc2016, 16-ea-30-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-30-jdk-windowsservercore, 16-ea-30-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-30-jdk, 16-ea-30, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-31-jdk-windowsservercore-ltsc2016, 16-ea-31-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-31-jdk-windowsservercore, 16-ea-31-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-31-jdk, 16-ea-31, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-30-jdk-nanoserver-1809, 16-ea-30-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-30-jdk-nanoserver, 16-ea-30-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-31-jdk-nanoserver-1809, 16-ea-31-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-31-jdk-nanoserver, 16-ea-31-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 2f484cbf97ce02d878aae5ed982b4588891494a7
+GitCommit: 3be6e5d73a7b83dfff2c0c51bcced11c752276ad
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/c4a4511: Update to 17-ea+4
- https://github.com/docker-library/openjdk/commit/3be6e5d: Update to 16-ea+31