### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
 Directory: 2.3/alpine
 
-Tags: 2.2.13, 2.2, lts
+Tags: 2.2.14, 2.2, lts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbf6af629fb5b81eaa1fbb2b8f28655b679e8ae5
+GitCommit: 99d68b7d5b3ec68cdfcb7e0cef173e054d491bcb
 Directory: 2.2
 
-Tags: 2.2.13-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.14-alpine, 2.2-alpine, lts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fbf6af629fb5b81eaa1fbb2b8f28655b679e8ae5
+GitCommit: 99d68b7d5b3ec68cdfcb7e0cef173e054d491bcb
 Directory: 2.2/alpine
 
 Tags: 2.0.22, 2.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/99d68b7: Update 2.2 to 2.2.14