### PR TITLE
[oraclelinux] Update oraclelinux:8 and 8-slim for CVE-2021-27219

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 237dc5c63b92e93b2292e58789518b2ceee231cb
+amd64-GitCommit: c7e35e32366f89bafa4f01f851b44a520ac80b91
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fc50d1823b7cf525a04968940c2a62add66c4950
+arm64v8-GitCommit: 6d217b04c31eeaed8133ccca9de4f83e9d6ef805
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/errata/ELSA-2021-2170.html>

Signed-off-by: Avi Miller <avi.miller@oracle.com>