### PR TITLE
[security] Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/redis/blob/8253b78187024dda7bf1ade64e6680ab6406e5c4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/231905d0841f52ee4f3a5b8b42d62cd6d14a1a93/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,13 +6,23 @@ GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 6.2.0, 6.2, 6, latest, 6.2.0-buster, 6.2-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
-Directory: 6
+GitCommit: 231905d0841f52ee4f3a5b8b42d62cd6d14a1a93
+Directory: 6.2
 
 Tags: 6.2.0-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.0-alpine3.13, 6.2-alpine3.13, 6-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8253b78187024dda7bf1ade64e6680ab6406e5c4
-Directory: 6/alpine
+GitCommit: 231905d0841f52ee4f3a5b8b42d62cd6d14a1a93
+Directory: 6.2/alpine
+
+Tags: 6.0.11, 6.0, 6.0.11-buster, 6.0-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 231905d0841f52ee4f3a5b8b42d62cd6d14a1a93
+Directory: 6.0
+
+Tags: 6.0.11-alpine, 6.0-alpine, 6.0.11-alpine3.13, 6.0-alpine3.13
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 231905d0841f52ee4f3a5b8b42d62cd6d14a1a93
+Directory: 6.0/alpine
 
 Tags: 5.0.11, 5.0, 5, 5.0.11-buster, 5.0-buster, 5-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/231905d: Add 6.0 back for 6.0.11

Turns out I was wrong in https://github.com/docker-library/official-images/pull/9675#issuecomment-783735906 :smile:

From https://github.com/redis/redis/releases/tag/6.0.11:

> Upgrade urgency: SECURITY if you use 32bit build of redis (see bellow), LOW otherwise.