### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 2.7-7.3.3, 2.7-7.3, 2.7-7, 2.7, 2-7.3.3, 2-7.3, 2-7, 2, 2.7-7.3.3-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.3-buster, 2-7.3-buster, 2-7-buster, 2-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: e26538802dd3029afc6702323c91b119980762f7
+GitCommit: 9625e09996380a78c53a9610915d839035245b57
 Directory: 2.7
 
 Tags: 2.7-7.3.3-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.3-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.3-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.3-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: e26538802dd3029afc6702323c91b119980762f7
+GitCommit: 9625e09996380a78c53a9610915d839035245b57
 Directory: 2.7/slim
 
 Tags: 3.6-7.3.3, 3.6-7.3, 3.6-7, 3.6, 3-7.3.3, 3-7.3, 3-7, 3, latest, 3.6-7.3.3-buster, 3.6-7.3-buster, 3.6-7-buster, 3.6-buster, 3-7.3.3-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
 Architectures: amd64, arm64v8, i386, s390x
-GitCommit: e26538802dd3029afc6702323c91b119980762f7
+GitCommit: 9625e09996380a78c53a9610915d839035245b57
 Directory: 3.6
 
 Tags: 3.6-7.3.3-slim, 3.6-7.3-slim, 3.6-7-slim, 3.6-slim, 3-7.3.3-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.6-7.3.3-slim-buster, 3.6-7.3-slim-buster, 3.6-7-slim-buster, 3.6-slim-buster, 3-7.3.3-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm64v8, i386, s390x
-GitCommit: e26538802dd3029afc6702323c91b119980762f7
+GitCommit: 9625e09996380a78c53a9610915d839035245b57
 Directory: 3.6/slim
 
 Tags: 3.7-7.3.3, 3.7-7.3, 3.7-7, 3.7, 3.7-7.3.3-buster, 3.7-7.3-buster, 3.7-7-buster, 3.7-buster
 Architectures: amd64, arm64v8, i386, s390x
-GitCommit: e26538802dd3029afc6702323c91b119980762f7
+GitCommit: 9625e09996380a78c53a9610915d839035245b57
 Directory: 3.7
 
 Tags: 3.7-7.3.3-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3.7-7.3.3-slim-buster, 3.7-7.3-slim-buster, 3.7-7-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm64v8, i386, s390x
-GitCommit: e26538802dd3029afc6702323c91b119980762f7
+GitCommit: 9625e09996380a78c53a9610915d839035245b57
 Directory: 3.7/slim


### PR DESCRIPTION
Changes:

- docker-library/pypy@60e28bf: Merge pull request docker-library/pypy#51 from infosiftr/pip-20
- docker-library/pypy@9625e09: Pin pip to 20.x (the last version to support Python 2)
- https://github.com/docker-library/pypy/commit/0cedf2f: Update to 7.3.3, pip 20.3.3