### PR TITLE
Odoo: update 12.0-14.0 to release 20210525

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 574de4ccbbe2578e50ee472a3ac31c798dd08ad3
+GitCommit: 6d95b778cfdd0673e1571f962a4aac70f67a685e
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of all Odoo maintained versions.

Thanks.