### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/8d23baaad7a11b8498e0d361d3761fc58a0380b3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/7b38d9a90c563b817b21c0d3c1365b8e95a8b2eb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 8d23baaad7a11b8498e0d361d3761fc58a0380b3
+GitCommit: 7b38d9a90c563b817b21c0d3c1365b8e95a8b2eb
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: cc81bf8a3c979f596af2d811a3910aeaa230e8ef
+amd64-GitCommit: 3d11ce4d95521ccc2da21ebc4e10ebe161a02f63
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 722ec71d87e5e958167f837d781758906b2b0490
+arm32v5-GitCommit: 063d964a011701186f2ef3bd7a97244b69cc9f38
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: cb1353b2bd45c9522323395bb44982d964735f39
+arm32v6-GitCommit: a900a30f32f39f091f14ec7a798c76f19ee18519
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: a5cede2b447f935dfbe7d0112d057bfdb635865d
+arm32v7-GitCommit: 626c86f2185a734183724033cc5f244020a45c94
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8a500845daeaeb926b25f73089c0668cac676e97
+arm64v8-GitCommit: 1d87b47832f6449256f8b9166d28bc7e3c2e31fe
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: eaac53822b57e9adc3a1971a4ce8d61c8206532d
+i386-GitCommit: 026e4989d26bdb2f151292249effca8b33d6cbca
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: f7d97c7849764668861d7ddf1071818000cd5a1a
+mips64le-GitCommit: 7824e7df2d9dd65a7cc58bd20e97e473770d6e1e
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: c0125333c4c3dfa4b9e5fd9fe6fbb875242f3613
+ppc64le-GitCommit: 4eabf21f658579588c0c1e0a60ca3a2d2adfe8b4
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: b7a4b4b99ca970fc62d19725c7de650e6c357600
+s390x-GitCommit: 503c9df17a999bdb303ae487dcf69d66919f5381
 
 Tags: 1.32.1-uclibc, 1.32-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/7b38d9a: Merge pull request https://github.com/docker-library/busybox/pull/99 from infosiftr/buildroot-2021.02.1
- https://github.com/docker-library/busybox/commit/19b4252: Update Buildroot to 2021.02.1