### PR TITLE
caddy: v2.4.0-beta.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,53 +1,7 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/2093c4a571bfe356447008d229195eb7063232b2/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/02028a9680f6df392d10272f0f701f1c07a38601/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
-
-Tags: 2.2.1-alpine
-SharedTags: 2.2.1
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.2/alpine
-GitCommit: 66905660327fd16a9d95c95da1e59a3302493dc8
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.2.1-builder-alpine
-SharedTags: 2.2.1-builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.2/builder
-GitCommit: 2093c4a571bfe356447008d229195eb7063232b2
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.2.1-windowsservercore-1809
-SharedTags: 2.2.1-windowsservercore, 2.2.1
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.2/windows/1809
-GitCommit: 66905660327fd16a9d95c95da1e59a3302493dc8
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
-Tags: 2.2.1-windowsservercore-ltsc2016
-SharedTags: 2.2.1-windowsservercore, 2.2.1
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.2/windows/ltsc2016
-GitCommit: 66905660327fd16a9d95c95da1e59a3302493dc8
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2016
-
-Tags: 2.2.1-builder-windowsservercore-1809
-SharedTags: 2.2.1-builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.2/windows-builder/1809
-GitCommit: 2093c4a571bfe356447008d229195eb7063232b2
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
-Tags: 2.2.1-builder-windowsservercore-ltsc2016
-SharedTags: 2.2.1-builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.2/windows-builder/ltsc2016
-GitCommit: 2093c4a571bfe356447008d229195eb7063232b2
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2016
 
 Tags: 2.3.0-alpine, 2-alpine, alpine
 SharedTags: 2.3.0, 2, latest
@@ -60,7 +14,7 @@ Tags: 2.3.0-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.3.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.3/builder
-GitCommit: 2093c4a571bfe356447008d229195eb7063232b2
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.3.0-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
@@ -83,7 +37,7 @@ Tags: 2.3.0-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, bu
 SharedTags: 2.3.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.3/windows-builder/1809
-GitCommit: 2093c4a571bfe356447008d229195eb7063232b2
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -91,7 +45,53 @@ Tags: 2.3.0-builder-windowsservercore-ltsc2016, 2-builder-windowsservercore-ltsc
 SharedTags: 2.3.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.3/windows-builder/ltsc2016
-GitCommit: 2093c4a571bfe356447008d229195eb7063232b2
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2016
+
+Tags: 2.4.0-beta.1-alpine
+SharedTags: 2.4.0-beta.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.4/alpine
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.4.0-beta.1-builder-alpine
+SharedTags: 2.4.0-beta.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.4/builder
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.4.0-beta.1-windowsservercore-1809
+SharedTags: 2.4.0-beta.1-windowsservercore, 2.4.0-beta.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.4/windows/1809
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.4.0-beta.1-windowsservercore-ltsc2016
+SharedTags: 2.4.0-beta.1-windowsservercore, 2.4.0-beta.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.4/windows/ltsc2016
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2016
+
+Tags: 2.4.0-beta.1-builder-windowsservercore-1809
+SharedTags: 2.4.0-beta.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.4/windows-builder/1809
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.4.0-beta.1-builder-windowsservercore-ltsc2016
+SharedTags: 2.4.0-beta.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.4/windows-builder/ltsc2016
+GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.4.0-beta.1

This also upgrades `xcaddy` to v0.1.8 and moves to the Go 1.16 images for v2.4.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>