### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,67 +4,67 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-5-jdk-oraclelinux8, 17-ea-5-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-5-jdk-oracle, 17-ea-5-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-5-jdk, 17-ea-5, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-6-jdk-oraclelinux8, 17-ea-6-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-6-jdk-oracle, 17-ea-6-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-6-jdk, 17-ea-6, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-5-jdk-oraclelinux7, 17-ea-5-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-6-jdk-oraclelinux7, 17-ea-6-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-5-jdk-buster, 17-ea-5-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-6-jdk-buster, 17-ea-6-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/buster
 
-Tags: 17-ea-5-jdk-slim-buster, 17-ea-5-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-5-jdk-slim, 17-ea-5-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-6-jdk-slim-buster, 17-ea-6-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-6-jdk-slim, 17-ea-6-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/slim-buster
 
-Tags: 17-ea-5-jdk-windowsservercore-1809, 17-ea-5-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-5-jdk-windowsservercore, 17-ea-5-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-5-jdk, 17-ea-5, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-6-jdk-windowsservercore-1809, 17-ea-6-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-6-jdk-windowsservercore, 17-ea-6-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-6-jdk, 17-ea-6, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-5-jdk-windowsservercore-ltsc2016, 17-ea-5-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-5-jdk-windowsservercore, 17-ea-5-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-5-jdk, 17-ea-5, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-6-jdk-windowsservercore-ltsc2016, 17-ea-6-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-6-jdk-windowsservercore, 17-ea-6-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-6-jdk, 17-ea-6, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-5-jdk-nanoserver-1809, 17-ea-5-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-5-jdk-nanoserver, 17-ea-5-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-6-jdk-nanoserver-1809, 17-ea-6-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-6-jdk-nanoserver, 17-ea-6-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: bd1693157205692f27d241f0883051b20604c908
+GitCommit: 64557ee2ad82aeaae093ac069b7212cd4a0ea987
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16-ea-32-jdk-oraclelinux8, 16-ea-32-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-32-jdk-oracle, 16-ea-32-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-32-jdk, 16-ea-32, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-33-jdk-oraclelinux8, 16-ea-33-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-33-jdk-oracle, 16-ea-33-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16-ea-33-jdk, 16-ea-33, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-32-jdk-oraclelinux7, 16-ea-32-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-ea-33-jdk-oraclelinux7, 16-ea-33-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-32-jdk-buster, 16-ea-32-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-ea-33-jdk-buster, 16-ea-33-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/buster
 
-Tags: 16-ea-32-jdk-slim-buster, 16-ea-32-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-32-jdk-slim, 16-ea-32-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-ea-33-jdk-slim-buster, 16-ea-33-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-33-jdk-slim, 16-ea-33-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/slim-buster
 
 Tags: 16-ea-32-jdk-alpine3.12, 16-ea-32-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12, 16-ea-32-jdk-alpine, 16-ea-32-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
@@ -72,24 +72,24 @@ Architectures: amd64
 GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
 Directory: 16/jdk/alpine3.12
 
-Tags: 16-ea-32-jdk-windowsservercore-1809, 16-ea-32-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-32-jdk-windowsservercore, 16-ea-32-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-32-jdk, 16-ea-32, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-33-jdk-windowsservercore-1809, 16-ea-33-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-ea-33-jdk-windowsservercore, 16-ea-33-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-33-jdk, 16-ea-33, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-32-jdk-windowsservercore-ltsc2016, 16-ea-32-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-32-jdk-windowsservercore, 16-ea-32-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-32-jdk, 16-ea-32, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-ea-33-jdk-windowsservercore-ltsc2016, 16-ea-33-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-ea-33-jdk-windowsservercore, 16-ea-33-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-33-jdk, 16-ea-33, 16-ea-jdk, 16-ea, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-32-jdk-nanoserver-1809, 16-ea-32-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-32-jdk-nanoserver, 16-ea-32-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-ea-33-jdk-nanoserver-1809, 16-ea-33-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-ea-33-jdk-nanoserver, 16-ea-33-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 7c1aa2acd512c1eba6ac0343f085975596648a0f
+GitCommit: 3f4ad224491abfb5ea96a80cbaf4ff7f1b8d9c66
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -137,23 +137,23 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.10-jdk-oraclelinux8, 11.0.10-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.10-jdk-oracle, 11.0.10-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: c464770f5765a0bc8b7498a8683bc6c9144796da
+GitCommit: 69023d13a209c206c1e676b3f97843a0ee208402
 Directory: 11/jdk/oraclelinux8
 
 Tags: 11.0.10-jdk-oraclelinux7, 11.0.10-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: c464770f5765a0bc8b7498a8683bc6c9144796da
+GitCommit: 69023d13a209c206c1e676b3f97843a0ee208402
 Directory: 11/jdk/oraclelinux7
 
 Tags: 11.0.10-jdk-buster, 11.0.10-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 SharedTags: 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: c464770f5765a0bc8b7498a8683bc6c9144796da
+GitCommit: 69023d13a209c206c1e676b3f97843a0ee208402
 Directory: 11/jdk/buster
 
 Tags: 11.0.10-jdk-slim-buster, 11.0.10-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.10-jdk-slim, 11.0.10-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: c464770f5765a0bc8b7498a8683bc6c9144796da
+GitCommit: 69023d13a209c206c1e676b3f97843a0ee208402
 Directory: 11/jdk/slim-buster
 
 Tags: 11.0.10-jdk-windowsservercore-1809, 11.0.10-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/64557ee: Update to 17-ea+6
- https://github.com/docker-library/openjdk/commit/69023d1: Update to 11.0.10
- https://github.com/docker-library/openjdk/commit/3f4ad22: Update to 16-ea+33
- https://github.com/docker-library/openjdk/commit/10ec99a: Update to 11.0.10