### PR TITLE
Haskell: drop old releases.

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -17,19 +17,3 @@ Directory: 8.10/buster
 Tags: 8.10.4-stretch, 8.10-stretch, 8-stretch
 GitCommit: 0f1e3f51f5930cce90aacefae4ae3c12f609a2be
 Directory: 8.10/stretch
-
-Tags: 8.10.3-buster, 8.10.3
-GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
-Directory: 8.10/buster
-
-Tags: 8.10.3-stretch
-GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
-Directory: 8.10/stretch
-
-Tags: 8.8.4-buster, 8.8-buster, 8.8.4, 8.8
-GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
-Directory: 8.8/buster
-
-Tags: 8.8.4-stretch, 8.8-stretch
-GitCommit: 9a8e8618c43ab5445798261da7f6b6cf5435a2ff
-Directory: 8.8/stretch


### PR DESCRIPTION
Follow-up to https://github.com/docker-library/official-images/pull/9895 :tada: 