### PR TITLE
MariaDB 10.6.1 beta release 20210524

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,27 +4,27 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 10.6.0-focal, 10.6-focal, alpha-focal, 10.6.0, 10.6, alpha
+Tags: 10.6.1-focal, 10.6-focal, beta-focal, 10.6.1, 10.6, beta
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
+GitCommit: 2ef69de05f84aee8a141c0d37cdb5b9790ac91d9
 Directory: 10.6
 
 Tags: 10.5.10-focal, 10.5-focal, 10-focal, focal, 10.5.10, 10.5, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
+GitCommit: 6f5d272ca053105901c23fcdc44884907aa4d11d
 Directory: 10.5
 
 Tags: 10.4.19-focal, 10.4-focal, 10.4.19, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
+GitCommit: 6f5d272ca053105901c23fcdc44884907aa4d11d
 Directory: 10.4
 
 Tags: 10.3.29-focal, 10.3-focal, 10.3.29, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
+GitCommit: 6f5d272ca053105901c23fcdc44884907aa4d11d
 Directory: 10.3
 
 Tags: 10.2.38-bionic, 10.2-bionic, 10.2.38, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8be7abacca5f19d487b137c7d8f9516d07116109
+GitCommit: 6f5d272ca053105901c23fcdc44884907aa4d11d
 Directory: 10.2


### PR DESCRIPTION
We've done our 10.6.1 beta release.