### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -11,7 +11,7 @@ Directory: 2.4-rc
 
 Tags: 2.4-dev6-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 63151039103973f61addbfd90c7eeb027d916682
+GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.4, 2.3, latest
@@ -21,7 +21,7 @@ Directory: 2.3
 
 Tags: 2.3.4-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2669f94efd40ced39016f4eff0e29e0c141b96b5
+GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
 Directory: 2.3/alpine
 
 Tags: 2.2.8, 2.2, lts
@@ -31,7 +31,7 @@ Directory: 2.2
 
 Tags: 2.2.8-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bee29ff5574db20488e4eb0b7914051fca328cfc
+GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
 Directory: 2.2/alpine
 
 Tags: 2.1.11, 2.1
@@ -41,7 +41,7 @@ Directory: 2.1
 
 Tags: 2.1.11-alpine, 2.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 77cae8f4011926668a3548acf133cfe635f4d68a
+GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
 Directory: 2.1/alpine
 
 Tags: 2.0.20, 2.0
@@ -51,7 +51,7 @@ Directory: 2.0
 
 Tags: 2.0.20-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a8a76545dc5ba20d2c08001dc7507b7b2161ed90
+GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
 Directory: 2.0/alpine
 
 Tags: 1.8.28, 1.8
@@ -61,7 +61,7 @@ Directory: 1.8
 
 Tags: 1.8.28-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74912d5713bfb45596c55a174342898bd2c58960
+GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/026bede: Merge pull request https://github.com/docker-library/haproxy/pull/140 from J0WI/alpine-3.13
- https://github.com/docker-library/haproxy/commit/e25db19: Add comment on why 1.7 is stuck on Alpine 3.12
- https://github.com/docker-library/haproxy/commit/dba80a9: Alpine 3.13