### PR TITLE
Fedora Update 20210427

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,48 +1,41 @@
 Maintainers: Clement Verna <cverna@fedoraproject.org> (@cverna), Vipul Siddharth <siddharthvipul1@fedoraproject.org> (@siddharthvipul)
 GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 
-Tags: 31
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitFetch: refs/heads/31
-GitCommit: 619a9d98269d556d030648ad486bb2c9f50f1768
-amd64-Directory: x86_64/
-arm64v8-Directory: aarch64/
-ppc64le-Directory: ppc64le/
-s390x-Directory: s390x/
-
 Tags: 32
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/32
-GitCommit: 7d59b0538a60562d1756644b02e51451a311ccdc
+GitCommit: ddec1000ce5ba6f6d48b83092baa0931c71463d2 
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
-Tags: latest, 33
+Tags: 33
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/33
-GitCommit: 84e8f980c203961f94e12e85bd2cee8fff08b70f
+GitCommit: e3da24893ca1252df3336f9d2066d7078f274173 
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
-Tags: 34
-Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
+Tags: 34, latest
+Architectures: amd64, arm64v8, s390x, arm32v7
 GitFetch: refs/heads/34
-GitCommit: fbf3385cf226b655a7e785c238232ea165badca7
+GitCommit: 46d8c9221562da5195fd41f8bff49d3f049a9757 
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
-ppc64le-Directory: ppc64le/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 
 Tags: rawhide, 35
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/34
-GitCommit: 5af98888c93fe29c5c738df708e9864d47e8e492
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
+GitFetch: refs/heads/35
+GitCommit:dbb2e4d43e7a3293107ce04923898fee8605bf77 
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
+ppc64le-Directory: ppc64le/
+s390x-Directory: s390x/
+arm32v7-Directory: armhfp/


### PR DESCRIPTION
Fedora 34 is now the latest.
Drop ppc64le from F34 until the image compose is fixed.

Signed-off-by: Clement Verna <cverna@tutanota.com>