### PR TITLE
Upgrade to XWiki 12.10.6

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -14,26 +14,12 @@ Architectures: amd64, arm64v8
 Directory: 13/postgres-tomcat
 GitCommit: aad779028a6f54d9821560d01d6a03633e180a8b
 
-Tags: 12, 12.10, 12.10.5, 12-mysql-tomcat, 12.10-mysql-tomcat, 12.10.5-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+Tags: 12, 12.10, 12.10.5, 12-mysql-tomcat, 12.10-mysql-tomcat, 12.10.6-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64
 Directory: 12/mysql-tomcat
-GitCommit: fa6a9086e02c084a0a3dd527a17af3cf24738e50
+GitCommit: 246a8efc36a5838f17930b773314b12c90181740
 
-Tags: 12-postgres-tomcat, 12.10-postgres-tomcat, 12.10.5-postgres-tomcat, lts-postgres-tomcat, lts-postgres
+Tags: 12-postgres-tomcat, 12.10-postgres-tomcat, 12.10.6-postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 12/postgres-tomcat
-GitCommit: fa6a9086e02c084a0a3dd527a17af3cf24738e50
-
-# This tag description should be removed now.
-Tags: 12.6, 12.6.8, 12.6-mysql-tomcat, 12.6.8-mysql-tomcat
-Architectures: amd64
-Directory: 12/mysql-tomcat
-GitCommit: 4f6080d2e7d4b358f09517b4d1e6537261c7574e
-GitFetch: refs/heads/stable-12.6.x
-
-# This tag description should be removed now.
-Tags: 12.6-postgres-tomcat, 12.6.8-postgres-tomcat
-Architectures: amd64, arm64v8
-Directory: 12/postgres-tomcat
-GitCommit: 4f6080d2e7d4b358f09517b4d1e6537261c7574e
-GitFetch: refs/heads/stable-12.6.x
+GitCommit: 246a8efc36a5838f17930b773314b12c90181740

--- a/library/xwiki
+++ b/library/xwiki
@@ -14,7 +14,7 @@ Architectures: amd64, arm64v8
 Directory: 13/postgres-tomcat
 GitCommit: aad779028a6f54d9821560d01d6a03633e180a8b
 
-Tags: 12, 12.10, 12.10.5, 12-mysql-tomcat, 12.10-mysql-tomcat, 12.10.6-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+Tags: 12, 12.10, 12.10.6, 12-mysql-tomcat, 12.10-mysql-tomcat, 12.10.6-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64
 Directory: 12/mysql-tomcat
 GitCommit: 246a8efc36a5838f17930b773314b12c90181740


### PR DESCRIPTION
* Bump XWiki LTS to 12.10.6
* Remove version not supported anymore