### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -10,7 +10,7 @@ GitCommit: 7736d321ea194e82731f0fa79b8a91f053e36aa2
 Directory: 4.2
 
 Tags: 4.2.1-passenger, 4.2-passenger, 4-passenger, passenger
-GitCommit: fc3182cf934fc112a0d9a4f819892d3f2450d05a
+GitCommit: 95a653cf645264889ba03008751fb36a9824ea13
 Directory: 4.2/passenger
 
 Tags: 4.2.1-alpine, 4.2-alpine, 4-alpine, alpine
@@ -23,7 +23,7 @@ GitCommit: 7736d321ea194e82731f0fa79b8a91f053e36aa2
 Directory: 4.1
 
 Tags: 4.1.3-passenger, 4.1-passenger
-GitCommit: 9cdb40719526a554a985422a554e481cbdf3e717
+GitCommit: 95a653cf645264889ba03008751fb36a9824ea13
 Directory: 4.1/passenger
 
 Tags: 4.1.3-alpine, 4.1-alpine
@@ -36,7 +36,7 @@ GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
 Directory: 4.0
 
 Tags: 4.0.9-passenger, 4.0-passenger
-GitCommit: 9cdb40719526a554a985422a554e481cbdf3e717
+GitCommit: 95a653cf645264889ba03008751fb36a9824ea13
 Directory: 4.0/passenger
 
 Tags: 4.0.9-alpine, 4.0-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/95a653c: Update to passenger 6.0.9
- https://github.com/docker-library/redmine/commit/bf02435: Switch update.sh to curl to fix wget cert issues