### PR TITLE
[oraclelinux] Fix regression in amd64/oraclelinux:7 and 7-slim

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,7 +4,7 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9659a1eee1b45f63e47f1b937ba8908ecb690d14
+amd64-GitCommit: 806a4f9347b7944031bbd50612172cc321215f3a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
 arm64v8-GitCommit: 6202c28679f143f8d468aca80ab9f5645116dd6f


### PR DESCRIPTION
The kernel-container meta-package went missing briefly, but we
found it and put it back where it belongs.

Signed-off-by: Avi Miller <avi.miller@oracle.com>