### PR TITLE
Update monica to v2.22.0

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -2,17 +2,17 @@
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 
-Tags: 2.21.0-apache, 2.21-apache, 2-apache, apache, 2.21.0, 2.21, 2, latest
+Tags: 2.22.0-apache, 2.22-apache, 2-apache, apache, 2.22.0, 2.22, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: b3f212609d699f9090f6087bd93d05405ef75ce8
+GitCommit: 58e3d7ac1610d85fdab3824c4054f71bc7372c9b
 
-Tags: 2.21.0-fpm, 2.21-fpm, 2-fpm, fpm
+Tags: 2.22.0-fpm, 2.22-fpm, 2-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: fpm
-GitCommit: b3f212609d699f9090f6087bd93d05405ef75ce8
+GitCommit: 58e3d7ac1610d85fdab3824c4054f71bc7372c9b
 
-Tags: 2.21.0-fpm-alpine, 2.21-fpm-alpine, 2-fpm-alpine, fpm-alpine
+Tags: 2.22.0-fpm-alpine, 2.22-fpm-alpine, 2-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: b3f212609d699f9090f6087bd93d05405ef75ce8
+GitCommit: 58e3d7ac1610d85fdab3824c4054f71bc7372c9b


### PR DESCRIPTION
Update monica to [v2.22.0](https://github.com/monicahq/monica/releases/tag/v2.22.0)
Remove sentry release commands from image