### PR TITLE
[nats] Release v2.2.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -3,31 +3,31 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Waldemar Salinas <wally@synadia.com> (@wallyqs),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: ad158caf47f416776f8b7df9c3d947218f0b4924
+GitCommit: 060868360489ec6400f3238d633b986103445dd5
 
-Tags: 2.1.9-alpine3.12, 2.1-alpine3.12, 2-alpine3.12, alpine3.12, 2.1.9-alpine, 2.1-alpine, 2-alpine, alpine
+Tags: 2.2.0-alpine3.13, 2.2-alpine3.13, 2-alpine3.13, alpine3.13, 2.2.0-alpine, 2.2-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.1.9/alpine3.12
+Directory: 2.2.0/alpine3.13
 
-Tags: 2.1.9-scratch, 2.1-scratch, 2-scratch, scratch, 2.1.9-linux, 2.1-linux, 2-linux, linux
-SharedTags: 2.1.9, 2.1, 2, latest
+Tags: 2.2.0-scratch, 2.2-scratch, 2-scratch, scratch, 2.2.0-linux, 2.2-linux, 2-linux, linux
+SharedTags: 2.2.0, 2.2, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.1.9/scratch
+Directory: 2.2.0/scratch
 
-Tags: 2.1.9-windowsservercore-1809, 2.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.1.9-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.2.0-windowsservercore-1809, 2.2-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.2.0-windowsservercore, 2.2-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.9/windowsservercore-1809
+Directory: 2.2.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.1.9-nanoserver-1809, 2.1-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.1.9-nanoserver, 2.1-nanoserver, 2-nanoserver, nanoserver, 2.1.9, 2.1, 2, latest
+Tags: 2.2.0-nanoserver-1809, 2.2-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.2.0-nanoserver, 2.2-nanoserver, 2-nanoserver, nanoserver, 2.2.0, 2.2, 2, latest
 Architectures: windows-amd64
-Directory: 2.1.9/nanoserver-1809
+Directory: 2.2.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.1.9-windowsservercore-ltsc2016, 2.1-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.1.9-windowsservercore, 2.1-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.2.0-windowsservercore-ltsc2016, 2.2-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.2.0-windowsservercore, 2.2-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.1.9/windowsservercore-ltsc2016
+Directory: 2.2.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.2.0)

Doc PR: https://github.com/docker-library/docs/pull/1893

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>