### PR TITLE
Bump Traefik to v2.4.8

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.4.7-windowsservercore-1809, 2.4.7-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.8-windowsservercore-1809, 2.4.8-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b3db6dc0374f70f7761b9820e991978ebee30510
+GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.7, 2.4.7, v2.4, 2.4, livarot, latest
+Tags: v2.4.8, 2.4.8, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b3db6dc0374f70f7761b9820e991978ebee30510
+GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
 Directory: alpine
 
 Tags: v1.7.28-windowsservercore-1809, 1.7.28-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.8](https://github.com/traefik/traefik/releases/tag/v2.4.8).

/cc @ldez @SantoDE @jbdoumenjou

Cheers
