### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.42.0, 3.42, 3, latest
+Tags: 3.42.1, 3.42, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 026e4fcfee2d7a511b62d97d60ac1068c1ffe389
+GitCommit: a96e8cbb7502c11c8be3dfdb782a8caf3846ba1c
 Directory: 3/debian
 
-Tags: 3.42.0-alpine, 3.42-alpine, 3-alpine, alpine
+Tags: 3.42.1-alpine, 3.42-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 026e4fcfee2d7a511b62d97d60ac1068c1ffe389
+GitCommit: a96e8cbb7502c11c8be3dfdb782a8caf3846ba1c
 Directory: 3/alpine
 
 Tags: 2.38.3, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/a96e8cb: Update to 3.42.1, ghost-cli 1.16.0