### PR TITLE
arangodb 3.7.9

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -5,6 +5,6 @@ Tags: 3.6, 3.6.12
 GitCommit: 1cd50692c702b03c2dfe2876a1b704b1e15f2fb9
 Directory: alpine/3.6.12
 
-Tags: 3.7, 3.7.8, latest
-GitCommit: e3a862b55fc75889e25e201d15c9479b1a828969
-Directory: alpine/3.7.8
+Tags: 3.7, 3.7.9, latest
+GitCommit: 7fefa1b279a1240d4fb22fa9e08457623baa2f6c
+Directory: alpine/3.7.9


### PR DESCRIPTION
Updated ArangoDB 3.7 to 3.7.9.