### PR TITLE
Gradle 6.x tags

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -5,53 +5,53 @@ GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 
 # Hotspot
 
-Tags: 7.0.0-jdk8, 7.0.0-jdk8-hotspot, 7.0-jdk8, 7.0-jdk8-hotspot, jdk8, jdk8-hotspot, 7.0.0-jdk, 7.0.0-jdk-hotspot, 7.0-jdk, 7.0-jdk-hotspot, jdk, jdk-hotspot, 7.0.0, 7.0.0-hotspot, 7.0, 7.0-hotspot, latest, hotspot
+Tags: 7.0.0-jdk8, 7.0.0-jdk8-hotspot, 7.0-jdk8, 7.0-jdk8-hotspot, 7-jdk8, 7-jdk8-hotspot, jdk8, jdk8-hotspot, 7.0.0-jdk, 7.0.0-jdk-hotspot, 7.0-jdk, 7.0-jdk-hotspot, 7-jdk, 7-jdk-hotspot, jdk, jdk-hotspot, 7.0.0, 7.0.0-hotspot, 7.0, 7.0-hotspot, 7, 7-hotspot, latest, hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk8
 
-Tags: 7.0.0-jre8, 7.0.0-jre8-hotspot, 7.0-jre8, 7.0-jre8-hotspot, jre8, jre8-hotspot, 7.0.0-jre, 7.0.0-jre-hotspot, 7.0-jre, 7.0-jre-hotspot, jre, jre-hotspot
+Tags: 7.0.0-jre8, 7.0.0-jre8-hotspot, 7.0-jre8, 7.0-jre8-hotspot, 7-jre8, 7-jre8-hotspot, jre8, jre8-hotspot, 7.0.0-jre, 7.0.0-jre-hotspot, 7.0-jre, 7.0-jre-hotspot, 7-jre, 7-jre-hotspot, jre, jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre8
 
-Tags: 7.0.0-jdk11, 7.0.0-jdk11-hotspot, 7.0-jdk11, 7.0-jdk11-hotspot, jdk11, jdk11-hotspot
+Tags: 7.0.0-jdk11, 7.0.0-jdk11-hotspot, 7.0-jdk11, 7.0-jdk11-hotspot, 7-jdk11, 7-jdk11-hotspot, jdk11, jdk11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk11
 
-Tags: 7.0.0-jre11, 7.0.0-jre11-hotspot, 7.0-jre11, 7.0-jre11-hotspot, jre11, jre11-hotspot
+Tags: 7.0.0-jre11, 7.0.0-jre11-hotspot, 7.0-jre11, 7.0-jre11-hotspot, 7-jre11, 7-jre11-hotspot, jre11, jre11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre11
 
-Tags: 7.0.0-jdk16, 7.0.0-jdk16-hotspot, 7.0-jdk16, 7.0-jdk16-hotspot, jdk16, jdk16-hotspot
+Tags: 7.0.0-jdk16, 7.0.0-jdk16-hotspot, 7.0-jdk16, 7.0-jdk16-hotspot, 7-jdk16, 7-jdk16-hotspot, jdk16, jdk16-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jdk16
 
-Tags: 7.0.0-jre16, 7.0.0-jre16-hotspot, 7.0-jre16, 7.0-jre16-hotspot, jre16, jre16-hotspot
+Tags: 7.0.0-jre16, 7.0.0-jre16-hotspot, 7.0-jre16, 7.0-jre16-hotspot, 7-jre16, 7-jre16-hotspot, jre16, jre16-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hotspot/jre16
 
 
 # OpenJ9
 
-Tags: 7.0.0-jdk8-openj9, 7.0-jdk8-openj9, jdk8-openj9, 7.0.0-jdk-openj9, 7.0-jdk-openj9, jdk-openj9, 7.0.0-openj9, 7.0-openj9, openj9
+Tags: 7.0.0-jdk8-openj9, 7.0-jdk8-openj9, 7-jdk8-openj9, jdk8-openj9, 7.0.0-jdk-openj9, 7.0-jdk-openj9, 7-jdk-openj9, jdk-openj9, 7.0.0-openj9, 7.0-openj9, 7-openj9, openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: openj9/jdk8
 
-Tags: 7.0.0-jre8-openj9, 7.0-jre8-openj9, jre8-openj9, 7.0.0-jre-openj9, 7.0-jre-openj9, jre-openj9
+Tags: 7.0.0-jre8-openj9, 7.0-jre8-openj9, 7-jre8-openj9, jre8-openj9, 7.0.0-jre-openj9, 7.0-jre-openj9, 7-jre-openj9, jre-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: openj9/jre8
 
-Tags: 7.0.0-jdk11-openj9, 7.0-jdk11-openj9, jdk11-openj9
+Tags: 7.0.0-jdk11-openj9, 7.0-jdk11-openj9, 7-jdk11-openj9, jdk11-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: openj9/jdk11
 
-Tags: 7.0.0-jre11-openj9, 7.0-jre11-openj9, jre11-openj9
+Tags: 7.0.0-jre11-openj9, 7.0-jre11-openj9, 7-jre11-openj9, jre11-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: openj9/jre11
 
-Tags: 7.0.0-jdk16-openj9, 7.0-jdk16-openj9, jdk16-openj9
+Tags: 7.0.0-jdk16-openj9, 7.0-jdk16-openj9, 7-jdk16-openj9, jdk16-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: openj9/jdk16
 
-Tags: 7.0.0-jre16-openj9, 7.0-jre16-openj9, jre16-openj9
+Tags: 7.0.0-jre16-openj9, 7.0-jre16-openj9, 7-jre16-openj9, jre16-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: openj9/jre16

--- a/library/gradle
+++ b/library/gradle
@@ -1,32 +1,36 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/keeganwitt/docker-gradle.git
-GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
-
 
 # Hotspot
 
 Tags: 7.0.0-jdk8, 7.0.0-jdk8-hotspot, 7.0-jdk8, 7.0-jdk8-hotspot, 7-jdk8, 7-jdk8-hotspot, jdk8, jdk8-hotspot, 7.0.0-jdk, 7.0.0-jdk-hotspot, 7.0-jdk, 7.0-jdk-hotspot, 7-jdk, 7-jdk-hotspot, jdk, jdk-hotspot, 7.0.0, 7.0.0-hotspot, 7.0, 7.0-hotspot, 7, 7-hotspot, latest, hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: hotspot/jdk8
 
 Tags: 7.0.0-jre8, 7.0.0-jre8-hotspot, 7.0-jre8, 7.0-jre8-hotspot, 7-jre8, 7-jre8-hotspot, jre8, jre8-hotspot, 7.0.0-jre, 7.0.0-jre-hotspot, 7.0-jre, 7.0-jre-hotspot, 7-jre, 7-jre-hotspot, jre, jre-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: hotspot/jre8
 
 Tags: 7.0.0-jdk11, 7.0.0-jdk11-hotspot, 7.0-jdk11, 7.0-jdk11-hotspot, 7-jdk11, 7-jdk11-hotspot, jdk11, jdk11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: hotspot/jdk11
 
 Tags: 7.0.0-jre11, 7.0.0-jre11-hotspot, 7.0-jre11, 7.0-jre11-hotspot, 7-jre11, 7-jre11-hotspot, jre11, jre11-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: hotspot/jre11
 
 Tags: 7.0.0-jdk16, 7.0.0-jdk16-hotspot, 7.0-jdk16, 7.0-jdk16-hotspot, 7-jdk16, 7-jdk16-hotspot, jdk16, jdk16-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: hotspot/jdk16
 
 Tags: 7.0.0-jre16, 7.0.0-jre16-hotspot, 7.0-jre16, 7.0-jre16-hotspot, 7-jre16, 7-jre16-hotspot, jre16, jre16-hotspot
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: hotspot/jre16
 
 
@@ -34,24 +38,84 @@ Directory: hotspot/jre16
 
 Tags: 7.0.0-jdk8-openj9, 7.0-jdk8-openj9, 7-jdk8-openj9, jdk8-openj9, 7.0.0-jdk-openj9, 7.0-jdk-openj9, 7-jdk-openj9, jdk-openj9, 7.0.0-openj9, 7.0-openj9, 7-openj9, openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: openj9/jdk8
 
 Tags: 7.0.0-jre8-openj9, 7.0-jre8-openj9, 7-jre8-openj9, jre8-openj9, 7.0.0-jre-openj9, 7.0-jre-openj9, 7-jre-openj9, jre-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: openj9/jre8
 
 Tags: 7.0.0-jdk11-openj9, 7.0-jdk11-openj9, 7-jdk11-openj9, jdk11-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: openj9/jdk11
 
 Tags: 7.0.0-jre11-openj9, 7.0-jre11-openj9, 7-jre11-openj9, jre11-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: openj9/jre11
 
 Tags: 7.0.0-jdk16-openj9, 7.0-jdk16-openj9, 7-jdk16-openj9, jdk16-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: openj9/jdk16
 
 Tags: 7.0.0-jre16-openj9, 7.0-jre16-openj9, 7-jre16-openj9, jre16-openj9
 Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 605a08fb025ad34e8e9d5d2391427886e64fc9f7
 Directory: openj9/jre16
+
+
+# Gradle 6.x Hotspot
+
+Tags: 6.8.3-jdk8, 6.8.3-jdk8-hotspot, 6.8-jdk8, 6.8-jdk8-hotspot, 6-jdk8, 6-jdk8-hotspot, 6.8.3-jdk, 6.8.3-jdk-hotspot, 6.8-jdk, 6.8-jdk-hotspot, 6-jdk, 6-jdk-hotspot, 6.8.3, 6.8.3-hotspot, 6.8, 6.8-hotspot, 6, 6-hotspot
+GitFetch: refs/heads/6
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: hotspot/jdk8
+
+Tags: 6.8.3-jre8, 6.8.3-jre8-hotspot, 6.8-jre8, 6.8-jre8-hotspot, 6-jre8, 6-jre8-hotspot, 6.8.3-jre, 6.8.3-jre-hotspot, 6.8-jre, 6.8-jre-hotspot, 6-jre, 6-jre-hotspot
+GitFetch: refs/heads/6
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: hotspot/jre8
+
+Tags: 6.8.3-jdk11, 6.8.3-jdk11-hotspot, 6.8-jdk11, 6.8-jdk11-hotspot, 6-jdk11, 6-jdk11-hotspot
+GitFetch: refs/heads/6
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: hotspot/jdk11
+
+Tags: 6.8.3-jre11, 6.8.3-jre11-hotspot, 6.8-jre11, 6.8-jre11-hotspot, 6-jre11, 6-jre11-hotspot
+GitFetch: refs/heads/6
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: hotspot/jre11
+
+
+# Gradle 6.x OpenJ9
+
+Tags: 6.8.3-jdk8-openj9, 6.8-jdk8-openj9, 6-jdk8-openj9, 6.8.3-jdk-openj9, 6.8-jdk-openj9, 6-jdk-openj9, 6.8.3-openj9, 6.8-openj9, 6-openj9
+GitFetch: refs/heads/6
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: openj9/jdk8
+
+Tags: 6.8.3-jre8-openj9, 6.8-jre8-openj9, 6-jre8-openj9, 6.8.3-jre-openj9, 6.8-jre-openj9, 6-jre-openj9
+GitFetch: refs/heads/6
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: openj9/jre8
+
+Tags: 6.8.3-jdk11-openj9, 6.8-jdk11-openj9, 6-jdk11-openj9
+GitFetch: refs/heads/6
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: openj9/jdk11
+
+Tags: 6.8.3-jre11-openj9, 6.8-jre11-openj9, 6-jre11-openj9
+GitFetch: refs/heads/6
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 019489a1187aac1788f5369048c34969462a0456
+Directory: openj9/jre11


### PR DESCRIPTION
Gradle is backporting some Gradle 7 features to the 6.x line, with an upcoming 6.9 release, so we'll need to publish images for both for some period of time.