### PR TITLE
[oraclelinux] Significantly reduce the size of oraclelinux:8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ae7ed9f8a7fc53fcc06b7137748c3a3ef84db4d9
+amd64-GitCommit: 500bbb9052a6193e71d1308b43be671dd498cfe3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 67dfa5b41bc3dcc5e734f5a675587b11c81a8271
+arm64v8-GitCommit: 85b269a3604ef25905f6c5c646be76c1d91baece
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Instead of installing 200MB worth of languages, just install
glibc-langpack-en. This almost halves the size of the final
images. Additional languages can be installed simply by
running: dnf install glibc-langpack-<LANG>

If all language packs are required, use the following command:
dnf swap glibc-langpack-en glibc-all-langpacks

Signed-off-by: Avi Miller <avi.miller@oracle.com>