### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 787536c6d9ad19a63be432a411ae479133f083f7
 Directory: 2.4-rc/alpine
 
-Tags: 2.3.9, 2.3, latest
+Tags: 2.3.10, 2.3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6cb254be8673430d79a04f1e27b3b722a5b2cadd
+GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
 Directory: 2.3
 
-Tags: 2.3.9-alpine, 2.3-alpine, alpine
+Tags: 2.3.10-alpine, 2.3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6cb254be8673430d79a04f1e27b3b722a5b2cadd
+GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
 Directory: 2.3/alpine
 
 Tags: 2.2.13, 2.2, lts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/db93350: Update 2.3 to 2.3.10