### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-11-jdk-oraclelinux8, 17-ea-11-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-11-jdk-oracle, 17-ea-11-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-11-jdk, 17-ea-11, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-12-jdk-oraclelinux8, 17-ea-12-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-12-jdk-oracle, 17-ea-12-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-12-jdk, 17-ea-12, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-11-jdk-oraclelinux7, 17-ea-11-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-12-jdk-oraclelinux7, 17-ea-12-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-11-jdk-buster, 17-ea-11-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-12-jdk-buster, 17-ea-12-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/buster
 
-Tags: 17-ea-11-jdk-slim-buster, 17-ea-11-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-11-jdk-slim, 17-ea-11-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-12-jdk-slim-buster, 17-ea-12-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-12-jdk-slim, 17-ea-12-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-10-jdk-alpine3.13, 17-ea-10-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-10-jdk-alpine, 17-ea-10-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,24 +35,24 @@ Architectures: amd64
 GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-11-jdk-windowsservercore-1809, 17-ea-11-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-11-jdk-windowsservercore, 17-ea-11-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-11-jdk, 17-ea-11, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-12-jdk-windowsservercore-1809, 17-ea-12-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-12-jdk-windowsservercore, 17-ea-12-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-12-jdk, 17-ea-12, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-11-jdk-windowsservercore-ltsc2016, 17-ea-11-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-11-jdk-windowsservercore, 17-ea-11-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-11-jdk, 17-ea-11, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-12-jdk-windowsservercore-ltsc2016, 17-ea-12-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-12-jdk-windowsservercore, 17-ea-12-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-12-jdk, 17-ea-12, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-11-jdk-nanoserver-1809, 17-ea-11-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-11-jdk-nanoserver, 17-ea-11-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-12-jdk-nanoserver-1809, 17-ea-12-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-12-jdk-nanoserver, 17-ea-12-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 431a3dfbf15aae44d34fad907401db7d275957bc
+GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/b32c2ac: Update 17 to 17-ea+12