### PR TITLE
Bump Traefik to v1.7.28

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -26,21 +26,21 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 5f8653509193f68c10ac12d5ebfe8657d7cd2bf7
 Directory: alpine
 
-Tags: v1.7.26-windowsservercore-1809, 1.7.26-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.28-windowsservercore-1809, 1.7.28-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
-GitRepo: https://github.com/containous/traefik-library-image.git
-GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 304f7cf2cf36f59e0bc93597579c61837ce2ea6f
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.26-alpine, 1.7.26-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.28-alpine, 1.7.28-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
-GitRepo: https://github.com/containous/traefik-library-image.git
-GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 304f7cf2cf36f59e0bc93597579c61837ce2ea6f
 Directory: alpine
 
-Tags: v1.7.26, 1.7.26, v1.7, 1.7, maroilles
+Tags: v1.7.28, 1.7.28, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
-GitRepo: https://github.com/containous/traefik-library-image.git
-GitCommit: b8acd6164a229d1a351ad635b471bbdd6d35e687
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 304f7cf2cf36f59e0bc93597579c61837ce2ea6f
 Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v1.7.28](https://github.com/traefik/traefik/releases/tag/v1.7.28).

/cc @kevinpollet @rtribotte @SantoDE @jbdoumenjou

Cheers
