### PR TITLE
alpine: bump 3.10.6, 3.11.8, 3.12.4 for openssl fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -37,10 +37,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.7, 3.11
+Tags: 3.11.8, 3.11
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: a5ed67f7508220a8f51ca7c39acacd2169e9188b
+GitCommit: 5818e51b0fec24d2ba8789a93fa23c9c89b662f9
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -25,10 +25,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.3, 3.12
+Tags: 3.12.4, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: 9f43992677cdb66a1ecbefe3bf409113b5f2127f
+GitCommit: 2f3c3015951938c521e752899a92ecd618e0c05b
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -49,10 +49,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.10.5, 3.10
+Tags: 3.10.6, 3.10
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
-GitCommit: a02be1f7da059d74c0743792b41d17626128c2a3
+GitCommit: f5d7605e90bbd6f26efadaaa2a28ceb046dc8772
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fixes:
- CVE-2021-23841
- CVE-2021-23840
- CVE-2021-23839
