### PR TITLE
archlinux: Release 20210418.0.20194

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -2,17 +2,16 @@
 
 Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Christian Rebischke <Chris.Rebischke@archlinux.org> (@shibumi),
-             Pierre Schmitz <pierre@archlinux.de> (@pierres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210404.0.18927
-GitCommit: 449ee3151cfdfba7e11103985460f447a9108351
-GitFetch: refs/tags/v20210404.0.18927
+Tags: latest, base, base-20210418.0.20194
+GitCommit: 6ef0c96738718f5d0b138619b6da91bc1ecf4271
+GitFetch: refs/tags/v20210418.0.20194
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210404.0.18927
-GitCommit: 449ee3151cfdfba7e11103985460f447a9108351
-GitFetch: refs/tags/v20210404.0.18927
+Tags: base-devel, base-devel-20210418.0.20194
+GitCommit: 6ef0c96738718f5d0b138619b6da91bc1ecf4271
+GitFetch: refs/tags/v20210418.0.20194
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks