### PR TITLE
MariaDB 10.6.0 alpha release, 10.1 is EOL

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,8 +1,13 @@
-# this file is generated via https://github.com/docker-library/mariadb/blob/c969655b3c92a1ae3f066e506ab7b32ff4ba4582/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/b180797cece7d65e23156fd872368e34d3d2a757/generate-stackbrew-library.sh
 
-Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
-             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
-GitRepo: https://github.com/docker-library/mariadb.git
+Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
+             Daniel Bartholomew <dbart@mariadb.com> (@dbart)
+GitRepo: https://github.com/MariaDB/mariadb-docker.git
+
+Tags: 10.6.0-focal, 10.6-focal, alpha-focal, 10.6.0, 10.6, alpha
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 40c61c4726ab063708a7f4137b81b39773e7dbd1
+Directory: 10.6
 
 Tags: 10.5.9-focal, 10.5-focal, 10-focal, focal, 10.5.9, 10.5, 10, latest
 Architectures: amd64, arm64v8, ppc64le
@@ -23,8 +28,3 @@ Tags: 10.2.37-bionic, 10.2-bionic, 10.2.37, 10.2
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f0e04a7e0e4b7d83691efc889865da8d6ae5f00e
 Directory: 10.2
-
-Tags: 10.1.48-bionic, 10.1-bionic, 10.1.48, 10.1
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0d197a924990af521cded73d04f113b06488844f
-Directory: 10.1


### PR DESCRIPTION
Hi,

We've done our 10.6.0 alpha release.

I've tested this against some updated tests https://github.com/grooverdan/official-images/blob/mariadb-tests/test/tests/mariadb-extras/run.sh that passes, (though it depends on local mysql for connections, so I do need to clean that up before submitting).

Next major release will be coming soon.