### PR TITLE
Update cirros to 0.5.2

### DIFF
--- a/library/cirros
+++ b/library/cirros
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/tianon/docker-brew-cirros/blob/b039392ba51709b7b461ec4eaef45bd722ae4c69//home/tianon/docker/hub/cirros/generate-stackbrew-library.sh
+# this file is generated via https://github.com/tianon/docker-brew-cirros/blob/bc178480989db677c1271933567a0555e35856dc/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-brew-cirros.git
 GitFetch: refs/heads/dist
-GitCommit: 0f4ac5ae1e2b7bbff60b81b554f7578be1caec3b
+GitCommit: 6b155af1eeb835ab219369aeec45139b2f4ba11b
 Architectures: amd64, arm32v5, arm64v8, i386, ppc64le
 amd64-Directory: arches/amd64
 arm32v5-Directory: arches/arm32v5
@@ -11,4 +11,4 @@ arm64v8-Directory: arches/arm64v8
 i386-Directory: arches/i386
 ppc64le-Directory: arches/ppc64le
 
-Tags: 0.5.1, 0.5, 0, latest
+Tags: 0.5.2, 0.5, 0, latest


### PR DESCRIPTION
Changes:

- https://github.com/tianon/docker-brew-cirros/commit/bc17848: Fix hilarious comment mixup
- https://github.com/tianon/docker-brew-cirros/commit/05fd2a7: Update generated README