### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.2.1, 6.2, 6, latest, 6.2.1-buster, 6.2-buster, 6-buster, buster
+Tags: 6.2.2, 6.2, 6, latest, 6.2.2-buster, 6.2-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6f1af45d6b0db298e0118ab4406cf8edb642c337
+GitCommit: 1511c433cdb80391d897b5d2a04c67c261bf5f4b
 Directory: 6.2
 
-Tags: 6.2.1-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.1-alpine3.13, 6.2-alpine3.13, 6-alpine3.13, alpine3.13
+Tags: 6.2.2-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.2-alpine3.13, 6.2-alpine3.13, 6-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f1af45d6b0db298e0118ab4406cf8edb642c337
+GitCommit: 1511c433cdb80391d897b5d2a04c67c261bf5f4b
 Directory: 6.2/alpine
 
 Tags: 6.0.12, 6.0, 6.0.12-buster, 6.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/1511c43: Update to 6.2.2