### PR TITLE
Refresh Couchbase Server 7.0.0-beta to newer build

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -2,11 +2,11 @@ Maintainers: Couchbase Docker Team <docker@couchbase.com> (@cb-robot)
 GitRepo: https://github.com/couchbase/docker
 
 Tags: 7.0.0-beta, enterprise-7.0.0-beta
-GitCommit: ad7853a807fb762694ec733c60f8233290e6b3c8
+GitCommit: 705652faaef8f56988ba13d181cb00109c7263d4
 Directory: enterprise/couchbase-server/7.0.0-beta
 
 Tags: community-7.0.0-beta
-GitCommit: ad7853a807fb762694ec733c60f8233290e6b3c8
+GitCommit: 705652faaef8f56988ba13d181cb00109c7263d4
 Directory: community/couchbase-server/7.0.0-beta
 
 Tags: latest, enterprise, 6.6.1, enterprise-6.6.1


### PR DESCRIPTION
Unfortunately we found a minor issue that required a new beta build