### PR TITLE
haxe 4.2.0

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,55 +1,95 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 4.1.5-buster, 4.1-buster
-SharedTags: 4.1.5, 4.1, latest
+Tags: 4.2.0-buster, 4.2-buster
+SharedTags: 4.2.0, 4.2, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: 100bda926beb145afea4f005fecce65c85db9a8f
+Directory: 4.2/buster
+
+Tags: 4.2.0-windowsservercore-1809, 4.2-windowsservercore-1809
+SharedTags: 4.2.0-windowsservercore, 4.2-windowsservercore, 4.2.0, 4.2, latest
+Architectures: windows-amd64
+GitCommit: 100bda926beb145afea4f005fecce65c85db9a8f
+Directory: 4.2/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 4.2.0-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016
+SharedTags: 4.2.0-windowsservercore, 4.2-windowsservercore, 4.2.0, 4.2, latest
+Architectures: windows-amd64
+GitCommit: 100bda926beb145afea4f005fecce65c85db9a8f
+Directory: 4.2/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 4.2.0-alpine3.13, 4.2-alpine3.13, 4.2.0-alpine, 4.2-alpine
+Architectures: amd64, arm64v8
+GitCommit: 100bda926beb145afea4f005fecce65c85db9a8f
+Directory: 4.2/alpine3.13
+
+Tags: 4.2.0-alpine3.12, 4.2-alpine3.12
+Architectures: amd64, arm64v8
+GitCommit: 353a469f0406127a52e98ff798c703f064d719c7
+Directory: 4.2/alpine3.12
+
+Tags: 4.2.0-alpine3.11, 4.2-alpine3.11
+Architectures: amd64, arm64v8
+GitCommit: 353a469f0406127a52e98ff798c703f064d719c7
+Directory: 4.2/alpine3.11
+
+Tags: 4.2.0-alpine3.10, 4.2-alpine3.10
+Architectures: amd64, arm64v8
+GitCommit: 353a469f0406127a52e98ff798c703f064d719c7
+Directory: 4.2/alpine3.10
+
+Tags: 4.1.5-buster, 4.1-buster
+SharedTags: 4.1.5, 4.1
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.1/buster
 
 Tags: 4.1.5-windowsservercore-1809, 4.1-windowsservercore-1809
-SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1, latest
+SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1
 Architectures: windows-amd64
 GitCommit: c01eea28361debd68bc2e1f5318aa0bf28ebb05a
 Directory: 4.1/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 4.1.5-windowsservercore-ltsc2016, 4.1-windowsservercore-ltsc2016
-SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1, latest
+SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1
 Architectures: windows-amd64
 GitCommit: c01eea28361debd68bc2e1f5318aa0bf28ebb05a
 Directory: 4.1/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.1.5-alpine3.12, 4.1-alpine3.12, 4.1.5-alpine, 4.1-alpine
+Tags: 4.1.5-alpine3.13, 4.1-alpine3.13, 4.1.5-alpine, 4.1-alpine
 Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: c195ebc0755b9debcfacbd6edc977a8ad1cd450e
+Directory: 4.1/alpine3.13
+
+Tags: 4.1.5-alpine3.12, 4.1-alpine3.12
+Architectures: amd64, arm64v8
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.1/alpine3.12
 
 Tags: 4.1.5-alpine3.11, 4.1-alpine3.11
 Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.1/alpine3.11
 
 Tags: 4.1.5-alpine3.10, 4.1-alpine3.10
 Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.1/alpine3.10
-
-Tags: 4.1.5-alpine3.9, 4.1-alpine3.9
-Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
-Directory: 4.1/alpine3.9
 
 Tags: 4.0.5-buster, 4.0-buster
 SharedTags: 4.0.5, 4.0
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.0/buster
 
 Tags: 4.0.5-stretch, 4.0-stretch
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.0/stretch
 
 Tags: 4.0.5-windowsservercore-1809, 4.0-windowsservercore-1809
@@ -66,25 +106,25 @@ GitCommit: 38b1ceb14a5692ae2c655c056baaff79d963da33
 Directory: 4.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.5-alpine3.12, 4.0-alpine3.12, 4.0.5-alpine, 4.0-alpine
+Tags: 4.0.5-alpine3.13, 4.0-alpine3.13, 4.0.5-alpine, 4.0-alpine
 Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: c195ebc0755b9debcfacbd6edc977a8ad1cd450e
+Directory: 4.0/alpine3.13
+
+Tags: 4.0.5-alpine3.12, 4.0-alpine3.12
+Architectures: amd64, arm64v8
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.0/alpine3.12
 
 Tags: 4.0.5-alpine3.11, 4.0-alpine3.11
 Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.0/alpine3.11
 
 Tags: 4.0.5-alpine3.10, 4.0-alpine3.10
 Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
+GitCommit: adf0e23e460a657c77c44f2502e5fa8cf820d020
 Directory: 4.0/alpine3.10
-
-Tags: 4.0.5-alpine3.9, 4.0-alpine3.9
-Architectures: amd64, arm64v8
-GitCommit: ca98e17b6eb6a696fc31788f43b81dba0effa417
-Directory: 4.0/alpine3.9
 
 Tags: 3.4.7-buster, 3.4-buster
 SharedTags: 3.4.7, 3.4
@@ -111,7 +151,12 @@ GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
 Directory: 3.4/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.4.7-alpine3.12, 3.4-alpine3.12, 3.4.7-alpine, 3.4-alpine
+Tags: 3.4.7-alpine3.13, 3.4-alpine3.13, 3.4.7-alpine, 3.4-alpine
+Architectures: amd64, arm64v8
+GitCommit: c195ebc0755b9debcfacbd6edc977a8ad1cd450e
+Directory: 3.4/alpine3.13
+
+Tags: 3.4.7-alpine3.12, 3.4-alpine3.12
 Architectures: amd64, arm64v8
 GitCommit: d902612570437c75dc21b83b6fe0afd39a8c260d
 Directory: 3.4/alpine3.12
@@ -125,11 +170,6 @@ Tags: 3.4.7-alpine3.10, 3.4-alpine3.10
 Architectures: amd64, arm64v8
 GitCommit: e57329c158b19f881c57a0496afbaf4446895fca
 Directory: 3.4/alpine3.10
-
-Tags: 3.4.7-alpine3.9, 3.4-alpine3.9
-Architectures: amd64, arm64v8
-GitCommit: bf02021c6d7938b000481a0878d029c5816437f8
-Directory: 3.4/alpine3.9
 
 Tags: 3.3.0-rc.1-buster, 3.3.0-buster, 3.3-buster
 SharedTags: 3.3.0-rc.1, 3.3.0, 3.3
@@ -156,7 +196,12 @@ GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
 Directory: 3.3/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.3.0-rc.1-alpine3.12, 3.3.0-rc.1-alpine, 3.3.0-alpine3.12, 3.3-alpine3.12, 3.3.0-alpine, 3.3-alpine
+Tags: 3.3.0-rc.1-alpine3.13, 3.3.0-rc.1-alpine, 3.3.0-alpine3.13, 3.3-alpine3.13, 3.3.0-alpine, 3.3-alpine
+Architectures: amd64, arm64v8
+GitCommit: c195ebc0755b9debcfacbd6edc977a8ad1cd450e
+Directory: 3.3/alpine3.13
+
+Tags: 3.3.0-rc.1-alpine3.12, 3.3.0-alpine3.12, 3.3-alpine3.12
 Architectures: amd64, arm64v8
 GitCommit: d902612570437c75dc21b83b6fe0afd39a8c260d
 Directory: 3.3/alpine3.12
@@ -170,11 +215,6 @@ Tags: 3.3.0-rc.1-alpine3.10, 3.3.0-alpine3.10, 3.3-alpine3.10
 Architectures: amd64, arm64v8
 GitCommit: e57329c158b19f881c57a0496afbaf4446895fca
 Directory: 3.3/alpine3.10
-
-Tags: 3.3.0-rc.1-alpine3.9, 3.3.0-alpine3.9, 3.3-alpine3.9
-Architectures: amd64, arm64v8
-GitCommit: bf02021c6d7938b000481a0878d029c5816437f8
-Directory: 3.3/alpine3.9
 
 Tags: 3.2.1-buster, 3.2-buster
 SharedTags: 3.2.1, 3.2
@@ -201,7 +241,12 @@ GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
 Directory: 3.2/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.2.1-alpine3.12, 3.2-alpine3.12, 3.2.1-alpine, 3.2-alpine
+Tags: 3.2.1-alpine3.13, 3.2-alpine3.13, 3.2.1-alpine, 3.2-alpine
+Architectures: amd64, arm64v8
+GitCommit: c195ebc0755b9debcfacbd6edc977a8ad1cd450e
+Directory: 3.2/alpine3.13
+
+Tags: 3.2.1-alpine3.12, 3.2-alpine3.12
 Architectures: amd64, arm64v8
 GitCommit: d902612570437c75dc21b83b6fe0afd39a8c260d
 Directory: 3.2/alpine3.12
@@ -215,11 +260,6 @@ Tags: 3.2.1-alpine3.10, 3.2-alpine3.10
 Architectures: amd64, arm64v8
 GitCommit: e57329c158b19f881c57a0496afbaf4446895fca
 Directory: 3.2/alpine3.10
-
-Tags: 3.2.1-alpine3.9, 3.2-alpine3.9
-Architectures: amd64, arm64v8
-GitCommit: bf02021c6d7938b000481a0878d029c5816437f8
-Directory: 3.2/alpine3.9
 
 Tags: 3.1.3-stretch, 3.1-stretch
 Architectures: amd64, arm32v7, arm64v8


### PR DESCRIPTION
 * update haxe to 4.2.0
 * add alpine 3.13, remove alpine 3.9
 * version pin a build dependancy (extlib) to fix build for haxe < 4.2