### PR TITLE
Re-tag Groovy 3.0.6

### DIFF
--- a/library/groovy
+++ b/library/groovy
@@ -6,32 +6,32 @@ GitRepo: https://github.com/groovy/docker-groovy.git
 
 Tags: 3.0.6-jdk8, 3.0-jdk8, 3.0.6-jdk, 3.0-jdk, jdk8, jdk
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a48a3fed614ad8a42f555cf6a5a8299ec47b658e
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk8
 
 Tags: 3.0.6-jre8, 3.0-jre8, 3.0.6-jre, 3.0-jre, 3.0.6, 3.0, jre8, jre, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a48a3fed614ad8a42f555cf6a5a8299ec47b658e
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre8
 
 Tags: 3.0.6-jdk11, 3.0-jdk11, jdk11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a48a3fed614ad8a42f555cf6a5a8299ec47b658e
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk11
 
 Tags: 3.0.6-jre11, 3.0-jre11, jre11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a48a3fed614ad8a42f555cf6a5a8299ec47b658e
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre11
 
 Tags: 3.0.6-jdk15, 3.0-jdk15, jdk15
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a48a3fed614ad8a42f555cf6a5a8299ec47b658e
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jdk15
 
 Tags: 3.0.6-jre15, 3.0-jre15, jre15
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a48a3fed614ad8a42f555cf6a5a8299ec47b658e
+GitCommit: 46cdb10a0d556411a7f83fe755cdac71a565b5e8
 Directory: jre15
 
 


### PR DESCRIPTION
Groovy 3.0.7 accidentally got pushed with 3.0.6 tags, so re-tagging 3.0.6.