### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,9 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.17-rc.1, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 10626fbe4fd6ef72a8d736d4d3274dca18c4945e
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.17-rc.1-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.17-rc.1-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 10626fbe4fd6ef72a8d736d4d3274dca18c4945e
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.17-rc.1-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.16, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e6c8ca467d3535bed9edd6c1e6a81ca1f07c2f0e
+GitCommit: cc2d7ce2009578e7f8113fc1dbc6d86c0340d9a2
 Directory: 3.8/ubuntu
 
 Tags: 3.8.16-management, 3.8-management, 3-management, management
@@ -16,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.16-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e6c8ca467d3535bed9edd6c1e6a81ca1f07c2f0e
+GitCommit: cc2d7ce2009578e7f8113fc1dbc6d86c0340d9a2
 Directory: 3.8/alpine
 
 Tags: 3.8.16-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- docker-library/rabbitmq@509e2e1: Merge pull request docker-library/rabbitmq#489 from infosiftr/regex
- docker-library/rabbitmq@1d9432d: Fix bug in detecting if management plugin is installed
- docker-library/rabbitmq@31efabf: Update 3.8-rc to 3.8.17-rc.1
- docker-library/rabbitmq@6b7c42f: Merge pull request docker-library/rabbitmq#487 from infosiftr/node-port
- docker-library/rabbitmq@f66ba3c: Add a workaround for RABBITMQ_NODE_PORT for 3.8.3+