### PR TITLE
Update Clear Linux OS to 34460

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c59270c4e45f93809f7dfc071b822d45e74e06d9
-GitFetch: refs/tags/clear-linux-34440
+GitCommit: b69cc5b9b024ee9ff51c0a27e2dc26586d2a4e0d
+GitFetch: refs/tags/clear-linux-34460


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34460

@bryteise @mdhorn @phmccarty