### PR TITLE
Update base image for all 6.x version of Couchbase Server

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -10,13 +10,60 @@ GitCommit: 705652faaef8f56988ba13d181cb00109c7263d4
 Directory: community/couchbase-server/7.0.0-beta
 
 Tags: latest, enterprise, 6.6.2, enterprise-6.6.2
-GitCommit: 9258627737f48d0b7c1015f48fdfd6242aefba6c
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
 Directory: enterprise/couchbase-server/6.6.2
 
 Tags: community, community-6.6.0
-GitCommit: 78cbcaa2c90ce4c975299e7cbfdce146a7bab081
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
 Directory: community/couchbase-server/6.6.0
 
 Tags: 6.0.5, enterprise-6.0.5
-GitCommit: fdd43ff22dbb4b10f262e95acef6b945dfacf214
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
 Directory: enterprise/couchbase-server/6.0.5
+
+# One-off updates of older versions as we have updated the
+# Ubuntu base image version to address security vulnerabilities
+
+Tags: 6.6.1, enterprise-6.6.1
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.6.1
+
+Tags: 6.6.0, enterprise-6.6.0
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.6.0
+
+Tags: 6.5.1, enterprise-6.5.1
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.5.1
+
+Tags: 6.5.0, enterprise-6.5.0
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.5.0
+
+Tags: 6.0.4, enterprise-6.0.4
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.0.4
+
+Tags: 6.0.3, enterprise-6.0.3
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.0.3
+
+Tags: 6.0.2, enterprise-6.0.2
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.0.2
+
+Tags: 6.0.1, enterprise-6.0.1
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: enterprise/couchbase-server/6.0.1
+
+Tags: 6.6.0, community-6.6.0
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: community/couchbase-server/6.6.0
+
+Tags: 6.5.1, community-6.5.1
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: community/couchbase-server/6.5.1
+
+Tags: 6.5.0, community-6.5.0
+GitCommit: fcda63424981fe67800c4e6adcea13ddf1f33cbf
+Directory: community/couchbase-server/6.5.1


### PR DESCRIPTION
We have updated the base image for all 6.x versions (except 6.0.0) to Ubuntu 18.04, and 6.6.2 to Ubuntu 20.04, as those are the newest versions of Ubuntu supported by the corresponding Server versions. This change updates the active 6.x images as well as a one-time update of all earlier 6.x versions. Those earlier versions will be removed from the next PR for library/couchbase.