### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.41.2, 3.41, 3, latest
+Tags: 3.41.3, 3.41, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 91565daf85b7b99697077a7229757872efe00a1c
+GitCommit: 71e50bb4edeea9b2744c52c715383f14704abae9
 Directory: 3/debian
 
-Tags: 3.41.2-alpine, 3.41-alpine, 3-alpine, alpine
+Tags: 3.41.3-alpine, 3.41-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 91565daf85b7b99697077a7229757872efe00a1c
+GitCommit: 71e50bb4edeea9b2744c52c715383f14704abae9
 Directory: 3/alpine
 
-Tags: 2.38.2, 2.38, 2
+Tags: 2.38.3, 2.38, 2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3eeb98378c4664f4f7813c3d45bfeee26d51ce58
+GitCommit: 520d77b96f88615fdcfa02434d1ca15a97bf62b6
 Directory: 2/debian
 
-Tags: 2.38.2-alpine, 2.38-alpine, 2-alpine
+Tags: 2.38.3-alpine, 2.38-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386
-GitCommit: 3eeb98378c4664f4f7813c3d45bfeee26d51ce58
+GitCommit: 520d77b96f88615fdcfa02434d1ca15a97bf62b6
 Directory: 2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/520d77b: Update to 2.38.3, ghost-cli 1.15.3