### PR TITLE
Haskell: GHC 9.0.1 and sync up on releases.

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,18 +2,34 @@ Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
              Herbert Valerio Riedel <hvr@gnu.org> (@hvr)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 8.10.2-buster, 8.10-buster, 8-buster, buster, 8.10.2, 8.10, 8, latest
-GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
+Tags: 9.0.1-buster, 9.0-buster, 9-buster, buster, 9.0.1, 9.0, 9, latest
+GitCommit: 0f1e3f51f5930cce90aacefae4ae3c12f609a2be
+Directory: 9.0/buster
+
+Tags: 9.0.1-stretch, 9.0-stretch, 9-stretch, stretch
+GitCommit: 0f1e3f51f5930cce90aacefae4ae3c12f609a2be
+Directory: 9.0/stretch
+
+Tags: 8.10.4-buster, 8.10-buster, 8-buster, 8.10.4, 8.10, 8
+GitCommit: 0f1e3f51f5930cce90aacefae4ae3c12f609a2be
 Directory: 8.10/buster
 
-Tags: 8.10.2-stretch, 8.10-stretch, 8-stretch, stretch
-GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
+Tags: 8.10.4-stretch, 8.10-stretch, 8-stretch
+GitCommit: 0f1e3f51f5930cce90aacefae4ae3c12f609a2be
+Directory: 8.10/stretch
+
+Tags: 8.10.3-buster, 8.10.3
+GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
+Directory: 8.10/buster
+
+Tags: 8.10.3-stretch
+GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
 Directory: 8.10/stretch
 
 Tags: 8.8.4-buster, 8.8-buster, 8.8.4, 8.8
-GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
+GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
 Directory: 8.8/buster
 
 Tags: 8.8.4-stretch, 8.8-stretch
-GitCommit: fb5c774c38a7ab2e7d233d95368be0f899353496
+GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
 Directory: 8.8/stretch


### PR DESCRIPTION
Releasing GHC 8.8.4 to pick up a newer `cabal` tool version before
closing out support of 8.8.x. We also missed the GHC 8.10.3 release, but
would still like to ship it for completeness. A follow-up change will
remove both of these to get us back in line with our two release support
strategy.