### PR TITLE
AdoptOpenJDK: Add back arm arches for builds that are now available.

### DIFF
--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -6,15 +6,15 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 #-----------------------------hotspot v8 images---------------------------------
 Tags: 8u282-b08-jdk-hotspot-focal, 8-jdk-hotspot-focal, 8-hotspot-focal
 SharedTags: 8u282-b08-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
-Architectures: amd64, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u282-b08-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
 SharedTags: 8u282-b08-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u282-b08-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -22,22 +22,22 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u282-b08-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u282-b08-jre-hotspot-focal, 8-jre-hotspot-focal
 SharedTags: 8u282-b08-jre-hotspot, 8-jre-hotspot, 8-jre
-Architectures: amd64, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u282-b08-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
 SharedTags: 8u282-b08-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u282-b08-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -45,7 +45,7 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u282-b08-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -55,14 +55,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.10_9-jdk-hotspot-focal, 11-jdk-hotspot-focal, 11-hotspot-focal
 SharedTags: 11.0.10_9-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.10_9-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
 SharedTags: 11.0.10_9-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.10_9-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -70,7 +70,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.10_9-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -78,14 +78,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.10_9-jre-hotspot-focal, 11-jre-hotspot-focal
 SharedTags: 11.0.10_9-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.10_9-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
 SharedTags: 11.0.10_9-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.10_9-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -93,7 +93,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.10_9-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -103,14 +103,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.2_7-jdk-hotspot-focal, 15-jdk-hotspot-focal, 15-hotspot-focal
 SharedTags: 15.0.2_7-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, 15
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.2_7-jdk-hotspot-windowsservercore-1809, 15-jdk-hotspot-windowsservercore-1809, 15-hotspot-windowsservercore-1809
 SharedTags: 15.0.2_7-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, 15.0.2_7-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -118,7 +118,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jdk-hotspot-windowsservercore-ltsc2016, 15-jdk-hotspot-windowsservercore-ltsc2016, 15-hotspot-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, 15.0.2_7-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -126,14 +126,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.2_7-jre-hotspot-focal, 15-jre-hotspot-focal
 SharedTags: 15.0.2_7-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.2_7-jre-hotspot-windowsservercore-1809, 15-jre-hotspot-windowsservercore-1809
 SharedTags: 15.0.2_7-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.2_7-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -141,7 +141,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jre-hotspot-windowsservercore-ltsc2016, 15-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.2_7-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -151,14 +151,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16_36-jdk-hotspot-focal, 16-jdk-hotspot-focal, 16-hotspot-focal, hotspot-focal
 SharedTags: 16_36-jdk-hotspot, 16-jdk-hotspot, 16-hotspot, hotspot, 16-jdk, 16, jdk, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 16_36-jdk-hotspot-windowsservercore-1809, 16-jdk-hotspot-windowsservercore-1809, 16-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
 SharedTags: 16_36-jdk-hotspot-windowsservercore, 16-jdk-hotspot-windowsservercore, 16-hotspot-windowsservercore, hotspot-windowsservercore, 16_36-jdk-hotspot, 16-jdk-hotspot, 16-hotspot, hotspot, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -166,7 +166,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jdk-hotspot-windowsservercore-ltsc2016, 16-jdk-hotspot-windowsservercore-ltsc2016, 16-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
 SharedTags: 16_36-jdk-hotspot-windowsservercore, 16-jdk-hotspot-windowsservercore, 16-hotspot-windowsservercore, hotspot-windowsservercore, 16_36-jdk-hotspot, 16-jdk-hotspot, 16-hotspot, hotspot, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -174,14 +174,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16_36-jre-hotspot-focal, 16-jre-hotspot-focal
 SharedTags: 16_36-jre-hotspot, 16-jre-hotspot, 16-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 16_36-jre-hotspot-windowsservercore-1809, 16-jre-hotspot-windowsservercore-1809
 SharedTags: 16_36-jre-hotspot-windowsservercore, 16-jre-hotspot-windowsservercore, 16_36-jre-hotspot, 16-jre-hotspot, 16-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -189,7 +189,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jre-hotspot-windowsservercore-ltsc2016, 16-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 16_36-jre-hotspot-windowsservercore, 16-jre-hotspot-windowsservercore, 16_36-jre-hotspot, 16-jre-hotspot, 16-jre
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -198,15 +198,15 @@ Constraints: windowsservercore-ltsc2016
 #-----------------------------openj9 v8 images---------------------------------
 Tags: 8u282-b08-jdk-openj9-0.24.0-focal, 8-jdk-openj9-focal, 8-openj9-focal
 SharedTags: 8u282-b08-jdk-openj9-0.24.0, 8-jdk-openj9, 8-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
 SharedTags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u282-b08-jdk-openj9-0.24.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -214,22 +214,22 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u282-b08-jdk-openj9-0.24.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 8u282-b08-jre-openj9-0.24.0-focal, 8-jre-openj9-focal
 SharedTags: 8u282-b08-jre-openj9-0.24.0, 8-jre-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 8u282-b08-jre-openj9-0.24.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
 SharedTags: 8u282-b08-jre-openj9-0.24.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u282-b08-jre-openj9-0.24.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -237,7 +237,7 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jre-openj9-0.24.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jre-openj9-0.24.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u282-b08-jre-openj9-0.24.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -246,15 +246,15 @@ Constraints: windowsservercore-ltsc2016
 #-----------------------------openj9 v11 images---------------------------------
 Tags: 11.0.10_9-jdk-openj9-0.24.0-focal, 11-jdk-openj9-focal, 11-openj9-focal
 SharedTags: 11.0.10_9-jdk-openj9-0.24.0, 11-jdk-openj9, 11-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
 SharedTags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.10_9-jdk-openj9-0.24.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -262,22 +262,22 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.10_9-jdk-openj9-0.24.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.10_9-jre-openj9-0.24.0-focal, 11-jre-openj9-focal
 SharedTags: 11.0.10_9-jre-openj9-0.24.0, 11-jre-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
 SharedTags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.10_9-jre-openj9-0.24.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -285,7 +285,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.10_9-jre-openj9-0.24.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -294,15 +294,15 @@ Constraints: windowsservercore-ltsc2016
 #-----------------------------openj9 v15 images---------------------------------
 Tags: 15.0.2_7-jdk-openj9-0.24.0-focal, 15-jdk-openj9-focal, 15-openj9-focal
 SharedTags: 15.0.2_7-jdk-openj9-0.24.0, 15-jdk-openj9, 15-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore-1809, 15-jdk-openj9-windowsservercore-1809, 15-openj9-windowsservercore-1809
 SharedTags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, 15.0.2_7-jdk-openj9-0.24.0, 15-jdk-openj9, 15-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -310,22 +310,22 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore-ltsc2016, 15-jdk-openj9-windowsservercore-ltsc2016, 15-openj9-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, 15.0.2_7-jdk-openj9-0.24.0, 15-jdk-openj9, 15-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 15.0.2_7-jre-openj9-0.24.0-focal, 15-jre-openj9-focal
 SharedTags: 15.0.2_7-jre-openj9-0.24.0, 15-jre-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore-1809, 15-jre-openj9-windowsservercore-1809
 SharedTags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.2_7-jre-openj9-0.24.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -333,7 +333,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore-ltsc2016, 15-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.2_7-jre-openj9-0.24.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -342,15 +342,15 @@ Constraints: windowsservercore-ltsc2016
 #-----------------------------openj9 v16 images---------------------------------
 Tags: 16_36-jdk-openj9-0.25.0-focal, 16-jdk-openj9-focal, 16-openj9-focal, openj9-focal
 SharedTags: 16_36-jdk-openj9-0.25.0, 16-jdk-openj9, 16-openj9, openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 16_36-jdk-openj9-0.25.0-windowsservercore-1809, 16-jdk-openj9-windowsservercore-1809, 16-openj9-windowsservercore-1809, openj9-windowsservercore-1809
 SharedTags: 16_36-jdk-openj9-0.25.0-windowsservercore, 16-jdk-openj9-windowsservercore, 16-openj9-windowsservercore, openj9-windowsservercore, 16_36-jdk-openj9-0.25.0, 16-jdk-openj9, 16-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -358,22 +358,22 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jdk-openj9-0.25.0-windowsservercore-ltsc2016, 16-jdk-openj9-windowsservercore-ltsc2016, 16-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
 SharedTags: 16_36-jdk-openj9-0.25.0-windowsservercore, 16-jdk-openj9-windowsservercore, 16-openj9-windowsservercore, openj9-windowsservercore, 16_36-jdk-openj9-0.25.0, 16-jdk-openj9, 16-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
 
 Tags: 16_36-jre-openj9-0.25.0-focal, 16-jre-openj9-focal
 SharedTags: 16_36-jre-openj9-0.25.0, 16-jre-openj9
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+Architectures: amd64, ppc64le, s390x
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 16_36-jre-openj9-0.25.0-windowsservercore-1809, 16-jre-openj9-windowsservercore-1809
 SharedTags: 16_36-jre-openj9-0.25.0-windowsservercore, 16-jre-openj9-windowsservercore, 16_36-jre-openj9-0.25.0, 16-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -381,7 +381,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jre-openj9-0.25.0-windowsservercore-ltsc2016, 16-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 16_36-jre-openj9-0.25.0-windowsservercore, 16-jre-openj9-windowsservercore, 16_36-jre-openj9-0.25.0, 16-jre-openj9
 Architectures: windows-amd64
-GitCommit: 820829025ee3eb66b5dc9e5fed0ee3171aababe9
+GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016

--- a/library/adoptopenjdk
+++ b/library/adoptopenjdk
@@ -7,14 +7,14 @@ GitRepo: https://github.com/AdoptOpenJDK/openjdk-docker.git
 Tags: 8u282-b08-jdk-hotspot-focal, 8-jdk-hotspot-focal, 8-hotspot-focal
 SharedTags: 8u282-b08-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u282-b08-jdk-hotspot-windowsservercore-1809, 8-jdk-hotspot-windowsservercore-1809, 8-hotspot-windowsservercore-1809
 SharedTags: 8u282-b08-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u282-b08-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +22,7 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jdk-hotspot-windowsservercore-ltsc2016, 8-jdk-hotspot-windowsservercore-ltsc2016, 8-hotspot-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jdk-hotspot-windowsservercore, 8-jdk-hotspot-windowsservercore, 8-hotspot-windowsservercore, 8u282-b08-jdk-hotspot, 8-jdk-hotspot, 8-hotspot, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -30,14 +30,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u282-b08-jre-hotspot-focal, 8-jre-hotspot-focal
 SharedTags: 8u282-b08-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 8u282-b08-jre-hotspot-windowsservercore-1809, 8-jre-hotspot-windowsservercore-1809
 SharedTags: 8u282-b08-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u282-b08-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -45,7 +45,7 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jre-hotspot-windowsservercore-ltsc2016, 8-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jre-hotspot-windowsservercore, 8-jre-hotspot-windowsservercore, 8u282-b08-jre-hotspot, 8-jre-hotspot, 8-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -55,14 +55,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.10_9-jdk-hotspot-focal, 11-jdk-hotspot-focal, 11-hotspot-focal
 SharedTags: 11.0.10_9-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.10_9-jdk-hotspot-windowsservercore-1809, 11-jdk-hotspot-windowsservercore-1809, 11-hotspot-windowsservercore-1809
 SharedTags: 11.0.10_9-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.10_9-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -70,7 +70,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jdk-hotspot-windowsservercore-ltsc2016, 11-jdk-hotspot-windowsservercore-ltsc2016, 11-hotspot-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jdk-hotspot-windowsservercore, 11-jdk-hotspot-windowsservercore, 11-hotspot-windowsservercore, 11.0.10_9-jdk-hotspot, 11-jdk-hotspot, 11-hotspot, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -78,14 +78,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.10_9-jre-hotspot-focal, 11-jre-hotspot-focal
 SharedTags: 11.0.10_9-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 11.0.10_9-jre-hotspot-windowsservercore-1809, 11-jre-hotspot-windowsservercore-1809
 SharedTags: 11.0.10_9-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.10_9-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -93,7 +93,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jre-hotspot-windowsservercore-ltsc2016, 11-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jre-hotspot-windowsservercore, 11-jre-hotspot-windowsservercore, 11.0.10_9-jre-hotspot, 11-jre-hotspot, 11-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -103,14 +103,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.2_7-jdk-hotspot-focal, 15-jdk-hotspot-focal, 15-hotspot-focal
 SharedTags: 15.0.2_7-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, 15
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.2_7-jdk-hotspot-windowsservercore-1809, 15-jdk-hotspot-windowsservercore-1809, 15-hotspot-windowsservercore-1809
 SharedTags: 15.0.2_7-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, 15.0.2_7-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -118,7 +118,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jdk-hotspot-windowsservercore-ltsc2016, 15-jdk-hotspot-windowsservercore-ltsc2016, 15-hotspot-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jdk-hotspot-windowsservercore, 15-jdk-hotspot-windowsservercore, 15-hotspot-windowsservercore, 15.0.2_7-jdk-hotspot, 15-jdk-hotspot, 15-hotspot, 15-jdk, 15
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -126,14 +126,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.2_7-jre-hotspot-focal, 15-jre-hotspot-focal
 SharedTags: 15.0.2_7-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 15.0.2_7-jre-hotspot-windowsservercore-1809, 15-jre-hotspot-windowsservercore-1809
 SharedTags: 15.0.2_7-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.2_7-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -141,7 +141,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jre-hotspot-windowsservercore-ltsc2016, 15-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jre-hotspot-windowsservercore, 15-jre-hotspot-windowsservercore, 15.0.2_7-jre-hotspot, 15-jre-hotspot, 15-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -151,14 +151,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16_36-jdk-hotspot-focal, 16-jdk-hotspot-focal, 16-hotspot-focal, hotspot-focal
 SharedTags: 16_36-jdk-hotspot, 16-jdk-hotspot, 16-hotspot, hotspot, 16-jdk, 16, jdk, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jdk/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 16_36-jdk-hotspot-windowsservercore-1809, 16-jdk-hotspot-windowsservercore-1809, 16-hotspot-windowsservercore-1809, hotspot-windowsservercore-1809
 SharedTags: 16_36-jdk-hotspot-windowsservercore, 16-jdk-hotspot-windowsservercore, 16-hotspot-windowsservercore, hotspot-windowsservercore, 16_36-jdk-hotspot, 16-jdk-hotspot, 16-hotspot, hotspot, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -166,7 +166,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jdk-hotspot-windowsservercore-ltsc2016, 16-jdk-hotspot-windowsservercore-ltsc2016, 16-hotspot-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
 SharedTags: 16_36-jdk-hotspot-windowsservercore, 16-jdk-hotspot-windowsservercore, 16-hotspot-windowsservercore, hotspot-windowsservercore, 16_36-jdk-hotspot, 16-jdk-hotspot, 16-hotspot, hotspot, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -174,14 +174,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16_36-jre-hotspot-focal, 16-jre-hotspot-focal
 SharedTags: 16_36-jre-hotspot, 16-jre-hotspot, 16-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jre/ubuntu
 File: Dockerfile.hotspot.releases.full
 
 Tags: 16_36-jre-hotspot-windowsservercore-1809, 16-jre-hotspot-windowsservercore-1809
 SharedTags: 16_36-jre-hotspot-windowsservercore, 16-jre-hotspot-windowsservercore, 16_36-jre-hotspot, 16-jre-hotspot, 16-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jre/windows/windowsservercore-1809
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-1809
@@ -189,7 +189,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jre-hotspot-windowsservercore-ltsc2016, 16-jre-hotspot-windowsservercore-ltsc2016
 SharedTags: 16_36-jre-hotspot-windowsservercore, 16-jre-hotspot-windowsservercore, 16_36-jre-hotspot, 16-jre-hotspot, 16-jre
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.hotspot.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -199,14 +199,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u282-b08-jdk-openj9-0.24.0-focal, 8-jdk-openj9-focal, 8-openj9-focal
 SharedTags: 8u282-b08-jdk-openj9-0.24.0, 8-jdk-openj9, 8-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore-1809, 8-jdk-openj9-windowsservercore-1809, 8-openj9-windowsservercore-1809
 SharedTags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u282-b08-jdk-openj9-0.24.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -214,7 +214,7 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore-ltsc2016, 8-jdk-openj9-windowsservercore-ltsc2016, 8-openj9-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jdk-openj9-0.24.0-windowsservercore, 8-jdk-openj9-windowsservercore, 8-openj9-windowsservercore, 8u282-b08-jdk-openj9-0.24.0, 8-jdk-openj9, 8-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -222,14 +222,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u282-b08-jre-openj9-0.24.0-focal, 8-jre-openj9-focal
 SharedTags: 8u282-b08-jre-openj9-0.24.0, 8-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 8u282-b08-jre-openj9-0.24.0-windowsservercore-1809, 8-jre-openj9-windowsservercore-1809
 SharedTags: 8u282-b08-jre-openj9-0.24.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u282-b08-jre-openj9-0.24.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -237,7 +237,7 @@ Constraints: windowsservercore-1809
 Tags: 8u282-b08-jre-openj9-0.24.0-windowsservercore-ltsc2016, 8-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 8u282-b08-jre-openj9-0.24.0-windowsservercore, 8-jre-openj9-windowsservercore, 8u282-b08-jre-openj9-0.24.0, 8-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -247,14 +247,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.10_9-jdk-openj9-0.24.0-focal, 11-jdk-openj9-focal, 11-openj9-focal
 SharedTags: 11.0.10_9-jdk-openj9-0.24.0, 11-jdk-openj9, 11-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore-1809, 11-jdk-openj9-windowsservercore-1809, 11-openj9-windowsservercore-1809
 SharedTags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.10_9-jdk-openj9-0.24.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -262,7 +262,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore-ltsc2016, 11-jdk-openj9-windowsservercore-ltsc2016, 11-openj9-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jdk-openj9-0.24.0-windowsservercore, 11-jdk-openj9-windowsservercore, 11-openj9-windowsservercore, 11.0.10_9-jdk-openj9-0.24.0, 11-jdk-openj9, 11-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -270,14 +270,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.10_9-jre-openj9-0.24.0-focal, 11-jre-openj9-focal
 SharedTags: 11.0.10_9-jre-openj9-0.24.0, 11-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore-1809, 11-jre-openj9-windowsservercore-1809
 SharedTags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.10_9-jre-openj9-0.24.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -285,7 +285,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore-ltsc2016, 11-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 11.0.10_9-jre-openj9-0.24.0-windowsservercore, 11-jre-openj9-windowsservercore, 11.0.10_9-jre-openj9-0.24.0, 11-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -295,14 +295,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.2_7-jdk-openj9-0.24.0-focal, 15-jdk-openj9-focal, 15-openj9-focal
 SharedTags: 15.0.2_7-jdk-openj9-0.24.0, 15-jdk-openj9, 15-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore-1809, 15-jdk-openj9-windowsservercore-1809, 15-openj9-windowsservercore-1809
 SharedTags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, 15.0.2_7-jdk-openj9-0.24.0, 15-jdk-openj9, 15-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -310,7 +310,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore-ltsc2016, 15-jdk-openj9-windowsservercore-ltsc2016, 15-openj9-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jdk-openj9-0.24.0-windowsservercore, 15-jdk-openj9-windowsservercore, 15-openj9-windowsservercore, 15.0.2_7-jdk-openj9-0.24.0, 15-jdk-openj9, 15-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -318,14 +318,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 15.0.2_7-jre-openj9-0.24.0-focal, 15-jre-openj9-focal
 SharedTags: 15.0.2_7-jre-openj9-0.24.0, 15-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore-1809, 15-jre-openj9-windowsservercore-1809
 SharedTags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.2_7-jre-openj9-0.24.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -333,7 +333,7 @@ Constraints: windowsservercore-1809
 Tags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore-ltsc2016, 15-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 15.0.2_7-jre-openj9-0.24.0-windowsservercore, 15-jre-openj9-windowsservercore, 15.0.2_7-jre-openj9-0.24.0, 15-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 15/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -343,14 +343,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16_36-jdk-openj9-0.25.0-focal, 16-jdk-openj9-focal, 16-openj9-focal, openj9-focal
 SharedTags: 16_36-jdk-openj9-0.25.0, 16-jdk-openj9, 16-openj9, openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jdk/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 16_36-jdk-openj9-0.25.0-windowsservercore-1809, 16-jdk-openj9-windowsservercore-1809, 16-openj9-windowsservercore-1809, openj9-windowsservercore-1809
 SharedTags: 16_36-jdk-openj9-0.25.0-windowsservercore, 16-jdk-openj9-windowsservercore, 16-openj9-windowsservercore, openj9-windowsservercore, 16_36-jdk-openj9-0.25.0, 16-jdk-openj9, 16-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -358,7 +358,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jdk-openj9-0.25.0-windowsservercore-ltsc2016, 16-jdk-openj9-windowsservercore-ltsc2016, 16-openj9-windowsservercore-ltsc2016, openj9-windowsservercore-ltsc2016
 SharedTags: 16_36-jdk-openj9-0.25.0-windowsservercore, 16-jdk-openj9-windowsservercore, 16-openj9-windowsservercore, openj9-windowsservercore, 16_36-jdk-openj9-0.25.0, 16-jdk-openj9, 16-openj9, openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -366,14 +366,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16_36-jre-openj9-0.25.0-focal, 16-jre-openj9-focal
 SharedTags: 16_36-jre-openj9-0.25.0, 16-jre-openj9
 Architectures: amd64, ppc64le, s390x
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jre/ubuntu
 File: Dockerfile.openj9.releases.full
 
 Tags: 16_36-jre-openj9-0.25.0-windowsservercore-1809, 16-jre-openj9-windowsservercore-1809
 SharedTags: 16_36-jre-openj9-0.25.0-windowsservercore, 16-jre-openj9-windowsservercore, 16_36-jre-openj9-0.25.0, 16-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jre/windows/windowsservercore-1809
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-1809
@@ -381,7 +381,7 @@ Constraints: windowsservercore-1809
 Tags: 16_36-jre-openj9-0.25.0-windowsservercore-ltsc2016, 16-jre-openj9-windowsservercore-ltsc2016
 SharedTags: 16_36-jre-openj9-0.25.0-windowsservercore, 16-jre-openj9-windowsservercore, 16_36-jre-openj9-0.25.0, 16-jre-openj9
 Architectures: windows-amd64
-GitCommit: 4f1c550c7c1a47a3bab419dcaf8892bdf03c8ad5
+GitCommit: 96ca1a1dd33a21f98a0c0eb979f5ccd9c1798718
 Directory: 16/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.openj9.releases.full
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Remove `arm64v8` for OpenJ9 for now as it is still EA and it is not properly tagged.