### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 3.42.1, 3.42, 3, latest
+Tags: 3.42.2, 3.42, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a96e8cbb7502c11c8be3dfdb782a8caf3846ba1c
+GitCommit: 94891835578da2a7c4c4d5a1661c55d98b865801
 Directory: 3/debian
 
-Tags: 3.42.1-alpine, 3.42-alpine, 3-alpine, alpine
+Tags: 3.42.2-alpine, 3.42-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: a96e8cbb7502c11c8be3dfdb782a8caf3846ba1c
+GitCommit: 94891835578da2a7c4c4d5a1661c55d98b865801
 Directory: 3/alpine
 
 Tags: 2.38.3, 2.38, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/9489183: Update to 3.42.2, ghost-cli 1.16.0