### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2b1ab821252292159f7caa2fb03ce90a120074ab
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.3, 2.3, latest
+Tags: 2.3.4, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f3778e806837b89d0e9ec6ebc126cdb3334fe35f
+GitCommit: 2669f94efd40ced39016f4eff0e29e0c141b96b5
 Directory: 2.3
 
-Tags: 2.3.3-alpine, 2.3-alpine, alpine
+Tags: 2.3.4-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f3778e806837b89d0e9ec6ebc126cdb3334fe35f
+GitCommit: 2669f94efd40ced39016f4eff0e29e0c141b96b5
 Directory: 2.3/alpine
 
-Tags: 2.2.7, 2.2, lts
+Tags: 2.2.8, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ea1e02e0d34325fe6dba5e3650ceffc58c0600e2
+GitCommit: bee29ff5574db20488e4eb0b7914051fca328cfc
 Directory: 2.2
 
-Tags: 2.2.7-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.8-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea1e02e0d34325fe6dba5e3650ceffc58c0600e2
+GitCommit: bee29ff5574db20488e4eb0b7914051fca328cfc
 Directory: 2.2/alpine
 
 Tags: 2.1.11, 2.1
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a8a76545dc5ba20d2c08001dc7507b7b2161ed90
 Directory: 2.0/alpine
 
-Tags: 1.8.27, 1.8
+Tags: 1.8.28, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 74912d5713bfb45596c55a174342898bd2c58960
 Directory: 1.8
 
-Tags: 1.8.27-alpine, 1.8-alpine
+Tags: 1.8.28-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 74912d5713bfb45596c55a174342898bd2c58960
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2669f94: Update to 2.3.4
- https://github.com/docker-library/haproxy/commit/74912d5: Update to 1.8.28
- https://github.com/docker-library/haproxy/commit/bee29ff: Update to 2.2.8