### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev9, 2.4-dev
+Tags: 2.4-dev10, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 73e4b3269e0261f760ac9053eac79c2acdf207b5
+GitCommit: 6188d7cb60b775f766a95444399ad2c330c5410e
 Directory: 2.4-rc
 
-Tags: 2.4-dev9-alpine, 2.4-dev-alpine
+Tags: 2.4-dev10-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 73e4b3269e0261f760ac9053eac79c2acdf207b5
+GitCommit: 6188d7cb60b775f766a95444399ad2c330c5410e
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.5, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6188d7c: Update to 2.4-dev10