### PR TITLE
Update Clear Linux OS to 34560

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 053d66913b6055fd64947f74e7b2c9daede7b4cc
-GitFetch: refs/tags/clear-linux-34540
+GitCommit: b155e09cc727f890848394426b59c6ce000b1072
+GitFetch: refs/tags/clear-linux-34560


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34560

@bryteise @mdhorn @phmccarty