### PR TITLE
Update Jetty versions to 9.4.39, 10.0.2 and 11.0.2

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,115 +4,115 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.1-jre11-slim
+Tags: 11.0.2-jre11-slim
 Architectures: amd64
 Directory: 11.0-jre11-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 11.0.1-jre11
+Tags: 11.0.2-jre11
 Architectures: amd64
 Directory: 11.0-jre11
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 11.0.1-jdk15-slim
+Tags: 11.0.2-jdk15-slim
 Architectures: amd64
 Directory: 11.0-jdk15-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 11.0.1, 11.0.1-jdk15
+Tags: 11.0.2, 11.0.2-jdk15
 Architectures: amd64
 Directory: 11.0-jdk15
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 11.0.1-jdk11-slim
+Tags: 11.0.2-jdk11-slim
 Architectures: amd64
 Directory: 11.0-jdk11-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 11.0.1-jdk11
+Tags: 11.0.2-jdk11
 Architectures: amd64
 Directory: 11.0-jdk11
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 10.0.1-jre11-slim
+Tags: 10.0.2-jre11-slim
 Architectures: amd64
 Directory: 10.0-jre11-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 10.0.1-jre11
+Tags: 10.0.2-jre11
 Architectures: amd64
 Directory: 10.0-jre11
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 10.0.1-jdk15-slim
+Tags: 10.0.2-jdk15-slim
 Architectures: amd64
 Directory: 10.0-jdk15-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 10.0.1, 10.0.1-jdk15
+Tags: 10.0.2, 10.0.2-jdk15
 Architectures: amd64
 Directory: 10.0-jdk15
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 10.0.1-jdk11-slim
+Tags: 10.0.2-jdk11-slim
 Architectures: amd64
 Directory: 10.0-jdk11-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 10.0.1-jdk11
+Tags: 10.0.2-jdk11
 Architectures: amd64
 Directory: 10.0-jdk11
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.39-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.39-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 9.4.39-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64
 Directory: 9.4-jre8-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.39-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jdk15-slim, 9.4-jdk15-slim, 9-jdk15-slim
+Tags: 9.4.39-jdk15-slim, 9.4-jdk15-slim, 9-jdk15-slim
 Architectures: amd64
 Directory: 9.4-jdk15-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38, 9.4, 9, 9.4.38-jdk15, 9.4-jdk15, 9-jdk15, latest, jdk15
+Tags: 9.4.39, 9.4, 9, 9.4.39-jdk15, 9.4-jdk15, 9-jdk15, latest, jdk15
 Architectures: amd64
 Directory: 9.4-jdk15
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 9.4.39-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64
 Directory: 9.4-jdk11-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 9.4.39-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64
 Directory: 9.4-jdk11
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 9.4.39-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64
 Directory: 9.4-jdk8-slim
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
-Tags: 9.4.38-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 9.4.39-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64
 Directory: 9.4-jdk8
-GitCommit: c116cb24981b4f49b0ce93857a6dbbefb5190f87
+GitCommit: a5956c18b302fce8eacb8d6e7944c638761bc052
 
 Tags: 9.3.29-jre8, 9.3-jre8
 Architectures: amd64


### PR DESCRIPTION
**Update Jetty Versions:**
`9.4.38` -> `9.4.39`
`10.0.1` -> `10.0.2`
`11.0.1` -> `11.0.2`