### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -1,31 +1,44 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/5c14293651c7d35cfcfe3947466ebf7fe166f89e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/fc3182cf934fc112a0d9a4f819892d3f2450d05a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.1.2, 4.1, 4, latest
+Tags: 4.2.0, 4.2, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ea093b382fbdb883daf868c5ea4a9c1fd27f3aca
+GitCommit: fc3182cf934fc112a0d9a4f819892d3f2450d05a
+Directory: 4.2
+
+Tags: 4.2.0-passenger, 4.2-passenger, 4-passenger, passenger
+GitCommit: fc3182cf934fc112a0d9a4f819892d3f2450d05a
+Directory: 4.2/passenger
+
+Tags: 4.2.0-alpine, 4.2-alpine, 4-alpine, alpine
+GitCommit: fc3182cf934fc112a0d9a4f819892d3f2450d05a
+Directory: 4.2/alpine
+
+Tags: 4.1.2, 4.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 45e9df1b1ae65eec6c7a6d1a9ac5baa9afb19693
 Directory: 4.1
 
-Tags: 4.1.2-passenger, 4.1-passenger, 4-passenger, passenger
-GitCommit: 7fdd6777cc21b0d1974884e6e54208d16a991b19
+Tags: 4.1.2-passenger, 4.1-passenger
+GitCommit: 9cdb40719526a554a985422a554e481cbdf3e717
 Directory: 4.1/passenger
 
-Tags: 4.1.2-alpine, 4.1-alpine, 4-alpine, alpine
-GitCommit: d93440fe33185a141fc6fbee809cd7cd886acf84
+Tags: 4.1.2-alpine, 4.1-alpine
+GitCommit: 45e9df1b1ae65eec6c7a6d1a9ac5baa9afb19693
 Directory: 4.1/alpine
 
 Tags: 4.0.8, 4.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ae11c0c35e0920781464c4afdac9096eec355c8b
+GitCommit: 45e9df1b1ae65eec6c7a6d1a9ac5baa9afb19693
 Directory: 4.0
 
 Tags: 4.0.8-passenger, 4.0-passenger
-GitCommit: 7fdd6777cc21b0d1974884e6e54208d16a991b19
+GitCommit: 9cdb40719526a554a985422a554e481cbdf3e717
 Directory: 4.0/passenger
 
 Tags: 4.0.8-alpine, 4.0-alpine
-GitCommit: d93440fe33185a141fc6fbee809cd7cd886acf84
+GitCommit: 45e9df1b1ae65eec6c7a6d1a9ac5baa9afb19693
 Directory: 4.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/a45e158: Merge pull request https://github.com/docker-library/redmine/pull/231 from jouve/master
- https://github.com/docker-library/redmine/commit/fc3182c: v4.2.0
- https://github.com/docker-library/redmine/commit/dc2686f: Merge pull request https://github.com/docker-library/redmine/pull/235 from jouve/bundle-deprecated
- https://github.com/docker-library/redmine/commit/45e9df1: install --without is deprecated
- https://github.com/docker-library/redmine/commit/f71ae38: Merge pull request https://github.com/docker-library/redmine/pull/234 from jouve/db-gems
- https://github.com/docker-library/redmine/commit/9cdb407: Update to passenger 6.0.8
- https://github.com/docker-library/redmine/commit/f3da3fe: document database.yml trick
- https://github.com/docker-library/redmine/commit/dd696cd: one Gemfile.lock for all adapters
- https://github.com/docker-library/redmine/commit/a382a34: Merge pull request https://github.com/docker-library/redmine/pull/233 from jouve/mime
- https://github.com/docker-library/redmine/commit/7e7d04e: download shared-mime-info db