### PR TITLE
Update influxdb versions for InfluxDB v1.8.5

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
-Maintainers: Daniel Moran <dmoran@influxdata.com> (@danxmoran)
+Maintainers: Cody Shepherd (@codyshepherd), Daniel Moran <dmoran@influxdata.com> (@danxmoran)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: c6eeae53da9cf62803ccce0c2550889acf5caed0
+GitCommit: c4d6651a3688b517cf29c7c6178f388fea5dad60
 
 Tags: 1.7, 1.7.11
 Architectures: amd64, arm32v7, arm64v8
@@ -21,23 +21,23 @@ Directory: influxdb/1.7/meta
 Tags: 1.7-meta-alpine, 1.7.11-meta-alpine
 Directory: influxdb/1.7/meta/alpine
 
-Tags: 1.8, 1.8.4
+Tags: 1.8, 1.8.5
 Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8
 
-Tags: 1.8-alpine, 1.8.4-alpine
+Tags: 1.8-alpine, 1.8.5-alpine
 Directory: influxdb/1.8/alpine
 
-Tags: 1.8-data, 1.8.3-data, data
+Tags: 1.8-data, 1.8.5-data, data
 Directory: influxdb/1.8/data
 
-Tags: 1.8-data-alpine, 1.8.3-data-alpine, data-alpine
+Tags: 1.8-data-alpine, 1.8.5-data-alpine, data-alpine
 Directory: influxdb/1.8/data/alpine
 
-Tags: 1.8-meta, 1.8.3-meta, meta
+Tags: 1.8-meta, 1.8.5-meta, meta
 Directory: influxdb/1.8/meta
 
-Tags: 1.8-meta-alpine, 1.8.3-meta-alpine, meta-alpine
+Tags: 1.8-meta-alpine, 1.8.5-meta-alpine, meta-alpine
 Directory: influxdb/1.8/meta/alpine
 
 Tags: 2.0, 2.0.4, latest


### PR DESCRIPTION
InfluxDB v1.8.5 has been released. This PR updates the image versions accordingly.

Also, I will be the primary maintainer of these images going forward :smile:. 