### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/e1811929ac59a89bbb12acd208c0736f51cde4a1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/76a4649761506eab69ad383e70a627a743f24610/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 2.7-7.3.3, 2.7-7.3, 2.7-7, 2.7, 2-7.3.3, 2-7.3, 2-7, 2, 2.7-7.3.3-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.3-buster, 2-7.3-buster, 2-7-buster, 2-buster
-Architectures: amd64, arm64v8, i386
-GitCommit: 9625e09996380a78c53a9610915d839035245b57
-Directory: 2.7
-
-Tags: 2.7-7.3.3-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.3-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.3-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.3-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
-Architectures: amd64, arm64v8, i386
-GitCommit: 9625e09996380a78c53a9610915d839035245b57
-Directory: 2.7/slim
-
-Tags: 3.6-7.3.3, 3.6-7.3, 3.6-7, 3.6, 3-7.3.3, 3-7.3, 3-7, 3, latest, 3.6-7.3.3-buster, 3.6-7.3-buster, 3.6-7-buster, 3.6-buster, 3-7.3.3-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
-Architectures: amd64, arm64v8, i386, s390x
-GitCommit: 9625e09996380a78c53a9610915d839035245b57
-Directory: 3.6
-
-Tags: 3.6-7.3.3-slim, 3.6-7.3-slim, 3.6-7-slim, 3.6-slim, 3-7.3.3-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.6-7.3.3-slim-buster, 3.6-7.3-slim-buster, 3.6-7-slim-buster, 3.6-slim-buster, 3-7.3.3-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
-Architectures: amd64, arm64v8, i386, s390x
-GitCommit: 9625e09996380a78c53a9610915d839035245b57
-Directory: 3.6/slim
-
 Tags: 3.7-7.3.3, 3.7-7.3, 3.7-7, 3.7, 3.7-7.3.3-buster, 3.7-7.3-buster, 3.7-7-buster, 3.7-buster
 Architectures: amd64, arm64v8, i386, s390x
-GitCommit: 9625e09996380a78c53a9610915d839035245b57
-Directory: 3.7
+GitCommit: 42286a6d407e44b56d8aca968f91a2e9214a35b2
+Directory: 3.7/buster
 
 Tags: 3.7-7.3.3-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3.7-7.3.3-slim-buster, 3.7-7.3-slim-buster, 3.7-7-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm64v8, i386, s390x
-GitCommit: 9625e09996380a78c53a9610915d839035245b57
-Directory: 3.7/slim
+GitCommit: 42286a6d407e44b56d8aca968f91a2e9214a35b2
+Directory: 3.7/slim-buster
+
+Tags: 3.6-7.3.3, 3.6-7.3, 3.6-7, 3.6, 3-7.3.3, 3-7.3, 3-7, 3, latest, 3.6-7.3.3-buster, 3.6-7.3-buster, 3.6-7-buster, 3.6-buster, 3-7.3.3-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
+Architectures: amd64, arm64v8, i386, s390x
+GitCommit: 42286a6d407e44b56d8aca968f91a2e9214a35b2
+Directory: 3.6/buster
+
+Tags: 3.6-7.3.3-slim, 3.6-7.3-slim, 3.6-7-slim, 3.6-slim, 3-7.3.3-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.6-7.3.3-slim-buster, 3.6-7.3-slim-buster, 3.6-7-slim-buster, 3.6-slim-buster, 3-7.3.3-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
+Architectures: amd64, arm64v8, i386, s390x
+GitCommit: 42286a6d407e44b56d8aca968f91a2e9214a35b2
+Directory: 3.6/slim-buster
+
+Tags: 2.7-7.3.3, 2.7-7.3, 2.7-7, 2.7, 2-7.3.3, 2-7.3, 2-7, 2, 2.7-7.3.3-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.3-buster, 2-7.3-buster, 2-7-buster, 2-buster
+Architectures: amd64, arm64v8, i386
+GitCommit: 76a4649761506eab69ad383e70a627a743f24610
+Directory: 2.7/buster
+
+Tags: 2.7-7.3.3-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.3-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.3-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.3-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
+Architectures: amd64, arm64v8, i386
+GitCommit: 42286a6d407e44b56d8aca968f91a2e9214a35b2
+Directory: 2.7/slim-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/d660df9: Merge pull request https://github.com/docker-library/pypy/pull/55 from infosiftr/thread-patch
- https://github.com/docker-library/pypy/commit/42286a6: Apply thread-related crypt patches in 3.x versions
- https://github.com/docker-library/pypy/commit/8b9d85c: Merge pull request https://github.com/docker-library/pypy/pull/53 from infosiftr/jq-template
- https://github.com/docker-library/pypy/commit/76a4649: Add initial jq-based templating engine