### PR TITLE
Update Clear Linux OS to 34420

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ce3c29fb43406f12628ea02a23f63905a1bb6758
-GitFetch: refs/tags/clear-linux-34370
+GitCommit: 7868c573b53617c5521317f8e7cf30c006c355b7
+GitFetch: refs/tags/clear-linux-34420


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34420

@bryteise @mdhorn @phmccarty