### PR TITLE
[ros] eloquent and melodic/debian stretch now use snapshots repository

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -59,7 +59,7 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: d017429ffef82c2ae91e5f81a4a60640b2ad6c1b
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
@@ -158,7 +158,7 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
+GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
@@ -168,7 +168,7 @@ Directory: ros/eloquent/ubuntu/bionic/ros-base
 
 Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
+GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
 Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
 
 


### PR DESCRIPTION
This is to trigger a final build of ROS eloquent images and ROS melodic on debian strretch before retiring them.

Related to https://github.com/docker-library/official-images/pull/8405, https://github.com/osrf/docker_images/pull/529 and https://github.com/osrf/docker_images/pull/430
