### PR TITLE
eclipse-mosquitto new versions 2.0.7 and 1.6.13

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,18 +1,18 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: f1180dd23a32f4c6b7651abbb2646823f73ee5e4
+GitCommit: 0736414306caa4229c5b476b616bb0491c423145
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 2.0.6, 2.0, 2
+Tags: 2.0.7, 2.0, 2, latest
 Directory: docker/2.0
 
-Tags: 2.0.6-openssl, 2.0-openssl, 2-openssl
+Tags: 2.0.7-openssl, 2.0-openssl, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
-Tags: 1.6.12, 1.6, latest
+Tags: 1.6.13, 1.6
 Directory: docker/1.6
 
-Tags: 1.6.12-openssl, 1.6-openssl, openssl
+Tags: 1.6.13-openssl, 1.6-openssl
 Directory: docker/1.6-openssl
 
 Tags: 1.5.10, 1.5


### PR DESCRIPTION
latest tag has moved from 1.6.x to 2.0.x
openssl tag has moved from 1.6.x-openssl to 2.0.x-openssl

The 2.0 release has been around since the start of December to give time for testing and migration for anyone on `latest`, and it was announced a week ago that the change to `latest` would be happening today.