### PR TITLE
[ros] swap key and list file to trigger rebuild

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
@@ -36,7 +36,7 @@ Directory: ros/kinetic/ubuntu/xenial/perception
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
@@ -59,7 +59,7 @@ Directory: ros/melodic/ubuntu/bionic/perception
 
 Tags: melodic-ros-core-stretch
 Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: d017429ffef82c2ae91e5f81a4a60640b2ad6c1b
 Directory: ros/melodic/debian/stretch/ros-core
 
 Tags: melodic-ros-base-stretch
@@ -109,7 +109,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: noetic-ros-core-buster
 Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
@@ -136,7 +136,7 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
@@ -146,7 +146,7 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0d38100e2fec914106507817e3122d467617e2ee
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 
@@ -158,7 +158,7 @@ Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 Tags: eloquent-ros-core, eloquent-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
+GitCommit: 45dbb7bd0bb08303e50ecde4a60e827f7cec0ab0
 Directory: ros/eloquent/ubuntu/bionic/ros-core
 
 Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
@@ -190,7 +190,7 @@ Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: bf35442257b504eac671418bcb70481807a7fa69
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 
@@ -202,7 +202,7 @@ Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 Tags: galactic-ros-core, galactic-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 6511d8fc0754616550b7f5ea31a40084c2462938
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/galactic/ubuntu/focal/ros-core
 
 Tags: galactic-ros-base, galactic-ros-base-focal, galactic
@@ -212,7 +212,7 @@ Directory: ros/galactic/ubuntu/focal/ros-base
 
 Tags: galactic-ros1-bridge, galactic-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 6511d8fc0754616550b7f5ea31a40084c2462938
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/galactic/ubuntu/focal/ros1-bridge
 
 
@@ -224,7 +224,7 @@ Directory: ros/galactic/ubuntu/focal/ros1-bridge
 
 Tags: rolling-ros-core, rolling-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: a5644adacdca4a49faf10221620048175cdd7262
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/rolling/ubuntu/focal/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-focal, rolling
@@ -234,5 +234,5 @@ Directory: ros/rolling/ubuntu/focal/ros-base
 
 Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: bf35442257b504eac671418bcb70481807a7fa69
+GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
 Directory: ros/rolling/ubuntu/focal/ros1-bridge


### PR DESCRIPTION
The ROS [apt repo key expired](https://status.ros.org/incidents/mhqz8yyhrtsg), a new key has been pushed, for apt to work in the docker images, they need to be rebuilt without cache.
To do so we modified our images to swap the creation of the source.list file and the retrieval of the key from the keyserver.

Another more futureprool approach would be to [ADD the key using a fixed URL.](https://github.com/osrf/docker_images/issues/535#issuecomment-850893664) If the key changes the cache would be burst and the images rebuilt, otherwise the cache would be kept. Is this an approach that would be acceptable in official images ?

Relates to https://github.com/osrf/docker_images/issues/535