### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,29 +1,8 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/11ebf982a9e74941ae5ed584afa5c322a267869c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/77e66571efd350467bc552ad80f127837e1af726/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
-
-Tags: 3.6.23-xenial, 3.6-xenial, 3-xenial
-SharedTags: 3.6.23, 3.6, 3
-# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/3.6/multiverse/
-Architectures: amd64, arm64v8
-GitCommit: b9073238e2a724f76e5f587a663baa55ab902e26
-Directory: 3.6
-
-Tags: 3.6.23-windowsservercore-1809, 3.6-windowsservercore-1809, 3-windowsservercore-1809
-SharedTags: 3.6.23-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.23, 3.6, 3
-Architectures: windows-amd64
-GitCommit: 38648d9dddd6a6f87f0d47885bf6525c20b63557
-Directory: 3.6/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 3.6.23-windowsservercore-ltsc2016, 3.6-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016
-SharedTags: 3.6.23-windowsservercore, 3.6-windowsservercore, 3-windowsservercore, 3.6.23, 3.6, 3
-Architectures: windows-amd64
-GitCommit: 38648d9dddd6a6f87f0d47885bf6525c20b63557
-Directory: 3.6/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 4.0.24-xenial, 4.0-xenial
 SharedTags: 4.0.24, 4.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/77e6657: Remove 3.6 (EOL)