### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.41.5, 3.41, 3, latest
+Tags: 3.41.6, 3.41, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 14fe1dffcbed89ecadaadb9fb12dc9e85944e749
+GitCommit: 2a2df4fed967959c31d2dba786d1bff2a34945ac
 Directory: 3/debian
 
-Tags: 3.41.5-alpine, 3.41-alpine, 3-alpine, alpine
+Tags: 3.41.6-alpine, 3.41-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 14fe1dffcbed89ecadaadb9fb12dc9e85944e749
+GitCommit: 2a2df4fed967959c31d2dba786d1bff2a34945ac
 Directory: 3/alpine
 
 Tags: 2.38.3, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/2a2df4f: Update to 3.41.6, ghost-cli 1.15.3