### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: a5937a0b39e55c174007c2b9c2f363cdd2142818
 Directory: 9
 # Docker EOL: 2021-09-12
 
-# Last Modified: 2020-03-04
-Tags: 8.4.0, 8.4, 8, 8.4.0-buster, 8.4-buster, 8-buster
+# Last Modified: 2021-05-14
+Tags: 8.5.0, 8.5, 8, 8.5.0-buster, 8.5-buster, 8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5937a0b39e55c174007c2b9c2f363cdd2142818
+GitCommit: 93a66921c867fd54e7672e852a8aec4619fbc6de
 Directory: 8
-# Docker EOL: 2021-09-04
+# Docker EOL: 2022-11-14


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/93a6692: Update 8 to 8.5.0