### PR TITLE
Bump Traefik to v2.3.7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e3a11c7578f6cbc690f64a964f794f604840a4bf
 Directory: alpine
 
-Tags: v2.3.6-windowsservercore-1809, 2.3.6-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.3.7-windowsservercore-1809, 2.3.7-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 52997b0fdb3c358e0eb73ff1f999e0359e15909e
+GitCommit: 5f8653509193f68c10ac12d5ebfe8657d7cd2bf7
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.3.6, 2.3.6, v2.3, 2.3, picodon, latest
+Tags: v2.3.7, 2.3.7, v2.3, 2.3, picodon, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 52997b0fdb3c358e0eb73ff1f999e0359e15909e
+GitCommit: 5f8653509193f68c10ac12d5ebfe8657d7cd2bf7
 Directory: alpine
 
 Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.3.7](https://github.com/traefik/traefik/releases/tag/v2.3.7).

/cc @ldez @jbdoumenjou @SantoDE

Cheers
