### PR TITLE
Update Clear Linux OS to 34620

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 1f75f0cd59b7fab26eeb2b12c4300a2e24a60ba0
-GitFetch: refs/tags/clear-linux-34590
+GitCommit: 17e8296aae4e34df56f4a9c0d03c15866ca358f3
+GitFetch: refs/tags/clear-linux-34620


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34620

@bryteise @mdhorn @phmccarty