### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.7.0-apache, 5.7-apache, 5-apache, apache, 5.7.0, 5.7, 5, latest, 5.7.0-php7.4-apache, 5.7-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.7.0-php7.4, 5.7-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php7.4/apache
 
 Tags: 5.7.0-fpm, 5.7-fpm, 5-fpm, fpm, 5.7.0-php7.4-fpm, 5.7-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php7.4/fpm
 
 Tags: 5.7.0-fpm-alpine, 5.7-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.7.0-php7.4-fpm-alpine, 5.7-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php7.4/fpm-alpine
 
 Tags: 5.7.0-php7.3-apache, 5.7-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.7.0-php7.3, 5.7-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php7.3/apache
 
 Tags: 5.7.0-php7.3-fpm, 5.7-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php7.3/fpm
 
 Tags: 5.7.0-php7.3-fpm-alpine, 5.7-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php7.3/fpm-alpine
 
 Tags: 5.7.0-php8.0-apache, 5.7-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.7.0-php8.0, 5.7-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php8.0/apache
 
 Tags: 5.7.0-php8.0-fpm, 5.7-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php8.0/fpm
 
 Tags: 5.7.0-php8.0-fpm-alpine, 5.7-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 891b7108294a629e6cc16c2f4bf643d9475894cc
+GitCommit: c313a26c26e936a4ef8c4601185dc60fc848779d
 Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/0f81a03: Merge pull request https://github.com/docker-library/wordpress/pull/577 from infosiftr/restore-default-env-values
- https://github.com/docker-library/wordpress/commit/c313a26: Remove newlines from `_FILE` contents
- https://github.com/docker-library/wordpress/commit/95ca33a: Use WordPress setup default values for env variables; use empty env values