### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.46, 2.4, 2, latest
+Tags: 2.4.47, 2.4, 2, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 077141ee37fca63972292c562ec0f632d0f831b1
+GitCommit: 08b2e41e4612102693429001b5f244ff7a0ab824
 Directory: 2.4
 
-Tags: 2.4.46-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.47-alpine, 2.4-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d36dfa56811155947b22eebb636bdfe9a74803a2
+GitCommit: 08b2e41e4612102693429001b5f244ff7a0ab824
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/08b2e41: Update to 2.4.47
- https://github.com/docker-library/httpd/commit/c38da8c: Update keys from https://downloads.apache.org/httpd/KEYS