### PR TITLE
Bump Traefik to v2.4.5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.4.3-windowsservercore-1809, 2.4.3-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.5-windowsservercore-1809, 2.4.5-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ab9d3837bef3cf4fbec9e0faf6ebee56999debda
+GitCommit: 9735fc9d15e7f6f31a5209464b1114fea4ba2b89
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.3, 2.4.3, v2.4, 2.4, livarot, latest
+Tags: v2.4.5, 2.4.5, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ab9d3837bef3cf4fbec9e0faf6ebee56999debda
+GitCommit: 9735fc9d15e7f6f31a5209464b1114fea4ba2b89
 Directory: alpine
 
 Tags: v1.7.28-windowsservercore-1809, 1.7.28-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.5](https://github.com/traefik/traefik/releases/tag/v2.4.5).

/cc @ldez @SantoDE @kevinpollet

Cheers
