### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3f0bdcbb46cc3f2ab7840278c9a5df6d595e52ff/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/4c1cc3e2d43b6d10c9cd58d69f01f7a5aab1860e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3f0bdcbb46cc3f2ab7840278c9a5df6d595e52ff
+GitCommit: 4c1cc3e2d43b6d10c9cd58d69f01f7a5aab1860e
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 01c0252fd2b32f3408a302996a1b8c6a583ef444
+amd64-GitCommit: 6a3fa4f3ee1437da18f6f017b75e7799b1ae910b
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 84bd038d5d9c4b5a1d550af1f77e717df3f5fd4d
+arm32v5-GitCommit: 7ba4db1c418f6ee955d47feadbfaa4421d6f9358
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 860ecd095f287daa2204cef1ef9728a29806cddd
+arm32v6-GitCommit: ac3117388507e850afc3e3f3661aa5a67ddb005f
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 12cb690b64557eb287d12657f806666c6083245a
+arm32v7-GitCommit: 1c90f843655937f14f4311393f83e999b84a854e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 345f3879292eb531527f360beec3edfe07a183fa
+arm64v8-GitCommit: d099efc0995072b40690aca7ae12b1153d86d4b8
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 64abb775125e4237de3b25dc7b2b461e6cfaa480
+i386-GitCommit: 11fa6cd31028cbe8ecd00e34b4714c6cd11005d8
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: a2e6a487308e45ccea49403b0a34ca77330ec97d
+mips64le-GitCommit: 809376c5217a280406d2f8738655be68f4073638
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: d5e7563c9b388bdbc811f0094dec9492aee0f18f
+ppc64le-GitCommit: 3556e81fab641ab84ead9635e508f5e321a77c35
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 6b7489397f9edf3b40ac885f680aa490cc1f5f30
+s390x-GitCommit: 2003d909bde49b85d0684909bec5e7cfdec48d67
 
 Tags: 1.33.1-uclibc, 1.33-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/4c1cc3e: Merge pull request https://github.com/docker-library/busybox/pull/103 from infosiftr/buildroot-2021.02.2
- https://github.com/docker-library/busybox/commit/8ef06f8: Update Buildroot to 2021.02.2