### PR TITLE
alpine: 3.10.8, 3.11.10, 3.12.6, 3.13.4 (CVE-2021-28831)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,10 +13,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.13.3, 3.13, 3, latest
+Tags: 3.13.4, 3.13, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.13
-GitCommit: 5601659c30d7fbb710d7d294ddc6ca40e7b805b5
+GitCommit: db57c96bfff7363dd9bccc56a0ce6e846261bbf8
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -25,10 +25,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.5, 3.12
+Tags: 3.12.6, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: 6fac3f1d2ce0866c8e18c152515cb9e1dce89bfc
+GitCommit: 87a91a76dacdb5525378b3ca0605d1c48a0b3efb
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -37,10 +37,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.9, 3.11
+Tags: 3.11.10, 3.11
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: f7bf276de87c202adba373622aa00060041b3d44
+GitCommit: 736a35a09787feb31462ef81f8ebca04593043ad
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -49,10 +49,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.10.7, 3.10
+Tags: 3.10.8, 3.10
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
-GitCommit: 0423a3b308844f06b97a8575e6f2bb278edbeeb7
+GitCommit: 8a136916be53ab1592301c394451faf33a31965c
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fix busybox CVE-2021-28831 in all stable branches
https://gitlab.alpinelinux.org/alpine/aports/-/issues/12566