### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/9f83d3a1b64980a74c66af30afcb472e1329aede/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/c2ba0f79840dc4dc96e049747f4e4f5326b2ed0e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 9f83d3a1b64980a74c66af30afcb472e1329aede
+GitCommit: c2ba0f79840dc4dc96e049747f4e4f5326b2ed0e
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 844e23eae6a28fd1faf9b25f8ed977ae4b168a0f
+amd64-GitCommit: 8e007ee409b22843ba78d19e5f68518505e9ff0d
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d7cdb7b3f9b596299c358ba02ca12be6bf991bf6
+arm32v5-GitCommit: e46e04656c581581b67574a45cc134dfb0bc7f47
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 6dcbfd99dcb53377cc0ec7f91f1ee34bf8311e05
+arm32v6-GitCommit: 6ca70ab577c4af80377d560f8d2b03b8906b2c7a
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: f967699a04d94ef4e8154b6e0caeeacb94730449
+arm32v7-GitCommit: cd1419225fb1efce57cee63b6384764715dbf79a
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c1c928bcef1c6fa3eb1a4e76df823b078a7642bf
+arm64v8-GitCommit: f1000afe5791e835ae9db37c55d1827e973a1097
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 9d15b86fc841ea26a6f4887fd554e9dfa2f7ad05
+i386-GitCommit: 78871cd00ddca6c633e0191796a0cabba8972b6b
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 853a29d2c7ba8c1092be620fef78402694ad29ae
+mips64le-GitCommit: 4fe7abcd3e66157e0d2830d18c4a62a75330dc35
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 453429cc27ba7d629435dfe42afa9b218bf010ad
+ppc64le-GitCommit: 153eb87cec1edf2c819ffb9f131f13cc3bd7b9a5
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: affd246366853a821748bd8d32563fbc1c3ce018
+s390x-GitCommit: f6a7edd4d9b897b997f9bcfae755d41095647c43
 
 Tags: 1.32.1-uclibc, 1.32-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/c2ba0f7: Merge pull request https://github.com/docker-library/busybox/pull/96 from infosiftr/buildroot
- https://github.com/docker-library/busybox/commit/8be3805: Update Buildroot to 2020.11.3