### PR TITLE
[security] Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,40 +1,30 @@
-# this file is generated via https://github.com/docker-library/redis/blob/4ef411f3182868638f538798966a48b585ecce24/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/8253b78187024dda7bf1ade64e6680ab6406e5c4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.2-rc3, 6.2-rc, rc, 6.2-rc3-buster, 6.2-rc-buster, rc-buster
+Tags: 6.2.0, 6.2, 6, latest, 6.2.0-buster, 6.2-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 37cd843e73b1395cfd89dbdbf897f7eafb7eb0ca
-Directory: 6.2-rc
+GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
+Directory: 6
 
-Tags: 6.2-rc3-alpine, 6.2-rc-alpine, rc-alpine, 6.2-rc3-alpine3.13, 6.2-rc-alpine3.13, rc-alpine3.13
+Tags: 6.2.0-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.0-alpine3.13, 6.2-alpine3.13, 6-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04e150e0c6fb21e1eb0a79dde9998c37903358d3
-Directory: 6.2-rc/alpine
+GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
+Directory: 6/alpine
 
-Tags: 6.0.10, 6.0, 6, latest, 6.0.10-buster, 6.0-buster, 6-buster, buster
+Tags: 5.0.11, 5.0, 5, 5.0.11-buster, 5.0-buster, 5-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f634377257f6a41eaded4fb57672260fea6369e1
-Directory: 6.0
+GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
+Directory: 5
 
-Tags: 6.0.10-alpine, 6.0-alpine, 6-alpine, alpine, 6.0.10-alpine3.13, 6.0-alpine3.13, 6-alpine3.13, alpine3.13
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68595be6067839e5c5c1a35bdbb6357d017a8a4e
-Directory: 6.0/alpine
-
-Tags: 5.0.10, 5.0, 5, 5.0.10-buster, 5.0-buster, 5-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1779e83980f7cc0e197c649ba560306991e2e4c6
-Directory: 5.0
-
-Tags: 5.0.10-32bit, 5.0-32bit, 5-32bit, 5.0.10-32bit-buster, 5.0-32bit-buster, 5-32bit-buster
+Tags: 5.0.11-32bit, 5.0-32bit, 5-32bit, 5.0.11-32bit-buster, 5.0-32bit-buster, 5-32bit-buster
 Architectures: amd64
-GitCommit: 1779e83980f7cc0e197c649ba560306991e2e4c6
-Directory: 5.0/32bit
+GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
+Directory: 5/32bit
 
-Tags: 5.0.10-alpine, 5.0-alpine, 5-alpine, 5.0.10-alpine3.13, 5.0-alpine3.13, 5-alpine3.13
+Tags: 5.0.11-alpine, 5.0-alpine, 5-alpine, 5.0.11-alpine3.13, 5.0-alpine3.13, 5-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68595be6067839e5c5c1a35bdbb6357d017a8a4e
-Directory: 5.0/alpine
+GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
+Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/0759064: Fix update.sh
- https://github.com/docker-library/redis/commit/8253b78: Adjust folder names to match upstream "support levels"
- https://github.com/docker-library/redis/commit/03170f9: Update 6.2.0 to "latest"
- https://github.com/docker-library/redis/commit/372ce66: Update to 6.2.0
- https://github.com/docker-library/redis/commit/225fb52: Update to 5.0.11

From https://github.com/redis/redis/releases/tag/6.2.0:

> Upgrade urgency: SECURITY if you use 32bit build of redis (see bellow), MODERATE if you used earlier versions of Redis 6.2, LOW otherwise.

From https://github.com/redis/redis/releases/tag/5.0.11:

> Upgrade urgency: SECURITY if you use 32bit build of redis (see bellow), LOW otherwise.