### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -1,12 +1,12 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/fc3182cf934fc112a0d9a4f819892d3f2450d05a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/3a41d66499222d90f2f4207c7f6dafd38f4001c5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 4.2.1, 4.2, 4, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7736d321ea194e82731f0fa79b8a91f053e36aa2
 Directory: 4.2
 
 Tags: 4.2.1-passenger, 4.2-passenger, 4-passenger, passenger
@@ -18,8 +18,8 @@ GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
 Directory: 4.2/alpine
 
 Tags: 4.1.3, 4.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7736d321ea194e82731f0fa79b8a91f053e36aa2
 Directory: 4.1
 
 Tags: 4.1.3-passenger, 4.1-passenger
@@ -31,7 +31,7 @@ GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
 Directory: 4.1/alpine
 
 Tags: 4.0.9, 4.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
 Directory: 4.0
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/c46672e: Merge pull request https://github.com/docker-library/redmine/pull/241 from orchitech/allow-ghostscript
- https://github.com/docker-library/redmine/commit/7736d32: Avoid changing imagemagicks' ghostscript policy for Redmine 4.0.
- https://github.com/docker-library/redmine/commit/db7be5c: Simplify sed according to @yosifkit's suggestion.
- https://github.com/docker-library/redmine/commit/37862c5: Allow ImageMagick to read ghostscript. See https://www.redmine.org/issues/34397. Fix https://github.com/docker-library/redmine/pull/225.
- https://github.com/docker-library/redmine/commit/3a41d66: Remove mips64le (no "gosu" until bullseye)