### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 427e4f4420c5cfd91ac2ad8dee873f4b5ebf377c
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.4, 2.3, latest
+Tags: 2.3.5, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2669f94efd40ced39016f4eff0e29e0c141b96b5
+GitCommit: 2ff774fa949e8d4d6e4efb9a9288b7c14f81ed6f
 Directory: 2.3
 
-Tags: 2.3.4-alpine, 2.3-alpine, alpine
+Tags: 2.3.5-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
+GitCommit: 2ff774fa949e8d4d6e4efb9a9288b7c14f81ed6f
 Directory: 2.3/alpine
 
-Tags: 2.2.8, 2.2, lts
+Tags: 2.2.9, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bee29ff5574db20488e4eb0b7914051fca328cfc
+GitCommit: 8c970f81306cfaf1c554bf41f63c0835da7839f3
 Directory: 2.2
 
-Tags: 2.2.8-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.9-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
+GitCommit: 8c970f81306cfaf1c554bf41f63c0835da7839f3
 Directory: 2.2/alpine
 
 Tags: 2.1.11, 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8c970f8: Update to 2.2.9
- https://github.com/docker-library/haproxy/commit/2ff774f: Update to 2.3.5