### PR TITLE
[flink] Update 1.12 to 1.12.2

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -4,6 +4,46 @@ Maintainers: Patrick Lucas <me@patricklucas.com> (@patricklucas),
              Ismaël Mejía <iemejia@gmail.com> (@iemejia)
 GitRepo: https://github.com/apache/flink-docker.git
 
+Tags: 1.12.2-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.2-scala_2.11, 1.12-scala_2.11, scala_2.11
+Architectures: amd64
+GitCommit: d9f24a0501b5ddd014a38e7262863e19d152086b
+Directory: ./1.12/scala_2.11-java8-debian
+
+Tags: 1.12.2-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
+Architectures: amd64
+GitCommit: d9f24a0501b5ddd014a38e7262863e19d152086b
+Directory: ./1.12/scala_2.11-java11-debian
+
+Tags: 1.12.2-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.2-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.2-java8, 1.12-java8, java8, 1.12.2, 1.12, latest
+Architectures: amd64
+GitCommit: d9f24a0501b5ddd014a38e7262863e19d152086b
+Directory: ./1.12/scala_2.12-java8-debian
+
+Tags: 1.12.2-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.2-java11, 1.12-java11, java11
+Architectures: amd64
+GitCommit: d9f24a0501b5ddd014a38e7262863e19d152086b
+Directory: ./1.12/scala_2.12-java11-debian
+
+Tags: 1.11.3-scala_2.11-java8, 1.11-scala_2.11-java8, 1.11.3-scala_2.11, 1.11-scala_2.11
+Architectures: amd64
+GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
+Directory: ./1.11/scala_2.11-java8-debian
+
+Tags: 1.11.3-scala_2.11-java11, 1.11-scala_2.11-java11
+Architectures: amd64
+GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
+Directory: ./1.11/scala_2.11-java11-debian
+
+Tags: 1.11.3-scala_2.12-java8, 1.11-scala_2.12-java8, 1.11.3-scala_2.12, 1.11-scala_2.12, 1.11.3-java8, 1.11-java8, 1.11.3, 1.11
+Architectures: amd64
+GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
+Directory: ./1.11/scala_2.12-java8-debian
+
+Tags: 1.11.3-scala_2.12-java11, 1.11-scala_2.12-java11, 1.11.3-java11, 1.11-java11
+Architectures: amd64
+GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
+Directory: ./1.11/scala_2.12-java11-debian
+
 Tags: 1.10.3-scala_2.11, 1.10-scala_2.11
 Architectures: amd64
 GitCommit: 2a89b61a261f803f8785fd5dd882b7f50ec33fce
@@ -13,43 +53,3 @@ Tags: 1.10.3-scala_2.12, 1.10-scala_2.12, 1.10.3, 1.10
 Architectures: amd64
 GitCommit: 2a89b61a261f803f8785fd5dd882b7f50ec33fce
 Directory: ./1.10/scala_2.12-debian
-
-Tags: 1.11.3-scala_2.11-java11, 1.11-scala_2.11-java11
-Architectures: amd64
-GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
-Directory: ./1.11/scala_2.11-java11-debian
-
-Tags: 1.11.3-scala_2.11-java8, 1.11-scala_2.11-java8, 1.11.3-scala_2.11, 1.11-scala_2.11
-Architectures: amd64
-GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
-Directory: ./1.11/scala_2.11-java8-debian
-
-Tags: 1.11.3-scala_2.12-java11, 1.11-scala_2.12-java11, 1.11.3-java11, 1.11-java11
-Architectures: amd64
-GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
-Directory: ./1.11/scala_2.12-java11-debian
-
-Tags: 1.11.3-scala_2.12-java8, 1.11-scala_2.12-java8, 1.11.3-scala_2.12, 1.11-scala_2.12, 1.11.3-java8, 1.11-java8, 1.11.3, 1.11
-Architectures: amd64
-GitCommit: 7035f03679b11352f2fdecd9f6a9bb0ec8bc2022
-Directory: ./1.11/scala_2.12-java8-debian
-
-Tags: 1.12.1-scala_2.11-java11, 1.12-scala_2.11-java11, scala_2.11-java11
-Architectures: amd64
-GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
-Directory: ./1.12/scala_2.11-java11-debian
-
-Tags: 1.12.1-scala_2.11-java8, 1.12-scala_2.11-java8, scala_2.11-java8, 1.12.1-scala_2.11, 1.12-scala_2.11, scala_2.11
-Architectures: amd64
-GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
-Directory: ./1.12/scala_2.11-java8-debian
-
-Tags: 1.12.1-scala_2.12-java11, 1.12-scala_2.12-java11, scala_2.12-java11, 1.12.1-java11, 1.12-java11, java11
-Architectures: amd64
-GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
-Directory: ./1.12/scala_2.12-java11-debian
-
-Tags: 1.12.1-scala_2.12-java8, 1.12-scala_2.12-java8, scala_2.12-java8, 1.12.1-scala_2.12, 1.12-scala_2.12, scala_2.12, 1.12.1-java8, 1.12-java8, java8, 1.12.1, 1.12, latest
-Architectures: amd64
-GitCommit: adc8432ea3ae7fa111172c2b3d3e6a923b9af4dd
-Directory: ./1.12/scala_2.12-java8-debian


### PR DESCRIPTION
Update 1.12 flink images from `1.12.1` to `1.12.2`.

Corresponding flink-docker PR: https://github.com/apache/flink-docker/pull/68