### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.14, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e3d1975eb0ae30435de5e1146ae8fcc2cd15fbe
+GitCommit: e0114b648b4ceceaa8783cca2f9326a3e4061c4f
 Directory: 3.8/ubuntu
 
 Tags: 3.8.14-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.14-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e3d1975eb0ae30435de5e1146ae8fcc2cd15fbe
+GitCommit: e0114b648b4ceceaa8783cca2f9326a3e4061c4f
 Directory: 3.8/alpine
 
 Tags: 3.8.14-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/28c3db6: Update 3.8-rc to otp 23.3
- https://github.com/docker-library/rabbitmq/commit/e0114b6: Update 3.8 to otp 23.3