### PR TITLE
Odoo: update 12.0-14.0 to release 20210210

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 44a0a3f1b32e72b55079fb1a6a05efdbda248bfe
+GitCommit: 6fb83876d016fcdcae40853c8e0d405dac7feaef
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported version.

Thanks.