### PR TITLE
Odoo: update 12.0-14.0 to release 20210407

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: ece2519a00a5609e73936e436575f5970fb52dc7
+GitCommit: 59b76d6aa31afebd093a8072ff558d87a6c2aa85
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here you can find the latest updates of Odoo supported versions.

Thanks