### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6cb254be8673430d79a04f1e27b3b722a5b2cadd
 Directory: 2.3/alpine
 
-Tags: 2.2.12, 2.2, lts
+Tags: 2.2.13, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60c1496ccf8a646e10ec45a5fc1f2e9ff14ac16c
+GitCommit: fbf6af629fb5b81eaa1fbb2b8f28655b679e8ae5
 Directory: 2.2
 
-Tags: 2.2.12-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.13-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 60c1496ccf8a646e10ec45a5fc1f2e9ff14ac16c
+GitCommit: fbf6af629fb5b81eaa1fbb2b8f28655b679e8ae5
 Directory: 2.2/alpine
 
 Tags: 2.0.21, 2.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fbf6af6: Update 2.2 to 2.2.13