### PR TITLE
[security] Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.14, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e0114b648b4ceceaa8783cca2f9326a3e4061c4f
+GitCommit: 55a2288f4601986a8d416bd34c22d634c05e368d
 Directory: 3.8/ubuntu
 
 Tags: 3.8.14-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.14-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e0114b648b4ceceaa8783cca2f9326a3e4061c4f
+GitCommit: 55a2288f4601986a8d416bd34c22d634c05e368d
 Directory: 3.8/alpine
 
 Tags: 3.8.14-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/6fde356: Update 3.8-rc to openssl 1.1.1k
- https://github.com/docker-library/rabbitmq/commit/55a2288: Update 3.8 to openssl 1.1.1k