### PR TITLE
eclipse-mosquitto 2.0.10

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,12 +1,12 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 9f21a43eeeafdbb998409d075b986df23c18e649
+GitCommit: 1c79920d78321c69add9d6d6f879dd73387bc25e
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 2.0.9, 2.0, 2, latest
+Tags: 2.0.10, 2.0, 2, latest
 Directory: docker/2.0
 
-Tags: 2.0.9-openssl, 2.0-openssl, 2-openssl, openssl
+Tags: 2.0.10-openssl, 2.0-openssl, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
 Tags: 1.6.14, 1.6


### PR DESCRIPTION
This includes a security issue that was submitted today in public. It does not have CVE assigned yet, but will.