### PR TITLE
Add missing architectures for chronograf builds.

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -8,6 +8,7 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.6
 
 Tags: 1.6-alpine, 1.6.2-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.6/alpine
 
 Tags: 1.7, 1.7.17
@@ -15,6 +16,7 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.7
 
 Tags: 1.7-alpine, 1.7.17-alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.7/alpine
 
 Tags: 1.8, 1.8.8, latest
@@ -22,4 +24,5 @@ Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.8
 
 Tags: 1.8-alpine, 1.8.8-alpine, alpine
+Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.8/alpine


### PR DESCRIPTION
These were omitted by accident