### PR TITLE
eclipse-mosquitto 2.0.8

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,12 +1,12 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 0736414306caa4229c5b476b616bb0491c423145
+GitCommit: 5c45bc4e8407d94d29b39152b580d2b4cc8082e9
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 2.0.7, 2.0, 2, latest
+Tags: 2.0.8, 2.0, 2, latest
 Directory: docker/2.0
 
-Tags: 2.0.7-openssl, 2.0-openssl, 2-openssl, openssl
+Tags: 2.0.8-openssl, 2.0-openssl, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
 Tags: 1.6.13, 1.6


### PR DESCRIPTION
As well as the version bump, the 2.0 images now have the option to
change runtime behaviour using an environment variable.