### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.11.2
+Tags: 7.12.0
 Architectures: amd64, arm64v8
-GitCommit: 512e14ed8f2f9456de9cc750aa257355ecbbc453
+GitCommit: 7a4ec49b0bee1e610e79076c5941b9376acba764
 Directory: 7
 
-Tags: 6.8.14
+Tags: 6.8.15
 Architectures: amd64
-GitCommit: 29bc2aba27cf15e72e0fd05fbfca2f6ac6d07606
+GitCommit: e1bc20d3147ba582bfaaf3e289ca1070797736f6
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.11.2
-GitCommit: 26d3606c64d6abb047aa74e6b7f4c22cc3fc5a4f
+Tags: 7.12.0
+GitCommit: 357513fc65a890add229f11f9379697f22af9c28
 Directory: 7
 
-Tags: 6.8.14
-GitCommit: a813600132694cac07a88cc664e9514fe182707d
+Tags: 6.8.15
+GitCommit: d6759ae96883bf483b449f26c97229442e13c5cc
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,10 +4,10 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.11.2
-GitCommit: 93759d0ebd12496805f239d4de088d7014def17f
+Tags: 7.12.0
+GitCommit: 5cbbe444c8ff8bf931fdf9177bb879398c47dd44
 Directory: 7
 
-Tags: 6.8.14
-GitCommit: 4a715b5d08700e32cd60b7b38d09eaa46bdf8587
+Tags: 6.8.15
+GitCommit: 3640745741d172b99cb90382e701de77726c43a5
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/7a4ec49: Update to 7.12.0
- https://github.com/docker-library/elasticsearch/commit/e1bc20d: Update to 6.8.15

logstash:
- https://github.com/docker-library/logstash/commit/5cbbe44: Update to 7.12.0
- https://github.com/docker-library/logstash/commit/3640745: Update to 6.8.15

kibana:
- https://github.com/docker-library/kibana/commit/357513f: Update to 7.12.0
- https://github.com/docker-library/kibana/commit/d6759ae: Update to 6.8.15