### PR TITLE
Abcl

### DIFF
--- a/library/abcl
+++ b/library/abcl
@@ -1,123 +1,159 @@
-# this file is generated via https://github.com/cl-docker-images/abcl/blob/e6c45d7980eae07ace9a7a77476516507bfd8b56/generate-stackbrew-library.sh
-Maintainers: Eric Timmons <nasafreak@gmail.com> (@etimmons)
+# this file is generated via https://github.com/cl-docker-images/abcl/blob/9f5e8dba91b92e7751417a563761c2192536e1d2/generate-stackbrew-library.sh
+Maintainers: Eric Timmons <nasafreak@gmail.com> (@daewok)
 GitRepo: https://github.com/cl-docker-images/abcl.git
 
 Tags: 1.8.0-jdk15-buster, 1-jdk15-buster, 1.8-jdk15-buster, jdk15-buster, 1.8.0-jdk-buster, 1-jdk-buster, 1.8-jdk-buster, jdk-buster, 1.8.0-buster, 1-buster, 1.8-buster, buster
 SharedTags: 1.8.0-jdk15, 1-jdk15, 1.8-jdk15, jdk15, 1.8.0-jdk, 1-jdk, 1.8-jdk, jdk, 1.8.0, 1, 1.8, latest
 Architectures: amd64, arm64v8
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/buster/jdk-15
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/buster/jdk-15/
+
+Tags: 1.8.0-jdk15-slim-buster, 1-jdk15-slim-buster, 1.8-jdk15-slim-buster, jdk15-slim-buster, 1.8.0-jdk-slim-buster, 1-jdk-slim-buster, 1.8-jdk-slim-buster, jdk-slim-buster, 1.8.0-slim-buster, 1-slim-buster, 1.8-slim-buster, slim-buster
+SharedTags: 1.8.0-jdk15-slim, 1-jdk15-slim, 1.8-jdk15-slim, jdk15-slim, 1.8.0-jdk-slim, 1-jdk-slim, 1.8-jdk-slim, jdk-slim, 1.8.0-slim, 1-slim, 1.8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/buster/jdk-15/slim
 
 Tags: 1.8.0-jdk11-buster, 1-jdk11-buster, 1.8-jdk11-buster, jdk11-buster
 SharedTags: 1.8.0-jdk11, 1-jdk11, 1.8-jdk11, jdk11
 Architectures: amd64, arm64v8
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/buster/jdk-11
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/buster/jdk-11/
+
+Tags: 1.8.0-jdk11-slim-buster, 1-jdk11-slim-buster, 1.8-jdk11-slim-buster, jdk11-slim-buster
+SharedTags: 1.8.0-jdk11-slim, 1-jdk11-slim, 1.8-jdk11-slim, jdk11-slim
+Architectures: amd64, arm64v8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/buster/jdk-11/slim
 
 Tags: 1.8.0-jdk8-buster, 1-jdk8-buster, 1.8-jdk8-buster, jdk8-buster
 SharedTags: 1.8.0-jdk8, 1-jdk8, 1.8-jdk8, jdk8
 Architectures: amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/buster/jdk-8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/buster/jdk-8/
+
+Tags: 1.8.0-jdk8-slim-buster, 1-jdk8-slim-buster, 1.8-jdk8-slim-buster, jdk8-slim-buster
+SharedTags: 1.8.0-jdk8-slim, 1-jdk8-slim, 1.8-jdk8-slim, jdk8-slim
+Architectures: amd64
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/buster/jdk-8/slim
 
 Tags: 1.8.0-jdk15-windowsservercore-1809, 1-jdk15-windowsservercore-1809, 1.8-jdk15-windowsservercore-1809, jdk15-windowsservercore-1809, 1.8.0-jdk-windowsservercore-1809, 1-jdk-windowsservercore-1809, 1.8-jdk-windowsservercore-1809, jdk-windowsservercore-1809, 1.8.0-windowsservercore-1809, 1-windowsservercore-1809, 1.8-windowsservercore-1809, windowsservercore-1809
 SharedTags: 1.8.0-jdk15, 1-jdk15, 1.8-jdk15, jdk15, 1.8.0-jdk, 1-jdk, 1.8-jdk, jdk, 1.8.0, 1, 1.8, latest, 1.8.0-jdk15-windowsservercore, 1-jdk15-windowsservercore, 1.8-jdk15-windowsservercore, jdk15-windowsservercore, 1.8.0-jdk-windowsservercore, 1-jdk-windowsservercore, 1.8-jdk-windowsservercore, jdk-windowsservercore, 1.8.0-windowsservercore, 1-windowsservercore, 1.8-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/windowsservercore-1809/jdk-15
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/windowsservercore-1809/jdk-15/
 Constraints: windowsservercore-1809
 
 Tags: 1.8.0-jdk11-windowsservercore-1809, 1-jdk11-windowsservercore-1809, 1.8-jdk11-windowsservercore-1809, jdk11-windowsservercore-1809
 SharedTags: 1.8.0-jdk11, 1-jdk11, 1.8-jdk11, jdk11, 1.8.0-jdk11-windowsservercore, 1-jdk11-windowsservercore, 1.8-jdk11-windowsservercore, jdk11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/windowsservercore-1809/jdk-11
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/windowsservercore-1809/jdk-11/
 Constraints: windowsservercore-1809
 
 Tags: 1.8.0-jdk8-windowsservercore-1809, 1-jdk8-windowsservercore-1809, 1.8-jdk8-windowsservercore-1809, jdk8-windowsservercore-1809
 SharedTags: 1.8.0-jdk8, 1-jdk8, 1.8-jdk8, jdk8, 1.8.0-jdk8-windowsservercore, 1-jdk8-windowsservercore, 1.8-jdk8-windowsservercore, jdk8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/windowsservercore-1809/jdk-8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/windowsservercore-1809/jdk-8/
 Constraints: windowsservercore-1809
 
 Tags: 1.8.0-jdk15-windowsservercore-ltsc2016, 1-jdk15-windowsservercore-ltsc2016, 1.8-jdk15-windowsservercore-ltsc2016, jdk15-windowsservercore-ltsc2016, 1.8.0-jdk-windowsservercore-ltsc2016, 1-jdk-windowsservercore-ltsc2016, 1.8-jdk-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, 1.8.0-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, 1.8-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 1.8.0-jdk15, 1-jdk15, 1.8-jdk15, jdk15, 1.8.0-jdk, 1-jdk, 1.8-jdk, jdk, 1.8.0, 1, 1.8, latest, 1.8.0-jdk15-windowsservercore, 1-jdk15-windowsservercore, 1.8-jdk15-windowsservercore, jdk15-windowsservercore, 1.8.0-jdk-windowsservercore, 1-jdk-windowsservercore, 1.8-jdk-windowsservercore, jdk-windowsservercore, 1.8.0-windowsservercore, 1-windowsservercore, 1.8-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/windowsservercore-ltsc2016/jdk-15
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/windowsservercore-ltsc2016/jdk-15/
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.8.0-jdk11-windowsservercore-ltsc2016, 1-jdk11-windowsservercore-ltsc2016, 1.8-jdk11-windowsservercore-ltsc2016, jdk11-windowsservercore-ltsc2016
 SharedTags: 1.8.0-jdk11, 1-jdk11, 1.8-jdk11, jdk11, 1.8.0-jdk11-windowsservercore, 1-jdk11-windowsservercore, 1.8-jdk11-windowsservercore, jdk11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/windowsservercore-ltsc2016/jdk-11
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/windowsservercore-ltsc2016/jdk-11/
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.8.0-jdk8-windowsservercore-ltsc2016, 1-jdk8-windowsservercore-ltsc2016, 1.8-jdk8-windowsservercore-ltsc2016, jdk8-windowsservercore-ltsc2016
 SharedTags: 1.8.0-jdk8, 1-jdk8, 1.8-jdk8, jdk8, 1.8.0-jdk8-windowsservercore, 1-jdk8-windowsservercore, 1.8-jdk8-windowsservercore, jdk8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.8.0/windowsservercore-ltsc2016/jdk-8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.8.0/windowsservercore-ltsc2016/jdk-8/
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.7.1-jdk15-buster, 1.7-jdk15-buster, 1.7.1-jdk-buster, 1.7-jdk-buster, 1.7.1-buster, 1.7-buster
 SharedTags: 1.7.1-jdk15, 1.7-jdk15, 1.7.1-jdk, 1.7-jdk, 1.7.1, 1.7
 Architectures: amd64, arm64v8
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/buster/jdk-15
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/buster/jdk-15/
+
+Tags: 1.7.1-jdk15-slim-buster, 1.7-jdk15-slim-buster, 1.7.1-jdk-slim-buster, 1.7-jdk-slim-buster, 1.7.1-slim-buster, 1.7-slim-buster
+SharedTags: 1.7.1-jdk15-slim, 1.7-jdk15-slim, 1.7.1-jdk-slim, 1.7-jdk-slim, 1.7.1-slim, 1.7-slim
+Architectures: amd64, arm64v8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/buster/jdk-15/slim
 
 Tags: 1.7.1-jdk11-buster, 1.7-jdk11-buster
 SharedTags: 1.7.1-jdk11, 1.7-jdk11
 Architectures: amd64, arm64v8
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/buster/jdk-11
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/buster/jdk-11/
+
+Tags: 1.7.1-jdk11-slim-buster, 1.7-jdk11-slim-buster
+SharedTags: 1.7.1-jdk11-slim, 1.7-jdk11-slim
+Architectures: amd64, arm64v8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/buster/jdk-11/slim
 
 Tags: 1.7.1-jdk8-buster, 1.7-jdk8-buster
 SharedTags: 1.7.1-jdk8, 1.7-jdk8
 Architectures: amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/buster/jdk-8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/buster/jdk-8/
+
+Tags: 1.7.1-jdk8-slim-buster, 1.7-jdk8-slim-buster
+SharedTags: 1.7.1-jdk8-slim, 1.7-jdk8-slim
+Architectures: amd64
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/buster/jdk-8/slim
 
 Tags: 1.7.1-jdk15-windowsservercore-1809, 1.7-jdk15-windowsservercore-1809, 1.7.1-jdk-windowsservercore-1809, 1.7-jdk-windowsservercore-1809, 1.7.1-windowsservercore-1809, 1.7-windowsservercore-1809
 SharedTags: 1.7.1-jdk15, 1.7-jdk15, 1.7.1-jdk, 1.7-jdk, 1.7.1, 1.7, 1.7.1-jdk15-windowsservercore, 1.7-jdk15-windowsservercore, 1.7.1-jdk-windowsservercore, 1.7-jdk-windowsservercore, 1.7.1-windowsservercore, 1.7-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/windowsservercore-1809/jdk-15
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/windowsservercore-1809/jdk-15/
 Constraints: windowsservercore-1809
 
 Tags: 1.7.1-jdk11-windowsservercore-1809, 1.7-jdk11-windowsservercore-1809
 SharedTags: 1.7.1-jdk11, 1.7-jdk11, 1.7.1-jdk11-windowsservercore, 1.7-jdk11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/windowsservercore-1809/jdk-11
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/windowsservercore-1809/jdk-11/
 Constraints: windowsservercore-1809
 
 Tags: 1.7.1-jdk8-windowsservercore-1809, 1.7-jdk8-windowsservercore-1809
 SharedTags: 1.7.1-jdk8, 1.7-jdk8, 1.7.1-jdk8-windowsservercore, 1.7-jdk8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/windowsservercore-1809/jdk-8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/windowsservercore-1809/jdk-8/
 Constraints: windowsservercore-1809
 
 Tags: 1.7.1-jdk15-windowsservercore-ltsc2016, 1.7-jdk15-windowsservercore-ltsc2016, 1.7.1-jdk-windowsservercore-ltsc2016, 1.7-jdk-windowsservercore-ltsc2016, 1.7.1-windowsservercore-ltsc2016, 1.7-windowsservercore-ltsc2016
 SharedTags: 1.7.1-jdk15, 1.7-jdk15, 1.7.1-jdk, 1.7-jdk, 1.7.1, 1.7, 1.7.1-jdk15-windowsservercore, 1.7-jdk15-windowsservercore, 1.7.1-jdk-windowsservercore, 1.7-jdk-windowsservercore, 1.7.1-windowsservercore, 1.7-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/windowsservercore-ltsc2016/jdk-15
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/windowsservercore-ltsc2016/jdk-15/
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.7.1-jdk11-windowsservercore-ltsc2016, 1.7-jdk11-windowsservercore-ltsc2016
 SharedTags: 1.7.1-jdk11, 1.7-jdk11, 1.7.1-jdk11-windowsservercore, 1.7-jdk11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/windowsservercore-ltsc2016/jdk-11
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/windowsservercore-ltsc2016/jdk-11/
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.7.1-jdk8-windowsservercore-ltsc2016, 1.7-jdk8-windowsservercore-ltsc2016
 SharedTags: 1.7.1-jdk8, 1.7-jdk8, 1.7.1-jdk8-windowsservercore, 1.7-jdk8-windowsservercore
 Architectures: windows-amd64
-GitCommit: 90356f1334c6f714845f8df80823c8cdee9ff8cc
-Directory: 1.7.1/windowsservercore-ltsc2016/jdk-8
+GitCommit: f3e8a2a6da84fa0a372e46bb7e8d5a6b696bec24
+Directory: 1.7.1/windowsservercore-ltsc2016/jdk-8/
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Add an official image for Armed Bear Common Lisp (ABCL).

-	[ ] associated with or contacted upstream?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
