### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,86 +5,86 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.16.4-buster, 1.16-buster, 1-buster, buster
-SharedTags: 1.16.4, 1.16, 1, latest
+Tags: 1.16.5-buster, 1.16-buster, 1-buster, buster
+SharedTags: 1.16.5, 1.16, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/buster
 
-Tags: 1.16.4-stretch, 1.16-stretch, 1-stretch, stretch
+Tags: 1.16.5-stretch, 1.16-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/stretch
 
-Tags: 1.16.4-alpine3.13, 1.16-alpine3.13, 1-alpine3.13, alpine3.13, 1.16.4-alpine, 1.16-alpine, 1-alpine, alpine
+Tags: 1.16.5-alpine3.13, 1.16-alpine3.13, 1-alpine3.13, alpine3.13, 1.16.5-alpine, 1.16-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/alpine3.13
 
-Tags: 1.16.4-alpine3.12, 1.16-alpine3.12, 1-alpine3.12, alpine3.12
+Tags: 1.16.5-alpine3.12, 1.16-alpine3.12, 1-alpine3.12, alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/alpine3.12
 
-Tags: 1.16.4-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.16.4-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.4, 1.16, 1, latest
+Tags: 1.16.5-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.16.5-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.5, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16.4-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.16.4-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.4, 1.16, 1, latest
+Tags: 1.16.5-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.16.5-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.5, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.16.4-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.16.4-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.16.5-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.16.5-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: ad65a7b21b2689de3a15334a7db2917a3b9216ec
+GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.15.12-buster, 1.15-buster
-SharedTags: 1.15.12, 1.15
+Tags: 1.15.13-buster, 1.15-buster
+SharedTags: 1.15.13, 1.15
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/buster
 
-Tags: 1.15.12-stretch, 1.15-stretch
+Tags: 1.15.13-stretch, 1.15-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/stretch
 
-Tags: 1.15.12-alpine3.13, 1.15-alpine3.13, 1.15.12-alpine, 1.15-alpine
+Tags: 1.15.13-alpine3.13, 1.15-alpine3.13, 1.15.13-alpine, 1.15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/alpine3.13
 
-Tags: 1.15.12-alpine3.12, 1.15-alpine3.12
+Tags: 1.15.13-alpine3.12, 1.15-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/alpine3.12
 
-Tags: 1.15.12-windowsservercore-1809, 1.15-windowsservercore-1809
-SharedTags: 1.15.12-windowsservercore, 1.15-windowsservercore, 1.15.12, 1.15
+Tags: 1.15.13-windowsservercore-1809, 1.15-windowsservercore-1809
+SharedTags: 1.15.13-windowsservercore, 1.15-windowsservercore, 1.15.13, 1.15
 Architectures: windows-amd64
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.15.12-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
-SharedTags: 1.15.12-windowsservercore, 1.15-windowsservercore, 1.15.12, 1.15
+Tags: 1.15.13-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
+SharedTags: 1.15.13-windowsservercore, 1.15-windowsservercore, 1.15.13, 1.15
 Architectures: windows-amd64
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.15.12-nanoserver-1809, 1.15-nanoserver-1809
-SharedTags: 1.15.12-nanoserver, 1.15-nanoserver
+Tags: 1.15.13-nanoserver-1809, 1.15-nanoserver-1809
+SharedTags: 1.15.13-nanoserver, 1.15-nanoserver
 Architectures: windows-amd64
-GitCommit: 35c42a11279b92365d376997fcfbfbdde756ea01
+GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
 Directory: 1.15/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/b879b60: Update 1.16 to 1.16.5
- https://github.com/docker-library/golang/commit/74370a4: Update 1.15 to 1.15.13