### PR TITLE
Bump IBM Java version to 1.8.0_sr6fp25 (8.0.6.25) and ubuntu base image for ibmjava upgraded to 20.04

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -5,30 +5,30 @@ GitRepo: https://github.com/ibmruntimes/ci.docker.git
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: ad52e78bdc22fab015d80038d0166f6f62831862
+GitCommit: c5169d151c9017fc88782df546cfc5ab107651e1
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-jre-alpine, jre-alpine
 Architectures: amd64
-GitCommit: ad52e78bdc22fab015d80038d0166f6f62831862
+GitCommit: c5169d151c9017fc88782df546cfc5ab107651e1
 Directory: ibmjava/8/jre/alpine
 
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: ad52e78bdc22fab015d80038d0166f6f62831862
+GitCommit: c5169d151c9017fc88782df546cfc5ab107651e1
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sfj-alpine, sfj-alpine
 Architectures: amd64
-GitCommit: ad52e78bdc22fab015d80038d0166f6f62831862
+GitCommit: c5169d151c9017fc88782df546cfc5ab107651e1
 Directory: ibmjava/8/sfj/alpine
 
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: ad52e78bdc22fab015d80038d0166f6f62831862
+GitCommit: c5169d151c9017fc88782df546cfc5ab107651e1
 Directory: ibmjava/8/sdk/ubuntu
 
 Tags: 8-sdk-alpine, sdk-alpine
 Architectures: amd64
-GitCommit: ad52e78bdc22fab015d80038d0166f6f62831862
+GitCommit: c5169d151c9017fc88782df546cfc5ab107651e1
 Directory: ibmjava/8/sdk/alpine


### PR DESCRIPTION
Bump IBM Java version to 1.8.0_sr6fp25 (8.0.6.25) and ubuntu base image for ibmjava upgraded to 20.04