### PR TITLE
archlinux: Release 20210110.0.13332

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20201220.0.11678
-GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc
-GitFetch: refs/tags/v20201220.0.11678
+Tags: latest, base, base-20210110.0.13332
+GitCommit: b9e9bfbd06fe63e1edfd09ae3c7ec2dabc18ff82
+GitFetch: refs/tags/v20210110.0.13332
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20201220.0.11678
-GitCommit: f9d83c7a5c3cc3f14caaf45e63fd8cebfc3d2ddc
-GitFetch: refs/tags/v20201220.0.11678
+Tags: base-devel, base-devel-20210110.0.13332
+GitCommit: b9e9bfbd06fe63e1edfd09ae3c7ec2dabc18ff82
+GitFetch: refs/tags/v20210110.0.13332
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
