### PR TITLE
Ubuntu update March 2021

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,40 +6,40 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 307c20ce58171e7e30925ddc2588f7f7bff6e167
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ec931883d8292935b62ac40757287491e6ff467e
+amd64-GitCommit: d8b441737e0291a5c1c99f817ff1ba9ab6ccac11
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: f2ed9c714e4231e0d964095eaba5504fb4ce017d
+arm32v7-GitCommit: 7da58241e384243bed9b0a1d83eebcde5b428f76
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 69b377c4bbe13073c3ae2dd0c541dc7b52cc32ba
+arm64v8-GitCommit: 9ba0abacca8efc9f80718f69dadecf9bb631dae6
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 68ae4b1742136f031c3a4770e3e4776a3618df1f
+i386-GitCommit: 3c257636882d9264449b3cd7479310d7449bfd39
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: eb34d4327f126b9f60a873362854b09293f6d9ff
+ppc64le-GitCommit: 52443324faa07d08e962cd542d4d6872aea292bc
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 0342e501a11386aedd5597555481cb9b10921eda
+s390x-GitCommit: 6b803dc68aa0b888eb62ba9d5d7e48dfd19a1638
 
-# 20210118 (bionic)
-Tags: 18.04, bionic-20210118, bionic
+# 20210222 (bionic)
+Tags: 18.04, bionic-20210222, bionic
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20210119 (focal)
-Tags: 20.04, focal-20210119, focal, latest
+# 20210217 (focal)
+Tags: 20.04, focal-20210217, focal, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: focal
 
-# 20210115 (groovy)
-Tags: 20.10, groovy-20210115, groovy, rolling
+# 20210225 (groovy)
+Tags: 20.10, groovy-20210225, groovy, rolling
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: groovy
 
-# 20210119 (hirsute)
-Tags: 21.04, hirsute-20210119, hirsute, devel
+# 20210224 (hirsute)
+Tags: 21.04, hirsute-20210224, hirsute, devel
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hirsute
 

--- a/library/ubuntu
+++ b/library/ubuntu
@@ -38,10 +38,16 @@ Tags: 20.10, groovy-20210225, groovy, rolling
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: groovy
 
-# 20210224 (hirsute)
-Tags: 21.04, hirsute-20210224, hirsute, devel
+# 20210119 (hirsute)
+Tags: 21.04, hirsute-20210119, hirsute, devel
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hirsute
+amd64-GitCommit: ec931883d8292935b62ac40757287491e6ff467e
+arm32v7-GitCommit: f2ed9c714e4231e0d964095eaba5504fb4ce017d
+arm64v8-GitCommit: 69b377c4bbe13073c3ae2dd0c541dc7b52cc32ba
+i386-GitCommit: 68ae4b1742136f031c3a4770e3e4776a3618df1f
+ppc64le-GitCommit: eb34d4327f126b9f60a873362854b09293f6d9ff
+s390x-GitCommit: 0342e501a11386aedd5597555481cb9b10921eda
 
 # 20191217 (trusty)
 Tags: 14.04, trusty-20191217, trusty


### PR DESCRIPTION
March update of Ubuntu images.

Due to bug https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1916485 we are
 holding back any updates to the Ubuntu 21.04 images until resolved.
