### PR TITLE
[security] Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -7,166 +7,166 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.10.0a6-buster, 3.10-rc-buster, rc-buster
 SharedTags: 3.10.0a6, 3.10-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.10-rc/buster
 
 Tags: 3.10.0a6-slim-buster, 3.10-rc-slim-buster, rc-slim-buster, 3.10.0a6-slim, 3.10-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.10-rc/buster/slim
 
 Tags: 3.10.0a6-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13, 3.10.0a6-alpine, 3.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.10-rc/alpine3.13
 
 Tags: 3.10.0a6-alpine3.12, 3.10-rc-alpine3.12, rc-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.10-rc/alpine3.12
 
 Tags: 3.10.0a6-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
 SharedTags: 3.10.0a6-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a6, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
+GitCommit: a1254c876799376455a39daa0da407ea0f3624fd
 Directory: 3.10-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.0a6-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 3.10.0a6-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a6, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: ec67f96b61c55ba35acd6c553f21641c5bf0ccc5
+GitCommit: a1254c876799376455a39daa0da407ea0f3624fd
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.9.2-buster, 3.9-buster, 3-buster, buster
-SharedTags: 3.9.2, 3.9, 3, latest
+Tags: 3.9.3-buster, 3.9-buster, 3-buster, buster
+SharedTags: 3.9.3, 3.9, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec1084fa7052275883a180653723ccb22e956252
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.9/buster
 
-Tags: 3.9.2-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster, 3.9.2-slim, 3.9-slim, 3-slim, slim
+Tags: 3.9.3-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster, 3.9.3-slim, 3.9-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec1084fa7052275883a180653723ccb22e956252
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.9/buster/slim
 
-Tags: 3.9.2-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13, 3.9.2-alpine, 3.9-alpine, 3-alpine, alpine
+Tags: 3.9.3-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13, 3.9.3-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec1084fa7052275883a180653723ccb22e956252
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.9/alpine3.13
 
-Tags: 3.9.2-alpine3.12, 3.9-alpine3.12, 3-alpine3.12, alpine3.12
+Tags: 3.9.3-alpine3.12, 3.9-alpine3.12, 3-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec1084fa7052275883a180653723ccb22e956252
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.9/alpine3.12
 
-Tags: 3.9.2-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.9.2-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.2, 3.9, 3, latest
+Tags: 3.9.3-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.9.3-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.3, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: ec1084fa7052275883a180653723ccb22e956252
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.9.2-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.9.2-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.2, 3.9, 3, latest
+Tags: 3.9.3-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.9.3-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.3, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: ec1084fa7052275883a180653723ccb22e956252
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.8.8-buster, 3.8-buster
-SharedTags: 3.8.8, 3.8
+Tags: 3.8.9-buster, 3.8-buster
+SharedTags: 3.8.9, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.8/buster
 
-Tags: 3.8.8-slim-buster, 3.8-slim-buster, 3.8.8-slim, 3.8-slim
+Tags: 3.8.9-slim-buster, 3.8-slim-buster, 3.8.9-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.8/buster/slim
 
-Tags: 3.8.8-alpine3.13, 3.8-alpine3.13, 3.8.8-alpine, 3.8-alpine
+Tags: 3.8.9-alpine3.13, 3.8-alpine3.13, 3.8.9-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.8/alpine3.13
 
-Tags: 3.8.8-alpine3.12, 3.8-alpine3.12
+Tags: 3.8.9-alpine3.12, 3.8-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.8/alpine3.12
 
-Tags: 3.8.8-windowsservercore-1809, 3.8-windowsservercore-1809
-SharedTags: 3.8.8-windowsservercore, 3.8-windowsservercore, 3.8.8, 3.8
+Tags: 3.8.9-windowsservercore-1809, 3.8-windowsservercore-1809
+SharedTags: 3.8.9-windowsservercore, 3.8-windowsservercore, 3.8.9, 3.8
 Architectures: windows-amd64
-GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.8/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.8.8-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016
-SharedTags: 3.8.8-windowsservercore, 3.8-windowsservercore, 3.8.8, 3.8
+Tags: 3.8.9-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016
+SharedTags: 3.8.9-windowsservercore, 3.8-windowsservercore, 3.8.9, 3.8
 Architectures: windows-amd64
-GitCommit: 3897bb4660fe97fc202f50431dd3e6cdc0dedd4a
+GitCommit: cb9a39a6c48d4606a68ae8f986373c9c64d430b5
 Directory: 3.8/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.7.10-buster, 3.7-buster
 SharedTags: 3.7.10, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.7/buster
 
 Tags: 3.7.10-slim-buster, 3.7-slim-buster, 3.7.10-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.7/buster/slim
 
 Tags: 3.7.10-stretch, 3.7-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.7/stretch
 
 Tags: 3.7.10-slim-stretch, 3.7-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.7/stretch/slim
 
 Tags: 3.7.10-alpine3.13, 3.7-alpine3.13, 3.7.10-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.7/alpine3.13
 
 Tags: 3.7.10-alpine3.12, 3.7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8167dd2574bb503a131d262c0c5721c6ba02c928
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.7/alpine3.12
 
 Tags: 3.6.13-buster, 3.6-buster
 SharedTags: 3.6.13, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.6/buster
 
 Tags: 3.6.13-slim-buster, 3.6-slim-buster, 3.6.13-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.6/buster/slim
 
 Tags: 3.6.13-stretch, 3.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.6/stretch
 
 Tags: 3.6.13-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.6/stretch/slim
 
 Tags: 3.6.13-alpine3.13, 3.6-alpine3.13, 3.6.13-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.6/alpine3.13
 
 Tags: 3.6.13-alpine3.12, 3.6-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fea75351b89c672f96c3bf622aec41912a14083
+GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
 Directory: 3.6/alpine3.12


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/6d2598a: Merge pull request https://github.com/docker-library/python/pull/600 from infosiftr/security
- https://github.com/docker-library/python/commit/cb9a39a: Update to 3.9.3 and 3.8.9 (security)
- https://github.com/docker-library/python/commit/cafa316: Merge pull request https://github.com/docker-library/python/pull/599 from infosiftr/keys.openpgp.org
- https://github.com/docker-library/python/commit/7217b72: Switch to "keys.openpgp.org"
- https://github.com/docker-library/python/commit/a1254c8: Fix "get-pip.py" URLs
- https://github.com/docker-library/python/commit/754afa8: Update to 3.10.0a6, pip 21.0.1
- https://github.com/docker-library/python/commit/1c34da0: Update to 3.7.10, pip 21.0.1
- https://github.com/docker-library/python/commit/8193390: Update to 3.9.2, pip 21.0.1
- https://github.com/docker-library/python/commit/83f5f25: Update to 3.8.8, pip 21.0.1
- https://github.com/docker-library/python/commit/4ea5fd1: Update to 3.6.13, pip 21.0.1
- https://github.com/docker-library/python/commit/8d0779f: Merge pull request https://github.com/docker-library/python/pull/588 from westonsteimel/update-get-pip-branch
- https://github.com/docker-library/python/commit/2128e9a: update pypa/get-pip branch from master -> main