### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev13, 2.4-dev
+Tags: 2.4-dev14, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: 7a69a7563a9f06fa46f5877ae9cf7467407bd096
 Directory: 2.4-rc
 
-Tags: 2.4-dev13-alpine, 2.4-dev-alpine
+Tags: 2.4-dev14-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: 7a69a7563a9f06fa46f5877ae9cf7467407bd096
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.8, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7a69a75: Update 2.4-rc to 2.4-dev14