### PR TITLE
archlinux: Release 20210228.0.16308

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210221.0.15908
-GitCommit: 3191c0b9a5122a50a3bf75835e12f3afa2df959d
-GitFetch: refs/tags/v20210221.0.15908
+Tags: latest, base, base-20210228.0.16308
+GitCommit: 96f93f1b36b4c4fb10f0da12d29ec799626264e6
+GitFetch: refs/tags/v20210228.0.16308
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210221.0.15908
-GitCommit: 3191c0b9a5122a50a3bf75835e12f3afa2df959d
-GitFetch: refs/tags/v20210221.0.15908
+Tags: base-devel, base-devel-20210228.0.16308
+GitCommit: 96f93f1b36b4c4fb10f0da12d29ec799626264e6
+GitFetch: refs/tags/v20210228.0.16308
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
