### PR TITLE
archlinux: Release 20210502.0.21321

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210425.0.20608
-GitCommit: d90390653741d84e557a6cbbb1d60738fdd4eee1
-GitFetch: refs/tags/v20210425.0.20608
+Tags: latest, base, base-20210502.0.21321
+GitCommit: 3300367f87e898f2a6ad278bb4084c4ea25bb30f
+GitFetch: refs/tags/v20210502.0.21321
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210425.0.20608
-GitCommit: d90390653741d84e557a6cbbb1d60738fdd4eee1
-GitFetch: refs/tags/v20210425.0.20608
+Tags: base-devel, base-devel-20210502.0.21321
+GitCommit: 3300367f87e898f2a6ad278bb4084c4ea25bb30f
+GitFetch: refs/tags/v20210502.0.21321
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks