### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev10, 2.4-dev
+Tags: 2.4-dev11, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6188d7cb60b775f766a95444399ad2c330c5410e
+GitCommit: 507aa42c2d3b66a0d746af96b700bbb538fa06a2
 Directory: 2.4-rc
 
-Tags: 2.4-dev10-alpine, 2.4-dev-alpine
+Tags: 2.4-dev11-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6188d7cb60b775f766a95444399ad2c330c5410e
+GitCommit: 507aa42c2d3b66a0d746af96b700bbb538fa06a2
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.6, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/507aa42: Update to 2.4-dev11