### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 4.3.3, 4.3, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b18246e50008cec5d9e0a8bbf3d3e03a438f4ba2
+GitCommit: 24abc83b36c13caa3d96731f9fa7f41a0d215ba9
 Directory: 4/debian
 
 Tags: 4.3.3-alpine, 4.3-alpine, 4-alpine, alpine
@@ -23,13 +23,3 @@ Tags: 3.42.5-alpine, 3.42-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: aafa3aef4bd6d39c9b883fb1b477e9f85eb88504
 Directory: 3/alpine
-
-Tags: 2.38.3, 2.38, 2
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 43436c4d7ff4f323dce29012582fb311bde50c27
-Directory: 2/debian
-
-Tags: 2.38.3-alpine, 2.38-alpine, 2-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386
-GitCommit: 43436c4d7ff4f323dce29012582fb311bde50c27
-Directory: 2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/2df9376: Merge pull request https://github.com/docker-library/ghost/pull/259 from acburdine/fix/debian-nonamd
- https://github.com/docker-library/ghost/commit/24abc83: Fix Ghost 4.x Debian build on non-amd64 archs
- https://github.com/docker-library/ghost/commit/b18246e: Revert 4/alpine to Node 12, Alpine 3.12
- https://github.com/docker-library/ghost/commit/325f2b3: Update to 4.3.3, ghost-cli 1.16.3