### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -98,192 +98,150 @@ GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 15.0.2-jdk-oraclelinux8, 15.0.2-oraclelinux8, 15.0-jdk-oraclelinux8, 15.0-oraclelinux8, 15-jdk-oraclelinux8, 15-oraclelinux8, 15.0.2-jdk-oracle, 15.0.2-oracle, 15.0-jdk-oracle, 15.0-oracle, 15-jdk-oracle, 15-oracle
-SharedTags: 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15
+Tags: 11.0.11-9-jdk-oraclelinux8, 11.0.11-9-oraclelinux8, 11.0.11-jdk-oraclelinux8, 11.0.11-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.11-9-jdk-oracle, 11.0.11-9-oracle, 11.0.11-jdk-oracle, 11.0.11-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/oraclelinux8
-
-Tags: 15.0.2-jdk-oraclelinux7, 15.0.2-oraclelinux7, 15.0-jdk-oraclelinux7, 15.0-oraclelinux7, 15-jdk-oraclelinux7, 15-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/oraclelinux7
-
-Tags: 15.0.2-jdk-buster, 15.0.2-buster, 15.0-jdk-buster, 15.0-buster, 15-jdk-buster, 15-buster
-Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/buster
-
-Tags: 15.0.2-jdk-slim-buster, 15.0.2-slim-buster, 15.0-jdk-slim-buster, 15.0-slim-buster, 15-jdk-slim-buster, 15-slim-buster, 15.0.2-jdk-slim, 15.0.2-slim, 15.0-jdk-slim, 15.0-slim, 15-jdk-slim, 15-slim
-Architectures: amd64, arm64v8
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/slim-buster
-
-Tags: 15.0.2-jdk-windowsservercore-1809, 15.0.2-windowsservercore-1809, 15.0-jdk-windowsservercore-1809, 15.0-windowsservercore-1809, 15-jdk-windowsservercore-1809, 15-windowsservercore-1809
-SharedTags: 15.0.2-jdk-windowsservercore, 15.0.2-windowsservercore, 15.0-jdk-windowsservercore, 15.0-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15
-Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 15.0.2-jdk-windowsservercore-ltsc2016, 15.0.2-windowsservercore-ltsc2016, 15.0-jdk-windowsservercore-ltsc2016, 15.0-windowsservercore-ltsc2016, 15-jdk-windowsservercore-ltsc2016, 15-windowsservercore-ltsc2016
-SharedTags: 15.0.2-jdk-windowsservercore, 15.0.2-windowsservercore, 15.0-jdk-windowsservercore, 15.0-windowsservercore, 15-jdk-windowsservercore, 15-windowsservercore, 15.0.2-jdk, 15.0.2, 15.0-jdk, 15.0, 15-jdk, 15
-Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 15.0.2-jdk-nanoserver-1809, 15.0.2-nanoserver-1809, 15.0-jdk-nanoserver-1809, 15.0-nanoserver-1809, 15-jdk-nanoserver-1809, 15-nanoserver-1809
-SharedTags: 15.0.2-jdk-nanoserver, 15.0.2-nanoserver, 15.0-jdk-nanoserver, 15.0-nanoserver, 15-jdk-nanoserver, 15-nanoserver
-Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
-Directory: 15/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 11.0.10-jdk-oraclelinux8, 11.0.10-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.10-jdk-oracle, 11.0.10-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
-Architectures: amd64, arm64v8
-GitCommit: 9b3a8e1ef4cea599a29ad3357ed3528904437236
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/oraclelinux8
 
-Tags: 11.0.10-jdk-oraclelinux7, 11.0.10-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
+Tags: 11.0.11-9-jdk-oraclelinux7, 11.0.11-9-oraclelinux7, 11.0.11-jdk-oraclelinux7, 11.0.11-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 9b3a8e1ef4cea599a29ad3357ed3528904437236
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/oraclelinux7
 
-Tags: 11.0.10-jdk-buster, 11.0.10-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
-SharedTags: 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.11-9-jdk-buster, 11.0.11-9-buster, 11.0.11-jdk-buster, 11.0.11-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
+SharedTags: 11.0.11-9-jdk, 11.0.11-9, 11.0.11-jdk, 11.0.11, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 9b3a8e1ef4cea599a29ad3357ed3528904437236
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/buster
 
-Tags: 11.0.10-jdk-slim-buster, 11.0.10-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.10-jdk-slim, 11.0.10-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.11-9-jdk-slim-buster, 11.0.11-9-slim-buster, 11.0.11-jdk-slim-buster, 11.0.11-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster, 11.0.11-9-jdk-slim, 11.0.11-9-slim, 11.0.11-jdk-slim, 11.0.11-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 9b3a8e1ef4cea599a29ad3357ed3528904437236
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/slim-buster
 
-Tags: 11.0.10-jdk-windowsservercore-1809, 11.0.10-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.10-jdk-windowsservercore, 11.0.10-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.11-9-jdk-windowsservercore-1809, 11.0.11-9-windowsservercore-1809, 11.0.11-jdk-windowsservercore-1809, 11.0.11-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.11-9-jdk-windowsservercore, 11.0.11-9-windowsservercore, 11.0.11-jdk-windowsservercore, 11.0.11-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.11-9-jdk, 11.0.11-9, 11.0.11-jdk, 11.0.11, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e01f827ecdea8b97a7b9a6416dab82b3a31cd391
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.10-jdk-windowsservercore-ltsc2016, 11.0.10-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.10-jdk-windowsservercore, 11.0.10-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.10-jdk, 11.0.10, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.11-9-jdk-windowsservercore-ltsc2016, 11.0.11-9-windowsservercore-ltsc2016, 11.0.11-jdk-windowsservercore-ltsc2016, 11.0.11-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.11-9-jdk-windowsservercore, 11.0.11-9-windowsservercore, 11.0.11-jdk-windowsservercore, 11.0.11-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.11-9-jdk, 11.0.11-9, 11.0.11-jdk, 11.0.11, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e01f827ecdea8b97a7b9a6416dab82b3a31cd391
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.10-jdk-nanoserver-1809, 11.0.10-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.10-jdk-nanoserver, 11.0.10-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.11-9-jdk-nanoserver-1809, 11.0.11-9-nanoserver-1809, 11.0.11-jdk-nanoserver-1809, 11.0.11-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.11-9-jdk-nanoserver, 11.0.11-9-nanoserver, 11.0.11-jdk-nanoserver, 11.0.11-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: e01f827ecdea8b97a7b9a6416dab82b3a31cd391
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.10-jre-buster, 11.0-jre-buster, 11-jre-buster
-SharedTags: 11.0.10-jre, 11.0-jre, 11-jre
+Tags: 11.0.11-9-jre-buster, 11.0.11-jre-buster, 11.0-jre-buster, 11-jre-buster
+SharedTags: 11.0.11-9-jre, 11.0.11-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: e01f827ecdea8b97a7b9a6416dab82b3a31cd391
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jre/buster
 
-Tags: 11.0.10-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.10-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.11-9-jre-slim-buster, 11.0.11-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster, 11.0.11-9-jre-slim, 11.0.11-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: e01f827ecdea8b97a7b9a6416dab82b3a31cd391
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jre/slim-buster
 
-Tags: 11.0.10-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.10-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.10-jre, 11.0-jre, 11-jre
+Tags: 11.0.11-9-jre-windowsservercore-1809, 11.0.11-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.11-9-jre-windowsservercore, 11.0.11-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.11-9-jre, 11.0.11-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 9b3a8e1ef4cea599a29ad3357ed3528904437236
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.10-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.10-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.10-jre, 11.0-jre, 11-jre
+Tags: 11.0.11-9-jre-windowsservercore-ltsc2016, 11.0.11-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.11-9-jre-windowsservercore, 11.0.11-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.11-9-jre, 11.0.11-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 9b3a8e1ef4cea599a29ad3357ed3528904437236
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.10-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.10-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.11-9-jre-nanoserver-1809, 11.0.11-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.11-9-jre-nanoserver, 11.0.11-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: e01f827ecdea8b97a7b9a6416dab82b3a31cd391
+GitCommit: 2bff20bd81e3ce1172d3adefcfb5cb994c8e0e4d
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u282-jdk-oraclelinux8, 8u282-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u282-jdk-oracle, 8u282-oracle, 8-jdk-oracle, 8-oracle
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+Tags: 8u292-jdk-oraclelinux8, 8u292-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u292-jdk-oracle, 8u292-oracle, 8-jdk-oracle, 8-oracle
+Architectures: amd64, arm64v8
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/oraclelinux8
 
-Tags: 8u282-jdk-oraclelinux7, 8u282-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+Tags: 8u292-jdk-oraclelinux7, 8u292-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
+Architectures: amd64, arm64v8
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/oraclelinux7
 
-Tags: 8u282-jdk-buster, 8u282-buster, 8-jdk-buster, 8-buster
-SharedTags: 8u282-jdk, 8u282, 8-jdk, 8
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+Tags: 8u292-jdk-buster, 8u292-buster, 8-jdk-buster, 8-buster
+SharedTags: 8u292-jdk, 8u292, 8-jdk, 8
+Architectures: amd64, arm64v8
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/buster
 
-Tags: 8u282-jdk-slim-buster, 8u282-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u282-jdk-slim, 8u282-slim, 8-jdk-slim, 8-slim
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+Tags: 8u292-jdk-slim-buster, 8u292-slim-buster, 8-jdk-slim-buster, 8-slim-buster, 8u292-jdk-slim, 8u292-slim, 8-jdk-slim, 8-slim
+Architectures: amd64, arm64v8
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/slim-buster
 
-Tags: 8u282-jdk-windowsservercore-1809, 8u282-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u282-jdk-windowsservercore, 8u282-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u282-jdk, 8u282, 8-jdk, 8
+Tags: 8u292-jdk-windowsservercore-1809, 8u292-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u292-jdk-windowsservercore, 8u292-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u292-jdk, 8u292, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u282-jdk-windowsservercore-ltsc2016, 8u282-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u282-jdk-windowsservercore, 8u282-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u282-jdk, 8u282, 8-jdk, 8
+Tags: 8u292-jdk-windowsservercore-ltsc2016, 8u292-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u292-jdk-windowsservercore, 8u292-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u292-jdk, 8u292, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u282-jdk-nanoserver-1809, 8u282-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u282-jdk-nanoserver, 8u282-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u292-jdk-nanoserver-1809, 8u292-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u292-jdk-nanoserver, 8u292-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u282-jre-buster, 8-jre-buster
-SharedTags: 8u282-jre, 8-jre
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+Tags: 8u292-jre-buster, 8-jre-buster
+SharedTags: 8u292-jre, 8-jre
+Architectures: amd64, arm64v8
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jre/buster
 
-Tags: 8u282-jre-slim-buster, 8-jre-slim-buster, 8u282-jre-slim, 8-jre-slim
-Architectures: amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+Tags: 8u292-jre-slim-buster, 8-jre-slim-buster, 8u292-jre-slim, 8-jre-slim
+Architectures: amd64, arm64v8
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jre/slim-buster
 
-Tags: 8u282-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u282-jre-windowsservercore, 8-jre-windowsservercore, 8u282-jre, 8-jre
+Tags: 8u292-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u292-jre-windowsservercore, 8-jre-windowsservercore, 8u292-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u282-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u282-jre-windowsservercore, 8-jre-windowsservercore, 8u282-jre, 8-jre
+Tags: 8u292-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
+SharedTags: 8u292-jre-windowsservercore, 8-jre-windowsservercore, 8u292-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u282-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u282-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u292-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u292-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 3fec00485b8448f6a9a4c150ad8a770306ca6814
+GitCommit: 765a1c4dd6fa4fd9c2a0cf540e9c17ca73eb227b
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/2bff20b: Update 11 to 11.0.11+9
- https://github.com/docker-library/openjdk/commit/7cafab2: Explicitly ensure version 11 has both arm64 and Windows
- https://github.com/docker-library/openjdk/commit/b5f96a6: Explicitly enforce that OpenJDK 11 needs to include arm64 also...
- https://github.com/docker-library/openjdk/commit/c74ad87: Remove 15 (EOL)
- https://github.com/docker-library/openjdk/commit/765a1c4: Update 8 to 8u292
- https://github.com/docker-library/openjdk/commit/0708934: Update 11