### PR TITLE
archlinux: Release 20210214.0.15477

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210207.0.15200
-GitCommit: da774f3f2e47e1e647ad13fa7e617cea1b94df4b
-GitFetch: refs/tags/v20210207.0.15200
+Tags: latest, base, base-20210214.0.15477
+GitCommit: c8031eaa181e1ed4814c2b26511e8ea0060c17ae
+GitFetch: refs/tags/v20210214.0.15477
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210207.0.15200
-GitCommit: da774f3f2e47e1e647ad13fa7e617cea1b94df4b
-GitFetch: refs/tags/v20210207.0.15200
+Tags: base-devel, base-devel-20210214.0.15477
+GitCommit: c8031eaa181e1ed4814c2b26511e8ea0060c17ae
+GitFetch: refs/tags/v20210214.0.15477
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
