### PR TITLE
Update clojure for tools-deps release 1.10.2.774 & invert architecture defaults

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 418a20e619eac56a317997aa5b8f975c154e44b6
+GitCommit: 4a571955122850ebcb7b01e517c505c2d1270726
 
 Tags: latest
 Architectures: amd64, arm64v8
@@ -20,10 +20,10 @@ Directory: target/openjdk-8-buster/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.1.763, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.1.763-buster
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.2.774, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.2.774-buster
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.1.763-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.2.774-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
 Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.5, lein, lein-2.9.5, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.5-buster, lein-buster, lein-2.9.5-buster
@@ -42,12 +42,12 @@ Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-
 Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.1.763, tools-deps, tools-deps-1.10.1.763, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.1.763-buster, tools-deps-buster, tools-deps-1.10.1.763-buster
 Architectures: amd64, arm64v8
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.2.774, tools-deps, tools-deps-1.10.2.774, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.2.774-buster, tools-deps-buster, tools-deps-1.10.2.774-buster
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.1.763-slim-buster, tools-deps-1.10.1.763-slim-buster, tools-deps-slim-buster
 Architectures: amd64, arm64v8
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.2.774-slim-buster, tools-deps-1.10.2.774-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
 Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.5, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.5-slim-buster
@@ -66,12 +66,12 @@ Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-15-buster/boot
 
-Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.1.763, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.1.763-slim-buster
 Architectures: amd64, arm64v8
+Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.2.774, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.2.774-slim-buster
 Directory: target/openjdk-15-slim-buster/tools-deps
 
-Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.1.763-buster
 Architectures: amd64, arm64v8
+Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.2.774-buster
 Directory: target/openjdk-15-buster/tools-deps
 
 Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.5, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.5-slim-buster
@@ -90,12 +90,12 @@ Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
 Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/boot
 
-Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.1.763, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.1.763-slim-buster
 Architectures: amd64, arm64v8
+Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.2.774, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.2.774-slim-buster
 Directory: target/openjdk-16-slim-buster/tools-deps
 
-Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.1.763-buster
 Architectures: amd64, arm64v8
+Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.2.774-buster
 Directory: target/openjdk-16-buster/tools-deps
 
 Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.5-alpine
@@ -104,5 +104,5 @@ Directory: target/openjdk-16-alpine/lein
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
 Directory: target/openjdk-16-alpine/boot
 
-Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.1.763-alpine
+Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.2.774-alpine
 Directory: target/openjdk-16-alpine/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -1,108 +1,98 @@
 Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
-Architectures: amd64
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
 GitCommit: 4a571955122850ebcb7b01e517c505c2d1270726
 
 Tags: latest
-Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/latest
 
 Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.5, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.5-buster
+Architectures: amd64
 Directory: target/openjdk-8-buster/lein
 
 Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.5-slim-buster
+Architectures: amd64
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
+Architectures: amd64
 Directory: target/openjdk-8-buster/boot
 
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
+Architectures: amd64
 Directory: target/openjdk-8-slim-buster/boot
 
 Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.2.774, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.2.774-buster
+Architectures: amd64
 Directory: target/openjdk-8-buster/tools-deps
 
 Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.2.774-slim-buster
+Architectures: amd64
 Directory: target/openjdk-8-slim-buster/tools-deps
 
 Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.5, lein, lein-2.9.5, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.5-buster, lein-buster, lein-2.9.5-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/lein
 
 Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.5-slim-buster, slim-buster, lein-slim-buster, lein-2.9.5-slim-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/lein
 
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-11-buster/boot
 
 Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-11-slim-buster/boot
 
-Architectures: amd64, arm64v8
 Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.2.774, tools-deps, tools-deps-1.10.2.774, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.2.774-buster, tools-deps-buster, tools-deps-1.10.2.774-buster
 Directory: target/openjdk-11-buster/tools-deps
 
-Architectures: amd64, arm64v8
 Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.2.774-slim-buster, tools-deps-1.10.2.774-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
 Tags: openjdk-15, openjdk-15-lein, openjdk-15-lein-2.9.5, openjdk-15-slim-buster, openjdk-15-lein-slim-buster, openjdk-15-lein-2.9.5-slim-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-15-slim-buster/lein
 
 Tags: openjdk-15-buster, openjdk-15-lein-buster, openjdk-15-lein-2.9.5-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-15-buster/lein
 
 Tags: openjdk-15-boot, openjdk-15-boot-2.8.3, openjdk-15-boot-slim-buster, openjdk-15-boot-2.8.3-slim-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-15-slim-buster/boot
 
 Tags: openjdk-15-boot-buster, openjdk-15-boot-2.8.3-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-15-buster/boot
 
-Architectures: amd64, arm64v8
 Tags: openjdk-15-tools-deps, openjdk-15-tools-deps-1.10.2.774, openjdk-15-tools-deps-slim-buster, openjdk-15-tools-deps-1.10.2.774-slim-buster
 Directory: target/openjdk-15-slim-buster/tools-deps
 
-Architectures: amd64, arm64v8
 Tags: openjdk-15-tools-deps-buster, openjdk-15-tools-deps-1.10.2.774-buster
 Directory: target/openjdk-15-buster/tools-deps
 
 Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.5, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.5-slim-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-slim-buster/lein
 
 Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.5-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/lein
 
 Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-slim-buster/boot
 
 Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
-Architectures: amd64, arm64v8
 Directory: target/openjdk-16-buster/boot
 
-Architectures: amd64, arm64v8
 Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.2.774, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.2.774-slim-buster
 Directory: target/openjdk-16-slim-buster/tools-deps
 
-Architectures: amd64, arm64v8
 Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.2.774-buster
 Directory: target/openjdk-16-buster/tools-deps
 
 Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.5-alpine
+Architectures: amd64
 Directory: target/openjdk-16-alpine/lein
 
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
+Architectures: amd64
 Directory: target/openjdk-16-alpine/boot
 
 Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.2.774-alpine
+Architectures: amd64
 Directory: target/openjdk-16-alpine/tools-deps


### PR DESCRIPTION
New upstream release and I inverted the architecture defaults so that we build amd64 & arm64v8 unless otherwise overridden. I'm wondering if there are other arm variants we can support by just adding them... I'll check out which ones the upstream images support and push more commits if so.