### PR TITLE
[oraclelinux] Update oraclelinux:7 and oraclelinux:8 for CVE-2020-8625

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3e7609501ec789e49b1591456ebacdabb7c215ed
+amd64-GitCommit: a27ac166608d64d0450ecda6fa8eb4e233a97d6d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d38ef6715f59724ba4ab7fc6753495f039608da8
+arm64v8-GitCommit: a5dd0a99a4b8253b0fa906d5f10eb9de019ba8a9
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated bind as per <https://linux.oracle.com/errata/ELSA-2021-0670.html>

Signed-off-by: Avi Miller <avi.miller@oracle.com>