### PR TITLE
[varnish] overload the binaries with scripts

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,13 +1,13 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/3b38b0e1c38c1f6324ac8afa156ff73cfbbffcf4/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: 6.0, 6.0.7-1, 6.0.7, stable
 Architectures: amd64
 Directory: stable/debian
-GitCommit: 3b38b0e1c38c1f6324ac8afa156ff73cfbbffcf4
+GitCommit: 51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa
 
 Tags: 6.6, 6.6.0-1, 6.6.0, 6, latest, fresh
 Architectures: amd64
 Directory: fresh/debian
-GitCommit: 3b38b0e1c38c1f6324ac8afa156ff73cfbbffcf4
+GitCommit: 51a66e74c3a56e4def767d3ad3f6c8ad1a4addaa

--- a/test/config.sh
+++ b/test/config.sh
@@ -262,6 +262,9 @@ imageTests+=(
 	[tomcat]='
 		tomcat-hello-world
 	'
+	[varnish]='
+		varnish
+	'
 	[wordpress:apache]='
 		wordpress-apache-run
 	'

--- a/test/tests/varnish/run.sh
+++ b/test/tests/varnish/run.sh
@@ -1,0 +1,39 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+vname="varnish-volume-$RANDOM-$RANDOM"
+trap "docker volume rm $vname > /dev/null" EXIT
+docker volume create --driver local \
+	--opt type=tmpfs \
+	--opt device=tmpfs \
+	--opt o=size=100m \
+	$vname
+
+
+cname="varnish-container-$RANDOM-$RANDOM"
+cid="$(
+	docker run -d \
+		-v $vname:/var/lib/varnish \
+		--name "$cname" \
+		"$image" \
+		varnishd -F -a 0:0 -f /etc/varnish/default.vcl
+)"
+trap "docker rm -vf $cid > /dev/null; docker volume rm $vname > /dev/null" EXIT
+
+sidecar() {
+	docker run --rm -i \
+		--network container:"$cid" \
+		-v $vname:/var/lib/varnish \
+		"$image" \
+		"$@" > /dev/null
+}
+
+sidecar varnishlog -d
+sidecar varnishncsa -d
+sidecar varnishstat -1
+sidecar varnishreload
+sidecar varnishadm ping


### PR DESCRIPTION
This is a follow-up of #9914. The now current approach works well EXCEPT
when people exec into the container with `bash` or whatever since the
entrypoint can't work it magic.

So, the blunt approach is to create a series of trampoline scripts that
will just add `-n /var/lib/varnish` before all arguments. It's not super
elegant, and I'm not a fan of overloading `PATH` but:
- it works transparently
- you can easily bypass the trampoline by using the binary's absolute
  path
- the logic is pretty obvious with `/varnish_cmds/` sitting proudly at
  the root level of the file-system.

I decided against generating the scripts from the `Dockerfile`s to avoid
escape hell, but I can be convinced otherwise if it makes reviews
easier.