### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.41.1, 3.41, 3, latest
+Tags: 3.41.2, 3.41, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1cae0d8b1a7e818f914b40946b89efd28e8c7082
+GitCommit: 91565daf85b7b99697077a7229757872efe00a1c
 Directory: 3/debian
 
-Tags: 3.41.1-alpine, 3.41-alpine, 3-alpine, alpine
+Tags: 3.41.2-alpine, 3.41-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 1cae0d8b1a7e818f914b40946b89efd28e8c7082
+GitCommit: 91565daf85b7b99697077a7229757872efe00a1c
 Directory: 3/alpine
 
 Tags: 2.38.2, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/91565da: Update to 3.41.2, ghost-cli 1.15.3