### PR TITLE
alpine: add 3.13.0 and remove EOL 3.9

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,7 +13,19 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.3, 3.12, 3, latest
+Tags: 3.13.0, 3.13, 3, latest
+Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
+GitFetch: refs/heads/v3.13
+GitCommit: 3d7c61e2b6aeaa2876ba6d35b990fb34e678625e
+arm64v8-Directory: aarch64/
+arm32v6-Directory: armhf/
+arm32v7-Directory: armv7/
+ppc64le-Directory: ppc64le/
+s390x-Directory: s390x/
+i386-Directory: x86/
+amd64-Directory: x86_64/
+
+Tags: 3.12.3, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
 GitCommit: 9f43992677cdb66a1ecbefe3bf409113b5f2127f
@@ -41,18 +53,6 @@ Tags: 3.10.5, 3.10
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
 GitCommit: a02be1f7da059d74c0743792b41d17626128c2a3
-arm64v8-Directory: aarch64/
-arm32v6-Directory: armhf/
-arm32v7-Directory: armv7/
-ppc64le-Directory: ppc64le/
-s390x-Directory: s390x/
-i386-Directory: x86/
-amd64-Directory: x86_64/
-
-Tags: 3.9.6, 3.9
-Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitFetch: refs/heads/v3.9
-GitCommit: d7eb97a39abbdfe6ba73236f844cb80b756280d1
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
https://alpinelinux.org/posts/Alpine-3.13.0-released.html