### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,34 +24,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: dd592f396df43d1b7f5f807168e413e96598c1e6
 Directory: 2.3/alpine
 
-Tags: 2.2.10, 2.2, lts
+Tags: 2.2.11, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d41c10ee5e2aba8248c4cdb802d31ca02ba8d7cc
+GitCommit: c81ce53445ae94ffbde9dc08827a1b6811290e62
 Directory: 2.2
 
-Tags: 2.2.10-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.11-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d41c10ee5e2aba8248c4cdb802d31ca02ba8d7cc
+GitCommit: c81ce53445ae94ffbde9dc08827a1b6811290e62
 Directory: 2.2/alpine
 
-Tags: 2.1.11, 2.1
+Tags: 2.1.12, 2.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77cae8f4011926668a3548acf133cfe635f4d68a
+GitCommit: 1c2c1d6296a178444fa8a8961e704f81a56086f5
 Directory: 2.1
 
-Tags: 2.1.11-alpine, 2.1-alpine
+Tags: 2.1.12-alpine, 2.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
+GitCommit: 1c2c1d6296a178444fa8a8961e704f81a56086f5
 Directory: 2.1/alpine
 
-Tags: 2.0.20, 2.0
+Tags: 2.0.21, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a8a76545dc5ba20d2c08001dc7507b7b2161ed90
+GitCommit: fb9129b2ec7491d322c49ea2904e89a359943911
 Directory: 2.0
 
-Tags: 2.0.20-alpine, 2.0-alpine
+Tags: 2.0.21-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
+GitCommit: fb9129b2ec7491d322c49ea2904e89a359943911
 Directory: 2.0/alpine
 
 Tags: 1.8.28, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fb9129b: Update to 2.0.21
- https://github.com/docker-library/haproxy/commit/1c2c1d6: Update to 2.1.12
- https://github.com/docker-library/haproxy/commit/c81ce53: Update to 2.2.11