### PR TITLE
[nats] Release v2.2.5

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -3,31 +3,31 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Waldemar Salinas <wally@synadia.com> (@wallyqs),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 9d4d58aeba59153d14e4c8977f1309975d87670f
+GitCommit: 2856206f91b57e45d8e4cc3312eb0df8ba9ee4cd
 
-Tags: 2.2.4-alpine3.13, 2.2-alpine3.13, 2-alpine3.13, alpine3.13, 2.2.4-alpine, 2.2-alpine, 2-alpine, alpine
+Tags: 2.2.5-alpine3.13, 2.2-alpine3.13, 2-alpine3.13, alpine3.13, 2.2.5-alpine, 2.2-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.2.4/alpine3.13
+Directory: 2.2.5/alpine3.13
 
-Tags: 2.2.4-scratch, 2.2-scratch, 2-scratch, scratch, 2.2.4-linux, 2.2-linux, 2-linux, linux
-SharedTags: 2.2.4, 2.2, 2, latest
+Tags: 2.2.5-scratch, 2.2-scratch, 2-scratch, scratch, 2.2.5-linux, 2.2-linux, 2-linux, linux
+SharedTags: 2.2.5, 2.2, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.2.4/scratch
+Directory: 2.2.5/scratch
 
-Tags: 2.2.4-windowsservercore-1809, 2.2-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.2.4-windowsservercore, 2.2-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.2.5-windowsservercore-1809, 2.2-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.2.5-windowsservercore, 2.2-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.2.4/windowsservercore-1809
+Directory: 2.2.5/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.2.4-nanoserver-1809, 2.2-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.2.4-nanoserver, 2.2-nanoserver, 2-nanoserver, nanoserver, 2.2.4, 2.2, 2, latest
+Tags: 2.2.5-nanoserver-1809, 2.2-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.2.5-nanoserver, 2.2-nanoserver, 2-nanoserver, nanoserver, 2.2.5, 2.2, 2, latest
 Architectures: windows-amd64
-Directory: 2.2.4/nanoserver-1809
+Directory: 2.2.5/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.2.4-windowsservercore-ltsc2016, 2.2-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.2.4-windowsservercore, 2.2-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.2.5-windowsservercore-ltsc2016, 2.2-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.2.5-windowsservercore, 2.2-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.2.4/windowsservercore-ltsc2016
+Directory: 2.2.5/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.2.5)

Doc PR: https://github.com/docker-library/docs/pull/1961

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>