### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.12, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed5380ff71481670fc852942c94ea7fee69b9704
+GitCommit: 6fe3632c4d052c2f8be26f4670224d5234642ccb
 Directory: 3.8/ubuntu
 
 Tags: 3.8.12-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.12-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed5380ff71481670fc852942c94ea7fee69b9704
+GitCommit: 6fe3632c4d052c2f8be26f4670224d5234642ccb
 Directory: 3.8/alpine
 
 Tags: 3.8.12-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2c9dced: Update 3.8-rc to otp 23.2.6
- https://github.com/docker-library/rabbitmq/commit/6fe3632: Update 3.8 to otp 23.2.6