### PR TITLE
archlinux: Release 20210124.0.14185

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210120.0.13969
-GitCommit: 9f8982193fa03d77b1836b2ff66b27cea8d337b3
-GitFetch: refs/tags/v20210120.0.13969
+Tags: latest, base, base-20210124.0.14185
+GitCommit: b505de76a596b73ff39b0137b78cd308dc541794
+GitFetch: refs/tags/v20210124.0.14185
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210120.0.13969
-GitCommit: 9f8982193fa03d77b1836b2ff66b27cea8d337b3
-GitFetch: refs/tags/v20210120.0.13969
+Tags: base-devel, base-devel-20210124.0.14185
+GitCommit: b505de76a596b73ff39b0137b78cd308dc541794
+GitFetch: refs/tags/v20210124.0.14185
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
