### PR TITLE
Releasing Neo4j 4.2.7

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -9,12 +9,22 @@ Maintainers: Chris Gioran <chris@neo4j.com> (@digitalstain),
              Bledi Feshti <bledi.feshti@neo4j.com> (@bfeshti)
 
 
-Tags: 4.2.6, 4.2.6-community, 4.2, 4.2-community, latest
+Tags: 4.2.7, 4.2.7-community, 4.2, 4.2-community, latest
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 63765f3df4a15acf07000c7382677db3c41da22f
+Directory: 4.2.7/community
+
+Tags: 4.2.7-enterprise, 4.2-enterprise, enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 63765f3df4a15acf07000c7382677db3c41da22f
+Directory: 4.2.6/enterprise
+
+Tags: 4.2.6, 4.2.6-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 1ad1f3f99e1572b3d1668475b3578626b89592fa
 Directory: 4.2.6/community
 
-Tags: 4.2.6-enterprise, 4.2-enterprise, enterprise
+Tags: 4.2.6-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 1ad1f3f99e1572b3d1668475b3578626b89592fa
 Directory: 4.2.6/enterprise

--- a/library/neo4j
+++ b/library/neo4j
@@ -9,7 +9,7 @@ Maintainers: Chris Gioran <chris@neo4j.com> (@digitalstain),
              Bledi Feshti <bledi.feshti@neo4j.com> (@bfeshti)
 
 
-Tags: 4.2.6, 4.2, latest
+Tags: 4.2.6, 4.2.6-community, 4.2, 4.2-community, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 1ad1f3f99e1572b3d1668475b3578626b89592fa
 Directory: 4.2.6/community
@@ -19,7 +19,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 1ad1f3f99e1572b3d1668475b3578626b89592fa
 Directory: 4.2.6/enterprise
 
-Tags: 4.2.5
+Tags: 4.2.5, 4.2.5-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d22293f2e465b63ee5a63f0a2b8f817717a64a8b
 Directory: 4.2.5/community
@@ -29,7 +29,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d22293f2e465b63ee5a63f0a2b8f817717a64a8b
 Directory: 4.2.5/enterprise
 
-Tags: 4.2.4
+Tags: 4.2.4, 4.2.4-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 21f86f780f950805e29e7789249d9f2a754a1ef1
 Directory: 4.2.4/community
@@ -39,7 +39,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 21f86f780f950805e29e7789249d9f2a754a1ef1
 Directory: 4.2.4/enterprise
 
-Tags: 4.2.3
+Tags: 4.2.3, 4.2.3-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 876140f24eb644b811a2bffc7bc09d9a39f341e7
 Directory: 4.2.3/community
@@ -49,7 +49,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 876140f24eb644b811a2bffc7bc09d9a39f341e7
 Directory: 4.2.3/enterprise
 
-Tags: 4.2.2
+Tags: 4.2.2, 4.2.2-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 4421ccd67610e65e501e201c226a8184edc24587
 Directory: 4.2.2/community
@@ -59,7 +59,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 4421ccd67610e65e501e201c226a8184edc24587
 Directory: 4.2.2/enterprise
 
-Tags: 4.2.1
+Tags: 4.2.1, 4.2.1-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 73963d86ca01456c695b7258d2fa1873cc4041bc
 Directory: 4.2.1/community
@@ -69,7 +69,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 73963d86ca01456c695b7258d2fa1873cc4041bc
 Directory: 4.2.1/enterprise
 
-Tags: 4.2.0
+Tags: 4.2.0, 4.2.0-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 0fee8c3d7314e7729f45781f03e3fe165fa371aa
 Directory: 4.2.0/community
@@ -79,7 +79,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 0fee8c3d7314e7729f45781f03e3fe165fa371aa
 Directory: 4.2.0/enterprise
 
-Tags: 4.1.9, 4.1
+Tags: 4.1.9, 4.1.9-community, 4.1, 4.1-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 7241a1884003b314d51bbb5dee858e03d91604cd
 Directory: 4.1.9/community
@@ -89,7 +89,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 7241a1884003b314d51bbb5dee858e03d91604cd
 Directory: 4.1.9/enterprise
 
-Tags: 4.1.8
+Tags: 4.1.8, 4.1.8-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 532e7003a2922d25baae22305345f27efdcb1bec
 Directory: 4.1.8/community
@@ -99,7 +99,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 532e7003a2922d25baae22305345f27efdcb1bec
 Directory: 4.1.8/enterprise
 
-Tags: 4.1.7
+Tags: 4.1.7, 4.1.7-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 04e62b180b0bc708341dbe097262271f0f422139
 Directory: 4.1.7/community
@@ -109,7 +109,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 04e62b180b0bc708341dbe097262271f0f422139
 Directory: 4.1.7/enterprise
 
-Tags: 4.1.6
+Tags: 4.1.6, 4.1.6-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 17c3e064335f47c1d4b1385dc24863843641f205
 Directory: 4.1.6/community
@@ -119,7 +119,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 17c3e064335f47c1d4b1385dc24863843641f205
 Directory: 4.1.6/enterprise
 
-Tags: 4.1.5
+Tags: 4.1.5, 4.1.5-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: a3e1de7d6215c50694fca04e92fc4917c1efa0eb
 Directory: 4.1.5/community
@@ -129,7 +129,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: a3e1de7d6215c50694fca04e92fc4917c1efa0eb
 Directory: 4.1.5/enterprise
 
-Tags: 4.1.4
+Tags: 4.1.4, 4.1.4-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8709faa63d9bda05c888ffc040a6035a8daf8394
 Directory: 4.1.4/community
@@ -139,7 +139,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 8709faa63d9bda05c888ffc040a6035a8daf8394
 Directory: 4.1.4/enterprise
 
-Tags: 4.1.3
+Tags: 4.1.3, 4.1.3-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d812e34c70a2487fae5ee5cbb7c447b20b346afa
 Directory: 4.1.3/community
@@ -149,7 +149,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d812e34c70a2487fae5ee5cbb7c447b20b346afa
 Directory: 4.1.3/enterprise
 
-Tags: 4.1.2
+Tags: 4.1.2, 4.1.2-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 5429da43884f5a41db2fd7aaaa3b1cd69a708f7f
 Directory: 4.1.2/community
@@ -159,7 +159,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 5429da43884f5a41db2fd7aaaa3b1cd69a708f7f
 Directory: 4.1.2/enterprise
 
-Tags: 4.1.1
+Tags: 4.1.1, 4.1.1-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.1.1/community
@@ -169,7 +169,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.1.1/enterprise
 
-Tags: 4.1.0
+Tags: 4.1.0, 4.1.0-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: c22866bb7f4baac356bf65494a003e490082b6c0
 Directory: 4.1.0/community
@@ -179,7 +179,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: c22866bb7f4baac356bf65494a003e490082b6c0
 Directory: 4.1.0/enterprise
 
-Tags: 4.0.11, 4.0
+Tags: 4.0.11, 4.0.11-community, 4.0, 4.0-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 014785e7fb71b0cda5c52b21e9a609878ebf567a
 Directory: 4.0.11/community
@@ -189,7 +189,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 014785e7fb71b0cda5c52b21e9a609878ebf567a
 Directory: 4.0.11/enterprise
 
-Tags: 4.0.10
+Tags: 4.0.10, 4.0.10-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 15eccd11b9755a650f0460e9b652239d54fa7fa9
 Directory: 4.0.10/community
@@ -199,7 +199,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 15eccd11b9755a650f0460e9b652239d54fa7fa9
 Directory: 4.0.10/enterprise
 
-Tags: 4.0.9
+Tags: 4.0.9, 4.0.9-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 04a30cb462de38246f8411b7b03c17d06b948009
 Directory: 4.0.9/community
@@ -209,7 +209,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 04a30cb462de38246f8411b7b03c17d06b948009
 Directory: 4.0.9/enterprise
 
-Tags: 4.0.8
+Tags: 4.0.8, 4.0.8-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 81342d372e1fa225d49b7643d3210b9bcdb962b9
 Directory: 4.0.8/community
@@ -219,7 +219,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 81342d372e1fa225d49b7643d3210b9bcdb962b9
 Directory: 4.0.8/enterprise
 
-Tags: 4.0.7
+Tags: 4.0.7, 4.0.7-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.0.7/community
@@ -229,7 +229,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d42c3ac9cde66e2a1dcb3f667fe73878dbf2218c
 Directory: 4.0.7/enterprise
 
-Tags: 4.0.6
+Tags: 4.0.6, 4.0.6-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 07dcb3dd43df67337f74af5a71decc45d50b712d
 Directory: 4.0.6/community
@@ -239,7 +239,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 07dcb3dd43df67337f74af5a71decc45d50b712d
 Directory: 4.0.6/enterprise
 
-Tags: 4.0.5
+Tags: 4.0.5, 4.0.5-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: b47f15c39f28e28e120adff7a00773e0a61c0efe
 Directory: 4.0.5/community
@@ -249,7 +249,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: b47f15c39f28e28e120adff7a00773e0a61c0efe
 Directory: 4.0.5/enterprise
 
-Tags: 4.0.4
+Tags: 4.0.4, 4.0.4-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d5e5e4b1999611ecfa8ec59166acf1ddb703b21c
 Directory: 4.0.4/community
@@ -259,7 +259,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d5e5e4b1999611ecfa8ec59166acf1ddb703b21c
 Directory: 4.0.4/enterprise
 
-Tags: 4.0.3
+Tags: 4.0.3, 4.0.3-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 51ed84f02e569a0d86c6e634fab3ae6540806a7e
 Directory: 4.0.3/community
@@ -269,7 +269,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 51ed84f02e569a0d86c6e634fab3ae6540806a7e
 Directory: 4.0.3/enterprise
 
-Tags: 4.0.2
+Tags: 4.0.2, 4.0.2-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 56d28624bc264497ed7fae8253a52a92611c6fee
 Directory: 4.0.2/community
@@ -279,7 +279,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 56d28624bc264497ed7fae8253a52a92611c6fee
 Directory: 4.0.2/enterprise
 
-Tags: 4.0.1
+Tags: 4.0.1, 4.0.1-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 13c288e9c36ee22e682b459fb218c9239e2c1083
 Directory: 4.0.1/community
@@ -289,7 +289,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 13c288e9c36ee22e682b459fb218c9239e2c1083
 Directory: 4.0.1/enterprise
 
-Tags: 4.0.0
+Tags: 4.0.0, 4.0.0-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 685fb314ef8e451217b6806028b9ac4dbf44d3fc
 Directory: 4.0.0/community
@@ -299,7 +299,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 685fb314ef8e451217b6806028b9ac4dbf44d3fc
 Directory: 4.0.0/enterprise
 
-Tags: 3.5.28, 3.5
+Tags: 3.5.28, 3.5.28-community, 3.5, 3.5-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 83141af227fa047421b3ea81dcb8c1f4a7c6180f
 Directory: 3.5.28/community
@@ -309,7 +309,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 83141af227fa047421b3ea81dcb8c1f4a7c6180f
 Directory: 3.5.28/enterprise
 
-Tags: 3.5.27
+Tags: 3.5.27, 3.5.27-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: ce4bfeffe18865c1b94f0622015087d1d6849fbb
 Directory: 3.5.27/community
@@ -319,7 +319,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: ce4bfeffe18865c1b94f0622015087d1d6849fbb
 Directory: 3.5.27/enterprise
 
-Tags: 3.5.26
+Tags: 3.5.26, 3.5.26-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: b76f780318bea75347b17ef9a941bef5490d6a5b
 Directory: 3.5.26/community
@@ -329,7 +329,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: b76f780318bea75347b17ef9a941bef5490d6a5b
 Directory: 3.5.26/enterprise
 
-Tags: 3.5.25
+Tags: 3.5.25, 3.5.25-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 7f640278e48b2ff205564e131cb142278c5e6f13
 Directory: 3.5.25/community
@@ -339,7 +339,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 7f640278e48b2ff205564e131cb142278c5e6f13
 Directory: 3.5.25/enterprise
 
-Tags: 3.5.24
+Tags: 3.5.24, 3.5.24-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: e0b946fee10795b1e565406b24a7ace32e761ab5
 Directory: 3.5.24/community
@@ -349,7 +349,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: e0b946fee10795b1e565406b24a7ace32e761ab5
 Directory: 3.5.24/enterprise
 
-Tags: 3.5.23
+Tags: 3.5.23, 3.5.23-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 0c06943b4f351597820c87adeb1571aaaabd2996
 Directory: 3.5.23/community
@@ -359,7 +359,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 0c06943b4f351597820c87adeb1571aaaabd2996
 Directory: 3.5.23/enterprise
 
-Tags: 3.5.22
+Tags: 3.5.22, 3.5.22-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: cebc260e5eac4f660ed85df6a81429a8327c3d26
 Directory: 3.5.22/community
@@ -369,7 +369,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: cebc260e5eac4f660ed85df6a81429a8327c3d26
 Directory: 3.5.22/enterprise
 
-Tags: 3.5.21
+Tags: 3.5.21, 3.5.21-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d44250b8c4e856e43f2e8e80b09d7b403f25eb75
 Directory: 3.5.21/community
@@ -379,7 +379,7 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: d44250b8c4e856e43f2e8e80b09d7b403f25eb75
 Directory: 3.5.21/enterprise
 
-Tags: 3.5.20
+Tags: 3.5.20, 3.5.20-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: daf79c6d15e38b90b2b424da1168f4843c578362
 Directory: 3.5.20/community
@@ -388,173 +388,3 @@ Tags: 3.5.20-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: daf79c6d15e38b90b2b424da1168f4843c578362
 Directory: 3.5.20/enterprise
-
-Tags: 3.5.19
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 2e3dda4f3b545c33fee51bc5fce089923a3cc1e7
-Directory: 3.5.19/community
-
-Tags: 3.5.19-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 2e3dda4f3b545c33fee51bc5fce089923a3cc1e7
-Directory: 3.5.19/enterprise
-
-Tags: 3.5.18
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 44c1a3d078dae162335e3c2c214513c1c193de2e
-Directory: 3.5.18/community
-
-Tags: 3.5.18-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 44c1a3d078dae162335e3c2c214513c1c193de2e
-Directory: 3.5.18/enterprise
-
-Tags: 3.5.17
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 617aeb42c7af81bb6dfdd6396eca4c42d98c41ce
-Directory: 3.5.17/community
-
-Tags: 3.5.17-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 617aeb42c7af81bb6dfdd6396eca4c42d98c41ce
-Directory: 3.5.17/enterprise
-
-Tags: 3.5.16
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: db34a05ac7abf4b2818222294ac9dc93b13d54a2
-Directory: 3.5.16/community
-
-Tags: 3.5.16-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: db34a05ac7abf4b2818222294ac9dc93b13d54a2
-Directory: 3.5.16/enterprise
-
-Tags: 3.5.15
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: a2b48dfb25b76250bced5e2d0c064615e3085379
-Directory: 3.5.15/community
-
-Tags: 3.5.15-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: a2b48dfb25b76250bced5e2d0c064615e3085379
-Directory: 3.5.15/enterprise
-
-Tags: 3.5.14
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 574e0a1d5e5eb27a633148198c028d9a28899a9a
-Directory: 3.5.14/community
-
-Tags: 3.5.14-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 574e0a1d5e5eb27a633148198c028d9a28899a9a
-Directory: 3.5.14/enterprise
-
-Tags: 3.5.13
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 846ee1e9ad2744182a52bc21eb6204858c1a8a48
-Directory: 3.5.13/community
-
-Tags: 3.5.13-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 846ee1e9ad2744182a52bc21eb6204858c1a8a48
-Directory: 3.5.13/enterprise
-
-Tags: 3.5.12
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: b4715971c153883225394b2c66d6c8ecf8a1bc93
-Directory: 3.5.12/community
-
-Tags: 3.5.12-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: b4715971c153883225394b2c66d6c8ecf8a1bc93
-Directory: 3.5.12/enterprise
-
-Tags: 3.5.11
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: c559931b4b33062e1b4fcbcd2f2e8278ff7b3390
-Directory: 3.5.11/community
-
-Tags: 3.5.11-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: c559931b4b33062e1b4fcbcd2f2e8278ff7b3390
-Directory: 3.5.11/enterprise
-
-Tags: 3.5.8
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 53d8c355498de280a7b6ad4b9259bb8f132a1839
-Directory: 3.5.8/community
-
-Tags: 3.5.8-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 53d8c355498de280a7b6ad4b9259bb8f132a1839
-Directory: 3.5.8/enterprise
-
-Tags: 3.5.7
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: ffc4f941cc9a301ad41d1649aa021c0fc727919b
-Directory: 3.5.7/community
-
-Tags: 3.5.7-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: ffc4f941cc9a301ad41d1649aa021c0fc727919b
-Directory: 3.5.7/enterprise
-
-Tags: 3.5.6
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: c3d38b9d9fbe589282d4974ce66af1d3f3da0c22
-Directory: 3.5.6/community
-
-Tags: 3.5.6-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: c3d38b9d9fbe589282d4974ce66af1d3f3da0c22
-Directory: 3.5.6/enterprise
-
-Tags: 3.4.18, 3.4
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: cb8d887126ae0d0f25f4f9e08b01f1f6e451ca37
-Directory: 3.4.18/community
-
-Tags: 3.4.18-enterprise, 3.4-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: cb8d887126ae0d0f25f4f9e08b01f1f6e451ca37
-Directory: 3.4.18/enterprise
-
-Tags: 3.4.17
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: bed0c061a286bc50115cec609c644cecf773c6fe
-Directory: 3.4.17/community
-
-Tags: 3.4.17-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: bed0c061a286bc50115cec609c644cecf773c6fe
-Directory: 3.4.17/enterprise
-
-Tags: 3.4.16
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 8dfb925dd168a35968d8113424e8a9a9bc6d6a6f
-Directory: 3.4.16/community
-
-Tags: 3.4.16-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 8dfb925dd168a35968d8113424e8a9a9bc6d6a6f
-Directory: 3.4.16/enterprise
-
-Tags: 3.4.15
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: a097f1663938dc56b81ae88f1cf7caba0b40004c
-Directory: 3.4.15/community
-
-Tags: 3.4.15-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: a097f1663938dc56b81ae88f1cf7caba0b40004c
-Directory: 3.4.15/enterprise
-
-Tags: 3.4.14
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e3ddc2d97443a058c19cd5997d8c0df48c1956a9
-Directory: 3.4.14/community
-
-Tags: 3.4.14-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e3ddc2d97443a058c19cd5997d8c0df48c1956a9
-Directory: 3.4.14/enterprise

--- a/library/neo4j
+++ b/library/neo4j
@@ -9,7 +9,7 @@ Maintainers: Chris Gioran <chris@neo4j.com> (@digitalstain),
              Bledi Feshti <bledi.feshti@neo4j.com> (@bfeshti)
 
 
-Tags: 4.2.7, 4.2.7-community, 4.2, 4.2-community, latest
+Tags: 4.2.7, 4.2.7-community, 4.2, 4.2-community, community, latest
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 GitCommit: 63765f3df4a15acf07000c7382677db3c41da22f
 Directory: 4.2.7/community


### PR DESCRIPTION
I also deleted a load of old versions from this list and added a `-community` tag to all the neo4j-community version images