### PR TITLE
websphere-liberty and open-liberty 21.0.0.2 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: c7ad269918729cfef66c5972e21231e3339e64a7
+GitCommit: fff7a69684a78c21b25a819fb53cfc4f8c9a024e
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: fff7a69684a78c21b25a819fb53cfc4f8c9a024e
+GitCommit: ce388adb04648887154867bba1ca0a6986fa635a
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -35,23 +35,23 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.1-kernel-slim-java8-openj9
-Directory: releases/21.0.0.1/kernel-slim
+Tags: 21.0.0.2-kernel-slim-java8-openj9
+Directory: releases/21.0.0.2/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.1-kernel-slim-java11-openj9
-Directory: releases/21.0.0.1/kernel-slim
+Tags: 21.0.0.2-kernel-slim-java11-openj9
+Directory: releases/21.0.0.2/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.1-full-java8-openj9
-Directory: releases/21.0.0.1/full
+Tags: 21.0.0.2-full-java8-openj9
+Directory: releases/21.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.1-full-java11-openj9
-Directory: releases/21.0.0.1/full
+Tags: 21.0.0.2-full-java11-openj9
+Directory: releases/21.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -23,20 +23,20 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.1-kernel-java8-ibmjava
-Directory: ga/21.0.0.1/kernel
+Tags: 21.0.0.2-kernel-java8-ibmjava
+Directory: ga/21.0.0.2/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.1-kernel-java11-openj9
-Directory: ga/21.0.0.1/kernel
+Tags: 21.0.0.2-kernel-java11-openj9
+Directory: ga/21.0.0.2/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.1-full-java8-ibmjava
-Directory: ga/21.0.0.1/full
+Tags: 21.0.0.2-full-java8-ibmjava
+Directory: ga/21.0.0.2/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.1-full-java11-openj9
+Tags: 21.0.0.2-full-java11-openj9
 Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 7fda7e1672896528abc19e0149e6cd8758f47360
+GitCommit: 57924976c86e94651b23d0f5cd5673947085a8e1
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: fc1f15394dcd59da0bfa865d0f370b26fa6e39d7
+GitCommit: 7fda7e1672896528abc19e0149e6cd8758f47360
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Updates for the releases of websphere-liberty and open-liberty version 21.0.0.2.
- Add 21.0.0.2 images
- Remove 21.0.0.1 images