### PR TITLE
Add missing architectures for influxdb builds.

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -7,18 +7,23 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7
 
 Tags: 1.7-alpine, 1.7.10-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7/alpine
 
 Tags: 1.7-data, 1.7.10-data
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7/data
 
 Tags: 1.7-data-alpine, 1.7.10-data-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7/data/alpine
 
 Tags: 1.7-meta, 1.7.10-meta
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7/meta
 
 Tags: 1.7-meta-alpine, 1.7.10-meta-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7/meta/alpine
 
 Tags: 1.8, 1.8.4, latest
@@ -26,16 +31,21 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8
 
 Tags: 1.8-alpine, 1.8.4-alpine, alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8/alpine
 
 Tags: 1.8-data, 1.8.3-data, data
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8/data
 
 Tags: 1.8-data-alpine, 1.8.3-data-alpine, data-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8/data/alpine
 
 Tags: 1.8-meta, 1.8.3-meta, meta
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8/meta
 
 Tags: 1.8-meta-alpine, 1.8.3-meta-alpine, meta-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8/meta/alpine


### PR DESCRIPTION
These were omitted by accident