### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6188d7cb60b775f766a95444399ad2c330c5410e
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.5, 2.3, latest
+Tags: 2.3.6, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2ff774fa949e8d4d6e4efb9a9288b7c14f81ed6f
+GitCommit: c28fbbfdc0a9f1860e339a8f6e1e0a133eecac55
 Directory: 2.3
 
-Tags: 2.3.5-alpine, 2.3-alpine, alpine
+Tags: 2.3.6-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2ff774fa949e8d4d6e4efb9a9288b7c14f81ed6f
+GitCommit: c28fbbfdc0a9f1860e339a8f6e1e0a133eecac55
 Directory: 2.3/alpine
 
-Tags: 2.2.9, 2.2, lts
+Tags: 2.2.10, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8c970f81306cfaf1c554bf41f63c0835da7839f3
+GitCommit: d41c10ee5e2aba8248c4cdb802d31ca02ba8d7cc
 Directory: 2.2
 
-Tags: 2.2.9-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.10-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8c970f81306cfaf1c554bf41f63c0835da7839f3
+GitCommit: d41c10ee5e2aba8248c4cdb802d31ca02ba8d7cc
 Directory: 2.2/alpine
 
 Tags: 2.1.11, 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c28fbbf: Update to 2.3.6
- https://github.com/docker-library/haproxy/commit/d41c10e: Update to 2.2.10