### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0-beta4, 4.0
+Tags: 4.0-rc1, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 03bef93db2ff4b5a3cbc954618f08c44ddcb7568
+GitCommit: f00a725cc0189ef166ac1d893227651bd81a6996
 Directory: 4.0
 
 Tags: 3.11.10, 3.11, 3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/f00a725: Update 4.0 to 4.0-rc1