### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6cb254be8673430d79a04f1e27b3b722a5b2cadd
 Directory: 2.3/alpine
 
-Tags: 2.2.11, 2.2, lts
+Tags: 2.2.12, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: 60c1496ccf8a646e10ec45a5fc1f2e9ff14ac16c
 Directory: 2.2
 
-Tags: 2.2.11-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.12-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: 60c1496ccf8a646e10ec45a5fc1f2e9ff14ac16c
 Directory: 2.2/alpine
 
 Tags: 2.0.21, 2.0
@@ -54,12 +54,12 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
 Directory: 1.8/alpine
 
-Tags: 1.7.13, 1.7
+Tags: 1.7.14, 1.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8cd07f9d33dac8436831b0a1f2f1a862061a237a
+GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
 Directory: 1.7
 
-Tags: 1.7.13-alpine, 1.7-alpine
+Tags: 1.7.14-alpine, 1.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 42989bf9ab08e05e7333261ce62fff00d0dcb08a
+GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
 Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/60c1496: Update 2.2 to 2.2.12
- https://github.com/docker-library/haproxy/commit/792f190: Merge pull request https://github.com/docker-library/haproxy/pull/151 from TimWolla/haproxy-1.7.14
- https://github.com/docker-library/haproxy/commit/2991130: Update 1.7 to 1.7.14