### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -51,7 +51,7 @@ Directory: debian/sid
 
 Tags: stretch-curl, oldstable-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
+GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55
 Directory: debian/stretch/curl
 
 Tags: stretch-scm, oldstable-scm
@@ -126,7 +126,7 @@ Directory: ubuntu/hirsute
 
 Tags: xenial-curl, 16.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
+GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55
 Directory: ubuntu/xenial/curl
 
 Tags: xenial-scm, 16.04-scm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/5be5c34: Merge pull request https://github.com/docker-library/buildpack-deps/pull/119 from Ripolin/master
- https://github.com/docker-library/buildpack-deps/commit/93d2a6f: Add package apt-transport-https for xenial & stretch