### PR TITLE
Mariadb release 20210510

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,25 +6,25 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.6.0-focal, 10.6-focal, alpha-focal, 10.6.0, 10.6, alpha
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 40c61c4726ab063708a7f4137b81b39773e7dbd1
+GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
 Directory: 10.6
 
-Tags: 10.5.9-focal, 10.5-focal, 10-focal, focal, 10.5.9, 10.5, 10, latest
+Tags: 10.5.10-focal, 10.5-focal, 10-focal, focal, 10.5.10, 10.5, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 5d57b119775458cd37994a0f313ea3a29603efbb
+GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
 Directory: 10.5
 
-Tags: 10.4.18-focal, 10.4-focal, 10.4.18, 10.4
+Tags: 10.4.19-focal, 10.4-focal, 10.4.19, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74078d37c547949e762bbabdd3b684f932c7be2e
+GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
 Directory: 10.4
 
-Tags: 10.3.28-focal, 10.3-focal, 10.3.28, 10.3
+Tags: 10.3.29-focal, 10.3-focal, 10.3.29, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ac4469cfa8e1a01093ce0a142ca0a03a5db58fce
+GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
 Directory: 10.3
 
-Tags: 10.2.37-bionic, 10.2-bionic, 10.2.37, 10.2
+Tags: 10.2.38-bionic, 10.2-bionic, 10.2.38, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f0e04a7e0e4b7d83691efc889865da8d6ae5f00e
+GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
 Directory: 10.2


### PR DESCRIPTION
We've done our MariaDB 2021 Q2 releases: MariaDB 10.5.10, 10.4.19, 10.3.29, and 10.2.38.