### PR TITLE
Clean up / fix entrypoint.sh for InfluxDB 2.0

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
 Maintainers: Daniel Moran <dmoran@influxdata.com> (@danxmoran)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: c3c73281e6c0dfa14383c1cf5cd4fb6a7521872a
+GitCommit: 368e52310cf5e5229e8e40149b2233faea7f623b
 
 Tags: 1.7, 1.7.10
 Architectures: amd64, arm32v7, arm64v8


### PR DESCRIPTION
The updated commit includes:
* @tianon's parting suggestions from #9594
* influxdata/influxdata-docker#464