### PR TITLE
Update yourls

### DIFF
--- a/library/yourls
+++ b/library/yourls
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/YOURLS/docker-yourls/blob/0b8dc066336508aeafae001698f970af7ca1ec27/bin/generate-stackbrew-library.sh
+# this file is generated via https://github.com/YOURLS/docker-yourls/blob/f1756127e0b8eebad4f301d4fe6790f6d9794ce2/bin/generate-stackbrew-library.sh
 
 Maintainers: YOURLS <yourls@yourls.org> (@YOURLS),
              Léo Colombaro <git@colombaro.fr> (@LeoColomb)
@@ -7,15 +7,15 @@ GitFetch: refs/heads/dist
 
 Tags: 1.8.1-apache, 1.8-apache, 1-apache, apache, 1.8.1, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b8dc066336508aeafae001698f970af7ca1ec27
+GitCommit: f1756127e0b8eebad4f301d4fe6790f6d9794ce2
 Directory: apache
 
 Tags: 1.8.1-fpm, 1.8-fpm, 1-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b8dc066336508aeafae001698f970af7ca1ec27
+GitCommit: f1756127e0b8eebad4f301d4fe6790f6d9794ce2
 Directory: fpm
 
 Tags: 1.8.1-fpm-alpine, 1.8-fpm-alpine, 1-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b8dc066336508aeafae001698f970af7ca1ec27
+GitCommit: f1756127e0b8eebad4f301d4fe6790f6d9794ce2
 Directory: fpm-alpine

--- a/library/yourls
+++ b/library/yourls
@@ -1,20 +1,21 @@
-# this file is generated via https://github.com/YOURLS/docker-yourls/blob/a358b4f51a61732a89347ba35d59c7bc4c65f6e6/bin/generate-stackbrew-library.sh
+# this file is generated via https://github.com/YOURLS/docker-yourls/blob/0b8dc066336508aeafae001698f970af7ca1ec27/bin/generate-stackbrew-library.sh
 
 Maintainers: YOURLS <yourls@yourls.org> (@YOURLS),
              Léo Colombaro <git@colombaro.fr> (@LeoColomb)
 GitRepo: https://github.com/YOURLS/docker-yourls.git
+GitFetch: refs/heads/dist
 
 Tags: 1.8.1-apache, 1.8-apache, 1-apache, apache, 1.8.1, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a358b4f51a61732a89347ba35d59c7bc4c65f6e6
+GitCommit: 0b8dc066336508aeafae001698f970af7ca1ec27
 Directory: apache
 
 Tags: 1.8.1-fpm, 1.8-fpm, 1-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a358b4f51a61732a89347ba35d59c7bc4c65f6e6
+GitCommit: 0b8dc066336508aeafae001698f970af7ca1ec27
 Directory: fpm
 
 Tags: 1.8.1-fpm-alpine, 1.8-fpm-alpine, 1-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a358b4f51a61732a89347ba35d59c7bc4c65f6e6
+GitCommit: 0b8dc066336508aeafae001698f970af7ca1ec27
 Directory: fpm-alpine

--- a/library/yourls
+++ b/library/yourls
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/YOURLS/docker-yourls/blob/eded14078d93e7c85b9be1cdc5f522f2d669019c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/YOURLS/docker-yourls/blob/a358b4f51a61732a89347ba35d59c7bc4c65f6e6/bin/generate-stackbrew-library.sh
 
 Maintainers: YOURLS <yourls@yourls.org> (@YOURLS),
              Léo Colombaro <git@colombaro.fr> (@LeoColomb)
@@ -6,15 +6,15 @@ GitRepo: https://github.com/YOURLS/docker-yourls.git
 
 Tags: 1.8.1-apache, 1.8-apache, 1-apache, apache, 1.8.1, 1.8, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1b71609d96e6f242f2b19dec702c18d9803275c1
+GitCommit: a358b4f51a61732a89347ba35d59c7bc4c65f6e6
 Directory: apache
 
 Tags: 1.8.1-fpm, 1.8-fpm, 1-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1b71609d96e6f242f2b19dec702c18d9803275c1
+GitCommit: a358b4f51a61732a89347ba35d59c7bc4c65f6e6
 Directory: fpm
 
 Tags: 1.8.1-fpm-alpine, 1.8-fpm-alpine, 1-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1b71609d96e6f242f2b19dec702c18d9803275c1
+GitCommit: a358b4f51a61732a89347ba35d59c7bc4c65f6e6
 Directory: fpm-alpine


### PR DESCRIPTION
This change won't affect published images, but reflect a refactor of https://github.com/YOURLS/docker-yourls repo.
* The main branch is now named `main`
* The built Dockerfiles and relative files are moved to a separate branch (`dist`)
  * They don't live in main branch anymore, only templates there
* CI/CD changes (we won't use @docker-library-bot help anymore. It was nice, thanks @tianon, now even better!)

I'm making this PR to make sure everything follow correctly, and to have a clean base for next concrete changes.
- [x] It seems to to be OK 