### PR TITLE
Update InfluxDB 1.8 OSS to 1.8.4

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 6f10af34465b675d9e6de241b57210f01d12b453
+GitCommit: 4d733eabcc1e3691e462a702db8eede9d19a9c0a
 
 Tags: 1.7, 1.7.10
 Architectures: amd64, arm32v7, arm64v8
@@ -21,11 +21,11 @@ Directory: influxdb/1.7/meta
 Tags: 1.7-meta-alpine, 1.7.10-meta-alpine
 Directory: influxdb/1.7/meta/alpine
 
-Tags: 1.8, 1.8.3, latest
+Tags: 1.8, 1.8.4, latest
 Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8
 
-Tags: 1.8-alpine, 1.8.3-alpine, alpine
+Tags: 1.8-alpine, 1.8.4-alpine, alpine
 Directory: influxdb/1.8/alpine
 
 Tags: 1.8-data, 1.8.3-data, data


### PR DESCRIPTION
The `data` and `meta` variants are purposefully still on 1.8.3 while we finish testing our Enterprise extensions