### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev6, 2.4-dev
+Tags: 2.4-dev7, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 63151039103973f61addbfd90c7eeb027d916682
+GitCommit: 427e4f4420c5cfd91ac2ad8dee873f4b5ebf377c
 Directory: 2.4-rc
 
-Tags: 2.4-dev6-alpine, 2.4-dev-alpine
+Tags: 2.4-dev7-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
+GitCommit: 427e4f4420c5cfd91ac2ad8dee873f4b5ebf377c
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.4, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/427e4f4: Update to 2.4-dev7