### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-9-jdk-oraclelinux8, 17-ea-9-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-9-jdk-oracle, 17-ea-9-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-9-jdk, 17-ea-9, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-10-jdk-oraclelinux8, 17-ea-10-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-10-jdk-oracle, 17-ea-10-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-10-jdk, 17-ea-10, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-9-jdk-oraclelinux7, 17-ea-9-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-10-jdk-oraclelinux7, 17-ea-10-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-9-jdk-buster, 17-ea-9-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-10-jdk-buster, 17-ea-10-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/buster
 
-Tags: 17-ea-9-jdk-slim-buster, 17-ea-9-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-9-jdk-slim, 17-ea-9-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-10-jdk-slim-buster, 17-ea-10-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-10-jdk-slim, 17-ea-10-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/slim-buster
 
-Tags: 17-ea-5-jdk-alpine3.13, 17-ea-5-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-5-jdk-alpine, 17-ea-5-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17-ea-10-jdk-alpine3.13, 17-ea-10-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-10-jdk-alpine, 17-ea-10-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/alpine3.13
 
-Tags: 17-ea-5-jdk-alpine3.12, 17-ea-5-alpine3.12, 17-ea-jdk-alpine3.12, 17-ea-alpine3.12, 17-jdk-alpine3.12, 17-alpine3.12
+Tags: 17-ea-10-jdk-alpine3.12, 17-ea-10-alpine3.12, 17-ea-jdk-alpine3.12, 17-ea-alpine3.12, 17-jdk-alpine3.12, 17-alpine3.12
 Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-9-jdk-windowsservercore-1809, 17-ea-9-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-9-jdk-windowsservercore, 17-ea-9-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-9-jdk, 17-ea-9, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-10-jdk-windowsservercore-1809, 17-ea-10-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-10-jdk-windowsservercore, 17-ea-10-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-10-jdk, 17-ea-10, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-9-jdk-windowsservercore-ltsc2016, 17-ea-9-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-9-jdk-windowsservercore, 17-ea-9-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-9-jdk, 17-ea-9, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-10-jdk-windowsservercore-ltsc2016, 17-ea-10-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-10-jdk-windowsservercore, 17-ea-10-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-10-jdk, 17-ea-10, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-9-jdk-nanoserver-1809, 17-ea-9-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-9-jdk-nanoserver, 17-ea-9-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-10-jdk-nanoserver-1809, 17-ea-10-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-10-jdk-nanoserver, 17-ea-10-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 8de448b9e03a8095e73ce06f921890e4194344b3
+GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/3487760: Update 17 to 17-ea+10, alpine 17-ea+10