### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,26 +1,33 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/7f1fc5e8be598446b2546b808572db546e959643/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/bb63178b4a0781555d904c3ac3897c9b81d922c8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2021-04-08
-Tags: 10.3.0, 10.3, 10, latest
+# Last Modified: 2021-04-27
+Tags: 11.1.0, 11.1, 11, latest, 11.1.0-bullseye, 11.1-bullseye, 11-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 15b89bbc6190e30a0dd657473e0cc9bfbd13610d
+GitCommit: bb63178b4a0781555d904c3ac3897c9b81d922c8
+Directory: 11
+# Docker EOL: 2022-10-27
+
+# Last Modified: 2021-04-08
+Tags: 10.3.0, 10.3, 10, 10.3.0-buster, 10.3-buster, 10-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: bb63178b4a0781555d904c3ac3897c9b81d922c8
 Directory: 10
 # Docker EOL: 2022-10-08
 
 # Last Modified: 2020-03-12
-Tags: 9.3.0, 9.3, 9
+Tags: 9.3.0, 9.3, 9, 9.3.0-buster, 9.3-buster, 9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 05aef2fc627328e12bbf77aca44fd399a22c7fc4
+GitCommit: bb63178b4a0781555d904c3ac3897c9b81d922c8
 Directory: 9
 # Docker EOL: 2021-09-12
 
 # Last Modified: 2020-03-04
-Tags: 8.4.0, 8.4, 8
+Tags: 8.4.0, 8.4, 8, 8.4.0-buster, 8.4-buster, 8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 05aef2fc627328e12bbf77aca44fd399a22c7fc4
+GitCommit: bb63178b4a0781555d904c3ac3897c9b81d922c8
 Directory: 8
 # Docker EOL: 2021-09-04


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/9c37e98: Merge pull request https://github.com/docker-library/gcc/pull/74 from infosiftr/11
- https://github.com/docker-library/gcc/commit/bb63178: Add 11.1
- https://github.com/docker-library/gcc/commit/05ff5c9: Merge pull request https://github.com/docker-library/gcc/pull/72 from infosiftr/jq-template
- https://github.com/docker-library/gcc/commit/aa33004: Add initial jq-based templating engine