### PR TITLE
update kapacitor

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,7 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              j. Emrys Landivar <landivar@gmail.com> (@docmerlin)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: ddc7c40154e2a1afed17cbc72cc132e122c07711
+GitCommit: 384f6e83c3764607084a38b1c842d240729561d4
 
 Tags: 1.4, 1.4.1
 Architectures: amd64, arm32v7, arm64v8


### PR DESCRIPTION
The last kap PR had the wrong GitCommit: 384f6e83c3764607084a38b1c842d240729561d4 and pointed to a old version of kapacitor.
This is to fix that.