### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev16, 2.4-dev
+Tags: 2.4-dev18, 2.4-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 787536c6d9ad19a63be432a411ae479133f083f7
+GitCommit: f4a6a117947695082117106a5dcc13007e384951
 Directory: 2.4-rc
 
-Tags: 2.4-dev16-alpine, 2.4-dev-alpine
+Tags: 2.4-dev18-alpine, 2.4-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 787536c6d9ad19a63be432a411ae479133f083f7
+GitCommit: f4a6a117947695082117106a5dcc13007e384951
 Directory: 2.4-rc/alpine
 
 Tags: 2.3.10, 2.3, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/f4a6a11: Update 2.4-rc to 2.4-dev18