### PR TITLE
Update Corretto-11 to 11.0.11.9.1, Corretto-8 to 8.292.10.1 and remove Corretto-15

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -4,17 +4,17 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Clive Verghese <verghese@amazon.com> (@cliveverghese)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/master
-GitCommit: 24e4faf0038a6efcda97b9f4b3bf972a7ea839bd
+GitCommit: 6d6413aa970660a8ce39ae4fd533c1431c913a30
 
-Tags: 8, 8u282, 8u282-al2, 8-al2-full,8-al2-jdk, latest
+Tags: 8, 8u292, 8u292-al2, 8-al2-full,8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 11, 11.0.10, 11.0.10-al2, 11-al2-jdk, 11-al2-full
+Tags: 11, 11.0.11, 11.0.11-al2, 11-al2-jdk, 11-al2-full
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 8-alpine, 8u282-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine, 8u292-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine
 
@@ -22,17 +22,9 @@ Tags: 8-alpine-jre, 8u282-alpine-jre
 Architectures: amd64
 Directory: 8/jre/alpine
 
-Tags: 11-alpine, 11.0.10-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine, 11.0.11-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine
-
-Tags: 15, 15.0.2, 15.0.2-al2, 15-al2-jdk, 15-al2-full
-Architectures: amd64, arm64v8
-Directory: 15/jdk/al2
-
-Tags: 15-alpine, 15.0.2-alpine, 15-alpine-full, 15-alpine-jdk
-Architectures: amd64
-Directory: 15/jdk/alpine
 
 Tags: 16, 16.0.0, 16.0.0-al2, 16-al2-jdk, 16-al2-full
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Corretto 2021 Q2 release for 11 & 8. We will update Corretto-16 images in a separate PR.

Corretto-15 is officially EOL and contains security vulnerabilities. Removed related tags.