### PR TITLE
[security] Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -109,78 +109,64 @@ GitCommit: e06cdfe67b154306266bd2ab4d84db0c3b4b3542
 Directory: 3.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.7.9-buster, 3.7-buster
-SharedTags: 3.7.9, 3.7
+Tags: 3.7.10-buster, 3.7-buster
+SharedTags: 3.7.10, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
+GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
 Directory: 3.7/buster
 
-Tags: 3.7.9-slim-buster, 3.7-slim-buster, 3.7.9-slim, 3.7-slim
+Tags: 3.7.10-slim-buster, 3.7-slim-buster, 3.7.10-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
+GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
 Directory: 3.7/buster/slim
 
-Tags: 3.7.9-stretch, 3.7-stretch
+Tags: 3.7.10-stretch, 3.7-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
+GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
 Directory: 3.7/stretch
 
-Tags: 3.7.9-slim-stretch, 3.7-slim-stretch
+Tags: 3.7.10-slim-stretch, 3.7-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
+GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
 Directory: 3.7/stretch/slim
 
-Tags: 3.7.9-alpine3.13, 3.7-alpine3.13, 3.7.9-alpine, 3.7-alpine
+Tags: 3.7.10-alpine3.13, 3.7-alpine3.13, 3.7.10-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8674e6765191491bd69161c41c89e37acb8b9f2
+GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
 Directory: 3.7/alpine3.13
 
-Tags: 3.7.9-alpine3.12, 3.7-alpine3.12
+Tags: 3.7.10-alpine3.12, 3.7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
+GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
 Directory: 3.7/alpine3.12
 
-Tags: 3.7.9-windowsservercore-1809, 3.7-windowsservercore-1809
-SharedTags: 3.7.9-windowsservercore, 3.7-windowsservercore, 3.7.9, 3.7
-Architectures: windows-amd64
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
-Directory: 3.7/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 3.7.9-windowsservercore-ltsc2016, 3.7-windowsservercore-ltsc2016
-SharedTags: 3.7.9-windowsservercore, 3.7-windowsservercore, 3.7.9, 3.7
-Architectures: windows-amd64
-GitCommit: 72724b61c96c9685e831991de913f633852e8e07
-Directory: 3.7/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.6.12-buster, 3.6-buster
-SharedTags: 3.6.12, 3.6
+Tags: 3.6.13-buster, 3.6-buster
+SharedTags: 3.6.13, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 729e780f3913e6f83002f4f71215d192f9eb92a5
+GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
 Directory: 3.6/buster
 
-Tags: 3.6.12-slim-buster, 3.6-slim-buster, 3.6.12-slim, 3.6-slim
+Tags: 3.6.13-slim-buster, 3.6-slim-buster, 3.6.13-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 729e780f3913e6f83002f4f71215d192f9eb92a5
+GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
 Directory: 3.6/buster/slim
 
-Tags: 3.6.12-stretch, 3.6-stretch
+Tags: 3.6.13-stretch, 3.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 729e780f3913e6f83002f4f71215d192f9eb92a5
+GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
 Directory: 3.6/stretch
 
-Tags: 3.6.12-slim-stretch, 3.6-slim-stretch
+Tags: 3.6.13-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 729e780f3913e6f83002f4f71215d192f9eb92a5
+GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
 Directory: 3.6/stretch/slim
 
-Tags: 3.6.12-alpine3.13, 3.6-alpine3.13, 3.6.12-alpine, 3.6-alpine
+Tags: 3.6.13-alpine3.13, 3.6-alpine3.13, 3.6.13-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8674e6765191491bd69161c41c89e37acb8b9f2
+GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
 Directory: 3.6/alpine3.13
 
-Tags: 3.6.12-alpine3.12, 3.6-alpine3.12
+Tags: 3.6.13-alpine3.12, 3.6-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 729e780f3913e6f83002f4f71215d192f9eb92a5
+GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
 Directory: 3.6/alpine3.12


### PR DESCRIPTION
Changes:

- docker-library/python@9ec46df: Update to 3.7.10, pip 21.0.1
- docker-library/python@df27704: Remove 3.7 Windows variants
- docker-library/python@ada46dd: Update to 3.6.13, pip 21.0.1