### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,35 +1,45 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/39812f8f0bb3a6c8777a018bbd5d251723367e1f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/ae10fbf9bae067e11222c34344c9032060ffa997/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.4-dev19, 2.4-dev
+Tags: 2.5-dev0, 2.5-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ac5bde7aa48b02c971cfc27b862e428d4c223c09
-Directory: 2.4-rc
+GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+Directory: 2.5-rc
 
-Tags: 2.4-dev19-alpine, 2.4-dev-alpine
+Tags: 2.5-dev0-alpine, 2.5-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ac5bde7aa48b02c971cfc27b862e428d4c223c09
-Directory: 2.4-rc/alpine
+GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+Directory: 2.5-rc/alpine
 
-Tags: 2.3.10, 2.3, latest
+Tags: 2.4.0, 2.4, lts, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+Directory: 2.4
+
+Tags: 2.4.0-alpine, 2.4-alpine, lts-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+Directory: 2.4/alpine
+
+Tags: 2.3.10, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
 Directory: 2.3
 
-Tags: 2.3.10-alpine, 2.3-alpine, alpine
+Tags: 2.3.10-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
 Directory: 2.3/alpine
 
-Tags: 2.2.14, 2.2, lts
+Tags: 2.2.14, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 99d68b7d5b3ec68cdfcb7e0cef173e054d491bcb
 Directory: 2.2
 
-Tags: 2.2.14-alpine, 2.2-alpine, lts-alpine
+Tags: 2.2.14-alpine, 2.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 99d68b7d5b3ec68cdfcb7e0cef173e054d491bcb
 Directory: 2.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/dc78844: Merge pull request https://github.com/docker-library/haproxy/pull/157 from TimWolla/2.4-gold
- https://github.com/docker-library/haproxy/commit/ae10fbf: Add HAProxy 2.4 / 2.5-rc