### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -7,19 +7,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: 3ee6a0ae683a64b606f1f2c5b577fd43f4022d2c
 
-Tags: 2.0.20210126.0, 2, latest
+Tags: 2.0.20210219.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 97f94de53b2fb9e592ca0b306e734b148f8de01e
+amd64-GitCommit: 5ec502b06d356315b689c5aa3b3cb27c81d216ec
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: cee4b21853f954bdc3dda26abbd32935d7408f0f
+arm64v8-GitCommit: 54ea3e6143b0ca1d3d27493c3a3bb5193bff000b
 
-Tags: 2.0.20210126.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20210219.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 14a690152e4a514dda18221da3af1d45af57f73d
+amd64-GitCommit: eb7cd9d5e954b189fbf0e2a42a7d1b2b2529a393
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 47b4ba56fd768b3ff9e55ff3795766c7fa0630a0
+arm64v8-GitCommit: 8837a086c129b47eabeda2cfa03bc9e38f09fa5d
 
 Tags: 2018.03.0.20210126.1, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This update for AL2 contains a fix for [CVE-2021-3177](https://alas.aws.amazon.com/AL2/ALAS-2021-1611.html). An AL1 image update will be released via another pull request.