### PR TITLE
Odoo: update 12.0-14.0 to release 20210204

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 8b937ea8137b0630526e059a2e790fd8acc740c3
+GitCommit: 44a0a3f1b32e72b55079fb1a6a05efdbda248bfe
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hi,

here are the latest updates of the current Odoo supported releases.

Thanks.