### PR TITLE
Update tag for alpine jre to 8u292

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -18,7 +18,7 @@ Tags: 8-alpine, 8u292-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine
 
-Tags: 8-alpine-jre, 8u282-alpine-jre
+Tags: 8-alpine-jre, 8u292-alpine-jre
 Architectures: amd64
 Directory: 8/jre/alpine
 


### PR DESCRIPTION
While updating the tags, we had not updated the 8u292 tag for alpine-jre. 