### PR TITLE
[security] Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -44,122 +44,122 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
 Directory: 8.0/alpine3.12/fpm
 
-Tags: 7.4.14-cli-buster, 7.4-cli-buster, 7-cli-buster, 7.4.14-buster, 7.4-buster, 7-buster, 7.4.14-cli, 7.4-cli, 7-cli, 7.4.14, 7.4, 7
+Tags: 7.4.15-cli-buster, 7.4-cli-buster, 7-cli-buster, 7.4.15-buster, 7.4-buster, 7-buster, 7.4.15-cli, 7.4-cli, 7-cli, 7.4.15, 7.4, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/buster/cli
 
-Tags: 7.4.14-apache-buster, 7.4-apache-buster, 7-apache-buster, 7.4.14-apache, 7.4-apache, 7-apache
+Tags: 7.4.15-apache-buster, 7.4-apache-buster, 7-apache-buster, 7.4.15-apache, 7.4-apache, 7-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/buster/apache
 
-Tags: 7.4.14-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, 7.4.14-fpm, 7.4-fpm, 7-fpm
+Tags: 7.4.15-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, 7.4.15-fpm, 7.4-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/buster/fpm
 
-Tags: 7.4.14-zts-buster, 7.4-zts-buster, 7-zts-buster, 7.4.14-zts, 7.4-zts, 7-zts
+Tags: 7.4.15-zts-buster, 7.4-zts-buster, 7-zts-buster, 7.4.15-zts, 7.4-zts, 7-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/buster/zts
 
-Tags: 7.4.14-cli-alpine3.13, 7.4-cli-alpine3.13, 7-cli-alpine3.13, 7.4.14-alpine3.13, 7.4-alpine3.13, 7-alpine3.13, 7.4.14-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, 7.4.14-alpine, 7.4-alpine, 7-alpine
+Tags: 7.4.15-cli-alpine3.13, 7.4-cli-alpine3.13, 7-cli-alpine3.13, 7.4.15-alpine3.13, 7.4-alpine3.13, 7-alpine3.13, 7.4.15-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, 7.4.15-alpine, 7.4-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/alpine3.13/cli
 
-Tags: 7.4.14-fpm-alpine3.13, 7.4-fpm-alpine3.13, 7-fpm-alpine3.13, 7.4.14-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine
+Tags: 7.4.15-fpm-alpine3.13, 7.4-fpm-alpine3.13, 7-fpm-alpine3.13, 7.4.15-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/alpine3.13/fpm
 
-Tags: 7.4.14-zts-alpine3.13, 7.4-zts-alpine3.13, 7-zts-alpine3.13, 7.4.14-zts-alpine, 7.4-zts-alpine, 7-zts-alpine
+Tags: 7.4.15-zts-alpine3.13, 7.4-zts-alpine3.13, 7-zts-alpine3.13, 7.4.15-zts-alpine, 7.4-zts-alpine, 7-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/alpine3.13/zts
 
-Tags: 7.4.14-cli-alpine3.12, 7.4-cli-alpine3.12, 7-cli-alpine3.12, 7.4.14-alpine3.12, 7.4-alpine3.12, 7-alpine3.12
+Tags: 7.4.15-cli-alpine3.12, 7.4-cli-alpine3.12, 7-cli-alpine3.12, 7.4.15-alpine3.12, 7.4-alpine3.12, 7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/alpine3.12/cli
 
-Tags: 7.4.14-fpm-alpine3.12, 7.4-fpm-alpine3.12, 7-fpm-alpine3.12
+Tags: 7.4.15-fpm-alpine3.12, 7.4-fpm-alpine3.12, 7-fpm-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/alpine3.12/fpm
 
-Tags: 7.4.14-zts-alpine3.12, 7.4-zts-alpine3.12, 7-zts-alpine3.12
+Tags: 7.4.15-zts-alpine3.12, 7.4-zts-alpine3.12, 7-zts-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 1ad18817e5de82df1a8855fe711de0b3c0c320b9
 Directory: 7.4/alpine3.12/zts
 
-Tags: 7.3.26-cli-buster, 7.3-cli-buster, 7.3.26-buster, 7.3-buster, 7.3.26-cli, 7.3-cli, 7.3.26, 7.3
+Tags: 7.3.27-cli-buster, 7.3-cli-buster, 7.3.27-buster, 7.3-buster, 7.3.27-cli, 7.3-cli, 7.3.27, 7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/buster/cli
 
-Tags: 7.3.26-apache-buster, 7.3-apache-buster, 7.3.26-apache, 7.3-apache
+Tags: 7.3.27-apache-buster, 7.3-apache-buster, 7.3.27-apache, 7.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/buster/apache
 
-Tags: 7.3.26-fpm-buster, 7.3-fpm-buster, 7.3.26-fpm, 7.3-fpm
+Tags: 7.3.27-fpm-buster, 7.3-fpm-buster, 7.3.27-fpm, 7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/buster/fpm
 
-Tags: 7.3.26-zts-buster, 7.3-zts-buster, 7.3.26-zts, 7.3-zts
+Tags: 7.3.27-zts-buster, 7.3-zts-buster, 7.3.27-zts, 7.3-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/buster/zts
 
-Tags: 7.3.26-cli-stretch, 7.3-cli-stretch, 7.3.26-stretch, 7.3-stretch
+Tags: 7.3.27-cli-stretch, 7.3-cli-stretch, 7.3.27-stretch, 7.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/stretch/cli
 
-Tags: 7.3.26-apache-stretch, 7.3-apache-stretch
+Tags: 7.3.27-apache-stretch, 7.3-apache-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/stretch/apache
 
-Tags: 7.3.26-fpm-stretch, 7.3-fpm-stretch
+Tags: 7.3.27-fpm-stretch, 7.3-fpm-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/stretch/fpm
 
-Tags: 7.3.26-zts-stretch, 7.3-zts-stretch
+Tags: 7.3.27-zts-stretch, 7.3-zts-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/stretch/zts
 
-Tags: 7.3.26-cli-alpine3.13, 7.3-cli-alpine3.13, 7.3.26-alpine3.13, 7.3-alpine3.13, 7.3.26-cli-alpine, 7.3-cli-alpine, 7.3.26-alpine, 7.3-alpine
+Tags: 7.3.27-cli-alpine3.13, 7.3-cli-alpine3.13, 7.3.27-alpine3.13, 7.3-alpine3.13, 7.3.27-cli-alpine, 7.3-cli-alpine, 7.3.27-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/alpine3.13/cli
 
-Tags: 7.3.26-fpm-alpine3.13, 7.3-fpm-alpine3.13, 7.3.26-fpm-alpine, 7.3-fpm-alpine
+Tags: 7.3.27-fpm-alpine3.13, 7.3-fpm-alpine3.13, 7.3.27-fpm-alpine, 7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/alpine3.13/fpm
 
-Tags: 7.3.26-zts-alpine3.13, 7.3-zts-alpine3.13, 7.3.26-zts-alpine, 7.3-zts-alpine
+Tags: 7.3.27-zts-alpine3.13, 7.3-zts-alpine3.13, 7.3.27-zts-alpine, 7.3-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/alpine3.13/zts
 
-Tags: 7.3.26-cli-alpine3.12, 7.3-cli-alpine3.12, 7.3.26-alpine3.12, 7.3-alpine3.12
+Tags: 7.3.27-cli-alpine3.12, 7.3-cli-alpine3.12, 7.3.27-alpine3.12, 7.3-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/alpine3.12/cli
 
-Tags: 7.3.26-fpm-alpine3.12, 7.3-fpm-alpine3.12
+Tags: 7.3.27-fpm-alpine3.12, 7.3-fpm-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/alpine3.12/fpm
 
-Tags: 7.3.26-zts-alpine3.12, 7.3-zts-alpine3.12
+Tags: 7.3.27-zts-alpine3.12, 7.3-zts-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74175669f4162058e1fb0d2b0cf342e35f9c0804
+GitCommit: 29b7e57a1522c47e480693e537acf0328e4a7207
 Directory: 7.3/alpine3.12/zts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/1ad1881: Update 7.4 to 7.4.15
- https://github.com/docker-library/php/commit/29b7e57: Update 7.3 to 7.3.27

There's also an 8.0.2 release, but according to https://www.php.net/ only these two are security releases and 8.0.2 failed in `update.sh` for reasons I need to dig further into (although no reason to hold up the things noted to be security updates on that).