### PR TITLE
chore: docker for kap1.5.9

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,7 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              j. Emrys Landivar <landivar@gmail.com> (@docmerlin)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 384f6e83c3764607084a38b1c842d240729561d4
+GitCommit: 63fe0684150d96916514a84cf5978c3512dc15fa
 
 Tags: 1.4, 1.4.1
 Architectures: amd64, arm32v7, arm64v8
@@ -10,9 +10,9 @@ Directory: kapacitor/1.4
 Tags: 1.4-alpine, 1.4.1-alpine
 Directory: kapacitor/1.4/alpine
 
-Tags: 1.5, 1.5.8, latest
+Tags: 1.5, 1.5.9, latest
 Architectures: amd64, arm32v7, arm64v8
 Directory: kapacitor/1.5
 
-Tags: 1.5-alpine, 1.5.8-alpine, alpine
+Tags: 1.5-alpine, 1.5.9-alpine, alpine
 Directory: kapacitor/1.5/alpine


### PR DESCRIPTION
Update for Kapacitor 1.5.9