### PR TITLE
Bump Traefik to v2.4.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.4.0-rc1-windowsservercore-1809, 2.4.0-rc1-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809
+Tags: v2.4.0-rc2-windowsservercore-1809, 2.4.0-rc2-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e3a11c7578f6cbc690f64a964f794f604840a4bf
+GitCommit: 89302d9c2acc57903e9d48790597860a08858d68
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.0-rc1, 2.4.0-rc1, v2.4, 2.4, livarot
+Tags: v2.4.0-rc2, 2.4.0-rc2, v2.4, 2.4, livarot
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e3a11c7578f6cbc690f64a964f794f604840a4bf
+GitCommit: 89302d9c2acc57903e9d48790597860a08858d68
 Directory: alpine
 
 Tags: v2.3.7-windowsservercore-1809, 2.3.7-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.4.0-rc2).

/cc @ldez @jbdoumenjou @SantoDE @kevinpollet

Cheers
