### PR TITLE
Update vault for latest releases

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -3,32 +3,17 @@ Maintainers: Chris Hoffman <choffman@hashicorp.com> (@chrishoffman),
              Matthew Irish <matthew@hashicorp.com> (@meirish)
 GitRepo: https://github.com/hashicorp/docker-vault.git
 
-Tags: 1.7.0, latest
+Tags: 1.7.1, latest
 Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: b53096266e28cb02e8d7d72eb35e71966c50e662
+GitCommit: 14d893cb83118fd3642e9e516f682c5e0e0a2c30
 Directory: 0.X
 
-Tags: 1.7.0-rc2
+Tags: 1.6.4
 Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: d859985bd2095f8990251d2bb7899da703997af3
+GitCommit: 88aeb655ea14e74bb9d9ae7e583f86c3e0d9a29f
 Directory: 0.X
 
-Tags: 1.7.0-rc1
+Tags: 1.5.8
 Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: cf73ab856a98b3f240f9545afe4184a22ec16b44
-Directory: 0.X
-
-Tags: 1.6.3
-Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: fb6bc85ef0828edb45abac40d5cb55a1d5bf50a6
-Directory: 0.X
-
-Tags: 1.5.7
-Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: 25c5a3a51e0730bd1aae9f924d3700a230f1488c
-Directory: 0.X
-
-Tags: 1.4.7
-Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: e4635725bcf8ce18f9d8fd5be5a69bf882d21223
+GitCommit: 1c4258acc24265a26b0581929954ec112230fb8d
 Directory: 0.X


### PR DESCRIPTION
Three new releases today:

1.5.8: https://github.com/hashicorp/docker-vault/commit/1c4258acc24265a26b0581929954ec112230fb8d
1.6.4: https://github.com/hashicorp/docker-vault/commit/88aeb655ea14e74bb9d9ae7e583f86c3e0d9a29f
1.7.1: https://github.com/hashicorp/docker-vault/commit/14d893cb83118fd3642e9e516f682c5e0e0a2c30