### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,11 +1,10 @@
 Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
-             iliana destroyer of worlds (@iliana),
              Frédérick Lefebvre (@fred-lefebvre),
              Samuel Karp (@samuelkarp),
              Stewart Smith (@stewartsmith),
              Jamie Anderson (@jamieand)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 3ee6a0ae683a64b606f1f2c5b577fd43f4022d2c
+GitCommit: fe9fa575014a79d219bf41e8ec60b933faa58d91
 
 Tags: 2.0.20210421.0, 2, latest
 Architectures: amd64, arm64v8
@@ -21,12 +20,12 @@ amd64-GitCommit: e72cb97b74ee2fd1208659acfc9918416f107312
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 0f4368397c145df45cb1273b37c86ab088889d10
 
-Tags: 2018.03.0.20210408.0, 2018.03, 1
+Tags: 2018.03.0.20210521.1, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: e6a92d956a01831339b480ab87d3497d307c1dda
+amd64-GitCommit: 92faacbbd63cacf5ad059da826c1e1ee9b603f84
 
-Tags: 2018.03.0.20210408.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20210521.1-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 735edc6b14558fdd2f1f43953b4a21e3a00ffe4e
+amd64-GitCommit: c784f486f5974aa5a28038c86700196ebc6e1306


### PR DESCRIPTION
Hi all, this will be my last update to this image on behalf of the Amazon Linux team. You'll hear from one of the other maintainers next time!

The AL1 image in this pull request does not actually have any package changes from the current AL1 image, however I went ahead and pushed it all the way through the process as part of handing this off to another team. If you'd like to avoid building something for lack of any changes that's fine, you can just close this pull request -- my maintainer line will get removed in the next PR we make.

Thanks!