### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,75 +1,65 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/efd86caa8356759e9462325302e949c83d82a820/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/39812f8f0bb3a6c8777a018bbd5d251723367e1f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev12, 2.4-dev
+Tags: 2.4-dev13, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 045060cad517d1008a4f429257d641d10847d8df
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.4-rc
 
-Tags: 2.4-dev12-alpine, 2.4-dev-alpine
+Tags: 2.4-dev13-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 045060cad517d1008a4f429257d641d10847d8df
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.7, 2.3, latest
+Tags: 2.3.8, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dd592f396df43d1b7f5f807168e413e96598c1e6
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.3
 
-Tags: 2.3.7-alpine, 2.3-alpine, alpine
+Tags: 2.3.8-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd592f396df43d1b7f5f807168e413e96598c1e6
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.3/alpine
 
 Tags: 2.2.11, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c81ce53445ae94ffbde9dc08827a1b6811290e62
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.2
 
 Tags: 2.2.11-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c81ce53445ae94ffbde9dc08827a1b6811290e62
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.2/alpine
-
-Tags: 2.1.12, 2.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c2c1d6296a178444fa8a8961e704f81a56086f5
-Directory: 2.1
-
-Tags: 2.1.12-alpine, 2.1-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c2c1d6296a178444fa8a8961e704f81a56086f5
-Directory: 2.1/alpine
 
 Tags: 2.0.21, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fb9129b2ec7491d322c49ea2904e89a359943911
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.0
 
 Tags: 2.0.21-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fb9129b2ec7491d322c49ea2904e89a359943911
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 2.0/alpine
 
 Tags: 1.8.29, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 840443817e8eebfb3a9d80de68ac5af1415c09c2
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 1.8
 
 Tags: 1.8.29-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 840443817e8eebfb3a9d80de68ac5af1415c09c2
+GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 1.8/alpine
 
-Tags: 1.7.12, 1.7
+Tags: 1.7.13, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 8cd07f9d33dac8436831b0a1f2f1a862061a237a
 Directory: 1.7
 
-Tags: 1.7.12-alpine, 1.7-alpine
+Tags: 1.7.13-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82ff028a25c55c36e8c39b16390e4e04efa2bc4a
+GitCommit: 42989bf9ab08e05e7333261ce62fff00d0dcb08a
 Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/414915c: Merge pull request https://github.com/docker-library/haproxy/pull/145 from TimWolla/haproxy-1.7
- https://github.com/docker-library/haproxy/commit/42989bf: (Re-)Apply the backported ebtree patch from upstream
- https://github.com/docker-library/haproxy/commit/8cd07f9: Update to 1.7.13
- https://github.com/docker-library/haproxy/commit/102c0e1: Merge pull request https://github.com/docker-library/haproxy/pull/148 from infosiftr/jq-template
- https://github.com/docker-library/haproxy/commit/39812f8: Add initial jq-based templating engine
- https://github.com/docker-library/haproxy/commit/ed0324b: Merge pull request https://github.com/docker-library/haproxy/pull/147 from TimWolla/haproxy-2.3.8
- https://github.com/docker-library/haproxy/commit/c2c4ab0: Update to 2.3.8
- https://github.com/docker-library/haproxy/commit/dacda08: Merge pull request https://github.com/docker-library/haproxy/pull/144 from TimWolla/remove-2.1
- https://github.com/docker-library/haproxy/commit/02a4f51: Merge pull request https://github.com/docker-library/haproxy/pull/146 from TimWolla/haproxy-2.4
- https://github.com/docker-library/haproxy/commit/1f1ec5e: Update to 2.4-dev13
- https://github.com/docker-library/haproxy/commit/c942740: Remove EOL 2.1