### PR TITLE
Ubuntu update March 18 2021

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,48 +6,42 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 307c20ce58171e7e30925ddc2588f7f7bff6e167
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d8b441737e0291a5c1c99f817ff1ba9ab6ccac11
+amd64-GitCommit: c53f3aa911010d483770e411f36857e23695becc
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7da58241e384243bed9b0a1d83eebcde5b428f76
+arm32v7-GitCommit: 9ebd40262cffa75ecdc7fba07106411b734297bb
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9ba0abacca8efc9f80718f69dadecf9bb631dae6
+arm64v8-GitCommit: b56b2b1bae7a9771e6aed20cdc90de5f499e6070
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 3c257636882d9264449b3cd7479310d7449bfd39
+i386-GitCommit: a063f1b7b0900dc73bf55b01f29e4b1a778752b8
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 52443324faa07d08e962cd542d4d6872aea292bc
+ppc64le-GitCommit: ba48c522f5817316546719c51a01cfaca581110d
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 6b803dc68aa0b888eb62ba9d5d7e48dfd19a1638
+s390x-GitCommit: 779979c3090b771137c73ba00b6e709185946211
 
-# 20210222 (bionic)
-Tags: 18.04, bionic-20210222, bionic
+# 20210309 (bionic)
+Tags: 18.04, bionic-20210309, bionic
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20210217 (focal)
-Tags: 20.04, focal-20210217, focal, latest
+# 20210309 (focal)
+Tags: 20.04, focal-20210309, focal, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: focal
 
-# 20210225 (groovy)
-Tags: 20.10, groovy-20210225, groovy, rolling
+# 20210316 (groovy)
+Tags: 20.10, groovy-20210316, groovy, rolling
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: groovy
 
-# 20210119 (hirsute)
-Tags: 21.04, hirsute-20210119, hirsute, devel
+# 20210318 (hirsute)
+Tags: 21.04, hirsute-20210318, hirsute, devel
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hirsute
-amd64-GitCommit: ec931883d8292935b62ac40757287491e6ff467e
-arm32v7-GitCommit: f2ed9c714e4231e0d964095eaba5504fb4ce017d
-arm64v8-GitCommit: 69b377c4bbe13073c3ae2dd0c541dc7b52cc32ba
-i386-GitCommit: 68ae4b1742136f031c3a4770e3e4776a3618df1f
-ppc64le-GitCommit: eb34d4327f126b9f60a873362854b09293f6d9ff
-s390x-GitCommit: 0342e501a11386aedd5597555481cb9b10921eda
 
 # 20191217 (trusty)
 Tags: 14.04, trusty-20191217, trusty


### PR DESCRIPTION
Bug blocking Ubuntu 21.04 Hirsute updates [1][2] has now been marked fix released for Ubuntu 21.04.

[1] https://bugs.launchpad.net/ubuntu/+source/glibc/+bug/1916485
[2] https://bugs.launchpad.net/ubuntu/+source/libseccomp/+bug/1891810