### PR TITLE
Update Sonarqube to 8.7.0

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,16 +4,22 @@ Maintainers: Janos Gyerik <janos.gyerik@sonarsource.com> (@janos-ss),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
              Michal Duda <michal.duda@sonarsource.com> (@michal-duda-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 73a85e01c1f5acfab08026318cfa9da598b9bfb1
+GitCommit: 7e2c6a2bf55a250c332f8e4bacf0a1fe87264ebf
 
 Tags: 7.9.5-community, 7.9-community, lts
 Directory: 7/community
 
-Tags: 8.6.1-community, 8.6-community, 8-community, community, latest
+Tags: 8.7.0-community, 8.7-community, 8-community, community, latest
 Directory: 8/community
 
-Tags: 8.6.1-developer, 8.6-developer, 8-developer, developer
+Tags: 8.7.0-developer, 8.7-developer, 8-developer, developer
 Directory: 8/developer
 
-Tags: 8.6.1-enterprise, 8.6-enterprise, 8-enterprise, enterprise
+Tags: 8.7.0-enterprise, 8.7-enterprise, 8-enterprise, enterprise
 Directory: 8/enterprise
+
+Tags: 8.7.0-datacenter-app, 8.7-datacenter-app, 8-datacenter-app, datacenter-app
+Directory: 8/datacenter/app
+
+Tags: 8.7.0-datacenter-search, 8.7-datacenter-search, 8-datacenter-search, datacenter-search
+Directory: 8/datacenter/search


### PR DESCRIPTION
- Add Sonarqube datacenter edition images. 
- Documentation is updated in the PR: https://github.com/docker-library/docs/pull/1877