### PR TITLE
InfluxDB v1.8.6

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
 Maintainers: Cody Shepherd (@codyshepherd), Daniel Moran <dmoran@influxdata.com> (@danxmoran)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: cfa0798e377578bedd622011cc2948c0993121f9
+GitCommit: 8d81b0d850949889038cd8652a9b2a32088ec3c3
 
 Tags: 1.7, 1.7.11
 Architectures: amd64, arm32v7, arm64v8
@@ -21,23 +21,23 @@ Directory: influxdb/1.7/meta
 Tags: 1.7-meta-alpine, 1.7.11-meta-alpine
 Directory: influxdb/1.7/meta/alpine
 
-Tags: 1.8, 1.8.5
+Tags: 1.8, 1.8.6
 Architectures: amd64, arm32v7, arm64v8
 Directory: influxdb/1.8
 
-Tags: 1.8-alpine, 1.8.5-alpine
+Tags: 1.8-alpine, 1.8.6-alpine
 Directory: influxdb/1.8/alpine
 
-Tags: 1.8-data, 1.8.5-data, data
+Tags: 1.8-data, 1.8.6-data, data
 Directory: influxdb/1.8/data
 
-Tags: 1.8-data-alpine, 1.8.5-data-alpine, data-alpine
+Tags: 1.8-data-alpine, 1.8.6-data-alpine, data-alpine
 Directory: influxdb/1.8/data/alpine
 
-Tags: 1.8-meta, 1.8.5-meta, meta
+Tags: 1.8-meta, 1.8.6-meta, meta
 Directory: influxdb/1.8/meta
 
-Tags: 1.8-meta-alpine, 1.8.5-meta-alpine, meta-alpine
+Tags: 1.8-meta-alpine, 1.8.6-meta-alpine, meta-alpine
 Directory: influxdb/1.8/meta/alpine
 
 Tags: 2.0, 2.0.6, latest


### PR DESCRIPTION
InfluxDB v1.8.6 has been released. This PR updates the image versions accordingly.