### PR TITLE
Update Solr to 8.8.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,14 +6,14 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.8.0, 8.8, 8, latest
+Tags: 8.8.1, 8.8, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 56d2b10fa195697cd02266959992bf6cbd0a752a
+GitCommit: 2c096ba85eec41a8da70fda15199f3ad6a7106e6
 Directory: 8.8
 
-Tags: 8.8.0-slim, 8.8-slim, 8-slim, slim
+Tags: 8.8.1-slim, 8.8-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 56d2b10fa195697cd02266959992bf6cbd0a752a
+GitCommit: 2c096ba85eec41a8da70fda15199f3ad6a7106e6
 Directory: 8.8/slim
 
 Tags: 8.7.0, 8.7


### PR DESCRIPTION
See the [official announcement](http://mail-archives.apache.org/mod_mbox/www-announce/202102.mbox/%3cCAJt9WnjwZdaLTw+Fno1kWhn43SahfxaqeqnQOLStS4_Y0PUTpA@mail.gmail.com%3e) which links to the [release notes](https://lucene.apache.org/solr/8_8_1/changes/Changes.html).

The bug fixes:

Bug Fixes (5):
* SOLR-15145: System property to control whether base_url is stored in state.json to enable back-compat with older SolrJ versions. 
* SOLR-15114: Fix bug that caused WAND optimization to be disabled in cases where the max score is requested (such as multi-shard requests in SolrCloud) 
* SOLR-15136: Reduce excessive logging introduced with Per Replica States feature 
* SOLR-15138: Collection creation for PerReplicaStates does not scale to large collections as well as regular collections 
* SOLR-15135: Admin UI display collections with perReplicaState=true in graph view 