### PR TITLE
Update Solr to 8.8.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,12 +6,22 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.7.0, 8.7, 8, latest
+Tags: 8.8.0, 8.8, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: 56d2b10fa195697cd02266959992bf6cbd0a752a
+Directory: 8.8
+
+Tags: 8.8.0-slim, 8.8-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 56d2b10fa195697cd02266959992bf6cbd0a752a
+Directory: 8.8/slim
+
+Tags: 8.7.0, 8.7
 Architectures: amd64, arm64v8
 GitCommit: 5ca83ea788711fb540d2073d95da115af53d1319
 Directory: 8.7
 
-Tags: 8.7.0-slim, 8.7-slim, 8-slim, slim
+Tags: 8.7.0-slim, 8.7-slim
 Architectures: amd64, arm64v8
 GitCommit: 5ca83ea788711fb540d2073d95da115af53d1319
 Directory: 8.7/slim


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/r5c8e590b25b491fef16dc2b236f46eed380db14e8c9a273e539bcd9d%40%3Csolr-user.lucene.apache.org%3E) which links to the [release notes](https://lucene.apache.org/solr/8_8_0/changes/Changes.html).

One change in this upgrading likely to be noticed by docker-solr users is the following:
* https://issues.apache.org/jira/browse/SOLR-15010 -- Missing jstack warning is alarming, when using bin/solr as client interface to solr.  This warning doesn't appear anymore, and furthermore, Solr is now able to use "jattach" to accomplish what jstack did.

Copy-pasting the release highlights:
* Reducing overseer bottlenecks using per-replica states. More stability and
lesser load on large cluster that use this feature.
* Better restart and collection creation performance.
* Interleaving support in Learning To Rank