### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,28 +4,28 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.1.1, 4.1, 4, latest
+Tags: 4.1.2, 4.1, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f5895d1d4bff53a590b6048e294dc96b26206883
+GitCommit: ea093b382fbdb883daf868c5ea4a9c1fd27f3aca
 Directory: 4.1
 
-Tags: 4.1.1-passenger, 4.1-passenger, 4-passenger, passenger
+Tags: 4.1.2-passenger, 4.1-passenger, 4-passenger, passenger
 GitCommit: 7fdd6777cc21b0d1974884e6e54208d16a991b19
 Directory: 4.1/passenger
 
-Tags: 4.1.1-alpine, 4.1-alpine, 4-alpine, alpine
-GitCommit: e224c25360a7a576ec53fd105b403d2ce4b92d5b
+Tags: 4.1.2-alpine, 4.1-alpine, 4-alpine, alpine
+GitCommit: ea093b382fbdb883daf868c5ea4a9c1fd27f3aca
 Directory: 4.1/alpine
 
-Tags: 4.0.7, 4.0
+Tags: 4.0.8, 4.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f5895d1d4bff53a590b6048e294dc96b26206883
+GitCommit: ae11c0c35e0920781464c4afdac9096eec355c8b
 Directory: 4.0
 
-Tags: 4.0.7-passenger, 4.0-passenger
+Tags: 4.0.8-passenger, 4.0-passenger
 GitCommit: 7fdd6777cc21b0d1974884e6e54208d16a991b19
 Directory: 4.0/passenger
 
-Tags: 4.0.7-alpine, 4.0-alpine
-GitCommit: e224c25360a7a576ec53fd105b403d2ce4b92d5b
+Tags: 4.0.8-alpine, 4.0-alpine
+GitCommit: ae11c0c35e0920781464c4afdac9096eec355c8b
 Directory: 4.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/ae11c0c: Update to 4.0.8
- https://github.com/docker-library/redmine/commit/ea093b3: Update to 4.1.2
- https://github.com/docker-library/redmine/commit/f35a8c1: Refactor Alpine "scanelf" to use similar "ldd" to Debian to avoid new errors in 4.1.2
- https://github.com/docker-library/redmine/commit/273f694: Merge pull request https://github.com/docker-library/redmine/pull/229 from pcworld/sha256
- https://github.com/docker-library/redmine/commit/10a154c: Use sha256 for checksumming