### PR TITLE
Update clojure tools-deps to 1.10.3.839

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wesmorgan@icloud.com> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: ddaecf97aff00c99cd80cba172967c9b8cad58fd
+GitCommit: 4d4751ded99e88117aff8487eeba0fb466723ab3
 
 Tags: latest
 Directory: target/openjdk-11-slim-buster/latest
@@ -23,11 +23,11 @@ Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Architectures: amd64
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.833, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.833-buster
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.839, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.839-buster
 Architectures: amd64
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.833-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.839-slim-buster
 Architectures: amd64
 Directory: target/openjdk-8-slim-buster/tools-deps
 
@@ -43,10 +43,10 @@ Directory: target/openjdk-11-buster/boot
 Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.833, tools-deps, tools-deps-1.10.3.833, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.833-buster, tools-deps-buster, tools-deps-1.10.3.833-buster
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.839, tools-deps, tools-deps-1.10.3.839, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.839-buster, tools-deps-buster, tools-deps-1.10.3.839-buster
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.833-slim-buster, tools-deps-1.10.3.833-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.839-slim-buster, tools-deps-1.10.3.839-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
 Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.6, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.6-slim-buster
@@ -61,10 +61,10 @@ Directory: target/openjdk-16-slim-buster/boot
 Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
 Directory: target/openjdk-16-buster/boot
 
-Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.3.833, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.3.833-slim-buster
+Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.3.839, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.3.839-slim-buster
 Directory: target/openjdk-16-slim-buster/tools-deps
 
-Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.3.833-buster
+Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.3.839-buster
 Directory: target/openjdk-16-buster/tools-deps
 
 Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.6, openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.6-slim-buster
@@ -79,10 +79,10 @@ Directory: target/openjdk-17-slim-buster/boot
 Tags: openjdk-17-boot-buster, openjdk-17-boot-2.8.3-buster
 Directory: target/openjdk-17-buster/boot
 
-Tags: openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.833, openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.833-slim-buster
+Tags: openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.839, openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.839-slim-buster
 Directory: target/openjdk-17-slim-buster/tools-deps
 
-Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.833-buster
+Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.839-buster
 Directory: target/openjdk-17-buster/tools-deps
 
 Tags: openjdk-17-alpine, openjdk-17-lein-alpine, openjdk-17-lein-2.9.6-alpine
@@ -93,6 +93,6 @@ Tags: openjdk-17-boot-alpine, openjdk-17-boot-2.8.3-alpine
 Architectures: amd64
 Directory: target/openjdk-17-alpine/boot
 
-Tags: openjdk-17-tools-deps-alpine, openjdk-17-tools-deps-1.10.3.833-alpine
+Tags: openjdk-17-tools-deps-alpine, openjdk-17-tools-deps-1.10.3.839-alpine
 Architectures: amd64
 Directory: target/openjdk-17-alpine/tools-deps


### PR DESCRIPTION
This should hopefully fix the `clj` breakage in 1.10.3.833.