### PR TITLE
Update Clear Linux OS to 34500

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: b69cc5b9b024ee9ff51c0a27e2dc26586d2a4e0d
-GitFetch: refs/tags/clear-linux-34460
+GitCommit: c2acbfceb9ff652b9f568cb98cc9b0202fce66e0
+GitFetch: refs/tags/clear-linux-34500


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34500

@bryteise @mdhorn @phmccarty