### PR TITLE
[security] Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,42 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.12-rc.3, 3.8-rc
+Tags: 3.8.12, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa38ea2b55e55ddcbefeb8907a8572e6a5bb5e5a
-Directory: 3.8-rc/ubuntu
-
-Tags: 3.8.12-rc.3-management, 3.8-rc-management
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
-Directory: 3.8-rc/ubuntu/management
-
-Tags: 3.8.12-rc.3-alpine, 3.8-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa38ea2b55e55ddcbefeb8907a8572e6a5bb5e5a
-Directory: 3.8-rc/alpine
-
-Tags: 3.8.12-rc.3-management-alpine, 3.8-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
-Directory: 3.8-rc/alpine/management
-
-Tags: 3.8.11, 3.8, 3, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d24429a1a07f6fe71b74b59712ec9cd5e6d7b79
+GitCommit: ed5380ff71481670fc852942c94ea7fee69b9704
 Directory: 3.8/ubuntu
 
-Tags: 3.8.11-management, 3.8-management, 3-management, management
+Tags: 3.8.12-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.11-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.12-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d24429a1a07f6fe71b74b59712ec9cd5e6d7b79
+GitCommit: ed5380ff71481670fc852942c94ea7fee69b9704
 Directory: 3.8/alpine
 
-Tags: 3.8.11-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.12-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/a4b8d64: Update 3.8-rc to openssl 1.1.1j
- https://github.com/docker-library/rabbitmq/commit/ed5380f: Update 3.8 to 3.8.12, openssl 1.1.1j
- https://github.com/docker-library/rabbitmq/commit/089a479: Update 3.8-rc to otp 23.2.5
- https://github.com/docker-library/rabbitmq/commit/634ba72: Update 3.8 to otp 23.2.5