### PR TITLE
Update MediaWiki

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,7 +2,7 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 38d4e7f77f8b5b4efda91f969ccba2475fc2c597
+GitCommit: dc240fc8771ce74bc2c420eb1283d718ebf1abe0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 Tags: 1.35.1, 1.35, lts, stable, latest

--- a/library/mediawiki
+++ b/library/mediawiki
@@ -5,13 +5,13 @@ GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitCommit: dc240fc8771ce74bc2c420eb1283d718ebf1abe0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.35.1, 1.35, lts, stable, latest
+Tags: 1.35.2, 1.35, lts, stable, latest
 Directory: 1.35/apache
 
-Tags: 1.35.1-fpm, 1.35-fpm, lts-fpm, stable-fpm
+Tags: 1.35.2-fpm, 1.35-fpm, lts-fpm, stable-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.1-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, stable-fpm-alpine
+Tags: 1.35.2-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 
@@ -25,12 +25,12 @@ Tags: 1.34.4-fpm-alpine, 1.34-fpm-alpine, legacy-fpm-alpline
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.34/fpm-alpine
 
-Tags: 1.31.12, 1.31, legacylts
+Tags: 1.31.14, 1.31, legacylts
 Directory: 1.31/apache
 
-Tags: 1.31.12-fpm, 1.31-fpm, legacylts-fpm
+Tags: 1.31.14-fpm, 1.31-fpm, legacylts-fpm
 Directory: 1.31/fpm
 
-Tags: 1.31.12-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.31.14-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.31/fpm-alpine


### PR DESCRIPTION
Updates to 1.35.2 & 1.31.14 security releases.

https://github.com/wikimedia/mediawiki-docker/pull/95