### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.2.3, 6.2, 6, latest, 6.2.3-buster, 6.2-buster, 6-buster, buster
+Tags: 6.2.4, 6.2, 6, latest, 6.2.4-buster, 6.2-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a2d5a5dc3f308ff7dc829dbd5bbf1bce36383fd3
+GitCommit: 4422738bea4a9d38971a87fc820525864bb5ff62
 Directory: 6.2
 
-Tags: 6.2.3-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.3-alpine3.13, 6.2-alpine3.13, 6-alpine3.13, alpine3.13
+Tags: 6.2.4-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.4-alpine3.13, 6.2-alpine3.13, 6-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2d5a5dc3f308ff7dc829dbd5bbf1bce36383fd3
+GitCommit: 4422738bea4a9d38971a87fc820525864bb5ff62
 Directory: 6.2/alpine
 
-Tags: 6.0.13, 6.0, 6.0.13-buster, 6.0-buster
+Tags: 6.0.14, 6.0, 6.0.14-buster, 6.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9e055b21bfc02cb9302695e0e4fc27db19819598
+GitCommit: 07eb60ebe0d977d5b26fea67f41af73ac1efceb2
 Directory: 6.0
 
-Tags: 6.0.13-alpine, 6.0-alpine, 6.0.13-alpine3.13, 6.0-alpine3.13
+Tags: 6.0.14-alpine, 6.0-alpine, 6.0.14-alpine3.13, 6.0-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9e055b21bfc02cb9302695e0e4fc27db19819598
+GitCommit: 07eb60ebe0d977d5b26fea67f41af73ac1efceb2
 Directory: 6.0/alpine
 
 Tags: 5.0.12, 5.0, 5, 5.0.12-buster, 5.0-buster, 5-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/07eb60e: Update to 6.0.14
- https://github.com/docker-library/redis/commit/4422738: Update to 6.2.4