### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.10.0a6-buster, 3.10-rc-buster, rc-buster
-SharedTags: 3.10.0a6, 3.10-rc, rc
+Tags: 3.10.0a7-buster, 3.10-rc-buster, rc-buster
+SharedTags: 3.10.0a7, 3.10-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
+GitCommit: 4bff010c9735707699dd72524c7d1a827f6f5933
 Directory: 3.10-rc/buster
 
-Tags: 3.10.0a6-slim-buster, 3.10-rc-slim-buster, rc-slim-buster, 3.10.0a6-slim, 3.10-rc-slim, rc-slim
+Tags: 3.10.0a7-slim-buster, 3.10-rc-slim-buster, rc-slim-buster, 3.10.0a7-slim, 3.10-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
+GitCommit: 4bff010c9735707699dd72524c7d1a827f6f5933
 Directory: 3.10-rc/buster/slim
 
-Tags: 3.10.0a6-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13, 3.10.0a6-alpine, 3.10-rc-alpine, rc-alpine
+Tags: 3.10.0a7-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13, 3.10.0a7-alpine, 3.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
+GitCommit: 4bff010c9735707699dd72524c7d1a827f6f5933
 Directory: 3.10-rc/alpine3.13
 
-Tags: 3.10.0a6-alpine3.12, 3.10-rc-alpine3.12, rc-alpine3.12
+Tags: 3.10.0a7-alpine3.12, 3.10-rc-alpine3.12, rc-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7217b72192c93ca2033051d7191d5689932d3912
+GitCommit: 4bff010c9735707699dd72524c7d1a827f6f5933
 Directory: 3.10-rc/alpine3.12
 
-Tags: 3.10.0a6-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 3.10.0a6-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a6, 3.10-rc, rc
+Tags: 3.10.0a7-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 3.10.0a7-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a7, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 0573fe30bbc472892553e1a7c85cff6be47e08df
+GitCommit: 4bff010c9735707699dd72524c7d1a827f6f5933
 Directory: 3.10-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.10.0a6-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.10.0a6-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a6, 3.10-rc, rc
+Tags: 3.10.0a7-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.10.0a7-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0a7, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: 0573fe30bbc472892553e1a7c85cff6be47e08df
+GitCommit: 4bff010c9735707699dd72524c7d1a827f6f5933
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/4bff010: Update to 3.10.0a7, pip 21.0.1