### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.15-rc.2, 3.8-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c9e77ef2e7b569523ba6f01dd84ed1315b62903
+GitCommit: 8983f3a2000b26a5658fccc99ee9fa3d66760d76
 Directory: 3.8-rc/ubuntu
 
 Tags: 3.8.15-rc.2-management, 3.8-rc-management
@@ -16,7 +16,7 @@ Directory: 3.8-rc/ubuntu/management
 
 Tags: 3.8.15-rc.2-alpine, 3.8-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c9e77ef2e7b569523ba6f01dd84ed1315b62903
+GitCommit: 8983f3a2000b26a5658fccc99ee9fa3d66760d76
 Directory: 3.8-rc/alpine
 
 Tags: 3.8.15-rc.2-management-alpine, 3.8-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.8-rc/alpine/management
 
 Tags: 3.8.14, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 10fb3def4f912ed753d81917ce6bdb48cd6a5f36
+GitCommit: 06aa7a5fb49fbc81e4264bf259ddde888d120b75
 Directory: 3.8/ubuntu
 
 Tags: 3.8.14-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.14-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 10fb3def4f912ed753d81917ce6bdb48cd6a5f36
+GitCommit: 06aa7a5fb49fbc81e4264bf259ddde888d120b75
 Directory: 3.8/alpine
 
 Tags: 3.8.14-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8983f3a: Update 3.8-rc to otp 23.3.2
- https://github.com/docker-library/rabbitmq/commit/06aa7a5: Update 3.8 to otp 23.3.2