### PR TITLE
Odoo: update 12.0-14.0 to release 20210111

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5bf43c28934f7a445b36cf411e11967daefcc0f4
+GitCommit: 8b937ea8137b0630526e059a2e790fd8acc740c3
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hi,

here are the latest releases of supported Odoo versions.

Thanks.