### PR TITLE
[oraclelinux] Updating oraclelinux:8/8-slim images for CVE-2021-20305

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 33f83bbf624a08724400ca4db1d1184cfb31fc3e
+amd64-GitCommit: 5214ad8b74906bb161e6b7ee6cbb018d35513aac
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 09650822c5333eb6d709bd9db79a880c0433fc53
+arm64v8-GitCommit: 61d197dba5c08b9c36a8ac4cf7afd59b0b121ff3
 
 Tags: 8.3, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/errata/ELSA-2021-1206.html> for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>