### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.10, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 650cb768fabc2b4d3f5b810f376ce28b2d0a90e2
+GitCommit: 0dd15492099d2d57ea3a55910c21381ce0e2e258
 Directory: 3.8/ubuntu
 
 Tags: 3.8.10-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.10-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 650cb768fabc2b4d3f5b810f376ce28b2d0a90e2
+GitCommit: 0dd15492099d2d57ea3a55910c21381ce0e2e258
 Directory: 3.8/alpine
 
 Tags: 3.8.10-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/fece030: Merge pull request https://github.com/docker-library/rabbitmq/pull/459 from infosiftr/erlang-sha256
- https://github.com/docker-library/rabbitmq/commit/0dd1549: Switch from Erlang generated SHA256 to published
- https://github.com/docker-library/rabbitmq/commit/010bc60: Update 3.8-rc to otp 23.2.3
- https://github.com/docker-library/rabbitmq/commit/28b674d: Update 3.8 to otp 23.2.3