### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/c2ba0f79840dc4dc96e049747f4e4f5326b2ed0e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/8d23baaad7a11b8498e0d361d3761fc58a0380b3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: c2ba0f79840dc4dc96e049747f4e4f5326b2ed0e
+GitCommit: 8d23baaad7a11b8498e0d361d3761fc58a0380b3
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8e007ee409b22843ba78d19e5f68518505e9ff0d
+amd64-GitCommit: cc81bf8a3c979f596af2d811a3910aeaa230e8ef
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: e46e04656c581581b67574a45cc134dfb0bc7f47
+arm32v5-GitCommit: 722ec71d87e5e958167f837d781758906b2b0490
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 6ca70ab577c4af80377d560f8d2b03b8906b2c7a
+arm32v6-GitCommit: cb1353b2bd45c9522323395bb44982d964735f39
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: cd1419225fb1efce57cee63b6384764715dbf79a
+arm32v7-GitCommit: a5cede2b447f935dfbe7d0112d057bfdb635865d
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f1000afe5791e835ae9db37c55d1827e973a1097
+arm64v8-GitCommit: 8a500845daeaeb926b25f73089c0668cac676e97
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 78871cd00ddca6c633e0191796a0cabba8972b6b
+i386-GitCommit: eaac53822b57e9adc3a1971a4ce8d61c8206532d
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 4fe7abcd3e66157e0d2830d18c4a62a75330dc35
+mips64le-GitCommit: f7d97c7849764668861d7ddf1071818000cd5a1a
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 153eb87cec1edf2c819ffb9f131f13cc3bd7b9a5
+ppc64le-GitCommit: c0125333c4c3dfa4b9e5fd9fe6fbb875242f3613
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: f6a7edd4d9b897b997f9bcfae755d41095647c43
+s390x-GitCommit: b7a4b4b99ca970fc62d19725c7de650e6c357600
 
 Tags: 1.32.1-uclibc, 1.32-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/8d23baa: Merge pull request https://github.com/docker-library/busybox/pull/97 from infosiftr/buildroot-2021.02
- https://github.com/docker-library/busybox/commit/28912c0: Update Buildroot to 2021.02