### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-7-jdk-oraclelinux8, 17-ea-7-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-7-jdk-oracle, 17-ea-7-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-7-jdk, 17-ea-7, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-8-jdk-oraclelinux8, 17-ea-8-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-8-jdk-oracle, 17-ea-8-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-8-jdk, 17-ea-8, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-7-jdk-oraclelinux7, 17-ea-7-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-8-jdk-oraclelinux7, 17-ea-8-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-7-jdk-buster, 17-ea-7-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-8-jdk-buster, 17-ea-8-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/buster
 
-Tags: 17-ea-7-jdk-slim-buster, 17-ea-7-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-7-jdk-slim, 17-ea-7-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-8-jdk-slim-buster, 17-ea-8-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-8-jdk-slim, 17-ea-8-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-5-jdk-alpine3.13, 17-ea-5-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-5-jdk-alpine, 17-ea-5-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,76 +35,66 @@ Architectures: amd64
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-7-jdk-windowsservercore-1809, 17-ea-7-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-7-jdk-windowsservercore, 17-ea-7-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-7-jdk, 17-ea-7, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-8-jdk-windowsservercore-1809, 17-ea-8-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-8-jdk-windowsservercore, 17-ea-8-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-8-jdk, 17-ea-8, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-7-jdk-windowsservercore-ltsc2016, 17-ea-7-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-7-jdk-windowsservercore, 17-ea-7-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-7-jdk, 17-ea-7, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-8-jdk-windowsservercore-ltsc2016, 17-ea-8-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-8-jdk-windowsservercore, 17-ea-8-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-8-jdk, 17-ea-8, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-7-jdk-nanoserver-1809, 17-ea-7-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-7-jdk-nanoserver, 17-ea-7-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-8-jdk-nanoserver-1809, 17-ea-8-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-8-jdk-nanoserver, 17-ea-8-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 5651c6bccc2f063fc0126482bc38facadf49ce4f
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16-ea-34-jdk-oraclelinux8, 16-ea-34-oraclelinux8, 16-ea-jdk-oraclelinux8, 16-ea-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16-ea-34-jdk-oracle, 16-ea-34-oracle, 16-ea-jdk-oracle, 16-ea-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16-ea-34-jdk, 16-ea-34, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-jdk-oraclelinux8, 16-oraclelinux8, 16-jdk-oracle, 16-oracle
+SharedTags: 16-jdk, 16
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-ea-34-jdk-oraclelinux7, 16-ea-34-oraclelinux7, 16-ea-jdk-oraclelinux7, 16-ea-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-ea-34-jdk-buster, 16-ea-34-buster, 16-ea-jdk-buster, 16-ea-buster, 16-jdk-buster, 16-buster
+Tags: 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/buster
 
-Tags: 16-ea-34-jdk-slim-buster, 16-ea-34-slim-buster, 16-ea-jdk-slim-buster, 16-ea-slim-buster, 16-jdk-slim-buster, 16-slim-buster, 16-ea-34-jdk-slim, 16-ea-34-slim, 16-ea-jdk-slim, 16-ea-slim, 16-jdk-slim, 16-slim
+Tags: 16-jdk-slim-buster, 16-slim-buster, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/slim-buster
 
-Tags: 16-ea-32-jdk-alpine3.13, 16-ea-32-alpine3.13, 16-ea-jdk-alpine3.13, 16-ea-alpine3.13, 16-jdk-alpine3.13, 16-alpine3.13, 16-ea-32-jdk-alpine, 16-ea-32-alpine, 16-ea-jdk-alpine, 16-ea-alpine, 16-jdk-alpine, 16-alpine
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 16/jdk/alpine3.13
-
-Tags: 16-ea-32-jdk-alpine3.12, 16-ea-32-alpine3.12, 16-ea-jdk-alpine3.12, 16-ea-alpine3.12, 16-jdk-alpine3.12, 16-alpine3.12
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 16/jdk/alpine3.12
-
-Tags: 16-ea-34-jdk-windowsservercore-1809, 16-ea-34-windowsservercore-1809, 16-ea-jdk-windowsservercore-1809, 16-ea-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-ea-34-jdk-windowsservercore, 16-ea-34-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-34-jdk, 16-ea-34, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16-jdk-windowsservercore, 16-windowsservercore, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-ea-34-jdk-windowsservercore-ltsc2016, 16-ea-34-windowsservercore-ltsc2016, 16-ea-jdk-windowsservercore-ltsc2016, 16-ea-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-ea-34-jdk-windowsservercore, 16-ea-34-windowsservercore, 16-ea-jdk-windowsservercore, 16-ea-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16-ea-34-jdk, 16-ea-34, 16-ea-jdk, 16-ea, 16-jdk, 16
+Tags: 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16-jdk-windowsservercore, 16-windowsservercore, 16-jdk, 16
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-ea-34-jdk-nanoserver-1809, 16-ea-34-nanoserver-1809, 16-ea-jdk-nanoserver-1809, 16-ea-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-ea-34-jdk-nanoserver, 16-ea-34-nanoserver, 16-ea-jdk-nanoserver, 16-ea-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5651c6b: Update 17 to 17-ea+8
- https://github.com/docker-library/openjdk/commit/07973f4: Update 16 to 16

Notably, this does *not* move `latest` to 16 yet because this 16 build is the first official release candidate (https://jdk.java.net/16/; https://openjdk.java.net/projects/jdk/16/).