### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-18-jdk-oraclelinux8, 17-ea-18-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-18-jdk-oracle, 17-ea-18-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-18-jdk, 17-ea-18, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-19-jdk-oraclelinux8, 17-ea-19-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-19-jdk-oracle, 17-ea-19-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-19-jdk, 17-ea-19, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-18-jdk-oraclelinux7, 17-ea-18-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-19-jdk-oraclelinux7, 17-ea-19-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-18-jdk-buster, 17-ea-18-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-19-jdk-buster, 17-ea-19-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/buster
 
-Tags: 17-ea-18-jdk-slim-buster, 17-ea-18-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-18-jdk-slim, 17-ea-18-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-19-jdk-slim-buster, 17-ea-19-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-19-jdk-slim, 17-ea-19-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-14-jdk-alpine3.13, 17-ea-14-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-14-jdk-alpine, 17-ea-14-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,24 +35,24 @@ Architectures: amd64
 GitCommit: 255fbc7cf6da6d76869b420dd2fe0bc94539b5eb
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-18-jdk-windowsservercore-1809, 17-ea-18-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-18-jdk-windowsservercore, 17-ea-18-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-18-jdk, 17-ea-18, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-19-jdk-windowsservercore-1809, 17-ea-19-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-19-jdk-windowsservercore, 17-ea-19-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-19-jdk, 17-ea-19, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-18-jdk-windowsservercore-ltsc2016, 17-ea-18-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-18-jdk-windowsservercore, 17-ea-18-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-18-jdk, 17-ea-18, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-19-jdk-windowsservercore-ltsc2016, 17-ea-19-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-19-jdk-windowsservercore, 17-ea-19-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-19-jdk, 17-ea-19, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-18-jdk-nanoserver-1809, 17-ea-18-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-18-jdk-nanoserver, 17-ea-18-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-19-jdk-nanoserver-1809, 17-ea-19-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-19-jdk-nanoserver, 17-ea-19-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 34376123448cd3e99ff7470d206681d090f1ca78
+GitCommit: 30a6328da2017e8cfca341aaa669a795ef759a57
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/30a6328: Update 17 to 17-ea+19