### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fbf6af629fb5b81eaa1fbb2b8f28655b679e8ae5
 Directory: 2.2/alpine
 
-Tags: 2.0.21, 2.0
+Tags: 2.0.22, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: a67c29391a51f0fa90c0256b35b5c27d8bc598ce
 Directory: 2.0
 
-Tags: 2.0.21-alpine, 2.0-alpine
+Tags: 2.0.22-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: a67c29391a51f0fa90c0256b35b5c27d8bc598ce
 Directory: 2.0/alpine
 
 Tags: 1.8.29, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a67c293: Update 2.0 to 2.0.22