### PR TITLE
[gazebo] bump gazebo 9 and 11 package versions

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -9,12 +9,12 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver9-xenial
 Architectures: amd64
-GitCommit: c1a6cab08c9a8b85c869d24b31f6243ad4646cee
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/9/ubuntu/xenial/gzserver9
 
 Tags: libgazebo9-xenial
 Architectures: amd64
-GitCommit: c1a6cab08c9a8b85c869d24b31f6243ad4646cee
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 ########################################
@@ -22,12 +22,12 @@ Directory: gazebo/9/ubuntu/xenial/libgazebo9
 
 Tags: gzserver9, gzserver9-bionic
 Architectures: amd64
-GitCommit: 7178a9d0d509c8c222fffa6edff4d84124fb46ee
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/9/ubuntu/bionic/gzserver9
 
 Tags: libgazebo9, libgazebo9-bionic
 Architectures: amd64
-GitCommit: 7178a9d0d509c8c222fffa6edff4d84124fb46ee
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
 
@@ -39,12 +39,12 @@ Directory: gazebo/9/ubuntu/bionic/libgazebo9
 
 Tags: gzserver11-bionic
 Architectures: amd64
-GitCommit: 48051c3f57c5c632407920a4beec2c2953f1b6f5
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/11/ubuntu/bionic/gzserver11
 
 Tags: libgazebo11-bionic
 Architectures: amd64
-GitCommit: 48051c3f57c5c632407920a4beec2c2953f1b6f5
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/11/ubuntu/bionic/libgazebo11
 
 ########################################
@@ -52,11 +52,11 @@ Directory: gazebo/11/ubuntu/bionic/libgazebo11
 
 Tags: gzserver11, gzserver11-focal
 Architectures: amd64
-GitCommit: 163a37c8a124c3e46872f7904c0fddf251d81160
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/11/ubuntu/focal/gzserver11
 
 Tags: libgazebo11, libgazebo11-focal, latest
 Architectures: amd64
-GitCommit: 163a37c8a124c3e46872f7904c0fddf251d81160
+GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
 Directory: gazebo/11/ubuntu/focal/libgazebo11
 


### PR DESCRIPTION
11.5.0-1 -> 11.5.1-1
9.17.0-1 -> 9.18.0-1

Signed-off-by: Mikael Arguedas <mikael.arguedas@gmail.com>