### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,28 +1,28 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/3fec00485b8448f6a9a4c150ad8a770306ca6814/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/4f281654d4934c36613261dab970e405068bd79a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-12-jdk-oraclelinux8, 17-ea-12-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-12-jdk-oracle, 17-ea-12-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-12-jdk, 17-ea-12, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-13-jdk-oraclelinux8, 17-ea-13-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-13-jdk-oracle, 17-ea-13-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-13-jdk, 17-ea-13, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-12-jdk-oraclelinux7, 17-ea-12-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-13-jdk-oraclelinux7, 17-ea-13-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-12-jdk-buster, 17-ea-12-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-13-jdk-buster, 17-ea-13-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/buster
 
-Tags: 17-ea-12-jdk-slim-buster, 17-ea-12-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-12-jdk-slim, 17-ea-12-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-13-jdk-slim-buster, 17-ea-13-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-13-jdk-slim, 17-ea-13-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-10-jdk-alpine3.13, 17-ea-10-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-10-jdk-alpine, 17-ea-10-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,24 +35,24 @@ Architectures: amd64
 GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-12-jdk-windowsservercore-1809, 17-ea-12-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-12-jdk-windowsservercore, 17-ea-12-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-12-jdk, 17-ea-12, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-13-jdk-windowsservercore-1809, 17-ea-13-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-13-jdk-windowsservercore, 17-ea-13-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-13-jdk, 17-ea-13, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-12-jdk-windowsservercore-ltsc2016, 17-ea-12-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-12-jdk-windowsservercore, 17-ea-12-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-12-jdk, 17-ea-12, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-13-jdk-windowsservercore-ltsc2016, 17-ea-13-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-13-jdk-windowsservercore, 17-ea-13-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-13-jdk, 17-ea-13, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-12-jdk-nanoserver-1809, 17-ea-12-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-12-jdk-nanoserver, 17-ea-12-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-13-jdk-nanoserver-1809, 17-ea-13-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-13-jdk-nanoserver, 17-ea-13-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: b32c2ac612f259e9f03e8bb52e2d335e0a7b6a5a
+GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -142,75 +142,75 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.10-jdk-oraclelinux8, 11.0.10-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.10-jdk-oracle, 11.0.10-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 4b66dda0a183517f14600278223ff014b541870a
 Directory: 11/jdk/oraclelinux8
 
 Tags: 11.0.10-jdk-oraclelinux7, 11.0.10-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 4b66dda0a183517f14600278223ff014b541870a
 Directory: 11/jdk/oraclelinux7
 
 Tags: 11.0.10-jdk-buster, 11.0.10-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 SharedTags: 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 4b66dda0a183517f14600278223ff014b541870a
 Directory: 11/jdk/buster
 
 Tags: 11.0.10-jdk-slim-buster, 11.0.10-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.10-jdk-slim, 11.0.10-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 4b66dda0a183517f14600278223ff014b541870a
 Directory: 11/jdk/slim-buster
 
 Tags: 11.0.10-jdk-windowsservercore-1809, 11.0.10-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.10-jdk-windowsservercore, 11.0.10-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: afad1bffdd2669d07c45199bc709037f21fe582b
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.10-jdk-windowsservercore-ltsc2016, 11.0.10-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.10-jdk-windowsservercore, 11.0.10-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: afad1bffdd2669d07c45199bc709037f21fe582b
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.10-jdk-nanoserver-1809, 11.0.10-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.10-jdk-nanoserver, 11.0.10-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: afad1bffdd2669d07c45199bc709037f21fe582b
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.10-jre-buster, 11.0-jre-buster, 11-jre-buster
 SharedTags: 11.0.10-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: e97a629873d7f32b7abb44678a50053bde2c37df
+GitCommit: 4b66dda0a183517f14600278223ff014b541870a
 Directory: 11/jre/buster
 
 Tags: 11.0.10-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.10-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: e97a629873d7f32b7abb44678a50053bde2c37df
+GitCommit: 4b66dda0a183517f14600278223ff014b541870a
 Directory: 11/jre/slim-buster
 
 Tags: 11.0.10-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.10-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.10-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: bcbdfda90768eb1d7e4f6f01edeff232835a8b9e
+GitCommit: afad1bffdd2669d07c45199bc709037f21fe582b
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.10-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
 SharedTags: 11.0.10-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.10-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: bcbdfda90768eb1d7e4f6f01edeff232835a8b9e
+GitCommit: afad1bffdd2669d07c45199bc709037f21fe582b
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.10-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.10-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: afad1bffdd2669d07c45199bc709037f21fe582b
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/96350fb: Update 17 to 17-ea+13
- https://github.com/docker-library/openjdk/commit/4b66dda: Add back arm64 and add "--retry" to curl
- https://github.com/docker-library/openjdk/commit/afad1bf: Update 11
- https://github.com/docker-library/openjdk/commit/4f28165: Add amd64 back to 11 (and a rough sanity check in versions.sh to ensure this doesn't happen)
- https://github.com/docker-library/openjdk/commit/3f32053: Update 11