### PR TITLE
caddy: v2.4.0-rc.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/384bfd3dac7009ad7095f511bef0a1528a2b2e8a/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/d1a09c6308adb9397a855fb7a591dd8d29240c4f/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.3.0-alpine, 2-alpine, alpine
@@ -14,7 +14,7 @@ Tags: 2.3.0-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.3.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.3/builder
-GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.3.0-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
@@ -37,7 +37,7 @@ Tags: 2.3.0-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, bu
 SharedTags: 2.3.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.3/windows-builder/1809
-GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -45,53 +45,53 @@ Tags: 2.3.0-builder-windowsservercore-ltsc2016, 2-builder-windowsservercore-ltsc
 SharedTags: 2.3.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.3/windows-builder/ltsc2016
-GitCommit: 02028a9680f6df392d10272f0f701f1c07a38601
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 
-Tags: 2.4.0-beta.2-alpine
-SharedTags: 2.4.0-beta.2
+Tags: 2.4.0-rc.1-alpine
+SharedTags: 2.4.0-rc.1
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/alpine
-GitCommit: 384bfd3dac7009ad7095f511bef0a1528a2b2e8a
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.4.0-beta.2-builder-alpine
-SharedTags: 2.4.0-beta.2-builder
+Tags: 2.4.0-rc.1-builder-alpine
+SharedTags: 2.4.0-rc.1-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/builder
-GitCommit: 384bfd3dac7009ad7095f511bef0a1528a2b2e8a
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.4.0-beta.2-windowsservercore-1809
-SharedTags: 2.4.0-beta.2-windowsservercore, 2.4.0-beta.2
+Tags: 2.4.0-rc.1-windowsservercore-1809
+SharedTags: 2.4.0-rc.1-windowsservercore, 2.4.0-rc.1
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows/1809
-GitCommit: 384bfd3dac7009ad7095f511bef0a1528a2b2e8a
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.4.0-beta.2-windowsservercore-ltsc2016
-SharedTags: 2.4.0-beta.2-windowsservercore, 2.4.0-beta.2
+Tags: 2.4.0-rc.1-windowsservercore-ltsc2016
+SharedTags: 2.4.0-rc.1-windowsservercore, 2.4.0-rc.1
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows/ltsc2016
-GitCommit: 384bfd3dac7009ad7095f511bef0a1528a2b2e8a
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 
-Tags: 2.4.0-beta.2-builder-windowsservercore-1809
-SharedTags: 2.4.0-beta.2-builder
+Tags: 2.4.0-rc.1-builder-windowsservercore-1809
+SharedTags: 2.4.0-rc.1-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows-builder/1809
-GitCommit: 384bfd3dac7009ad7095f511bef0a1528a2b2e8a
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.4.0-beta.2-builder-windowsservercore-ltsc2016
-SharedTags: 2.4.0-beta.2-builder
+Tags: 2.4.0-rc.1-builder-windowsservercore-ltsc2016
+SharedTags: 2.4.0-rc.1-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows-builder/ltsc2016
-GitCommit: 384bfd3dac7009ad7095f511bef0a1528a2b2e8a
+GitCommit: d1a09c6308adb9397a855fb7a591dd8d29240c4f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.4.0-rc.1

Also updates xcaddy - https://github.com/caddyserver/xcaddy/releases/tag/v0.1.9

Signed-off-by: Dave Henderson <dhenderson@gmail.com>