### PR TITLE
Update Clear Linux OS to 34540

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: f052f179e16a1fe91fdf52970d26e1c6f6ed0503
-GitFetch: refs/tags/clear-linux-34520
+GitCommit: 053d66913b6055fd64947f74e7b2c9daede7b4cc
+GitFetch: refs/tags/clear-linux-34540


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34540

@bryteise @mdhorn @phmccarty