### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,40 +5,40 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.16beta1-buster, 1.16-rc-buster, rc-buster
-SharedTags: 1.16beta1, 1.16-rc, rc
+Tags: 1.16rc1-buster, 1.16-rc-buster, rc-buster
+SharedTags: 1.16rc1, 1.16-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2d03ce7ef01477465c84c13d68818ab2bedc7b16
+GitCommit: 820226fa71a0eaf46e76815c5db1e51a42d6d04d
 Directory: 1.16-rc/buster
 
-Tags: 1.16beta1-alpine3.13, 1.16-rc-alpine3.13, rc-alpine3.13, 1.16beta1-alpine, 1.16-rc-alpine, rc-alpine
+Tags: 1.16rc1-alpine3.13, 1.16-rc-alpine3.13, rc-alpine3.13, 1.16rc1-alpine, 1.16-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e069ef401a3eee2d16b5ad4dce939eaa02ae1bd1
+GitCommit: 820226fa71a0eaf46e76815c5db1e51a42d6d04d
 Directory: 1.16-rc/alpine3.13
 
-Tags: 1.16beta1-alpine3.12, 1.16-rc-alpine3.12, rc-alpine3.12
+Tags: 1.16rc1-alpine3.12, 1.16-rc-alpine3.12, rc-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e069ef401a3eee2d16b5ad4dce939eaa02ae1bd1
+GitCommit: 820226fa71a0eaf46e76815c5db1e51a42d6d04d
 Directory: 1.16-rc/alpine3.12
 
-Tags: 1.16beta1-windowsservercore-1809, 1.16-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.16beta1-windowsservercore, 1.16-rc-windowsservercore, rc-windowsservercore, 1.16beta1, 1.16-rc, rc
+Tags: 1.16rc1-windowsservercore-1809, 1.16-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.16rc1-windowsservercore, 1.16-rc-windowsservercore, rc-windowsservercore, 1.16rc1, 1.16-rc, rc
 Architectures: windows-amd64
-GitCommit: 2d03ce7ef01477465c84c13d68818ab2bedc7b16
+GitCommit: 820226fa71a0eaf46e76815c5db1e51a42d6d04d
 Directory: 1.16-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16beta1-windowsservercore-ltsc2016, 1.16-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.16beta1-windowsservercore, 1.16-rc-windowsservercore, rc-windowsservercore, 1.16beta1, 1.16-rc, rc
+Tags: 1.16rc1-windowsservercore-ltsc2016, 1.16-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.16rc1-windowsservercore, 1.16-rc-windowsservercore, rc-windowsservercore, 1.16rc1, 1.16-rc, rc
 Architectures: windows-amd64
-GitCommit: 2d03ce7ef01477465c84c13d68818ab2bedc7b16
+GitCommit: 820226fa71a0eaf46e76815c5db1e51a42d6d04d
 Directory: 1.16-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.16beta1-nanoserver-1809, 1.16-rc-nanoserver-1809, rc-nanoserver-1809
-SharedTags: 1.16beta1-nanoserver, 1.16-rc-nanoserver, rc-nanoserver
+Tags: 1.16rc1-nanoserver-1809, 1.16-rc-nanoserver-1809, rc-nanoserver-1809
+SharedTags: 1.16rc1-nanoserver, 1.16-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 2d03ce7ef01477465c84c13d68818ab2bedc7b16
+GitCommit: 820226fa71a0eaf46e76815c5db1e51a42d6d04d
 Directory: 1.16-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/820226f: Update 1.16-rc to 1.16rc1