### PR TITLE
[Flink] add 1.10.3 ; update to 1.12.1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -4,6 +4,16 @@ Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
+Tags: 1.10.3-scala_2.11, 1.10-scala_2.11
+Architectures: amd64
+GitCommit: 2a89b61a261f803f8785fd5dd882b7f50ec33fce
+Directory: ./1.10/scala_2.11-debian
+
+Tags: 1.10.3-scala_2.12, 1.10-scala_2.12, 1.10.3, 1.10
+Architectures: amd64
+GitCommit: 2a89b61a261f803f8785fd5dd882b7f50ec33fce
+Directory: ./1.10/scala_2.12-debian
+
 Tags: 1.11.3-scala_2.11-java11, 1.11-scala_2.11-java11
 Architectures: amd64
 GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
@@ -24,22 +34,22 @@ Architectures: amd64
 GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
 Directory: ./1.11/scala_2.12-java8-debian
 
-Tags: 1.12.0-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
+Tags: 1.12.1-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
 Architectures: amd64
-GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
 Directory: ./1.12/scala_2.11-java11-debian
 
-Tags: 1.12.0-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.0-scala_2.11, 1.12-scala_2.11, scala_2.11
+Tags: 1.12.1-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.1-scala_2.11, 1.12-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
 Directory: ./1.12/scala_2.11-java8-debian
 
-Tags: 1.12.0-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.0-java11, 1.12-java11, java11
+Tags: 1.12.1-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.1-java11, 1.12-java11, java11
 Architectures: amd64
-GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
 Directory: ./1.12/scala_2.12-java11-debian
 
-Tags: 1.12.0-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.0-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.0-java8, 1.12-java8, java8, 1.12.0, 1.12, latest
+Tags: 1.12.1-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.1-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.1-java8, 1.12-java8, java8, 1.12.1, 1.12, latest
 Architectures: amd64
-GitCommit: 4d7cb3068d670bef274975c9412d5e40317fba3f
+GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
 Directory: ./1.12/scala_2.12-java8-debian


### PR DESCRIPTION
During the review process of the 1.12.0 official image, Apache Flink published 1.10.3 and 1.12.1 bugfix releases.
This PR is to add official images for these two released.