### PR TITLE
maven: switch latest to openjdk-16

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -41,7 +41,7 @@ Architectures: amd64, arm64v8
 GitCommit: 26ba49149787c85b9c51222b47c00879b2a0afde
 Directory: openjdk-11-slim
 
-Tags: 3.6.3-openjdk-15, 3.6.3, 3.6.3-openjdk, 3.6-openjdk-15, 3.6, 3.6-openjdk, 3-openjdk-15, 3, latest, 3-openjdk, openjdk
+Tags: 3.6.3-openjdk-15, 3.6-openjdk-15, 3-openjdk-15
 Architectures: amd64, arm64v8
 GitCommit: a7de5419ae52d514d0fd5bcd08694fce2334aed4
 Directory: openjdk-15
@@ -51,7 +51,7 @@ Architectures: amd64, arm64v8
 GitCommit: cc080bd044b5ae09731e5cb5f8de61fb5bdb32a5
 Directory: openjdk-15-slim
 
-Tags: 3.6.3-openjdk-16, 3.6-openjdk-16, 3-openjdk-16
+Tags: 3.6.3-openjdk-16, 3.6.3, 3.6.3-openjdk, 3.6-openjdk-16, 3.6, 3.6-openjdk, 3-openjdk-16, 3, latest, 3-openjdk, openjdk
 Architectures: amd64, arm64v8
 GitCommit: a7de5419ae52d514d0fd5bcd08694fce2334aed4
 Directory: openjdk-16


### PR DESCRIPTION
Fixes https://github.com/carlossg/docker-maven/issues/201