### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.8.16, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1808fc2040150a8ea7c8bbcb291fdb1536b4ca2
+GitCommit: 445123fab775aceb924181b99821c82551128cfa
 Directory: 3.8/ubuntu
 
 Tags: 3.8.16-management, 3.8-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.16-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f1808fc2040150a8ea7c8bbcb291fdb1536b4ca2
+GitCommit: 445123fab775aceb924181b99821c82551128cfa
 Directory: 3.8/alpine
 
 Tags: 3.8.16-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/bee7a1c: Update 3.8-rc to otp 23.3.4.1
- https://github.com/docker-library/rabbitmq/commit/445123f: Update 3.8 to otp 23.3.4.1