### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,86 +5,86 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.16.0-buster, 1.16-buster, 1-buster, buster
-SharedTags: 1.16.0, 1.16, 1, latest
+Tags: 1.16.1-buster, 1.16-buster, 1-buster, buster
+SharedTags: 1.16.1, 1.16, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01c68e748081c5878806f4e384351b7e66781711
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/buster
 
-Tags: 1.16.0-stretch, 1.16-stretch, 1-stretch, stretch
+Tags: 1.16.1-stretch, 1.16-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 312517a2094ec399778c7dbb6799188dc4017bb7
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/stretch
 
-Tags: 1.16.0-alpine3.13, 1.16-alpine3.13, 1-alpine3.13, alpine3.13, 1.16.0-alpine, 1.16-alpine, 1-alpine, alpine
+Tags: 1.16.1-alpine3.13, 1.16-alpine3.13, 1-alpine3.13, alpine3.13, 1.16.1-alpine, 1.16-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01c68e748081c5878806f4e384351b7e66781711
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/alpine3.13
 
-Tags: 1.16.0-alpine3.12, 1.16-alpine3.12, 1-alpine3.12, alpine3.12
+Tags: 1.16.1-alpine3.12, 1.16-alpine3.12, 1-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01c68e748081c5878806f4e384351b7e66781711
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/alpine3.12
 
-Tags: 1.16.0-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.16.0-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.0, 1.16, 1, latest
+Tags: 1.16.1-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.16.1-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.1, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: b36af443fb19f5d7d036e8bc787e3e40862cd550
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16.0-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.16.0-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.0, 1.16, 1, latest
+Tags: 1.16.1-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.16.1-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.1, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: b36af443fb19f5d7d036e8bc787e3e40862cd550
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.16.0-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.16.0-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.16.1-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.16.1-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: b36af443fb19f5d7d036e8bc787e3e40862cd550
+GitCommit: 74d09bc11afd9b38a688f36d877e791087ba46a9
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.15.8-buster, 1.15-buster
-SharedTags: 1.15.8, 1.15
+Tags: 1.15.9-buster, 1.15-buster
+SharedTags: 1.15.9, 1.15
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01c68e748081c5878806f4e384351b7e66781711
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/buster
 
-Tags: 1.15.8-stretch, 1.15-stretch
+Tags: 1.15.9-stretch, 1.15-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 312517a2094ec399778c7dbb6799188dc4017bb7
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/stretch
 
-Tags: 1.15.8-alpine3.13, 1.15-alpine3.13, 1.15.8-alpine, 1.15-alpine
+Tags: 1.15.9-alpine3.13, 1.15-alpine3.13, 1.15.9-alpine, 1.15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01c68e748081c5878806f4e384351b7e66781711
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/alpine3.13
 
-Tags: 1.15.8-alpine3.12, 1.15-alpine3.12
+Tags: 1.15.9-alpine3.12, 1.15-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01c68e748081c5878806f4e384351b7e66781711
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/alpine3.12
 
-Tags: 1.15.8-windowsservercore-1809, 1.15-windowsservercore-1809
-SharedTags: 1.15.8-windowsservercore, 1.15-windowsservercore, 1.15.8, 1.15
+Tags: 1.15.9-windowsservercore-1809, 1.15-windowsservercore-1809
+SharedTags: 1.15.9-windowsservercore, 1.15-windowsservercore, 1.15.9, 1.15
 Architectures: windows-amd64
-GitCommit: f0f1b321e3e8013373f89e939f2a83e0a536e546
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.15.8-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
-SharedTags: 1.15.8-windowsservercore, 1.15-windowsservercore, 1.15.8, 1.15
+Tags: 1.15.9-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
+SharedTags: 1.15.9-windowsservercore, 1.15-windowsservercore, 1.15.9, 1.15
 Architectures: windows-amd64
-GitCommit: f0f1b321e3e8013373f89e939f2a83e0a536e546
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.15.8-nanoserver-1809, 1.15-nanoserver-1809
-SharedTags: 1.15.8-nanoserver, 1.15-nanoserver
+Tags: 1.15.9-nanoserver-1809, 1.15-nanoserver-1809
+SharedTags: 1.15.9-nanoserver, 1.15-nanoserver
 Architectures: windows-amd64
-GitCommit: f0f1b321e3e8013373f89e939f2a83e0a536e546
+GitCommit: c873d16201da14d2d23ae9d7955520db03db6d88
 Directory: 1.15/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/74d09bc: Update 1.16 to 1.16.1
- https://github.com/docker-library/golang/commit/c873d16: Update 1.15 to 1.15.9