### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 13.1, 13, latest
+Tags: 13.2, 13, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ba302205a1300a5ad262ee770f7ac8a1038e8fde
+GitCommit: 7bd41786539082857396f4d1b4f1cb326ebee8de
 Directory: 13
 
-Tags: 13.1-alpine, 13-alpine, alpine
+Tags: 13.2-alpine, 13-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8cb2acbb372f0c89219792f82b0bdd2e405602f
+GitCommit: a7aa19b8501df4c459dad78fd18e2b36fded9643
 Directory: 13/alpine
 
-Tags: 12.5, 12
+Tags: 12.6, 12
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ba302205a1300a5ad262ee770f7ac8a1038e8fde
+GitCommit: b349a7e67b5f434768f6ae685113e0accaed0842
 Directory: 12
 
-Tags: 12.5-alpine, 12-alpine
+Tags: 12.6-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8cb2acbb372f0c89219792f82b0bdd2e405602f
+GitCommit: 4cec33a2ee0bbfbfa73d1ff7dd08e66cd2c74297
 Directory: 12/alpine
 
-Tags: 11.10, 11
+Tags: 11.11, 11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: ba302205a1300a5ad262ee770f7ac8a1038e8fde
+GitCommit: 14f13e4b399ed1848fa24c2c1f5bd40c25732bdd
 Directory: 11
 
-Tags: 11.10-alpine, 11-alpine
+Tags: 11.11-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8cb2acbb372f0c89219792f82b0bdd2e405602f
+GitCommit: 9693709797a818a5d56dfb81ecd34a2754eba2f7
 Directory: 11/alpine
 
-Tags: 10.15, 10
+Tags: 10.16, 10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: ba302205a1300a5ad262ee770f7ac8a1038e8fde
+GitCommit: cbe3131bd8e6d454d80d5c05695276b1d468b261
 Directory: 10
 
-Tags: 10.15-alpine, 10-alpine
+Tags: 10.16-alpine, 10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8cb2acbb372f0c89219792f82b0bdd2e405602f
+GitCommit: 1267a1f1bb39bcf97d9ae498e1edcfd864c8db1d
 Directory: 10/alpine
 
-Tags: 9.6.20, 9.6, 9
+Tags: 9.6.21, 9.6, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: ba302205a1300a5ad262ee770f7ac8a1038e8fde
+GitCommit: 11119157a345c282fea29b13d374bdea602a39ac
 Directory: 9.6
 
-Tags: 9.6.20-alpine, 9.6-alpine, 9-alpine
+Tags: 9.6.21-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8cb2acbb372f0c89219792f82b0bdd2e405602f
+GitCommit: 45cbba060d3674d4ff0529450267bb4656692363
 Directory: 9.6/alpine
 
-Tags: 9.5.24, 9.5
+Tags: 9.5.25, 9.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: ba302205a1300a5ad262ee770f7ac8a1038e8fde
+GitCommit: b122f60426e69df9d6effbda45fe2ef659c1d4f2
 Directory: 9.5
 
-Tags: 9.5.24-alpine, 9.5-alpine
+Tags: 9.5.25-alpine, 9.5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8cb2acbb372f0c89219792f82b0bdd2e405602f
+GitCommit: 6667795da15f1a2d2791021659f2f766828a4321
 Directory: 9.5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/14f13e4: Update to 11.11-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/4cec33a: Update to 12.6
- https://github.com/docker-library/postgres/commit/a7aa19b: Update to 13.2
- https://github.com/docker-library/postgres/commit/6667795: Update to 9.5.25
- https://github.com/docker-library/postgres/commit/9693709: Update to 11.11
- https://github.com/docker-library/postgres/commit/b122f60: Update to 9.5.25-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/7bd4178: Update to 13.2-1.pgdg100+1
- https://github.com/docker-library/postgres/commit/1111915: Update to 9.6.21-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/45cbba0: Update to 9.6.21
- https://github.com/docker-library/postgres/commit/cbe3131: Update to 10.16-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/b349a7e: Update to 12.6-1.pgdg100+1
- https://github.com/docker-library/postgres/commit/1267a1f: Update to 10.16