### PR TITLE
archlinux: Release 20210321.0.17674

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -6,13 +6,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210314.0.17164
-GitCommit: c97e007f6a1d53852bad25e15018762cc560e7df
-GitFetch: refs/tags/v20210314.0.17164
+Tags: latest, base, base-20210321.0.17674
+GitCommit: ca981f05ce4541731c575ca3750c1746a80dcf03
+GitFetch: refs/tags/v20210321.0.17674
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210314.0.17164
-GitCommit: c97e007f6a1d53852bad25e15018762cc560e7df
-GitFetch: refs/tags/v20210314.0.17164
+Tags: base-devel, base-devel-20210321.0.17674
+GitCommit: ca981f05ce4541731c575ca3750c1746a80dcf03
+GitFetch: refs/tags/v20210321.0.17674
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

Maintainers: @SantiagoTorres @shibumi @pierres @hashworks

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml
