### PR TITLE
Update CentOS Linux images for 8.4.2105

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -2,13 +2,13 @@ Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
 GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
 Directory: docker
 
-Tags: latest, centos8, 8, centos8.3.2011, 8.3.2011
+Tags: latest, centos8, 8, centos8.4.2105, 8.4.2105
 GitFetch: refs/heads/CentOS-8-x86_64
-GitCommit: ccd17799397027acf9ee6d660e75b8fce4c852e8
+GitCommit: 607af70702bacc6f46fab2ded055ab23d9113831
 arm64v8-GitFetch: refs/heads/CentOS-8-aarch64
-arm64v8-GitCommit: 88b3ec90d3e01f637cab87ad124e8917f60839af
+arm64v8-GitCommit: e79ccf67325a31bf0bb79a8a0e82d3d8a4de2da8
 ppc64le-GitFetch: refs/heads/CentOS-8-ppc64le
-ppc64le-GitCommit: cf1c88f0b706f6c6192e4e80ec8ec5be5c499eaa
+ppc64le-GitCommit: 76f876b31bb82108a1acf2cee1032c1d2ebc3bd9
 Architectures: amd64, arm64v8, ppc64le
 
 Tags: centos7, 7, centos7.9.2009, 7.9.2009


### PR DESCRIPTION
We have a new CentOS Linux Release announced today:
https://lists.centos.org/pipermail/centos-announce/2021-June/048316.html

Here are the latest images.

Signed-off-by: Brian Stinson <bstinson@centosproject.org>