### PR TITLE
AlmaLinux: initial aarch64 release for 8.4 version

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,6 +1,9 @@
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
-Tags: latest, 8
+Tags: latest, 8, 8.4
 GitFetch: refs/heads/almalinux-8-x86_64
 GitCommit: 3317c1f96704c1cbbab9257ac51a791fb7e28987
+arm64v8-GitFetch: refs/heads/almalinux-8-aarch64
+arm64v8-GitCommit: 22f71ba269cb4ecb6dd771912f27cf5d8cc9da9a
+Architectures: amd64, arm64v8


### PR DESCRIPTION
The first AlmaLinux OS aarch64 image based on 8.4 beta release for ARM64. Discussed in #10264.