### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 3.6.21-xenial, 3.6-xenial, 3-xenial
-SharedTags: 3.6.21, 3.6, 3
+Tags: 3.6.22-xenial, 3.6-xenial, 3-xenial
+SharedTags: 3.6.22, 3.6, 3
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/3.6/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: d98dc3a1e7f217ac0294db4e6ed4c3f667a1b579
+GitCommit: 0b9f973c630e5fc50c20789d311612bf052d78ee
 Directory: 3.6
 
-Tags: 3.6.21-windowsservercore-1809, 3.6-windowsservercore-1809, 3-windowsservercore-1809
-SharedTags: 3.6.21-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.21, 3.6, 3
+Tags: 3.6.22-windowsservercore-1809, 3.6-windowsservercore-1809, 3-windowsservercore-1809
+SharedTags: 3.6.22-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.22, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 69ff4eedfbae6012b7c56de2c0fed730b70b3d18
+GitCommit: 0b9f973c630e5fc50c20789d311612bf052d78ee
 Directory: 3.6/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.6.21-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.21-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.21, 3.6, 3
+Tags: 3.6.22-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
+SharedTags: 3.6.22-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.22, 3.6, 3
 Architectures: windows-amd64
-GitCommit: 69ff4eedfbae6012b7c56de2c0fed730b70b3d18
+GitCommit: 0b9f973c630e5fc50c20789d311612bf052d78ee
 Directory: 3.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
@@ -29,7 +29,7 @@ Tags: 4.0.22-xenial, 4.0-xenial
 SharedTags: 4.0.22, 4.0
 # see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: d98dc3a1e7f217ac0294db4e6ed4c3f667a1b579
+GitCommit: bc7b2d08696f84ef9b85cf98cfefb189c6a1f30e
 Directory: 4.0
 
 Tags: 4.0.22-windowsservercore-1809, 4.0-windowsservercore-1809
@@ -50,7 +50,7 @@ Tags: 4.2.12-bionic, 4.2-bionic
 SharedTags: 4.2.12, 4.2
 # see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/
 Architectures: amd64, arm64v8
-GitCommit: 2914dde5c52b3c1680a0573418c94d0a3de581de
+GitCommit: bc7b2d08696f84ef9b85cf98cfefb189c6a1f30e
 Directory: 4.2
 
 Tags: 4.2.12-windowsservercore-1809, 4.2-windowsservercore-1809
@@ -71,7 +71,7 @@ Tags: 4.4.3-bionic, 4.4-bionic, 4-bionic, bionic
 SharedTags: 4.4.3, 4.4, 4, latest
 # see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.4/multiverse/
 Architectures: amd64, arm64v8, s390x
-GitCommit: d98dc3a1e7f217ac0294db4e6ed4c3f667a1b579
+GitCommit: bc7b2d08696f84ef9b85cf98cfefb189c6a1f30e
 Directory: 4.4
 
 Tags: 4.4.3-windowsservercore-1809, 4.4-windowsservercore-1809, 4-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/0b9f973: Update to 3.6.22
- https://github.com/docker-library/mongo/commit/bc7b2d0: Keep the systemctl workaround always -- it's included in the new 3.6.22...