### PR TITLE
feat(ghost): update ghost-basics tests for Ghost v4

### DIFF
--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -30,14 +30,13 @@ _request() {
 }
 
 # Make sure that Ghost is listening and ready
-. "$dir/../../retry.sh" '_request GET / --output /dev/null'
+. "$dir/../../retry.sh" '_request GET / --output /dev/null --fail'
 
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
 ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"
 case "$ghostVersion" in
-	0.*) _request GET '/ghost/' -I |tac|tac| grep -q '^Location: .*setup' ;;
-	1.*) _request GET '/ghost/api/v0.1/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 	2.*) _request GET '/ghost/api/v2/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 	3.*) _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	4.*) _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 	*) echo "no tests for version ${ghostVersion}" && exit 1 ;;
 esac

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -30,7 +30,7 @@ _request() {
 }
 
 # Make sure that Ghost is listening and ready
-. "$dir/../../retry.sh" '_request GET / --output /dev/null --fail'
+. "$dir/../../retry.sh" '_request GET / --output /dev/null'
 
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
 ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"

--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -37,6 +37,6 @@ ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{e
 case "$ghostVersion" in
 	2.*) _request GET '/ghost/api/v2/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 	3.*) _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
-	4.*) _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	4.*) _request GET '/ghost/api/v4/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
 	*) echo "no tests for version ${ghostVersion}" && exit 1 ;;
 esac


### PR DESCRIPTION
this change does a couple of things:
- removes Ghost v0 and v1 since they're no longer in use/supported
- ~Updates the curl command to fail on non-2xx status codes - Ghost v4 serves a "maintenance" page with a 503 code while it's booting, and in order to avoid testing while the maintenance page is loading we want to retry until it finishes loading~ 🤦🏻 should have read the docs, `-f` is already being supplied
- adds ghost v4 endpoint to test cases