### PR TITLE
21.0.0.5 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 6b6c72047caece0a9ff0e58ca02f78f520d1c363
+GitCommit: 651f2794c93bc454aeae12eda58be1430f731e0e
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: a84c9e6b2adefcf1f8d830f533222b087874aefb
+GitCommit: 6b6c72047caece0a9ff0e58ca02f78f520d1c363
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -35,23 +35,23 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.4-kernel-slim-java8-openj9
-Directory: releases/21.0.0.4/kernel-slim
+Tags: 21.0.0.5-kernel-slim-java8-openj9
+Directory: releases/21.0.0.5/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.4-kernel-slim-java11-openj9
-Directory: releases/21.0.0.4/kernel-slim
+Tags: 21.0.0.5-kernel-slim-java11-openj9
+Directory: releases/21.0.0.5/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.4-full-java8-openj9
-Directory: releases/21.0.0.4/full
+Tags: 21.0.0.5-full-java8-openj9
+Directory: releases/21.0.0.5/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.4-full-java11-openj9
-Directory: releases/21.0.0.4/full
+Tags: 21.0.0.5-full-java11-openj9
+Directory: releases/21.0.0.5/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 498fd2562d74c98227db511bd7920c2406b4d921
+GitCommit: 6b6c72047caece0a9ff0e58ca02f78f520d1c363
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -23,21 +23,21 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.4-kernel-java8-ibmjava
-Directory: ga/21.0.0.4/kernel
+Tags: 21.0.0.5-kernel-java8-ibmjava
+Directory: ga/21.0.0.5/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.4-kernel-java11-openj9
-Directory: ga/21.0.0.4/kernel
+Tags: 21.0.0.5-kernel-java11-openj9
+Directory: ga/21.0.0.5/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.4-full-java8-ibmjava
-Directory: ga/21.0.0.4/full
+Tags: 21.0.0.5-full-java8-ibmjava
+Directory: ga/21.0.0.5/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.4-full-java11-openj9
-Directory: ga/21.0.0.4/full
+Tags: 21.0.0.5-full-java11-openj9
+Directory: ga/21.0.0.5/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 6b6c72047caece0a9ff0e58ca02f78f520d1c363
+GitCommit: 8d30234391a62a3a6b2c32b45801cb5e914781fa
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
Updates to `open-liberty` and `websphere-liberty` for the release of Liberty version 21.0.0.5.