### PR TITLE
Ubuntu update

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -3,48 +3,48 @@
 
 Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
 GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
-GitCommit: 44a6b26ba9c7ca5fdd8b8137ca52256e8203cef5
+GitCommit: 0b8f2d3178be022d9696ab7e2a786f3ab6406c41
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c5bc8f61f0e0a8aa3780a8dc3a09ae6558693117
+amd64-GitCommit: 1c090689a541a57452ae21cb76ef038b9f339fb2
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7246f77e7641753266f76fd6779f8c313d1e854c
+arm32v7-GitCommit: 5149b4dec8a0c4c6d980ae3a097e4c618c4309fc
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c2823241a80c314483e15f25262a8113377ee8a9
+arm64v8-GitCommit: 013cb1c5dffb4c1c49de6c81e6792791d19044c3
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: d417210a0b4e10d06c14b1e0d2bc72db6d00172b
+i386-GitCommit: c98f198abb6d7148cad91a75137804c52d702968
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: dec3d31802c089d25707fa76a5b501154239faa9
+ppc64le-GitCommit: 44f517c0b9e9f22a8695c9681824dd371f828188
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 40aca93258bae00bd5e3d9812ef11336406e75ee
+s390x-GitCommit: bae1f1838c6c61e98329912fdb59ba5ca70f0e2e
 
-# 20210512 (bionic)
-Tags: 18.04, bionic-20210512, bionic
+# 20210615.1 (bionic)
+Tags: 18.04, bionic-20210615.1, bionic
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20210416 (focal)
-Tags: 20.04, focal-20210416, focal, latest
+# 20210609 (focal)
+Tags: 20.04, focal-20210609, focal, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: focal
 
-# 20210524 (groovy)
-Tags: 20.10, groovy-20210524, groovy
+# 20210614 (groovy)
+Tags: 20.10, groovy-20210614, groovy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: groovy
 
-# 20210522 (hirsute)
-Tags: 21.04, hirsute-20210522, hirsute, rolling
+# 20210602 (hirsute)
+Tags: 21.04, hirsute-20210602, hirsute, rolling
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: hirsute
 
-# 20210519 (impish)
-Tags: 21.10, impish-20210519, impish, devel
+# 20210606 (impish)
+Tags: 21.10, impish-20210606, impish, devel
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 Directory: impish
 
@@ -53,7 +53,7 @@ Tags: 14.04, trusty-20191217, trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: trusty
 
-# 20210429 (xenial)
-Tags: 16.04, xenial-20210429, xenial
+# 20210611 (xenial)
+Tags: 16.04, xenial-20210611, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: xenial


### PR DESCRIPTION
This update includes the switch from
https://partner-images.canonical.com/core/ to
https://partner-images.canonical.com/oci/ for bionic and later.