### PR TITLE
Update Monica v3.0.1

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -2,17 +2,17 @@
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 
-Tags: 3.0.0-apache, 3.0-apache, 3-apache, apache, 3.0.0, 3.0, 3, latest
+Tags: 3.0.1-apache, 3.0-apache, 3-apache, apache, 3.0.1, 3.0, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: 219154530e308d10d6dff32274ca1a8384c8f471
+GitCommit: 8e338da17d09d8b9a0b7b8c4aa734ecd400bca07
 
-Tags: 3.0.0-fpm, 3.0-fpm, 3-fpm, fpm
+Tags: 3.0.1-fpm, 3.0-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: fpm
-GitCommit: 219154530e308d10d6dff32274ca1a8384c8f471
+GitCommit: 8e338da17d09d8b9a0b7b8c4aa734ecd400bca07
 
-Tags: 3.0.0-fpm-alpine, 3.0-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.0.1-fpm-alpine, 3.0-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: 219154530e308d10d6dff32274ca1a8384c8f471
+GitCommit: 8e338da17d09d8b9a0b7b8c4aa734ecd400bca07


### PR DESCRIPTION
Update to [Monica v3.0.1](https://github.com/monicahq/monica/releases/tag/v3.0.1)
Remove imagick dependency, allowing us to switch to php8.0