### PR TITLE
[nats-streaming] Release v0.21.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,30 +1,30 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 70a87b9e248c9a04e9b6c320164522217b7a5269
+GitCommit: f1a356e4e3ea82365f0a89fe1258f6c413f0e87b
 
-Tags: 0.20.0-alpine3.12, 0.20-alpine3.12, alpine3.12, 0.20.0-alpine, 0.20-alpine, alpine
+Tags: 0.21.0-alpine3.13, 0.21-alpine3.13, alpine3.13, 0.21.0-alpine, 0.21-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.20.0/alpine3.12
+Directory: 0.21.0/alpine3.13
 
-Tags: 0.20.0-scratch, 0.20-scratch, scratch, 0.20.0-linux, 0.20-linux, linux
-SharedTags: 0.20.0, 0.20, latest
+Tags: 0.21.0-scratch, 0.21-scratch, scratch, 0.21.0-linux, 0.21-linux, linux
+SharedTags: 0.21.0, 0.21, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.20.0/scratch
+Directory: 0.21.0/scratch
 
-Tags: 0.20.0-windowsservercore-1809, 0.20-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.20.0-windowsservercore, 0.20-windowsservercore, windowsservercore
+Tags: 0.21.0-windowsservercore-1809, 0.21-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.21.0-windowsservercore, 0.21-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.20.0/windowsservercore-1809
+Directory: 0.21.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 0.20.0-nanoserver-1809, 0.20-nanoserver-1809, nanoserver-1809
-SharedTags: 0.20.0-nanoserver, 0.20-nanoserver, nanoserver, 0.20.0, 0.20, latest
+Tags: 0.21.0-nanoserver-1809, 0.21-nanoserver-1809, nanoserver-1809
+SharedTags: 0.21.0-nanoserver, 0.21-nanoserver, nanoserver, 0.21.0, 0.21, latest
 Architectures: windows-amd64
-Directory: 0.20.0/nanoserver-1809
+Directory: 0.21.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 0.20.0-windowsservercore-ltsc2016, 0.20-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 0.20.0-windowsservercore, 0.20-windowsservercore, windowsservercore
+Tags: 0.21.0-windowsservercore-ltsc2016, 0.21-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 0.21.0-windowsservercore, 0.21-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.20.0/windowsservercore-ltsc2016
+Directory: 0.21.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.21.0)

Doc PR: https://github.com/docker-library/docs/pull/1883

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>