### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 045060cad517d1008a4f429257d641d10847d8df
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.6, 2.3, latest
+Tags: 2.3.7, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c28fbbfdc0a9f1860e339a8f6e1e0a133eecac55
+GitCommit: dd592f396df43d1b7f5f807168e413e96598c1e6
 Directory: 2.3
 
-Tags: 2.3.6-alpine, 2.3-alpine, alpine
+Tags: 2.3.7-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c28fbbfdc0a9f1860e339a8f6e1e0a133eecac55
+GitCommit: dd592f396df43d1b7f5f807168e413e96598c1e6
 Directory: 2.3/alpine
 
 Tags: 2.2.10, 2.2, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/dd592f3: Update to 2.3.7