### PR TITLE
[nats-streaming] Release v0.22.0

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,30 +1,30 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitCommit: 878420260fc33929e4d3b272a8c813d64dbbbaa2
+GitCommit: 024b04f6c0d4658cf5751b21b48555bbe9280be5
 
-Tags: 0.21.2-alpine3.13, 0.21-alpine3.13, alpine3.13, 0.21.2-alpine, 0.21-alpine, alpine
+Tags: 0.22.0-alpine3.13, 0.22-alpine3.13, alpine3.13, 0.22.0-alpine, 0.22-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.21.2/alpine3.13
+Directory: 0.22.0/alpine3.13
 
-Tags: 0.21.2-scratch, 0.21-scratch, scratch, 0.21.2-linux, 0.21-linux, linux
-SharedTags: 0.21.2, 0.21, latest
+Tags: 0.22.0-scratch, 0.22-scratch, scratch, 0.22.0-linux, 0.22-linux, linux
+SharedTags: 0.22.0, 0.22, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.21.2/scratch
+Directory: 0.22.0/scratch
 
-Tags: 0.21.2-windowsservercore-1809, 0.21-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.21.2-windowsservercore, 0.21-windowsservercore, windowsservercore
+Tags: 0.22.0-windowsservercore-1809, 0.22-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.22.0-windowsservercore, 0.22-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.21.2/windowsservercore-1809
+Directory: 0.22.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 0.21.2-nanoserver-1809, 0.21-nanoserver-1809, nanoserver-1809
-SharedTags: 0.21.2-nanoserver, 0.21-nanoserver, nanoserver, 0.21.2, 0.21, latest
+Tags: 0.22.0-nanoserver-1809, 0.22-nanoserver-1809, nanoserver-1809
+SharedTags: 0.22.0-nanoserver, 0.22-nanoserver, nanoserver, 0.22.0, 0.22, latest
 Architectures: windows-amd64
-Directory: 0.21.2/nanoserver-1809
+Directory: 0.22.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 0.21.2-windowsservercore-ltsc2016, 0.21-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 0.21.2-windowsservercore, 0.21-windowsservercore, windowsservercore
+Tags: 0.22.0-windowsservercore-ltsc2016, 0.22-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 0.22.0-windowsservercore, 0.22-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.21.2/windowsservercore-ltsc2016
+Directory: 0.22.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.22.0)

Doc PR: https://github.com/docker-library/docs/pull/1972

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>