### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev7, 2.4-dev
+Tags: 2.4-dev8, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 427e4f4420c5cfd91ac2ad8dee873f4b5ebf377c
+GitCommit: 827001ed9bd67c3b50168a978859c5007576d56a
 Directory: 2.4-rc
 
-Tags: 2.4-dev7-alpine, 2.4-dev-alpine
+Tags: 2.4-dev8-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 427e4f4420c5cfd91ac2ad8dee873f4b5ebf377c
+GitCommit: 827001ed9bd67c3b50168a978859c5007576d56a
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.5, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/827001e: Update to 2.4-dev8