### PR TITLE
[oraclelinux] Update Oracle Linux 7 for ELSA-2021-0348

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 500bbb9052a6193e71d1308b43be671dd498cfe3
+amd64-GitCommit: 3e7609501ec789e49b1591456ebacdabb7c215ed
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 85b269a3604ef25905f6c5c646be76c1d91baece
+arm64v8-GitCommit: d38ef6715f59724ba4ab7fc6753495f039608da8
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This incorporates fixes for the the following three CVEs:

CVE-2020-10029: <https://linux.oracle.com/cve/CVE-2020-10029.html>
CVE-2020-29573: <https://linux.oracle.com/cve/CVE-2020-29573.html>
CVE-2019-25013: <https://linux.oracle.com/cve/CVE-2019-25013.html>

Signed-off-by: Avi Miller <avi.miller@oracle.com>