### PR TITLE
Update Debian to 20210408 (esp. for recent curl CVEs)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -7,31 +7,31 @@ GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
 GitCommit: 90a83b6b730031399d45a49809364b07df0d0087
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 38b06b2a8a31d805359f1ca3ef5f3203b8a536a7
+amd64-GitCommit: 0590e3720f7f87992202bfcca4c13c374ff304bc
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 50f33c595e3d17abed6ec839f392768658394c8a
+arm32v5-GitCommit: c41fa7af2e9ea89d47a1ac7bf4bed142bdac1c1a
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: c87684e7d92292c52f2dddb802cbe86aa2aa9838
+arm32v7-GitCommit: 3e9ac7f5417794d5f21a4c088e23437a1de68223
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 00a82cf727e144f5437360d09f3145fde767c860
+arm64v8-GitCommit: 30f206fb7cbb927313bb5de1ca226b05b2208146
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 4ef41a4b1c11ee9b507bbe436ee23b4b4f3fe39b
+i386-GitCommit: e89b1e13425eceb5521a271c6ac4172d8e115548
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: b16e75237adc9713270df52445ad07bdc777acea
+mips64le-GitCommit: 1646942083878e00c66a1a8f71eef2a023f8c0f7
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 38cbfed2d70ba2f921076b31736a4e25b62f4a7b
+ppc64le-GitCommit: 66d540261facaa27482c43f25936cdff502bb924
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 7e74e491c53de553a1cf177a4cd747cd04430cc3
+s390x-GitCommit: 5289e94dc609cd1efee8352b82fad87a1cbb91bc
 
 # bullseye -- Debian x.y Testing distribution - Not Released
-Tags: bullseye, bullseye-20210329
+Tags: bullseye, bullseye-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: bullseye
 
@@ -39,12 +39,12 @@ Tags: bullseye-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: bullseye/backports
 
-Tags: bullseye-slim, bullseye-20210329-slim
+Tags: bullseye-slim, bullseye-20210408-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: bullseye/slim
 
 # buster -- Debian 10.9 Released 27 March 2021
-Tags: buster, buster-20210329, 10.9, 10, latest
+Tags: buster, buster-20210408, 10.9, 10, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: buster
 
@@ -52,17 +52,17 @@ Tags: buster-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: buster/backports
 
-Tags: buster-slim, buster-20210329-slim, 10.9-slim, 10-slim
+Tags: buster-slim, buster-20210408-slim, 10.9-slim, 10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: buster/slim
 
 # experimental -- Experimental packages - not released; use at your own risk.
-Tags: experimental, experimental-20210329
+Tags: experimental, experimental-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: experimental
 
 # oldstable -- Debian 9.13 Released 18 July 2020
-Tags: oldstable, oldstable-20210329
+Tags: oldstable, oldstable-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: oldstable
 
@@ -70,26 +70,26 @@ Tags: oldstable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: oldstable/backports
 
-Tags: oldstable-slim, oldstable-20210329-slim
+Tags: oldstable-slim, oldstable-20210408-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: oldstable/slim
 
 # rc-buggy -- Experimental packages - not released; use at your own risk.
-Tags: rc-buggy, rc-buggy-20210329
+Tags: rc-buggy, rc-buggy-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: rc-buggy
 
 # sid -- Debian x.y Unstable - Not Released
-Tags: sid, sid-20210329
+Tags: sid, sid-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: sid
 
-Tags: sid-slim, sid-20210329-slim
+Tags: sid-slim, sid-20210408-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: sid/slim
 
 # stable -- Debian 10.9 Released 27 March 2021
-Tags: stable, stable-20210329
+Tags: stable, stable-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: stable
 
@@ -97,12 +97,12 @@ Tags: stable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: stable/backports
 
-Tags: stable-slim, stable-20210329-slim
+Tags: stable-slim, stable-20210408-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: stable/slim
 
 # stretch -- Debian 9.13 Released 18 July 2020
-Tags: stretch, stretch-20210329, 9.13, 9
+Tags: stretch, stretch-20210408, 9.13, 9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: stretch
 
@@ -110,12 +110,12 @@ Tags: stretch-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: stretch/backports
 
-Tags: stretch-slim, stretch-20210329-slim, 9.13-slim, 9-slim
+Tags: stretch-slim, stretch-20210408-slim, 9.13-slim, 9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 Directory: stretch/slim
 
 # testing -- Debian x.y Testing distribution - Not Released
-Tags: testing, testing-20210329
+Tags: testing, testing-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: testing
 
@@ -123,15 +123,15 @@ Tags: testing-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: testing/backports
 
-Tags: testing-slim, testing-20210329-slim
+Tags: testing-slim, testing-20210408-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: testing/slim
 
 # unstable -- Debian x.y Unstable - Not Released
-Tags: unstable, unstable-20210329
+Tags: unstable, unstable-20210408
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: unstable
 
-Tags: unstable-slim, unstable-20210329-slim
+Tags: unstable-slim, unstable-20210408-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: unstable/slim


### PR DESCRIPTION
See https://lists.debian.org/debian-changes/2021/04/msg00000.html

Of those listed/fixed, the ones that catch my eye are:

- https://security-tracker.debian.org/tracker/CVE-2020-8286
- https://security-tracker.debian.org/tracker/CVE-2020-8231
- https://security-tracker.debian.org/tracker/CVE-2020-8169 (to a lesser degree)