### PR TITLE
alpine: bump 3.10.9, 3.11.11, 3.12.7, 3.13.5 (CVE-2021-30139)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -13,10 +13,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.13.4, 3.13, 3, latest
+Tags: 3.13.5, 3.13, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.13
-GitCommit: db57c96bfff7363dd9bccc56a0ce6e846261bbf8
+GitCommit: 37579d92b9faa70398240431bc46720242faa5e5
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -25,10 +25,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.6, 3.12
+Tags: 3.12.7, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: 87a91a76dacdb5525378b3ca0605d1c48a0b3efb
+GitCommit: 8b8051f1c11daff18ada363488e145af9e201802
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -37,10 +37,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.10, 3.11
+Tags: 3.11.11, 3.11
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: 736a35a09787feb31462ef81f8ebca04593043ad
+GitCommit: 2cd76fb18830708f4af5a6927c3aa40867a4e8bb
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -49,10 +49,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.10.8, 3.10
+Tags: 3.10.9, 3.10
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.10
-GitCommit: 8a136916be53ab1592301c394451faf33a31965c
+GitCommit: 5a9faa421c89dc3d516bc84e9d47907d560fc2bd
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fix security issue in apk-tools
https://gitlab.alpinelinux.org/alpine/aports/-/issues/12606