### PR TITLE
Bump Traefik to v2.4.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,29 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
 
-Tags: v2.4.0-rc2-windowsservercore-1809, 2.4.0-rc2-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809
+Tags: v2.4.0-windowsservercore-1809, 2.4.0-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 89302d9c2acc57903e9d48790597860a08858d68
+GitCommit: 5e77e1dc9f9f30035cabec0f898581caabeccc10
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.0-rc2, 2.4.0-rc2, v2.4, 2.4, livarot
+Tags: v2.4.0, 2.4.0, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 89302d9c2acc57903e9d48790597860a08858d68
-Directory: alpine
-
-Tags: v2.3.7-windowsservercore-1809, 2.3.7-windowsservercore-1809, v2.3-windowsservercore-1809, 2.3-windowsservercore-1809, picodon-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 5f8653509193f68c10ac12d5ebfe8657d7cd2bf7
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.3.7, 2.3.7, v2.3, 2.3, picodon, latest
-Architectures: amd64, arm32v6, arm64v8
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 5f8653509193f68c10ac12d5ebfe8657d7cd2bf7
+GitCommit: 5e77e1dc9f9f30035cabec0f898581caabeccc10
 Directory: alpine
 
 Tags: v1.7.28-windowsservercore-1809, 1.7.28-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,4 +1,4 @@
-Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Vincent Demeester <vincent@sbr.pm> (@vdemeester), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur)
+Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
 Tags: v2.4.0-windowsservercore-1809, 2.4.0-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.0](https://github.com/traefik/traefik/releases/tag/v2.4.0).

/cc @kevinpollet @rtribotte @SantoDE @jbdoumenjou

Cheers
