### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -7,166 +7,166 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.10.0a5-buster, 3.10-rc-buster, rc-buster
 SharedTags: 3.10.0a5, 3.10-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 903be329e07ba3c212dab940f891a6f9ed7ece75
+GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
 Directory: 3.10-rc/buster
 
 Tags: 3.10.0a5-slim-buster, 3.10-rc-slim-buster, rc-slim-buster, 3.10.0a5-slim, 3.10-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 903be329e07ba3c212dab940f891a6f9ed7ece75
+GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
 Directory: 3.10-rc/buster/slim
 
 Tags: 3.10.0a5-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13, 3.10.0a5-alpine, 3.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e8674e6765191491bd69161c41c89e37acb8b9f2
+GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
 Directory: 3.10-rc/alpine3.13
 
 Tags: 3.10.0a5-alpine3.12, 3.10-rc-alpine3.12, rc-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 903be329e07ba3c212dab940f891a6f9ed7ece75
+GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
 Directory: 3.10-rc/alpine3.12
 
 Tags: 3.10.0a5-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
 SharedTags: 3.10.0a5-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a5, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 903be329e07ba3c212dab940f891a6f9ed7ece75
+GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
 Directory: 3.10-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.0a5-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 3.10.0a5-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a5, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 903be329e07ba3c212dab940f891a6f9ed7ece75
+GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.9.2-buster, 3.9-buster, 3-buster, buster
 SharedTags: 3.9.2, 3.9, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c285e28792d1607bc4fec1ab916bc0ee43fc62ee
+GitCommit: ec1084fa7052275883a180653723ccb22e956252
 Directory: 3.9/buster
 
 Tags: 3.9.2-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster, 3.9.2-slim, 3.9-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c285e28792d1607bc4fec1ab916bc0ee43fc62ee
+GitCommit: ec1084fa7052275883a180653723ccb22e956252
 Directory: 3.9/buster/slim
 
 Tags: 3.9.2-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13, 3.9.2-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c285e28792d1607bc4fec1ab916bc0ee43fc62ee
+GitCommit: ec1084fa7052275883a180653723ccb22e956252
 Directory: 3.9/alpine3.13
 
 Tags: 3.9.2-alpine3.12, 3.9-alpine3.12, 3-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c285e28792d1607bc4fec1ab916bc0ee43fc62ee
+GitCommit: ec1084fa7052275883a180653723ccb22e956252
 Directory: 3.9/alpine3.12
 
 Tags: 3.9.2-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.9.2-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.2, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: c285e28792d1607bc4fec1ab916bc0ee43fc62ee
+GitCommit: ec1084fa7052275883a180653723ccb22e956252
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.9.2-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.9.2-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.2, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: c285e28792d1607bc4fec1ab916bc0ee43fc62ee
+GitCommit: ec1084fa7052275883a180653723ccb22e956252
 Directory: 3.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.8.8-buster, 3.8-buster
 SharedTags: 3.8.8, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 91cbd74aaa34fd8ee1c2cc541b676128ea51651d
+GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
 Directory: 3.8/buster
 
 Tags: 3.8.8-slim-buster, 3.8-slim-buster, 3.8.8-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 91cbd74aaa34fd8ee1c2cc541b676128ea51651d
+GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
 Directory: 3.8/buster/slim
 
 Tags: 3.8.8-alpine3.13, 3.8-alpine3.13, 3.8.8-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91cbd74aaa34fd8ee1c2cc541b676128ea51651d
+GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
 Directory: 3.8/alpine3.13
 
 Tags: 3.8.8-alpine3.12, 3.8-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91cbd74aaa34fd8ee1c2cc541b676128ea51651d
+GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
 Directory: 3.8/alpine3.12
 
 Tags: 3.8.8-windowsservercore-1809, 3.8-windowsservercore-1809
 SharedTags: 3.8.8-windowsservercore, 3.8-windowsservercore, 3.8.8, 3.8
 Architectures: windows-amd64
-GitCommit: 91cbd74aaa34fd8ee1c2cc541b676128ea51651d
+GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
 Directory: 3.8/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.8.8-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016
 SharedTags: 3.8.8-windowsservercore, 3.8-windowsservercore, 3.8.8, 3.8
 Architectures: windows-amd64
-GitCommit: 91cbd74aaa34fd8ee1c2cc541b676128ea51651d
+GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
 Directory: 3.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.10-buster, 3.7-buster
 SharedTags: 3.7.10, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
+GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
 Directory: 3.7/buster
 
 Tags: 3.7.10-slim-buster, 3.7-slim-buster, 3.7.10-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
+GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
 Directory: 3.7/buster/slim
 
 Tags: 3.7.10-stretch, 3.7-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
+GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
 Directory: 3.7/stretch
 
 Tags: 3.7.10-slim-stretch, 3.7-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
+GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.10-alpine3.13, 3.7-alpine3.13, 3.7.10-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
+GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
 Directory: 3.7/alpine3.13
 
 Tags: 3.7.10-alpine3.12, 3.7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ec46dfcf80d128ebe48aa3b10430be201e5639c
+GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
 Directory: 3.7/alpine3.12
 
 Tags: 3.6.13-buster, 3.6-buster
 SharedTags: 3.6.13, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
+GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
 Directory: 3.6/buster
 
 Tags: 3.6.13-slim-buster, 3.6-slim-buster, 3.6.13-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
+GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
 Directory: 3.6/buster/slim
 
 Tags: 3.6.13-stretch, 3.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
+GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
 Directory: 3.6/stretch
 
 Tags: 3.6.13-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
+GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.13-alpine3.13, 3.6-alpine3.13, 3.6.13-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
+GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
 Directory: 3.6/alpine3.13
 
 Tags: 3.6.13-alpine3.12, 3.6-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ada46ddd5cd0676833d9ef568e085f935da6fc8e
+GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
 Directory: 3.6/alpine3.12


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/1a131f9: Update to 3.10.0a5, pip 21.0.1
- https://github.com/docker-library/python/commit/8167dd2: Update to 3.7.10, pip 21.0.1
- https://github.com/docker-library/python/commit/ec1084f: Update to 3.9.2, pip 21.0.1
- https://github.com/docker-library/python/commit/3897bb4: Update to 3.8.8, pip 21.0.1
- https://github.com/docker-library/python/commit/6fea753: Update to 3.6.13, pip 21.0.1

See https://github.com/pypa/get-pip/compare/4be3fe44ad9dedc028629ed1497052d65d281b8e..b60e2320d9e8d02348525bd74e871e466afdf77c#diff-333f925f52b4ce75f65b3e49a8a71acd851ab66561480309d9e34de7a888a452, especially https://github.com/pypa/get-pip/pull/85 which now automates updates to `get-pip.py` :partying_face: 