### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.14, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4ee9e4de687859c624edc40440463cf90964afe4
+GitCommit: ba20774ca40808752d9b936e2f304f7fade762fa
 Directory: 3.8/ubuntu
 
 Tags: 3.8.14-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.14-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4ee9e4de687859c624edc40440463cf90964afe4
+GitCommit: ba20774ca40808752d9b936e2f304f7fade762fa
 Directory: 3.8/alpine
 
 Tags: 3.8.14-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/28b08a0: Update 3.8-rc to otp 23.2.7
- https://github.com/docker-library/rabbitmq/commit/ba20774: Update 3.8 to otp 23.2.7