### PR TITLE
[varnish] force workdir

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,18 +1,13 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/82d7e7a3e0d39bed9f799b9a9455335b27ee0e83/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/3b38b0e1c38c1f6324ac8afa156ff73cfbbffcf4/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: 6.0, 6.0.7-1, 6.0.7, stable
 Architectures: amd64
 Directory: stable/debian
-GitCommit: c0846f15b04cd499a1df1fb62f0693b41a84e636
+GitCommit: 3b38b0e1c38c1f6324ac8afa156ff73cfbbffcf4
 
 Tags: 6.6, 6.6.0-1, 6.6.0, 6, latest, fresh
 Architectures: amd64
 Directory: fresh/debian
-GitCommit: 702cb88b01771ff6940b865f0a1f86e98bc41b0a
-
-Tags: 6.5, 6.5.1-1, 6.5.1
-Architectures: amd64
-Directory: fresh/debian
-GitCommit: f26947e3a1d7ab5e3e76114d58e54f0ddee13534
+GitCommit: 3b38b0e1c38c1f6324ac8afa156ff73cfbbffcf4


### PR DESCRIPTION
Hi,

This one is probably more of an RFC than a PR as I'm not sure this is the best approach.

The gist of the problem is that `varnishd` uses `/varlib/varnish/$HOSTNAME` as workdir to write logs, metrics and whatnot. So if you have sidecars want to fetch logs or metrics, you need to pass `-n /common/volume` to everyone, in addition of mounting said volume everywhere already (but that can't be helped).

The proposed situation is to detect if the user is running a `varnish*` tool and set `-n /var/lib/varnish` so everyone agrees on the workdir, while still being user-settable.

Question is: is that too much magic?