### PR TITLE
Odoo: update 12.0-14.0 to release 20210506

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: ce4d60e845aa94bd30685df5b6598cbb5f6c8614
+GitCommit: c963853d004e7cb517e8229b60fd3e29197fdac9
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of supported Odoo versions.

Thanks