### PR TITLE
Update Clear Linux OS to 34440

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 7868c573b53617c5521317f8e7cf30c006c355b7
-GitFetch: refs/tags/clear-linux-34420
+GitCommit: c59270c4e45f93809f7dfc071b822d45e74e06d9
+GitFetch: refs/tags/clear-linux-34440


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34440

@bryteise @mdhorn @phmccarty