### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.2-rc1, 6.2-rc, rc, 6.2-rc1-buster, 6.2-rc-buster, rc-buster
+Tags: 6.2-rc2, 6.2-rc, rc, 6.2-rc2-buster, 6.2-rc-buster, rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4ef411f3182868638f538798966a48b585ecce24
+GitCommit: f621fd1249e1e0fa86fb70ec735370979a94ab6f
 Directory: 6.2-rc
 
-Tags: 6.2-rc1-alpine, 6.2-rc-alpine, rc-alpine, 6.2-rc1-alpine3.12, 6.2-rc-alpine3.12, rc-alpine3.12
+Tags: 6.2-rc2-alpine, 6.2-rc-alpine, rc-alpine, 6.2-rc2-alpine3.12, 6.2-rc-alpine3.12, rc-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4ef411f3182868638f538798966a48b585ecce24
+GitCommit: f621fd1249e1e0fa86fb70ec735370979a94ab6f
 Directory: 6.2-rc/alpine
 
-Tags: 6.0.9, 6.0, 6, latest, 6.0.9-buster, 6.0-buster, 6-buster, buster
+Tags: 6.0.10, 6.0, 6, latest, 6.0.10-buster, 6.0-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7ccc22760cc9b659916678a52654be8f43757551
+GitCommit: f634377257f6a41eaded4fb57672260fea6369e1
 Directory: 6.0
 
-Tags: 6.0.9-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.9-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
+Tags: 6.0.10-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.10-alpine3.12, 6.0-alpine3.12, 6-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ccc22760cc9b659916678a52654be8f43757551
+GitCommit: f634377257f6a41eaded4fb57672260fea6369e1
 Directory: 6.0/alpine
 
 Tags: 5.0.10, 5.0, 5, 5.0.10-buster, 5.0-buster, 5-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/f634377: Update to 6.0.10
- https://github.com/docker-library/redis/commit/f621fd1: Update to 6.2-rc2