### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fb9129b2ec7491d322c49ea2904e89a359943911
 Directory: 2.0/alpine
 
-Tags: 1.8.28, 1.8
+Tags: 1.8.29, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74912d5713bfb45596c55a174342898bd2c58960
+GitCommit: 840443817e8eebfb3a9d80de68ac5af1415c09c2
 Directory: 1.8
 
-Tags: 1.8.28-alpine, 1.8-alpine
+Tags: 1.8.29-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dba80a9d073ce4d624fb52c4e8afd449561654c8
+GitCommit: 840443817e8eebfb3a9d80de68ac5af1415c09c2
 Directory: 1.8/alpine
 
 Tags: 1.7.12, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8404438: Update to 1.8.29