### PR TITLE
archlinux: Release 20210117.0.13798

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210110.0.13332
-GitCommit: b9e9bfbd06fe63e1edfd09ae3c7ec2dabc18ff82
-GitFetch: refs/tags/v20210110.0.13332
+Tags: latest, base, base-20210117.0.13798
+GitCommit: 0ee196cf51da2d915a965ea05e51148e06cbdb7e
+GitFetch: refs/tags/v20210117.0.13798
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210110.0.13332
-GitCommit: b9e9bfbd06fe63e1edfd09ae3c7ec2dabc18ff82
-GitFetch: refs/tags/v20210110.0.13332
+Tags: base-devel, base-devel-20210117.0.13798
+GitCommit: 0ee196cf51da2d915a965ea05e51148e06cbdb7e
+GitFetch: refs/tags/v20210117.0.13798
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
