### PR TITLE
Odoo: update 12.0-14.0 to release 20210318

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 99e3de2f03d74d087313edade9620f0912f9212e
+GitCommit: d76e5a9120e02ab985829e7562ab6227b30819c9
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks