### PR TITLE
AlmaLinux: release 8.4 x86_64 version

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -3,4 +3,4 @@ GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 Tags: latest, 8
 GitFetch: refs/heads/almalinux-8-x86_64
-GitCommit: 1dc91dd3b9f69fd2f570c94441104004a9ef9811
+GitCommit: 3317c1f96704c1cbbab9257ac51a791fb7e28987


### PR DESCRIPTION
Hello!

There is a difference on a package level between AlmaLinux 8.3 and 8.4 images:

```diff
+cracklib-dicts
-ima-evm-utils
+hwdata
+ima-evm-utils0
+libibverbs
+libnl3
+pciutils
+pciutils-libs
+rdma-core
```

Unfortunately, in EL 8.4 those packages became systemd dependencies and removing of any of them leads to something like this:
```
Error:
 Problem: The operation would result in removing the following protected packages: systemd
(try to add '--skip-broken' to skip uninstallable packages or '--nobest' to use not only best candidate packages)
```

I've checked it with RHEL 8.4 and CentOS 8 Stream with the same result.