### PR TITLE
New mga 8 image and Rebuilt mga 7 and caludron images

### DIFF
--- a/library/mageia
+++ b/library/mageia
@@ -1,8 +1,16 @@
 Maintainers: Juan Luis Baptiste <juancho@mageia.org> (@juanluisbaptiste)
 GitRepo: https://github.com/juanluisbaptiste/docker-brew-mageia.git
 
+Tags: 8, rc
+GitCommit: 723f7d8c483da1b72d0ab80b0e515e431aa0fd71
+GitFetch: refs/heads/dist
+Architectures: amd64, arm32v7, arm64v8
+amd64-Directory: dist/8/x86_64
+arm32v7-Directory: dist/8/armv7hl
+arm64v8-Directory: dist/8/aarch64
+
 Tags: 7, latest
-GitCommit: d6147eff57f9453625efceebb5f5c432b94ca5e5
+GitCommit: 723f7d8c483da1b72d0ab80b0e515e431aa0fd71
 GitFetch: refs/heads/dist
 Architectures: amd64, arm32v7, arm64v8
 amd64-Directory: dist/7/x86_64
@@ -10,7 +18,7 @@ arm32v7-Directory: dist/7/armv7hl
 arm64v8-Directory: dist/7/aarch64
 
 Tags: cauldron
-GitCommit: d6147eff57f9453625efceebb5f5c432b94ca5e5
+GitCommit: 723f7d8c483da1b72d0ab80b0e515e431aa0fd71
 GitFetch: refs/heads/dist
 Architectures: amd64, arm32v7, arm64v8
 amd64-Directory: dist/cauldron/x86_64


### PR DESCRIPTION
Hi @tianon, we are pushing new images for the upcoming mageia 8 that entered release candidate status last week.

Related Issue juanluisbaptiste/docker-brew-mageia#18