### PR TITLE
Fix bugs in influxdb 2.0 entrypoint scripts.

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
 Maintainers: Cody Shepherd (@codyshepherd), Daniel Moran <dmoran@influxdata.com> (@danxmoran)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 9cde7f32f367c48d2eda0ff811a8c7f367da7de4
+GitCommit: cfa0798e377578bedd622011cc2948c0993121f9
 
 Tags: 1.7, 1.7.11
 Architectures: amd64, arm32v7, arm64v8


### PR DESCRIPTION
* Remove arbitrary timeout from initial DB boot.
* Skip booting temporary DB instance if not needed.
* Detect and handle when --help is passed.
* Detect and handle when TLS is enabled in DB config.