### PR TITLE
Update Solr to 8.8.2

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,14 +6,14 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.8.1, 8.8, 8, latest
+Tags: 8.8.2, 8.8, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 2c096ba85eec41a8da70fda15199f3ad6a7106e6
+GitCommit: 2e73e7067302f889eb42ade28df4adaf3b527d95
 Directory: 8.8
 
-Tags: 8.8.1-slim, 8.8-slim, 8-slim, slim
+Tags: 8.8.2-slim, 8.8-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 2c096ba85eec41a8da70fda15199f3ad6a7106e6
+GitCommit: 2e73e7067302f889eb42ade28df4adaf3b527d95
 Directory: 8.8/slim
 
 Tags: 8.7.0, 8.7


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/r08f6b8444ea5ff712067cd5344a206f6535b24ea5dd434c5ba319ba4%40%3Cdev.solr.apache.org%3E) which links to the [release notes](https://solr.apache.org/docs/8_8_2/changes/Changes.html).

Bug Fixes   (4)
* SOLR-15249: Properly set ZK ACLs on /security.json (Mike Drob)
* SOLR-15288: Hardening NODEDOWN event in PRS collections (noble)
* SOLR-15233: Set doAs param in ConfigurableInternodeAuthHadoopPlugin (Geza Nagy, Jason Gerlowski, Mike Drob)
* SOLR-15217: Use shardsWhitelist in ReplicationHandler.  (Bruno Roustant)