### PR TITLE
consul: 1.9.4, 1.8.9 and 1.7.13

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,19 +1,19 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.9.3, 1.9, latest
+Tags: 1.9.4, 1.9, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 88083596dc12ae51ca058d00d4efdc606c2fa811
+GitCommit: eac0f7bd73879c55aa8abac4cd4beab38c6b8060
 Directory: 0.X
 
-Tags: 1.8.8, 1.8
+Tags: 1.8.9, 1.8
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: d77e626900b77e4bc915f2f5cf59e8b86495a770
+GitCommit: 101dfc394af1b47973d04d575ecefd4a6097f85f
 Directory: 0.X
 
-Tags: 1.7.12, 1.7
+Tags: 1.7.13, 1.7
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 32e78b95ddc3ace7d706fcd88601b3f9db2e9aba
+GitCommit: 17d1f6275832dfe0e2e0b1538ce863d57631c00e
 Directory: 0.X


### PR DESCRIPTION
Will push a new commit shortly to rerun CI for 1.8.9 and 1.7.13 (publishing delay on our side).