### PR TITLE
Add "cassandra.ring_delay_ms" to "cassandra-basics" test for 4.0+

### DIFF
--- a/test/tests/cassandra-basics/run.sh
+++ b/test/tests/cassandra-basics/run.sh
@@ -17,9 +17,10 @@ cid="$(
 		-e MAX_HEAP_SIZE='128m' \
 		-e HEAP_NEWSIZE='32m' \
 		-e JVM_OPTS='
+			-Dcassandra.ring_delay_ms=0
+			-Dcom.sun.management.jmxremote.authenticate=false
 			-Dcom.sun.management.jmxremote.port=7199
 			-Dcom.sun.management.jmxremote.ssl=false
-			-Dcom.sun.management.jmxremote.authenticate=false
 		' \
 		"$image"
 )"


### PR DESCRIPTION
This is a new feature in 4.0 that delays the startup for 30 seconds (by default; https://github.com/apache/cassandra/blob/5e8f7f591dfec5a61d8eb2e9e977ec29f3a2bbe4/src/java/org/apache/cassandra/service/StorageService.java#L150-L162).

See https://github.com/docker-library/cassandra/issues/221, especially https://github.com/docker-library/cassandra/issues/221#issuecomment-764939173. :+1: