### PR TITLE
[security] Updated nginx to 1.20.1 and 1.21.0

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,44 +1,44 @@
-# this file is generated via https://github.com/nginxinc/docker-nginx/blob/1612733ec60173d9d4a18a0916b860a0ff255e74/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nginxinc/docker-nginx/blob/f3fe494531f9b157d9c09ba509e412dace54cd4f/generate-stackbrew-library.sh
 
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.19.10, mainline, 1, 1.19, latest
+Tags: 1.21.0, mainline, 1, 1.21, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 464886ab21ebe4b036ceb36d7557bf491f6d9320
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: mainline/debian
 
-Tags: 1.19.10-perl, mainline-perl, 1-perl, 1.19-perl, perl
+Tags: 1.21.0-perl, mainline-perl, 1-perl, 1.21-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 464886ab21ebe4b036ceb36d7557bf491f6d9320
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: mainline/debian-perl
 
-Tags: 1.19.10-alpine, mainline-alpine, 1-alpine, 1.19-alpine, alpine
+Tags: 1.21.0-alpine, mainline-alpine, 1-alpine, 1.21-alpine, alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 464886ab21ebe4b036ceb36d7557bf491f6d9320
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: mainline/alpine
 
-Tags: 1.19.10-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.19-alpine-perl, alpine-perl
+Tags: 1.21.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.21-alpine-perl, alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 464886ab21ebe4b036ceb36d7557bf491f6d9320
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: mainline/alpine-perl
 
-Tags: 1.20.0, stable, 1.20
+Tags: 1.20.1, stable, 1.20
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab8516ed3a212d8a03392567c8f55c570c839e59
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: stable/debian
 
-Tags: 1.20.0-perl, stable-perl, 1.20-perl
+Tags: 1.20.1-perl, stable-perl, 1.20-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab8516ed3a212d8a03392567c8f55c570c839e59
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: stable/debian-perl
 
-Tags: 1.20.0-alpine, stable-alpine, 1.20-alpine
+Tags: 1.20.1-alpine, stable-alpine, 1.20-alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: ab8516ed3a212d8a03392567c8f55c570c839e59
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: stable/alpine
 
-Tags: 1.20.0-alpine-perl, stable-alpine-perl, 1.20-alpine-perl
+Tags: 1.20.1-alpine-perl, stable-alpine-perl, 1.20-alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: ab8516ed3a212d8a03392567c8f55c570c839e59
+GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
 Directory: stable/alpine-perl


### PR DESCRIPTION
The releases contain a fix for the 1-byte memory overwrite vulnerability in resolver (CVE-2021-23017).