### PR TITLE
Bump Traefik to v1.7.29

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,21 +13,21 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
 Directory: alpine
 
-Tags: v1.7.28-windowsservercore-1809, 1.7.28-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.29-windowsservercore-1809, 1.7.29-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 304f7cf2cf36f59e0bc93597579c61837ce2ea6f
+GitCommit: 7dd8fea4e6dd7dae69900c171b356d91d696fca6
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.28-alpine, 1.7.28-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.29-alpine, 1.7.29-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 304f7cf2cf36f59e0bc93597579c61837ce2ea6f
+GitCommit: 7dd8fea4e6dd7dae69900c171b356d91d696fca6
 Directory: alpine
 
-Tags: v1.7.28, 1.7.28, v1.7, 1.7, maroilles
+Tags: v1.7.29, 1.7.29, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 304f7cf2cf36f59e0bc93597579c61837ce2ea6f
+GitCommit: 7dd8fea4e6dd7dae69900c171b356d91d696fca6
 Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v1.7.29](https://github.com/traefik/traefik/releases/tag/v1.7.29).

/cc @kevinpollet @rtribotte @SantoDE @jbdoumenjou

Cheers
