### PR TITLE
Add missing Architectures for kapacitor builds.

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -8,6 +8,7 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: kapacitor/1.4
 
 Tags: 1.4-alpine, 1.4.1-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: kapacitor/1.4/alpine
 
 Tags: 1.5, 1.5.8, latest
@@ -15,4 +16,5 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: kapacitor/1.5
 
 Tags: 1.5-alpine, 1.5.8-alpine, alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: kapacitor/1.5/alpine


### PR DESCRIPTION
These were omitted by accident