### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev11, 2.4-dev
+Tags: 2.4-dev12, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 507aa42c2d3b66a0d746af96b700bbb538fa06a2
+GitCommit: 045060cad517d1008a4f429257d641d10847d8df
 Directory: 2.4-rc
 
-Tags: 2.4-dev11-alpine, 2.4-dev-alpine
+Tags: 2.4-dev12-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 507aa42c2d3b66a0d746af96b700bbb538fa06a2
+GitCommit: 045060cad517d1008a4f429257d641d10847d8df
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.6, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/045060c: Update to 2.4-dev12