### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ee3c59f90e29e2cf0087053a1d016c8186cab6ab
 Directory: cli/php8.0/alpine
 
-Tags: beta-5.7-beta3-apache, beta-5.7-apache, beta-5-apache, beta-apache, beta-5.7-beta3, beta-5.7, beta-5, beta, beta-5.7-beta3-php7.4-apache, beta-5.7-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.7-beta3-php7.4, beta-5.7-php7.4, beta-5-php7.4, beta-php7.4
+Tags: beta-5.7-RC1-apache, beta-5.7-apache, beta-5-apache, beta-apache, beta-5.7-RC1, beta-5.7, beta-5, beta, beta-5.7-RC1-php7.4-apache, beta-5.7-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.7-RC1-php7.4, beta-5.7-php7.4, beta-5-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php7.4/apache
 
-Tags: beta-5.7-beta3-fpm, beta-5.7-fpm, beta-5-fpm, beta-fpm, beta-5.7-beta3-php7.4-fpm, beta-5.7-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-5.7-RC1-fpm, beta-5.7-fpm, beta-5-fpm, beta-fpm, beta-5.7-RC1-php7.4-fpm, beta-5.7-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php7.4/fpm
 
-Tags: beta-5.7-beta3-fpm-alpine, beta-5.7-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.7-beta3-php7.4-fpm-alpine, beta-5.7-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-5.7-RC1-fpm-alpine, beta-5.7-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.7-RC1-php7.4-fpm-alpine, beta-5.7-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-5.7-beta3-php7.3-apache, beta-5.7-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.7-beta3-php7.3, beta-5.7-php7.3, beta-5-php7.3, beta-php7.3
+Tags: beta-5.7-RC1-php7.3-apache, beta-5.7-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.7-RC1-php7.3, beta-5.7-php7.3, beta-5-php7.3, beta-php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php7.3/apache
 
-Tags: beta-5.7-beta3-php7.3-fpm, beta-5.7-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
+Tags: beta-5.7-RC1-php7.3-fpm, beta-5.7-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php7.3/fpm
 
-Tags: beta-5.7-beta3-php7.3-fpm-alpine, beta-5.7-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
+Tags: beta-5.7-RC1-php7.3-fpm-alpine, beta-5.7-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php7.3/fpm-alpine
 
-Tags: beta-5.7-beta3-php8.0-apache, beta-5.7-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.7-beta3-php8.0, beta-5.7-php8.0, beta-5-php8.0, beta-php8.0
+Tags: beta-5.7-RC1-php8.0-apache, beta-5.7-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.7-RC1-php8.0, beta-5.7-php8.0, beta-5-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php8.0/apache
 
-Tags: beta-5.7-beta3-php8.0-fpm, beta-5.7-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-5.7-RC1-php8.0-fpm, beta-5.7-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php8.0/fpm
 
-Tags: beta-5.7-beta3-php8.0-fpm-alpine, beta-5.7-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-5.7-RC1-php8.0-fpm-alpine, beta-5.7-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 44d43ba7218589a4478b8742b4c1a8ea0c4d120f
+GitCommit: 639f02b048918cd41ad4b984a35369d39d6446f4
 Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/639f02b: Update beta to 5.7-RC1