### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,52 +1,52 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/8f5bcc1c980fce198bd191cfb7f51a3e76bb59cd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/891b7108294a629e6cc16c2f4bf643d9475894cc/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.6.2-apache, 5.6-apache, 5-apache, apache, 5.6.2, 5.6, 5, latest, 5.6.2-php7.4-apache, 5.6-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.6.2-php7.4, 5.6-php7.4, 5-php7.4, php7.4
+Tags: 5.7.0-apache, 5.7-apache, 5-apache, apache, 5.7.0, 5.7, 5, latest, 5.7.0-php7.4-apache, 5.7-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.7.0-php7.4, 5.7-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php7.4/apache
 
-Tags: 5.6.2-fpm, 5.6-fpm, 5-fpm, fpm, 5.6.2-php7.4-fpm, 5.6-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.7.0-fpm, 5.7-fpm, 5-fpm, fpm, 5.7.0-php7.4-fpm, 5.7-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php7.4/fpm
 
-Tags: 5.6.2-fpm-alpine, 5.6-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.6.2-php7.4-fpm-alpine, 5.6-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.7.0-fpm-alpine, 5.7-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.7.0-php7.4-fpm-alpine, 5.7-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.6.2-php7.3-apache, 5.6-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.6.2-php7.3, 5.6-php7.3, 5-php7.3, php7.3
+Tags: 5.7.0-php7.3-apache, 5.7-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.7.0-php7.3, 5.7-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php7.3/apache
 
-Tags: 5.6.2-php7.3-fpm, 5.6-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.7.0-php7.3-fpm, 5.7-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php7.3/fpm
 
-Tags: 5.6.2-php7.3-fpm-alpine, 5.6-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.7.0-php7.3-fpm-alpine, 5.7-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.6.2-php8.0-apache, 5.6-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.6.2-php8.0, 5.6-php8.0, 5-php8.0, php8.0
+Tags: 5.7.0-php8.0-apache, 5.7-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.7.0-php8.0, 5.7-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php8.0/apache
 
-Tags: 5.6.2-php8.0-fpm, 5.6-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.7.0-php8.0-fpm, 5.7-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php8.0/fpm
 
-Tags: 5.6.2-php8.0-fpm-alpine, 5.6-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.7.0-php8.0-fpm-alpine, 5.7-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b5d8e4f40bef55630fcf52a0f2830619f4df140e
+GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
 Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4
@@ -63,48 +63,3 @@ Tags: cli-2.4.0-php8.0, cli-2.4-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ee3c59f90e29e2cf0087053a1d016c8186cab6ab
 Directory: cli/php8.0/alpine
-
-Tags: beta-5.7-RC3-apache, beta-5.7-apache, beta-5-apache, beta-apache, beta-5.7-RC3, beta-5.7, beta-5, beta, beta-5.7-RC3-php7.4-apache, beta-5.7-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.7-RC3-php7.4, beta-5.7-php7.4, beta-5-php7.4, beta-php7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php7.4/apache
-
-Tags: beta-5.7-RC3-fpm, beta-5.7-fpm, beta-5-fpm, beta-fpm, beta-5.7-RC3-php7.4-fpm, beta-5.7-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php7.4/fpm
-
-Tags: beta-5.7-RC3-fpm-alpine, beta-5.7-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.7-RC3-php7.4-fpm-alpine, beta-5.7-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php7.4/fpm-alpine
-
-Tags: beta-5.7-RC3-php7.3-apache, beta-5.7-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.7-RC3-php7.3, beta-5.7-php7.3, beta-5-php7.3, beta-php7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php7.3/apache
-
-Tags: beta-5.7-RC3-php7.3-fpm, beta-5.7-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php7.3/fpm
-
-Tags: beta-5.7-RC3-php7.3-fpm-alpine, beta-5.7-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php7.3/fpm-alpine
-
-Tags: beta-5.7-RC3-php8.0-apache, beta-5.7-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.7-RC3-php8.0, beta-5.7-php8.0, beta-5-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php8.0/apache
-
-Tags: beta-5.7-RC3-php8.0-fpm, beta-5.7-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php8.0/fpm
-
-Tags: beta-5.7-RC3-php8.0-fpm-alpine, beta-5.7-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9af49aa4f49385bf999626c89838b98ab2b980ad
-Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/fb920c6: Merge pull request https://github.com/docker-library/wordpress/pull/572 from infosiftr/un-beta
- https://github.com/docker-library/wordpress/commit/891b710: Move "wp-config-docker.php" to non-beta (5.7 GA)
- https://github.com/docker-library/wordpress/commit/24c4469: Update latest to 5.7.0
- https://github.com/docker-library/wordpress/commit/59404ef: Update beta to 5.7.0

**Important Note:** now that 5.7 is GA, this includes https://github.com/docker-library/wordpress/pull/557 in all tags (no longer `beta`-only).