### PR TITLE
Update phpMyAdmin to version 5.1.1

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -3,17 +3,17 @@ Maintainers: Isaac Bennetch <bennetch@gmail.com> (@ibennetch),
              William Desportes <williamdes@wdes.fr> (@williamdes)
 GitRepo: https://github.com/phpmyadmin/docker.git
 
-Tags: 5.1.0-apache, 5.1-apache, 5-apache, apache, 5.1.0, 5.1, 5, latest
+Tags: 5.1.1-apache, 5.1-apache, 5-apache, apache, 5.1.1, 5.1, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d8c2ba403fa091a19c6f16762d50663e57f8969
+GitCommit: 935605b8d0a4e8632c1b63fbba4967b22c1a5a15
 Directory: apache
 
-Tags: 5.1.0-fpm, 5.1-fpm, 5-fpm, fpm
+Tags: 5.1.1-fpm, 5.1-fpm, 5-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d8c2ba403fa091a19c6f16762d50663e57f8969
+GitCommit: 935605b8d0a4e8632c1b63fbba4967b22c1a5a15
 Directory: fpm
 
-Tags: 5.1.0-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine
+Tags: 5.1.1-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d8c2ba403fa091a19c6f16762d50663e57f8969
+GitCommit: 935605b8d0a4e8632c1b63fbba4967b22c1a5a15
 Directory: fpm-alpine


### PR DESCRIPTION
We've just released the latest phpMyAdmin version 5.1.1.

Signed-off-by: Isaac Bennetch <bennetch@gmail.com>