### PR TITLE
Update Clear Linux OS to 34640

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 17e8296aae4e34df56f4a9c0d03c15866ca358f3
-GitFetch: refs/tags/clear-linux-34620
+GitCommit: f20c51efb61e553f19d5cfc52b1176ecee30e38d
+GitFetch: refs/tags/clear-linux-34640


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34640

@bryteise @mdhorn @phmccarty