### PR TITLE
Add Official AlmaLinux OS Image

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,0 +1,6 @@
+Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org>
+GitRepo: https://github.com/AlmaLinux/docker-images.git
+
+Tags: latest, 8
+GitFetch: refs/heads/almalinux-8-x86_64
+GitCommit: c025bfbb88c3feb7af00161954300abf0749bbfc

--- a/library/almalinux
+++ b/library/almalinux
@@ -3,4 +3,4 @@ GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 Tags: latest, 8
 GitFetch: refs/heads/almalinux-8-x86_64
-GitCommit: 1abb4676b55e031758ab309336f47cf168def64c
+GitCommit: b85d003827c40b7eb259d5dfba9b7f9c4963132f

--- a/library/almalinux
+++ b/library/almalinux
@@ -1,4 +1,4 @@
-Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org>
+Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 Tags: latest, 8

--- a/library/almalinux
+++ b/library/almalinux
@@ -3,4 +3,4 @@ GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 Tags: latest, 8
 GitFetch: refs/heads/almalinux-8-x86_64
-GitCommit: b85d003827c40b7eb259d5dfba9b7f9c4963132f
+GitCommit: 1dc91dd3b9f69fd2f570c94441104004a9ef9811

--- a/library/almalinux
+++ b/library/almalinux
@@ -3,4 +3,4 @@ GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 Tags: latest, 8
 GitFetch: refs/heads/almalinux-8-x86_64
-GitCommit: c025bfbb88c3feb7af00161954300abf0749bbfc
+GitCommit: 1abb4676b55e031758ab309336f47cf168def64c


### PR DESCRIPTION
Hello, we would like to add an official image for the [AlmaLinux OS](https://almalinux.org/).

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    -  https://github.com/AlmaLinux/docker-images, I'm the AlmaLinux OS Foundation board member and one of the core developers
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    -  base distribution 
-	[x] is it reasonably popular, or does it solve a particular use case well?
    -  AlmaLinux OS was released on March 30th 2021 and, as the only currently available CentOS replacement, has almost 20K downloads. AlmaLinux OS solves multiple use cases where the use of RHEL would be not viable, impossible or not feasible. AlmaLinux OS provides a long-term supported enterprise-grade OS which allows for any type of stack or workload to run on.
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/1920
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] ~existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)~
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
