### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.10.0a5-buster, 3.10-rc-buster, rc-buster
-SharedTags: 3.10.0a5, 3.10-rc, rc
+Tags: 3.10.0a6-buster, 3.10-rc-buster, rc-buster
+SharedTags: 3.10.0a6, 3.10-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
+GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
 Directory: 3.10-rc/buster
 
-Tags: 3.10.0a5-slim-buster, 3.10-rc-slim-buster, rc-slim-buster, 3.10.0a5-slim, 3.10-rc-slim, rc-slim
+Tags: 3.10.0a6-slim-buster, 3.10-rc-slim-buster, rc-slim-buster, 3.10.0a6-slim, 3.10-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
+GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
 Directory: 3.10-rc/buster/slim
 
-Tags: 3.10.0a5-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13, 3.10.0a5-alpine, 3.10-rc-alpine, rc-alpine
+Tags: 3.10.0a6-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13, 3.10.0a6-alpine, 3.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
+GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
 Directory: 3.10-rc/alpine3.13
 
-Tags: 3.10.0a5-alpine3.12, 3.10-rc-alpine3.12, rc-alpine3.12
+Tags: 3.10.0a6-alpine3.12, 3.10-rc-alpine3.12, rc-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
+GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
 Directory: 3.10-rc/alpine3.12
 
-Tags: 3.10.0a5-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 3.10.0a5-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a5, 3.10-rc, rc
+Tags: 3.10.0a6-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 3.10.0a6-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a6, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
+GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
 Directory: 3.10-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.10.0a5-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.10.0a5-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a5, 3.10-rc, rc
+Tags: 3.10.0a6-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.10.0a6-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a6, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 1a131f951a38e765c832c98d9ec2d81d323f4905
+GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/ec67f96: Update to 3.10.0a6, pip 21.0.1