### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-21-jdk-oraclelinux8, 17-ea-21-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-21-jdk-oracle, 17-ea-21-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-21-jdk, 17-ea-21, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-22-jdk-oraclelinux8, 17-ea-22-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-22-jdk-oracle, 17-ea-22-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-22-jdk, 17-ea-22, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-21-jdk-oraclelinux7, 17-ea-21-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-22-jdk-oraclelinux7, 17-ea-22-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-21-jdk-buster, 17-ea-21-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-22-jdk-buster, 17-ea-22-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/buster
 
-Tags: 17-ea-21-jdk-slim-buster, 17-ea-21-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-21-jdk-slim, 17-ea-21-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-22-jdk-slim-buster, 17-ea-22-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-22-jdk-slim, 17-ea-22-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-14-jdk-alpine3.13, 17-ea-14-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-14-jdk-alpine, 17-ea-14-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,24 +35,24 @@ Architectures: amd64
 GitCommit: 255fbc7cf6da6d76869b420dd2fe0bc94539b5eb
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-21-jdk-windowsservercore-1809, 17-ea-21-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-21-jdk-windowsservercore, 17-ea-21-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-21-jdk, 17-ea-21, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-22-jdk-windowsservercore-1809, 17-ea-22-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-22-jdk-windowsservercore, 17-ea-22-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-22-jdk, 17-ea-22, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-21-jdk-windowsservercore-ltsc2016, 17-ea-21-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-21-jdk-windowsservercore, 17-ea-21-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-21-jdk, 17-ea-21, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-22-jdk-windowsservercore-ltsc2016, 17-ea-22-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-22-jdk-windowsservercore, 17-ea-22-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-22-jdk, 17-ea-22, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-21-jdk-nanoserver-1809, 17-ea-21-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-21-jdk-nanoserver, 17-ea-21-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-22-jdk-nanoserver-1809, 17-ea-22-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-22-jdk-nanoserver, 17-ea-22-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: a3a76b8b5c583d10a76028c52a0a09b8e411be0c
+GitCommit: 5406fd20087c806d912d794bcc02494de917bf61
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5406fd2: Update 17 to 17-ea+22