### PR TITLE
[oraclelinux] update oraclelinux:7 on amd64/arm64v8 for ELSA-2021-9107

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0fee477d6d6edbf33246c260448afb14834bca13
+amd64-GitCommit: d3619c33485bda7891b39056dc2182a1547213d6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9c00d30ea05f25e77d0ebea02572d5a19b64d618
+arm64v8-GitCommit: fd8597ba0e89502ab262a4e0025de081235b2e0e
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/errata/ELSA-2021-9107.html>

Signed-off-by: Avi Miller <avi.miller@oracle.com>