### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,60 +6,60 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.7.2-apache, 5.7-apache, 5-apache, apache, 5.7.2, 5.7, 5, latest, 5.7.2-php7.4-apache, 5.7-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.7.2-php7.4, 5.7-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php7.4/apache
 
 Tags: 5.7.2-fpm, 5.7-fpm, 5-fpm, fpm, 5.7.2-php7.4-fpm, 5.7-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php7.4/fpm
 
 Tags: 5.7.2-fpm-alpine, 5.7-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.7.2-php7.4-fpm-alpine, 5.7-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php7.4/fpm-alpine
 
 Tags: 5.7.2-php7.3-apache, 5.7-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.7.2-php7.3, 5.7-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php7.3/apache
 
 Tags: 5.7.2-php7.3-fpm, 5.7-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php7.3/fpm
 
 Tags: 5.7.2-php7.3-fpm-alpine, 5.7-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php7.3/fpm-alpine
 
 Tags: 5.7.2-php8.0-apache, 5.7-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.7.2-php8.0, 5.7-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php8.0/apache
 
 Tags: 5.7.2-php8.0-fpm, 5.7-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php8.0/fpm
 
 Tags: 5.7.2-php8.0-fpm-alpine, 5.7-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d6cedc3a993142ed4597579ad4084b9a81cd3e59
+GitCommit: 16151c9fb776b1b83fd9275eac48278890824620
 Directory: latest/php8.0/fpm-alpine
 
-Tags: cli-2.4.0, cli-2.4, cli-2, cli, cli-2.4.0-php7.4, cli-2.4-php7.4, cli-2-php7.4, cli-php7.4
+Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e068a27fd0f3885c04af0f0c40347bc34bbf569
+GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
 Directory: cli/php7.4/alpine
 
-Tags: cli-2.4.0-php7.3, cli-2.4-php7.3, cli-2-php7.3, cli-php7.3
+Tags: cli-2.5.0-php7.3, cli-2.5-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e068a27fd0f3885c04af0f0c40347bc34bbf569
+GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
 Directory: cli/php7.3/alpine
 
-Tags: cli-2.4.0-php8.0, cli-2.4-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.5.0-php8.0, cli-2.5-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ee3c59f90e29e2cf0087053a1d016c8186cab6ab
+GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
 Directory: cli/php8.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/9300bc2: Update cli to 2.5.0
- https://github.com/docker-library/wordpress/commit/16151c9: Apply more upstream config adjustments
- https://github.com/docker-library/wordpress/commit/856567c: Update wp-config comments to match upstream sample changes