### PR TITLE
Update Ubuntu to address openssl CVE-2021-3449

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,35 +6,35 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 307c20ce58171e7e30925ddc2588f7f7bff6e167
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d8b441737e0291a5c1c99f817ff1ba9ab6ccac11
+amd64-GitCommit: e72e50c16ab07b13c35af97bed0cc7860369e0c6
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7da58241e384243bed9b0a1d83eebcde5b428f76
+arm32v7-GitCommit: 7ea37b34b92ba79aa17515ffffd7c3fe1610014f
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9ba0abacca8efc9f80718f69dadecf9bb631dae6
+arm64v8-GitCommit: 6bc96465ec1bc64f4f91b4656fa560ccda3e07bf
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 3c257636882d9264449b3cd7479310d7449bfd39
+i386-GitCommit: e5a8b7d32e5a0c45f8b376e8e972518349fa3421
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 52443324faa07d08e962cd542d4d6872aea292bc
+ppc64le-GitCommit: f44f90ccc338f3c6331c9bd489e7c14f15dd4e88
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 6b803dc68aa0b888eb62ba9d5d7e48dfd19a1638
+s390x-GitCommit: f581ef59da43737fdafbb76931e9ba6285da9266
 
-# 20210222 (bionic)
-Tags: 18.04, bionic-20210222, bionic
+# 20210325 (bionic)
+Tags: 18.04, bionic-20210325, bionic
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20210217 (focal)
-Tags: 20.04, focal-20210217, focal, latest
+# 20210325 (focal)
+Tags: 20.04, focal-20210325, focal, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: focal
 
-# 20210225 (groovy)
-Tags: 20.10, groovy-20210225, groovy, rolling
+# 20210325 (groovy)
+Tags: 20.10, groovy-20210325, groovy, rolling
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: groovy
 


### PR DESCRIPTION
See

* https://ubuntu.com/security/CVE-2021-3449
* https://ubuntu.com/security/notices/USN-4891-1

For more details on this CVE.

This update does not update Ubuntu 21.04 due to issues with debootstrap pulling in unneeded packages.

See

* https://github.com/docker-library/official-images/pull/9813
* https://bugs.launchpad.net/ubuntu/+source/debootstrap/+bug/1920055

For more details on this.