### PR TITLE
Add bullseye images for Rust

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang-nursery/docker-rust/blob/267790f45f67986c1f5cec39206ba10a20df9624/x.py
+# this file is generated via https://github.com/rust-lang-nursery/docker-rust/blob/e12dcd68da678ded3919606bcebab011b748371c/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
 GitRepo: https://github.com/rust-lang-nursery/docker-rust.git
@@ -12,6 +12,16 @@ Tags: 1-slim-buster, 1.51-slim-buster, 1.51.0-slim-buster, slim-buster, 1-slim, 
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 267790f45f67986c1f5cec39206ba10a20df9624
 Directory: 1.51.0/buster/slim
+
+Tags: 1-bullseye, 1.51-bullseye, 1.51.0-bullseye, bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: e12dcd68da678ded3919606bcebab011b748371c
+Directory: 1.51.0/bullseye
+
+Tags: 1-slim-bullseye, 1.51-slim-bullseye, 1.51.0-slim-bullseye, slim-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: e12dcd68da678ded3919606bcebab011b748371c
+Directory: 1.51.0/bullseye/slim
 
 Tags: 1-alpine3.12, 1.51-alpine3.12, 1.51.0-alpine3.12, alpine3.12
 Architectures: amd64, arm64v8


### PR DESCRIPTION
We'll switch the default from buster to bullseye in the 1.52.0 release.