### PR TITLE
Revert official docker kapacitor to 1.5.7

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,9 +3,9 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: devel-20210315, devel
+Tags: devel-20210322, devel
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5e48786cd7ca85ac0a8ca8113c885a4e1d4da07d
+GitCommit: e2d3792f49520d1d1ce01ec123b685aadc1b1ea4
 Directory: devel
 
 Tags: 5.1.4, 5.1, 5, latest

--- a/library/ghost
+++ b/library/ghost
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.1.0, 4.1, 4, latest
+Tags: 4.1.1, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc0d302a71d43a1e58fc45506226325ab159eb59
+GitCommit: c316a2f7e80e52581e4e905f1949a97e30179af1
 Directory: 4/debian
 
-Tags: 4.1.0-alpine, 4.1-alpine, 4-alpine, alpine
+Tags: 4.1.1-alpine, 4.1-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: fc0d302a71d43a1e58fc45506226325ab159eb59
+GitCommit: c316a2f7e80e52581e4e905f1949a97e30179af1
 Directory: 4/alpine
 
-Tags: 3.42.3, 3.42, 3
+Tags: 3.42.4, 3.42, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 21461407dc8dfe1bf4f8b78dabfca4209b411d8b
+GitCommit: 73ffcc88f26de88b4c68149f16d8aaf2237f9348
 Directory: 3/debian
 
-Tags: 3.42.3-alpine, 3.42-alpine, 3-alpine
+Tags: 3.42.4-alpine, 3.42-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 21461407dc8dfe1bf4f8b78dabfca4209b411d8b
+GitCommit: 73ffcc88f26de88b4c68149f16d8aaf2237f9348
 Directory: 3/alpine
 
 Tags: 2.38.3, 2.38, 2

--- a/library/influxdb
+++ b/library/influxdb
@@ -1,24 +1,24 @@
 Maintainers: Daniel Moran <dmoran@influxdata.com> (@danxmoran)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 368e52310cf5e5229e8e40149b2233faea7f623b
+GitCommit: c6eeae53da9cf62803ccce0c2550889acf5caed0
 
-Tags: 1.7, 1.7.10
+Tags: 1.7, 1.7.11
 Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.7
 
-Tags: 1.7-alpine, 1.7.10-alpine
+Tags: 1.7-alpine, 1.7.11-alpine
 Directory: influxdb/1.7/alpine
 
-Tags: 1.7-data, 1.7.10-data
+Tags: 1.7-data, 1.7.11-data
 Directory: influxdb/1.7/data
 
-Tags: 1.7-data-alpine, 1.7.10-data-alpine
+Tags: 1.7-data-alpine, 1.7.11-data-alpine
 Directory: influxdb/1.7/data/alpine
 
-Tags: 1.7-meta, 1.7.10-meta
+Tags: 1.7-meta, 1.7.11-meta
 Directory: influxdb/1.7/meta
 
-Tags: 1.7-meta-alpine, 1.7.10-meta-alpine
+Tags: 1.7-meta-alpine, 1.7.11-meta-alpine
 Directory: influxdb/1.7/meta/alpine
 
 Tags: 1.8, 1.8.4

--- a/library/maven
+++ b/library/maven
@@ -41,7 +41,7 @@ Architectures: amd64, arm64v8
 GitCommit: 26ba49149787c85b9c51222b47c00879b2a0afde
 Directory: openjdk-11-slim
 
-Tags: 3.6.3-openjdk-15, 3.6.3, 3.6.3-openjdk, 3.6-openjdk-15, 3.6, 3.6-openjdk, 3-openjdk-15, 3, latest, 3-openjdk, openjdk
+Tags: 3.6.3-openjdk-15, 3.6-openjdk-15, 3-openjdk-15
 Architectures: amd64, arm64v8
 GitCommit: a7de5419ae52d514d0fd5bcd08694fce2334aed4
 Directory: openjdk-15
@@ -51,7 +51,7 @@ Architectures: amd64, arm64v8
 GitCommit: cc080bd044b5ae09731e5cb5f8de61fb5bdb32a5
 Directory: openjdk-15-slim
 
-Tags: 3.6.3-openjdk-16, 3.6-openjdk-16, 3-openjdk-16
+Tags: 3.6.3-openjdk-16, 3.6.3, 3.6.3-openjdk, 3.6-openjdk-16, 3.6, 3.6-openjdk, 3-openjdk-16, 3, latest, 3-openjdk, openjdk
 Architectures: amd64, arm64v8
 GitCommit: a7de5419ae52d514d0fd5bcd08694fce2334aed4
 Directory: openjdk-16

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.4.7-windowsservercore-1809, 2.4.7-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.8-windowsservercore-1809, 2.4.8-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b3db6dc0374f70f7761b9820e991978ebee30510
+GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.7, 2.4.7, v2.4, 2.4, livarot, latest
+Tags: v2.4.8, 2.4.8, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b3db6dc0374f70f7761b9820e991978ebee30510
+GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
 Directory: alpine
 
 Tags: v1.7.28-windowsservercore-1809, 1.7.28-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/varnish
+++ b/library/varnish
@@ -1,4 +1,4 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/702cb88b01771ff6940b865f0a1f86e98bc41b0a/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/82d7e7a3e0d39bed9f799b9a9455335b27ee0e83/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
@@ -7,7 +7,12 @@ Architectures: amd64
 Directory: stable/debian
 GitCommit: c0846f15b04cd499a1df1fb62f0693b41a84e636
 
-Tags: 6.5, 6.6.0-1, 6.6.0, 6.6, 6, latest, fresh
+Tags: 6.6, 6.6.0-1, 6.6.0, 6, latest, fresh
 Architectures: amd64
 Directory: fresh/debian
 GitCommit: 702cb88b01771ff6940b865f0a1f86e98bc41b0a
+
+Tags: 6.5, 6.5.1-1, 6.5.1
+Architectures: amd64
+Directory: fresh/debian
+GitCommit: f26947e3a1d7ab5e3e76114d58e54f0ddee13534


### PR DESCRIPTION
We found a rather large bug in 1.5.8 and we want to revert the docker kapacitor downloads to 1.5.7