### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 2b9abbea083ffe4b8e86eb5951f470d04a2aa9c0
+GitCommit: 4d8c121c54e2dba1f5b58dc8167d1069ff24f496
 Directory: dockerfiles-generated
 
 Tags: 0.20.0-python3.8-buster, 0.20-python3.8-buster, 0-python3.8-buster, python3.8-buster, 0.20.0-buster, 0.20-buster, 0-buster, buster
@@ -72,14 +72,3 @@ SharedTags: 0.20.0-pypy3.7, 0.20-pypy3.7, 0-pypy3.7, pypy3.7, 0.20.0-pypy, 0.20-
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.pypy3.7-windowsservercore-1809
-
-Tags: 0.20.0-pypy3.6-buster, 0.20-pypy3.6-buster, 0-pypy3.6-buster, pypy3.6-buster
-SharedTags: 0.20.0-pypy3.6, 0.20-pypy3.6, 0-pypy3.6, pypy3.6
-Architectures: amd64, arm64v8, i386, s390x
-File: Dockerfile.pypy3.6-buster
-
-Tags: 0.20.0-pypy3.6-windowsservercore-1809, 0.20-pypy3.6-windowsservercore-1809, 0-pypy3.6-windowsservercore-1809, pypy3.6-windowsservercore-1809
-SharedTags: 0.20.0-pypy3.6, 0.20-pypy3.6, 0-pypy3.6, pypy3.6
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-File: Dockerfile.pypy3.6-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/4d8c121: Remove the now-deprecated pypy3.6 images