### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.41.7, 3.41, 3, latest
+Tags: 3.41.8, 3.41, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d597db3b33396195576710c3af6c4c9dffbc454d
+GitCommit: d201401bdb9d4ca78d74cca3b43efcc53b0b26ce
 Directory: 3/debian
 
-Tags: 3.41.7-alpine, 3.41-alpine, 3-alpine, alpine
+Tags: 3.41.8-alpine, 3.41-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d597db3b33396195576710c3af6c4c9dffbc454d
+GitCommit: d201401bdb9d4ca78d74cca3b43efcc53b0b26ce
 Directory: 3/alpine
 
 Tags: 2.38.3, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/d201401: Update to 3.41.8, ghost-cli 1.15.3