### PR TITLE
archlinux: Release 20210530.0.24217

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210523.0.23638
-GitCommit: e9df7b4a04dc65a1b33bcac93da6ec69dedf994a
-GitFetch: refs/tags/v20210523.0.23638
+Tags: latest, base, base-20210530.0.24217
+GitCommit: 8e49d6a72042437cb48b995615ab6ceaa3ce8005
+GitFetch: refs/tags/v20210530.0.24217
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210523.0.23638
-GitCommit: e9df7b4a04dc65a1b33bcac93da6ec69dedf994a
-GitFetch: refs/tags/v20210523.0.23638
+Tags: base-devel, base-devel-20210530.0.24217
+GitCommit: 8e49d6a72042437cb48b995615ab6ceaa3ce8005
+GitFetch: refs/tags/v20210530.0.24217
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks