### PR TITLE
archlinux: Release 20210131.0.14634

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210124.0.14185
-GitCommit: b505de76a596b73ff39b0137b78cd308dc541794
-GitFetch: refs/tags/v20210124.0.14185
+Tags: latest, base, base-20210131.0.14634
+GitCommit: fe5afeda1a556c6cf06538590e2c44a57ff34422
+GitFetch: refs/tags/v20210131.0.14634
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210124.0.14185
-GitCommit: b505de76a596b73ff39b0137b78cd308dc541794
-GitFetch: refs/tags/v20210124.0.14185
+Tags: base-devel, base-devel-20210131.0.14634
+GitCommit: fe5afeda1a556c6cf06538590e2c44a57ff34422
+GitFetch: refs/tags/v20210131.0.14634
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
