### PR TITLE
Upgrade Zookeeper to 3.6.3

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -1,22 +1,17 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 
-Tags: 3.4.14, 3.4
-Architectures: amd64
-GitCommit: 95e63be6a0767ed462db2e5aa779047672cc3b35
-Directory: 3.4.14
-
 Tags: 3.5.9, 3.5
 Architectures: amd64, arm64v8
-GitCommit: 9709912dffaab63865d05a76aaa6539aeb795ad4
+GitCommit: 10a34d67458bd30a4f334166860d8213f84e97a7
 Directory: 3.5.9
 
-Tags: 3.6.2, 3.6
+Tags: 3.6.3, 3.6
 Architectures: amd64, arm64v8
-GitCommit: 2373492c6f8e74d3c1167726b19babe8ac7055dd
-Directory: 3.6.2
+GitCommit: 10a34d67458bd30a4f334166860d8213f84e97a7
+Directory: 3.6.3
 
 Tags: 3.7.0, 3.7, latest
 Architectures: amd64, arm64v8
-GitCommit: 088d6cc2d70c0d6898c4d0afd953d85052dd2aa2
+GitCommit: 10a34d67458bd30a4f334166860d8213f84e97a7
 Directory: 3.7.0


### PR DESCRIPTION
* Remove 3.4 (End-of-Life 1st June, 2020)
* Do not chown $ZOO_CONF_DIR when container starts