### PR TITLE
couchdb dropping ppc64le support

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,20 +3,22 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: 47d2a972604e1d33969a244e46b68f45c0382390
+GitCommit: e3ca492e13f65ffd72593ac3d7c43c737787e2b2
 
 Tags: latest, 3.1.1, 3.1, 3
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8
 Directory: 3.1.1
 
 Tags: 3.0.1, 3.0
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8
 Directory: 3.0.1
 
 Tags: 2.3.1, 2.3, 2
 Architectures: amd64, arm64v8
 Directory: 2.3.1
 
+# ppc64le support is dropped until we have CI support for the platform.
+#
 # 1.x is no longer supported by the Apache CouchDB team.
 #
 # dev, dev-cluster versions must not be published officially per


### PR DESCRIPTION
We've lost support for ppc64le on the team proper, so we are dropping it from our supported platform list. If and when we get ppc64le CI support back and a team sponsor for it, we'll revisit the decision.