### PR TITLE
Re-tag Gradle 6.7

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -1,59 +1,59 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
-GitCommit: c618fa59f4cf872845a6f38bf7cce948fbf8dbc4
+GitCommit: fa9021708ab3315acbf4208125f6ca316e903ac6
 
 
 # Hotspot
 
-Tags: 6.8.0-jdk8, 6.8.0-jdk8-hotspot, 6.7-jdk8, 6.7-jdk8-hotspot, jdk8, jdk8-hotspot, 6.8.0-jdk, 6.8.0-jdk-hotspot, 6.7-jdk, 6.7-jdk-hotspot, jdk, jdk-hotspot, 6.8.0, 6.8.0-hotspot, 6.7, 6.7-hotspot, latest, hotspot
+Tags: 6.7.1-jdk8, 6.7.1-jdk8-hotspot, 6.7-jdk8, 6.7-jdk8-hotspot, jdk8, jdk8-hotspot, 6.7.1-jdk, 6.7.1-jdk-hotspot, 6.7-jdk, 6.7-jdk-hotspot, jdk, jdk-hotspot, 6.7.1, 6.7.1-hotspot, 6.7, 6.7-hotspot, latest, hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk8
 
-Tags: 6.8.0-jre8, 6.8.0-jre8-hotspot, 6.7-jre8, 6.7-jre8-hotspot, jre8, jre8-hotspot, 6.8.0-jre, 6.8.0-jre-hotspot, 6.7-jre, 6.7-jre-hotspot, jre, jre-hotspot
+Tags: 6.7.1-jre8, 6.7.1-jre8-hotspot, 6.7-jre8, 6.7-jre8-hotspot, jre8, jre8-hotspot, 6.7.1-jre, 6.7.1-jre-hotspot, 6.7-jre, 6.7-jre-hotspot, jre, jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre8
 
-Tags: 6.8.0-jdk11, 6.8.0-jdk11-hotspot, 6.7-jdk11, 6.7-jdk11-hotspot, jdk11, jdk11-hotspot
+Tags: 6.7.1-jdk11, 6.7.1-jdk11-hotspot, 6.7-jdk11, 6.7-jdk11-hotspot, jdk11, jdk11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk11
 
-Tags: 6.8.0-jre11, 6.8.0-jre11-hotspot, 6.7-jre11, 6.7-jre11-hotspot, jre11, jre11-hotspot
+Tags: 6.7.1-jre11, 6.7.1-jre11-hotspot, 6.7-jre11, 6.7-jre11-hotspot, jre11, jre11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre11
 
-Tags: 6.8.0-jdk15, 6.8.0-jdk15-hotspot, 6.7-jdk15, 6.7-jdk15-hotspot, jdk15, jdk15-hotspot
+Tags: 6.7.1-jdk15, 6.7.1-jdk15-hotspot, 6.7-jdk15, 6.7-jdk15-hotspot, jdk15, jdk15-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk15
 
-Tags: 6.8.0-jre15, 6.8.0-jre15-hotspot, 6.7-jre15, 6.7-jre15-hotspot, jre15, jre15-hotspot
+Tags: 6.7.1-jre15, 6.7.1-jre15-hotspot, 6.7-jre15, 6.7-jre15-hotspot, jre15, jre15-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre15
 
 
 # OpenJ9
 
-Tags: 6.8.0-jdk8-openj9, 6.7-jdk8-openj9, jdk8-openj9, 6.8.0-jdk-openj9, 6.7-jdk-openj9, jdk-openj9, 6.8.0-openj9, 6.7-openj9, openj9
+Tags: 6.7.1-jdk8-openj9, 6.7-jdk8-openj9, jdk8-openj9, 6.7.1-jdk-openj9, 6.7-jdk-openj9, jdk-openj9, 6.7.1-openj9, 6.7-openj9, openj9
 Architectures: amd64, ppc64le, s390x
 Directory: openj9/jdk8
 
-Tags: 6.8.0-jre8-openj9, 6.7-jre8-openj9, jre8-openj9, 6.8.0-jre-openj9, 6.7-jre-openj9, jre-openj9
+Tags: 6.7.1-jre8-openj9, 6.7-jre8-openj9, jre8-openj9, 6.7.1-jre-openj9, 6.7-jre-openj9, jre-openj9
 Architectures: amd64, ppc64le, s390x
 Directory: openj9/jre8
 
-Tags: 6.8.0-jdk11-openj9, 6.7-jdk11-openj9, jdk11-openj9
+Tags: 6.7.1-jdk11-openj9, 6.7-jdk11-openj9, jdk11-openj9
 Architectures: amd64, ppc64le, s390x
 Directory: openj9/jdk11
 
-Tags: 6.8.0-jre11-openj9, 6.7-jre11-openj9, jre11-openj9
+Tags: 6.7.1-jre11-openj9, 6.7-jre11-openj9, jre11-openj9
 Architectures: amd64, ppc64le, s390x
 Directory: openj9/jre11
 
 # temporarily commented out, due to OpenJ9 bug
-#Tags: 6.8.0-jdk15-openj9, 6.7-jdk15-openj9, jdk15-openj9
+#Tags: 6.7.1-jdk15-openj9, 6.7-jdk15-openj9, jdk15-openj9
 #Architectures: amd64, ppc64le, s390x
 #Directory: openj9/jdk15
 
 # temporarily commented out, due to OpenJ9 bug
-#Tags: 6.8.0-jre15-openj9, 6.7-jre15-openj9, jre15-openj9
+#Tags: 6.7.1-jre15-openj9, 6.7-jre15-openj9, jre15-openj9
 #Architectures: amd64, ppc64le, s390x
 #Directory: openj9/jre15


### PR DESCRIPTION
I mistakenly didn't replace all the 6.7 references in the tags when I did the 6.8 release. So I'm retagging 6.7 and then will have a second PR to fix the 6.8 tags (#9474).