### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,29 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.10-rc.5, 3.8-rc
+Tags: 3.8.10-rc.6, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 630036862655d3d1af27104052634b8751e35ac2
+GitCommit: 26394ade45d4751c020d8283151e47b7e4e6f9ec
 Directory: 3.8-rc/ubuntu
 
-Tags: 3.8.10-rc.5-management, 3.8-rc-management
+Tags: 3.8.10-rc.6-management, 3.8-rc-management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
 Directory: 3.8-rc/ubuntu/management
 
-Tags: 3.8.10-rc.5-alpine, 3.8-rc-alpine
+Tags: 3.8.10-rc.6-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 630036862655d3d1af27104052634b8751e35ac2
+GitCommit: 26394ade45d4751c020d8283151e47b7e4e6f9ec
 Directory: 3.8-rc/alpine
 
-Tags: 3.8.10-rc.5-management-alpine, 3.8-rc-management-alpine
+Tags: 3.8.10-rc.6-management-alpine, 3.8-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
 Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.9, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e59f96860d646b2f2c5972af8155fcf871ecfcc
+GitCommit: b3e6547ddd34594b2d371fe0f0b270a16c1dc622
 Directory: 3.8/ubuntu
 
 Tags: 3.8.9-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.9-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e59f96860d646b2f2c5972af8155fcf871ecfcc
+GitCommit: b3e6547ddd34594b2d371fe0f0b270a16c1dc622
 Directory: 3.8/alpine
 
 Tags: 3.8.9-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- docker-library/rabbitmq@26394ad: Update 3.8-rc to 3.8.10-rc.6
- docker-library/rabbitmq@b699944: Update 3.8-rc to otp 23.2.2
- docker-library/rabbitmq@b3e6547: Update 3.8 to otp 23.2.2