### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,28 +1,28 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/4f281654d4934c36613261dab970e405068bd79a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/1c120f817997a67599a5970a84689528596b60fe/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-13-jdk-oraclelinux8, 17-ea-13-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-13-jdk-oracle, 17-ea-13-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-13-jdk, 17-ea-13, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-14-jdk-oraclelinux8, 17-ea-14-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-14-jdk-oracle, 17-ea-14-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-14-jdk, 17-ea-14, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-13-jdk-oraclelinux7, 17-ea-13-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-14-jdk-oraclelinux7, 17-ea-14-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-13-jdk-buster, 17-ea-13-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-14-jdk-buster, 17-ea-14-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/buster
 
-Tags: 17-ea-13-jdk-slim-buster, 17-ea-13-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-13-jdk-slim, 17-ea-13-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-14-jdk-slim-buster, 17-ea-14-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-14-jdk-slim, 17-ea-14-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-10-jdk-alpine3.13, 17-ea-10-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-10-jdk-alpine, 17-ea-10-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,106 +35,106 @@ Architectures: amd64
 GitCommit: 3487760f41217ce478a1fe4cee88d8edde180a0b
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-13-jdk-windowsservercore-1809, 17-ea-13-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-13-jdk-windowsservercore, 17-ea-13-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-13-jdk, 17-ea-13, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-14-jdk-windowsservercore-1809, 17-ea-14-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-14-jdk-windowsservercore, 17-ea-14-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-14-jdk, 17-ea-14, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-13-jdk-windowsservercore-ltsc2016, 17-ea-13-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-13-jdk-windowsservercore, 17-ea-13-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-13-jdk, 17-ea-13, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-14-jdk-windowsservercore-ltsc2016, 17-ea-14-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-14-jdk-windowsservercore, 17-ea-14-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-14-jdk, 17-ea-14, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-13-jdk-nanoserver-1809, 17-ea-13-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-13-jdk-nanoserver, 17-ea-13-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-14-jdk-nanoserver-1809, 17-ea-14-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-14-jdk-nanoserver, 17-ea-14-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 96350fbdfe70d6f71b933b33a40c417e98e505fe
+GitCommit: 9089ceb01cb8c5785cee80a66b21f46bcc6b8905
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16-jdk-oraclelinux8, 16-oraclelinux8, 16-jdk-oracle, 16-oracle
-SharedTags: 16-jdk, 16
+Tags: 16-jdk-oraclelinux8, 16-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 16-jdk-oracle, 16-oracle, jdk-oracle, oracle
+SharedTags: 16-jdk, 16, jdk, latest
 Architectures: amd64, arm64v8
 GitCommit: e3e3d529643940779bc694d96d7586986e38ed3b
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16-jdk-oraclelinux7, 16-oraclelinux7
+Tags: 16-jdk-oraclelinux7, 16-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: e3e3d529643940779bc694d96d7586986e38ed3b
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16-jdk-buster, 16-buster
+Tags: 16-jdk-buster, 16-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
 GitCommit: e3e3d529643940779bc694d96d7586986e38ed3b
 Directory: 16/jdk/buster
 
-Tags: 16-jdk-slim-buster, 16-slim-buster, 16-jdk-slim, 16-slim
+Tags: 16-jdk-slim-buster, 16-slim-buster, jdk-slim-buster, slim-buster, 16-jdk-slim, 16-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
 GitCommit: e3e3d529643940779bc694d96d7586986e38ed3b
 Directory: 16/jdk/slim-buster
 
-Tags: 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16-jdk-windowsservercore, 16-windowsservercore, 16-jdk, 16
+Tags: 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
 GitCommit: e3e3d529643940779bc694d96d7586986e38ed3b
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16-jdk-windowsservercore, 16-windowsservercore, 16-jdk, 16
+Tags: 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
 GitCommit: e3e3d529643940779bc694d96d7586986e38ed3b
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16-jdk-nanoserver, 16-nanoserver
+Tags: 16-jdk-nanoserver-1809, 16-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 16-jdk-nanoserver, 16-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: 07973f4c38b7b735e400d3ed7fc5efd8648d6cc1
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15.0.2-jdk-oraclelinux8, 15.0.2-oraclelinux8, 15.0-jdk-oraclelinux8, 15.0-oraclelinux8, 15-jdk-oraclelinux8, 15-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 15.0.2-jdk-oracle, 15.0.2-oracle, 15.0-jdk-oracle, 15.0-oracle, 15-jdk-oracle, 15-oracle, jdk-oracle, oracle
-SharedTags: 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15, jdk, latest
+Tags: 15.0.2-jdk-oraclelinux8, 15.0.2-oraclelinux8, 15.0-jdk-oraclelinux8, 15.0-oraclelinux8, 15-jdk-oraclelinux8, 15-oraclelinux8, 15.0.2-jdk-oracle, 15.0.2-oracle, 15.0-jdk-oracle, 15.0-oracle, 15-jdk-oracle, 15-oracle
+SharedTags: 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15
 Architectures: amd64, arm64v8
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/oraclelinux8
 
-Tags: 15.0.2-jdk-oraclelinux7, 15.0.2-oraclelinux7, 15.0-jdk-oraclelinux7, 15.0-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7, jdk-oraclelinux7, oraclelinux7
+Tags: 15.0.2-jdk-oraclelinux7, 15.0.2-oraclelinux7, 15.0-jdk-oraclelinux7, 15.0-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/oraclelinux7
 
-Tags: 15.0.2-jdk-buster, 15.0.2-buster, 15.0-jdk-buster, 15.0-buster, 15-jdk-buster, 15-buster, jdk-buster, buster
+Tags: 15.0.2-jdk-buster, 15.0.2-buster, 15.0-jdk-buster, 15.0-buster, 15-jdk-buster, 15-buster
 Architectures: amd64, arm64v8
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/buster
 
-Tags: 15.0.2-jdk-slim-buster, 15.0.2-slim-buster, 15.0-jdk-slim-buster, 15.0-slim-buster, 15-jdk-slim-buster, 15-slim-buster, jdk-slim-buster, slim-buster, 15.0.2-jdk-slim, 15.0.2-slim, 15.0-jdk-slim, 15.0-slim, 15-jdk-slim, 15-slim, jdk-slim, slim
+Tags: 15.0.2-jdk-slim-buster, 15.0.2-slim-buster, 15.0-jdk-slim-buster, 15.0-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15.0.2-jdk-slim, 15.0.2-slim, 15.0-jdk-slim, 15.0-slim, 15-jdk-slim, 15-slim
 Architectures: amd64, arm64v8
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/slim-buster
 
-Tags: 15.0.2-jdk-windowsservercore-1809, 15.0.2-windowsservercore-1809, 15.0-jdk-windowsservercore-1809, 15.0-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 15.0.2-jdk-windowsservercore, 15.0.2-windowsservercore, 15.0-jdk-windowsservercore, 15.0-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, jdk-windowsservercore, windowsservercore, 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15, jdk, latest
+Tags: 15.0.2-jdk-windowsservercore-1809, 15.0.2-windowsservercore-1809, 15.0-jdk-windowsservercore-1809, 15.0-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
+SharedTags: 15.0.2-jdk-windowsservercore, 15.0.2-windowsservercore, 15.0-jdk-windowsservercore, 15.0-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15
 Architectures: windows-amd64
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 15.0.2-jdk-windowsservercore-ltsc2016, 15.0.2-windowsservercore-ltsc2016, 15.0-jdk-windowsservercore-ltsc2016, 15.0-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 15.0.2-jdk-windowsservercore, 15.0.2-windowsservercore, 15.0-jdk-windowsservercore, 15.0-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, jdk-windowsservercore, windowsservercore, 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15, jdk, latest
+Tags: 15.0.2-jdk-windowsservercore-ltsc2016, 15.0.2-windowsservercore-ltsc2016, 15.0-jdk-windowsservercore-ltsc2016, 15.0-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
+SharedTags: 15.0.2-jdk-windowsservercore, 15.0.2-windowsservercore, 15.0-jdk-windowsservercore, 15.0-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15
 Architectures: windows-amd64
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 15.0.2-jdk-nanoserver-1809, 15.0.2-nanoserver-1809, 15.0-jdk-nanoserver-1809, 15.0-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 15.0.2-jdk-nanoserver, 15.0.2-nanoserver, 15.0-jdk-nanoserver, 15.0-nanoserver, 15-jdk-nanoserver, 15-nanoserver, jdk-nanoserver, nanoserver
+Tags: 15.0.2-jdk-nanoserver-1809, 15.0.2-nanoserver-1809, 15.0-jdk-nanoserver-1809, 15.0-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
+SharedTags: 15.0.2-jdk-nanoserver, 15.0.2-nanoserver, 15.0-jdk-nanoserver, 15.0-nanoserver, 15-jdk-nanoserver, 15-nanoserver
 Architectures: windows-amd64
 GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
 Directory: 15/jdk/windows/nanoserver-1809
@@ -142,23 +142,23 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.10-jdk-oraclelinux8, 11.0.10-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.10-jdk-oracle, 11.0.10-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: 4b66dda0a183517f14600278223ff014b541870a
+GitCommit: a931d588491254902ef85d9d8afd79064cad57eb
 Directory: 11/jdk/oraclelinux8
 
 Tags: 11.0.10-jdk-oraclelinux7, 11.0.10-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 4b66dda0a183517f14600278223ff014b541870a
+GitCommit: a931d588491254902ef85d9d8afd79064cad57eb
 Directory: 11/jdk/oraclelinux7
 
 Tags: 11.0.10-jdk-buster, 11.0.10-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 SharedTags: 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 4b66dda0a183517f14600278223ff014b541870a
+GitCommit: a931d588491254902ef85d9d8afd79064cad57eb
 Directory: 11/jdk/buster
 
 Tags: 11.0.10-jdk-slim-buster, 11.0.10-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.10-jdk-slim, 11.0.10-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 4b66dda0a183517f14600278223ff014b541870a
+GitCommit: a931d588491254902ef85d9d8afd79064cad57eb
 Directory: 11/jdk/slim-buster
 
 Tags: 11.0.10-jdk-windowsservercore-1809, 11.0.10-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809


### PR DESCRIPTION
Changes:
- https://github.com/docker-library/openjdk/commit/9089ceb: Update 17 to 17-ea+14
- https://github.com/docker-library/openjdk/commit/1c120f8: Update latest to 16 (which is GA)
- https://github.com/docker-library/openjdk/commit/a931d58: Update 11
- https://github.com/docker-library/openjdk/commit/dcefdff: Update 11