### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.6.1-apache, 5.6-apache, 5-apache, apache, 5.6.1, 5.6, 5, latest, 5.6.1-php7.4-apache, 5.6-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.6.1-php7.4, 5.6-php7.4, 5-php7.4, php7.4
+Tags: 5.6.2-apache, 5.6-apache, 5-apache, apache, 5.6.2, 5.6, 5, latest, 5.6.2-php7.4-apache, 5.6-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.6.2-php7.4, 5.6-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php7.4/apache
 
-Tags: 5.6.1-fpm, 5.6-fpm, 5-fpm, fpm, 5.6.1-php7.4-fpm, 5.6-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.6.2-fpm, 5.6-fpm, 5-fpm, fpm, 5.6.2-php7.4-fpm, 5.6-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php7.4/fpm
 
-Tags: 5.6.1-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.6.1-php7.4-fpm-alpine, 5.6-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.6.2-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.6.2-php7.4-fpm-alpine, 5.6-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.6.1-php7.3-apache, 5.6-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.6.1-php7.3, 5.6-php7.3, 5-php7.3, php7.3
+Tags: 5.6.2-php7.3-apache, 5.6-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.6.2-php7.3, 5.6-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php7.3/apache
 
-Tags: 5.6.1-php7.3-fpm, 5.6-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.6.2-php7.3-fpm, 5.6-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php7.3/fpm
 
-Tags: 5.6.1-php7.3-fpm-alpine, 5.6-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.6.2-php7.3-fpm-alpine, 5.6-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.6.1-php8.0-apache, 5.6-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.6.1-php8.0, 5.6-php8.0, 5-php8.0, php8.0
+Tags: 5.6.2-php8.0-apache, 5.6-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.6.2-php8.0, 5.6-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php8.0/apache
 
-Tags: 5.6.1-php8.0-fpm, 5.6-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.6.2-php8.0-fpm, 5.6-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php8.0/fpm
 
-Tags: 5.6.1-php8.0-fpm-alpine, 5.6-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.6.2-php8.0-fpm-alpine, 5.6-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed60fb3b988d10e54b003d2cc881218af29694f9
+GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
 Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/b5d8e4f: Update latest to 5.6.2