### PR TITLE
Odoo: update 12.0-14.0 to release 20210226

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: f8212600f6478a15fac9ff3e7d8a926f78435860
+GitCommit: ef15321cddf021d9a7559c11a9a3ca85f211a03f
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo supported versions.

Thanks