### PR TITLE
library/perl: update for 5.34.0 + rebuild for older versions

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,89 +1,443 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 738a3ccc0f422408c153aa9b3d58d7403b7aed0c
+GitCommit: 311f05366d91427d289740dd15fb9401dc4347ef
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 
-Tags: latest, 5, 5.32, 5.32.1, 5-buster, 5.32-buster, 5.32.1-buster
+Tags: 5.34.0, 5.34, 5, latest, 5.34.0-buster, 5.34-buster, 5-buster, buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 5.034.000-main-buster
+
+Tags: 5.34.0-slim, 5.34-slim, 5-slim, slim, 5.34.0-slim-buster, 5.34-slim-buster, 5-slim-buster, slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 5.034.000-slim-buster
+
+Tags: 5.34.0-threaded, 5.34-threaded, 5-threaded, threaded, 5.34.0-threaded-buster, 5.34-threaded-buster, 5-threaded-buster, threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 5.034.000-main,threaded-buster
+
+Tags: 5.34.0-slim-threaded, 5.34-slim-threaded, 5-slim-threaded, slim-threaded, 5.34.0-slim-threaded-buster, 5.34-slim-threaded-buster, 5-slim-threaded-buster, slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 5.034.000-slim,threaded-buster
+
+Tags: 5.32.1, 5.32, 5.32.1-buster, 5.32-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.032.001-main-buster
 
-Tags: 5-stretch, 5.32-stretch, 5.32.1-stretch
+Tags: 5.32.1-stretch, 5.32-stretch, 5-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.032.001-main-stretch
 
-Tags: slim, 5-slim, 5.32-slim, 5.32.1-slim, slim-buster, 5-slim-buster, 5.32-slim-buster, 5.32.1-slim-buster
+Tags: 5.32.1-slim, 5.32-slim, 5.32.1-slim-buster, 5.32-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.032.001-slim-buster
 
-Tags: slim-stretch, 5-slim-stretch, 5.32-slim-stretch, 5.32.1-slim-stretch
+Tags: 5.32.1-slim-stretch, 5.32-slim-stretch, 5-slim-stretch, slim-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.032.001-slim-stretch
 
-Tags: threaded, 5-threaded, 5.32-threaded, 5.32.1-threaded, threaded-buster, 5-threaded-buster, 5.32-threaded-buster, 5.32.1-threaded-buster
+Tags: 5.32.1-threaded, 5.32-threaded, 5.32.1-threaded-buster, 5.32-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.032.001-main,threaded-buster
 
-Tags: threaded-stretch, 5-threaded-stretch, 5.32-threaded-stretch, 5.32.1-threaded-stretch
+Tags: 5.32.1-threaded-stretch, 5.32-threaded-stretch, 5-threaded-stretch, threaded-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.032.001-main,threaded-stretch
 
-Tags: slim-threaded, 5-slim-threaded, 5.32-slim-threaded, 5.32.1-slim-threaded, slim-threaded-buster, 5-slim-threaded-buster, 5.32-slim-threaded-buster, 5.32.1-slim-threaded-buster
+Tags: 5.32.1-slim-threaded, 5.32-slim-threaded, 5.32.1-slim-threaded-buster, 5.32-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.032.001-slim,threaded-buster
 
-Tags: slim-threaded-stretch, 5-slim-threaded-stretch, 5.32-slim-threaded-stretch, 5.32.1-slim-threaded-stretch
+Tags: 5.32.1-slim-threaded-stretch, 5.32-slim-threaded-stretch, 5-slim-threaded-stretch, slim-threaded-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.032.001-slim,threaded-stretch
 
-Tags: 5.30, 5.30.3, 5.30-buster, 5.30.3-buster
+Tags: 5.30.3, 5.30, 5.30.3-buster, 5.30-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.030.003-main-buster
 
-Tags: 5.30-stretch, 5.30.3-stretch
+Tags: 5.30.3-stretch, 5.30-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.030.003-main-stretch
 
-Tags: 5.30-slim, 5.30.3-slim, 5.30-slim-buster, 5.30.3-slim-buster
+Tags: 5.30.3-slim, 5.30-slim, 5.30.3-slim-buster, 5.30-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.030.003-slim-buster
 
-Tags: 5.30-slim-stretch, 5.30.3-slim-stretch
+Tags: 5.30.3-slim-stretch, 5.30-slim-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.030.003-slim-stretch
 
-Tags: 5.30-threaded, 5.30.3-threaded, 5.30-threaded-buster, 5.30.3-threaded-buster
+Tags: 5.30.3-threaded, 5.30-threaded, 5.30.3-threaded-buster, 5.30-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.030.003-main,threaded-buster
 
-Tags: 5.30-threaded-stretch, 5.30.3-threaded-stretch
+Tags: 5.30.3-threaded-stretch, 5.30-threaded-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.030.003-main,threaded-stretch
 
-Tags: 5.30-slim-threaded, 5.30.3-slim-threaded, 5.30-slim-threaded-buster, 5.30.3-slim-threaded-buster
+Tags: 5.30.3-slim-threaded, 5.30-slim-threaded, 5.30.3-slim-threaded-buster, 5.30-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.030.003-slim,threaded-buster
 
-Tags: 5.30-slim-threaded-stretch, 5.30.3-slim-threaded-stretch
+Tags: 5.30.3-slim-threaded-stretch, 5.30-slim-threaded-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.030.003-slim,threaded-stretch
 
-Tags: 5.28, 5.28.3, 5.28-buster, 5.28.3-buster
-Directory: 5.028.003-main-buster
+#
+# THE FOLLOWING (EOL) TAGS ARE INTENDED AS A ONE-TIME BACKFILL/REBUILD
+#
+#   (they will be removed after they are successfully rebuilt)
+#
 
-Tags: 5.28-stretch, 5.28.3-stretch
+Tags: 5.28.3-buster, 5.28-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.028.003-main-buster
+
+Tags: 5.28.3-stretch, 5.28-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.028.003-main-stretch
+Directory: eol/5.028.003-main-stretch
 
-Tags: 5.28-slim, 5.28.3-slim, 5.28-slim-buster, 5.28.3-slim-buster
-Directory: 5.028.003-slim-buster
+Tags: 5.28.3-slim-buster, 5.28-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.028.003-slim-buster
 
-Tags: 5.28-slim-stretch, 5.28.3-slim-stretch
+Tags: 5.28.3-slim-stretch, 5.28-slim-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.028.003-slim-stretch
+Directory: eol/5.028.003-slim-stretch
 
-Tags: 5.28-threaded, 5.28.3-threaded, 5.28-threaded-buster, 5.28.3-threaded-buster
-Directory: 5.028.003-main,threaded-buster
+Tags: 5.28.3-threaded-buster, 5.28-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.028.003-main,threaded-buster
 
-Tags: 5.28-threaded-stretch, 5.28.3-threaded-stretch
+Tags: 5.28.3-threaded-stretch, 5.28-threaded-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.028.003-main,threaded-stretch
+Directory: eol/5.028.003-main,threaded-stretch
 
-Tags: 5.28-slim-threaded, 5.28.3-slim-threaded, 5.28-slim-threaded-buster, 5.28.3-slim-threaded-buster
-Directory: 5.028.003-slim,threaded-buster
+Tags: 5.28.3-slim-threaded-buster, 5.28-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.028.003-slim,threaded-buster
 
-Tags: 5.28-slim-threaded-stretch, 5.28.3-slim-threaded-stretch
+Tags: 5.28.3-slim-threaded-stretch, 5.28-slim-threaded-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.028.003-slim,threaded-stretch
+Directory: eol/5.028.003-slim,threaded-stretch
+
+Tags: 5.26.3-buster, 5.26-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.026.003-main-buster
+
+Tags: 5.26.3-stretch, 5.26-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.026.003-main-stretch
+
+Tags: 5.26.3-slim-buster, 5.26-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.026.003-slim-buster
+
+Tags: 5.26.3-slim-stretch, 5.26-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.026.003-slim-stretch
+
+Tags: 5.26.3-threaded-buster, 5.26-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.026.003-main,threaded-buster
+
+Tags: 5.26.3-threaded-stretch, 5.26-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.026.003-main,threaded-stretch
+
+Tags: 5.26.3-slim-threaded-buster, 5.26-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.026.003-slim,threaded-buster
+
+Tags: 5.26.3-slim-threaded-stretch, 5.26-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.026.003-slim,threaded-stretch
+
+Tags: 5.24.4-buster, 5.24-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.024.004-main-buster
+
+Tags: 5.24.4-stretch, 5.24-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.024.004-main-stretch
+
+Tags: 5.24.4-slim-buster, 5.24-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.024.004-slim-buster
+
+Tags: 5.24.4-slim-stretch, 5.24-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.024.004-slim-stretch
+
+Tags: 5.24.4-threaded-buster, 5.24-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.024.004-main,threaded-buster
+
+Tags: 5.24.4-threaded-stretch, 5.24-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.024.004-main,threaded-stretch
+
+Tags: 5.24.4-slim-threaded-buster, 5.24-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.024.004-slim,threaded-buster
+
+Tags: 5.24.4-slim-threaded-stretch, 5.24-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.024.004-slim,threaded-stretch
+
+Tags: 5.22.4-buster, 5.22-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.022.004-main-buster
+
+Tags: 5.22.4-stretch, 5.22-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.022.004-main-stretch
+
+Tags: 5.22.4-slim-buster, 5.22-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.022.004-slim-buster
+
+Tags: 5.22.4-slim-stretch, 5.22-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.022.004-slim-stretch
+
+Tags: 5.22.4-threaded-buster, 5.22-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.022.004-main,threaded-buster
+
+Tags: 5.22.4-threaded-stretch, 5.22-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.022.004-main,threaded-stretch
+
+Tags: 5.22.4-slim-threaded-buster, 5.22-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.022.004-slim,threaded-buster
+
+Tags: 5.22.4-slim-threaded-stretch, 5.22-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.022.004-slim,threaded-stretch
+
+Tags: 5.20.3-buster, 5.20-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.020.003-main-buster
+
+Tags: 5.20.3-stretch, 5.20-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.020.003-main-stretch
+
+Tags: 5.20.3-slim-buster, 5.20-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.020.003-slim-buster
+
+Tags: 5.20.3-slim-stretch, 5.20-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.020.003-slim-stretch
+
+Tags: 5.20.3-threaded-buster, 5.20-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.020.003-main,threaded-buster
+
+Tags: 5.20.3-threaded-stretch, 5.20-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.020.003-main,threaded-stretch
+
+Tags: 5.20.3-slim-threaded-buster, 5.20-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.020.003-slim,threaded-buster
+
+Tags: 5.20.3-slim-threaded-stretch, 5.20-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.020.003-slim,threaded-stretch
+
+Tags: 5.18.4-buster, 5.18-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.018.004-main-buster
+
+Tags: 5.18.4-stretch, 5.18-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.018.004-main-stretch
+
+Tags: 5.18.4-slim-buster, 5.18-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.018.004-slim-buster
+
+Tags: 5.18.4-slim-stretch, 5.18-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.018.004-slim-stretch
+
+Tags: 5.18.4-threaded-buster, 5.18-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.018.004-main,threaded-buster
+
+Tags: 5.18.4-threaded-stretch, 5.18-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.018.004-main,threaded-stretch
+
+Tags: 5.18.4-slim-threaded-buster, 5.18-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.018.004-slim,threaded-buster
+
+Tags: 5.18.4-slim-threaded-stretch, 5.18-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.018.004-slim,threaded-stretch
+
+Tags: 5.16.3-buster, 5.16-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.016.003-main-buster
+
+Tags: 5.16.3-stretch, 5.16-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.016.003-main-stretch
+
+Tags: 5.16.3-slim-buster, 5.16-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.016.003-slim-buster
+
+Tags: 5.16.3-slim-stretch, 5.16-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.016.003-slim-stretch
+
+Tags: 5.16.3-threaded-buster, 5.16-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.016.003-main,threaded-buster
+
+Tags: 5.16.3-threaded-stretch, 5.16-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.016.003-main,threaded-stretch
+
+Tags: 5.16.3-slim-threaded-buster, 5.16-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.016.003-slim,threaded-buster
+
+Tags: 5.16.3-slim-threaded-stretch, 5.16-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.016.003-slim,threaded-stretch
+
+Tags: 5.14.4-buster, 5.14-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.014.004-main-buster
+
+Tags: 5.14.4-stretch, 5.14-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.014.004-main-stretch
+
+Tags: 5.14.4-slim-buster, 5.14-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.014.004-slim-buster
+
+Tags: 5.14.4-slim-stretch, 5.14-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.014.004-slim-stretch
+
+Tags: 5.14.4-threaded-buster, 5.14-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.014.004-main,threaded-buster
+
+Tags: 5.14.4-threaded-stretch, 5.14-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.014.004-main,threaded-stretch
+
+Tags: 5.14.4-slim-threaded-buster, 5.14-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.014.004-slim,threaded-buster
+
+Tags: 5.14.4-slim-threaded-stretch, 5.14-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.014.004-slim,threaded-stretch
+
+Tags: 5.12.5-buster, 5.12-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.012.005-main-buster
+
+Tags: 5.12.5-stretch, 5.12-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.012.005-main-stretch
+
+Tags: 5.12.5-slim-buster, 5.12-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.012.005-slim-buster
+
+Tags: 5.12.5-slim-stretch, 5.12-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.012.005-slim-stretch
+
+Tags: 5.12.5-threaded-buster, 5.12-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.012.005-main,threaded-buster
+
+Tags: 5.12.5-threaded-stretch, 5.12-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.012.005-main,threaded-stretch
+
+Tags: 5.12.5-slim-threaded-buster, 5.12-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.012.005-slim,threaded-buster
+
+Tags: 5.12.5-slim-threaded-stretch, 5.12-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.012.005-slim,threaded-stretch
+
+Tags: 5.10.1-buster, 5.10-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.010.001-main-buster
+
+Tags: 5.10.1-stretch, 5.10-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.010.001-main-stretch
+
+Tags: 5.10.1-slim-buster, 5.10-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.010.001-slim-buster
+
+Tags: 5.10.1-slim-stretch, 5.10-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.010.001-slim-stretch
+
+Tags: 5.10.1-threaded-buster, 5.10-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.010.001-main,threaded-buster
+
+Tags: 5.10.1-threaded-stretch, 5.10-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.010.001-main,threaded-stretch
+
+Tags: 5.10.1-slim-threaded-buster, 5.10-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.010.001-slim,threaded-buster
+
+Tags: 5.10.1-slim-threaded-stretch, 5.10-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.010.001-slim,threaded-stretch
+
+Tags: 5.8.9-buster, 5.8-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.008.009-main-buster
+
+Tags: 5.8.9-stretch, 5.8-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.008.009-main-stretch
+
+Tags: 5.8.9-slim-buster, 5.8-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.008.009-slim-buster
+
+Tags: 5.8.9-slim-stretch, 5.8-slim-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.008.009-slim-stretch
+
+Tags: 5.8.9-threaded-buster, 5.8-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.008.009-main,threaded-buster
+
+Tags: 5.8.9-threaded-stretch, 5.8-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.008.009-main,threaded-stretch
+
+Tags: 5.8.9-slim-threaded-buster, 5.8-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: eol/5.008.009-slim,threaded-buster
+
+Tags: 5.8.9-slim-threaded-stretch, 5.8-slim-threaded-stretch
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: eol/5.008.009-slim,threaded-stretch


### PR DESCRIPTION
Ref https://github.com/Perl/docker-perl/pull/104

This latest release of Perl now only builds against Debian buster base, see https://github.com/Perl/docker-perl/issues/88.

Furthermore, some tags for older (unsupported) Perl versions are requested for rebuild, see https://github.com/Perl/docker-perl/issues/100 - these tags will be removed in a subsequent PR once done.