### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/983db56256d00139016363cdc6720c0da303ef12/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/9f83d3a1b64980a74c66af30afcb472e1329aede/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 983db56256d00139016363cdc6720c0da303ef12
+GitCommit: 9f83d3a1b64980a74c66af30afcb472e1329aede
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 795a8cc57141baf321a34a602cb18ad85daac216
+amd64-GitCommit: 844e23eae6a28fd1faf9b25f8ed977ae4b168a0f
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: a6247dad37bda065fb8945c465ddbeebdf047151
+arm32v5-GitCommit: d7cdb7b3f9b596299c358ba02ca12be6bf991bf6
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 972fd669d037a688c9d668662ad3b35e03b93301
+arm32v6-GitCommit: 6dcbfd99dcb53377cc0ec7f91f1ee34bf8311e05
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: decd790ace11d23ba9fe9cae8c76ffb81c472c42
+arm32v7-GitCommit: f967699a04d94ef4e8154b6e0caeeacb94730449
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 385dcf62178190a3cc8ef5129a3236466d3abab5
+arm64v8-GitCommit: c1c928bcef1c6fa3eb1a4e76df823b078a7642bf
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 6c25c0f67e0023d05936fedfc836636ead8954f0
+i386-GitCommit: 9d15b86fc841ea26a6f4887fd554e9dfa2f7ad05
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: e4053715658caaf251ca555cc529c027ef00e6ff
+mips64le-GitCommit: 853a29d2c7ba8c1092be620fef78402694ad29ae
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: b82f67ef98672aa4841a7b391454ed8d5c03ebd9
+ppc64le-GitCommit: 453429cc27ba7d629435dfe42afa9b218bf010ad
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ae5dd8d26f3b83fa4accef79d4cedb040b8a5962
+s390x-GitCommit: affd246366853a821748bd8d32563fbc1c3ce018
 
 Tags: 1.32.1-uclibc, 1.32-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/9f83d3a: Merge pull request https://github.com/docker-library/busybox/pull/95 from J0WI/alpine-3.13
- https://github.com/docker-library/busybox/commit/407a561: Update Buildroot to 2020.11.2
- https://github.com/docker-library/busybox/commit/fd5562d: Alpine 3.13