### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2b1ab821252292159f7caa2fb03ce90a120074ab
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.2, 2.3, latest
+Tags: 2.3.3, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: f3778e806837b89d0e9ec6ebc126cdb3334fe35f
 Directory: 2.3
 
-Tags: 2.3.2-alpine, 2.3-alpine, alpine
+Tags: 2.3.3-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: f3778e806837b89d0e9ec6ebc126cdb3334fe35f
 Directory: 2.3/alpine
 
-Tags: 2.2.6, 2.2, lts
+Tags: 2.2.7, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: ea1e02e0d34325fe6dba5e3650ceffc58c0600e2
 Directory: 2.2
 
-Tags: 2.2.6-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.7-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: ea1e02e0d34325fe6dba5e3650ceffc58c0600e2
 Directory: 2.2/alpine
 
-Tags: 2.1.10, 2.1
+Tags: 2.1.11, 2.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 77cae8f4011926668a3548acf133cfe635f4d68a
 Directory: 2.1
 
-Tags: 2.1.10-alpine, 2.1-alpine
+Tags: 2.1.11-alpine, 2.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 77cae8f4011926668a3548acf133cfe635f4d68a
 Directory: 2.1/alpine
 
-Tags: 2.0.19, 2.0
+Tags: 2.0.20, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: a8a76545dc5ba20d2c08001dc7507b7b2161ed90
 Directory: 2.0
 
-Tags: 2.0.19-alpine, 2.0-alpine
+Tags: 2.0.20-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: a8a76545dc5ba20d2c08001dc7507b7b2161ed90
 Directory: 2.0/alpine
 
 Tags: 1.8.27, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a8a7654: Update to 2.0.20
- https://github.com/docker-library/haproxy/commit/f3778e8: Update to 2.3.3
- https://github.com/docker-library/haproxy/commit/77cae8f: Update to 2.1.11
- https://github.com/docker-library/haproxy/commit/ea1e02e: Update to 2.2.7