### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,14 +44,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a67c29391a51f0fa90c0256b35b5c27d8bc598ce
 Directory: 2.0/alpine
 
-Tags: 1.8.29, 1.8
+Tags: 1.8.30, 1.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: 0e7b078d5ff2ed9f29e4223a5d3d38d191818505
 Directory: 1.8
 
-Tags: 1.8.29-alpine, 1.8-alpine
+Tags: 1.8.30-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39812f8f0bb3a6c8777a018bbd5d251723367e1f
+GitCommit: 0e7b078d5ff2ed9f29e4223a5d3d38d191818505
 Directory: 1.8/alpine
 
 Tags: 1.7.14, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/0e7b078: Update 1.8 to 1.8.30