### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -18,12 +18,12 @@ GitCommit: a5937a0b39e55c174007c2b9c2f363cdd2142818
 Directory: 10
 # Docker EOL: 2022-10-08
 
-# Last Modified: 2020-03-12
-Tags: 9.3.0, 9.3, 9, 9.3.0-buster, 9.3-buster, 9-buster
+# Last Modified: 2021-06-01
+Tags: 9.4.0, 9.4, 9, 9.4.0-buster, 9.4-buster, 9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5937a0b39e55c174007c2b9c2f363cdd2142818
+GitCommit: 2c4cae395157000ce7b0f89ea47268f66f320bb1
 Directory: 9
-# Docker EOL: 2021-09-12
+# Docker EOL: 2022-12-01
 
 # Last Modified: 2021-05-14
 Tags: 8.5.0, 8.5, 8, 8.5.0-buster, 8.5-buster, 8-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/2c4cae3: Update 9 to 9.4.0