### PR TITLE
archlinux: Release 20210523.0.23638

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210516.0.23009
-GitCommit: aeae557310328ede3dcdb969c48d1cd6f141b0f2
-GitFetch: refs/tags/v20210516.0.23009
+Tags: latest, base, base-20210523.0.23638
+GitCommit: e9df7b4a04dc65a1b33bcac93da6ec69dedf994a
+GitFetch: refs/tags/v20210523.0.23638
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210516.0.23009
-GitCommit: aeae557310328ede3dcdb969c48d1cd6f141b0f2
-GitFetch: refs/tags/v20210516.0.23009
+Tags: base-devel, base-devel-20210523.0.23638
+GitCommit: e9df7b4a04dc65a1b33bcac93da6ec69dedf994a
+GitFetch: refs/tags/v20210523.0.23638
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks