### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,68 +1,113 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/77e66571efd350467bc552ad80f127837e1af726/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/6377a52b25e9b7790c7082fbdc3f587069255d27/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 4.0.24-xenial, 4.0-xenial
-SharedTags: 4.0.24, 4.0
-# see http://repo.mongodb.org/apt/ubuntu/dists/xenial/mongodb-org/4.0/multiverse/
+Tags: 4.9.0-rc1-focal, 4.9-rc-focal
+SharedTags: 4.9.0-rc1, 4.9-rc
 Architectures: amd64, arm64v8
-GitCommit: b9073238e2a724f76e5f587a663baa55ab902e26
-Directory: 4.0
+GitCommit: 2e9ea18db4f51698949cbc0416fea3bf89aa1e03
+Directory: 4.9-rc
 
-Tags: 4.0.24-windowsservercore-1809, 4.0-windowsservercore-1809
-SharedTags: 4.0.24-windowsservercore, 4.0-windowsservercore, 4.0.24, 4.0
+Tags: 4.9.0-rc1-windowsservercore-1809, 4.9-rc-windowsservercore-1809
+SharedTags: 4.9.0-rc1-windowsservercore, 4.9-rc-windowsservercore, 4.9.0-rc1, 4.9-rc
 Architectures: windows-amd64
-GitCommit: 8806928aa5596f4b310dc2d9371a6e153f18d3b4
-Directory: 4.0/windows/windowsservercore-1809
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.9-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.0.24-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016
-SharedTags: 4.0.24-windowsservercore, 4.0-windowsservercore, 4.0.24, 4.0
+Tags: 4.9.0-rc1-windowsservercore-ltsc2016, 4.9-rc-windowsservercore-ltsc2016
+SharedTags: 4.9.0-rc1-windowsservercore, 4.9-rc-windowsservercore, 4.9.0-rc1, 4.9-rc
 Architectures: windows-amd64
-GitCommit: 8806928aa5596f4b310dc2d9371a6e153f18d3b4
-Directory: 4.0/windows/windowsservercore-ltsc2016
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.9-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.2.14-bionic, 4.2-bionic
-SharedTags: 4.2.14, 4.2
-# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.2/multiverse/
-Architectures: amd64, arm64v8
-GitCommit: b9073238e2a724f76e5f587a663baa55ab902e26
-Directory: 4.2
-
-Tags: 4.2.14-windowsservercore-1809, 4.2-windowsservercore-1809
-SharedTags: 4.2.14-windowsservercore, 4.2-windowsservercore, 4.2.14, 4.2
+Tags: 4.9.0-rc1-nanoserver-1809, 4.9-rc-nanoserver-1809
+SharedTags: 4.9.0-rc1-nanoserver, 4.9-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: d328982a097f4f1224a95097ede86a5b23b32ac8
-Directory: 4.2/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 4.2.14-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016
-SharedTags: 4.2.14-windowsservercore, 4.2-windowsservercore, 4.2.14, 4.2
-Architectures: windows-amd64
-GitCommit: d328982a097f4f1224a95097ede86a5b23b32ac8
-Directory: 4.2/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.9-rc/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 4.4.6-bionic, 4.4-bionic, 4-bionic, bionic
 SharedTags: 4.4.6, 4.4, 4, latest
-# see http://repo.mongodb.org/apt/ubuntu/dists/bionic/mongodb-org/4.4/multiverse/
 Architectures: amd64, arm64v8, s390x
-GitCommit: 447e058c5615b47aae283110c4f36c7ea48ccc2f
+GitCommit: 791d400b9e84a298356b78db01956d98db973b9d
 Directory: 4.4
 
 Tags: 4.4.6-windowsservercore-1809, 4.4-windowsservercore-1809, 4-windowsservercore-1809, windowsservercore-1809
 SharedTags: 4.4.6-windowsservercore, 4.4-windowsservercore, 4-windowsservercore, windowsservercore, 4.4.6, 4.4, 4, latest
 Architectures: windows-amd64
-GitCommit: 447e058c5615b47aae283110c4f36c7ea48ccc2f
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
 Directory: 4.4/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 4.4.6-windowsservercore-ltsc2016, 4.4-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 4.4.6-windowsservercore, 4.4-windowsservercore, 4-windowsservercore, windowsservercore, 4.4.6, 4.4, 4, latest
 Architectures: windows-amd64
-GitCommit: 447e058c5615b47aae283110c4f36c7ea48ccc2f
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
 Directory: 4.4/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
+
+Tags: 4.4.6-nanoserver-1809, 4.4-nanoserver-1809, 4-nanoserver-1809, nanoserver-1809
+SharedTags: 4.4.6-nanoserver, 4.4-nanoserver, 4-nanoserver, nanoserver
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.4/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
+
+Tags: 4.2.14-bionic, 4.2-bionic
+SharedTags: 4.2.14, 4.2
+Architectures: amd64, arm64v8
+GitCommit: 791d400b9e84a298356b78db01956d98db973b9d
+Directory: 4.2
+
+Tags: 4.2.14-windowsservercore-1809, 4.2-windowsservercore-1809
+SharedTags: 4.2.14-windowsservercore, 4.2-windowsservercore, 4.2.14, 4.2
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.2/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 4.2.14-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016
+SharedTags: 4.2.14-windowsservercore, 4.2-windowsservercore, 4.2.14, 4.2
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.2/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 4.2.14-nanoserver-1809, 4.2-nanoserver-1809
+SharedTags: 4.2.14-nanoserver, 4.2-nanoserver
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.2/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
+
+Tags: 4.0.24-xenial, 4.0-xenial
+SharedTags: 4.0.24, 4.0
+Architectures: amd64, arm64v8
+GitCommit: 791d400b9e84a298356b78db01956d98db973b9d
+Directory: 4.0
+
+Tags: 4.0.24-windowsservercore-1809, 4.0-windowsservercore-1809
+SharedTags: 4.0.24-windowsservercore, 4.0-windowsservercore, 4.0.24, 4.0
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.0/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 4.0.24-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016
+SharedTags: 4.0.24-windowsservercore, 4.0-windowsservercore, 4.0.24, 4.0
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.0/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 4.0.24-nanoserver-1809, 4.0-nanoserver-1809
+SharedTags: 4.0.24-nanoserver, 4.0-nanoserver
+Architectures: windows-amd64
+GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+Directory: 4.0/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/dc35ba5: Add nanoserver-1809 container images using multi-stage builds (https://github.com/docker-library/mongo/pull/470)
- https://github.com/docker-library/mongo/commit/b3edd5a: Merge pull request https://github.com/docker-library/mongo/pull/472 from infosiftr/4.9-rc
- https://github.com/docker-library/mongo/commit/2e9ea18: Add 4.9-rc
- https://github.com/docker-library/mongo/commit/7ae285a: Merge pull request https://github.com/docker-library/mongo/pull/471 from infosiftr/jq-template
- https://github.com/docker-library/mongo/commit/791d400: Add initial jq-based templating engine
- https://github.com/docker-library/mongo/commit/77e6657: Remove 3.6 (EOL)