### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,37 +1,37 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/4c1cc3e2d43b6d10c9cd58d69f01f7a5aab1860e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/6fce185cf328515b4ac9093efccc5adf212a2573/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 4c1cc3e2d43b6d10c9cd58d69f01f7a5aab1860e
+GitCommit: 6fce185cf328515b4ac9093efccc5adf212a2573
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6a3fa4f3ee1437da18f6f017b75e7799b1ae910b
+amd64-GitCommit: 2bcc4bf56c2a4594aa31feb8b42d5eab76d168bb
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 7ba4db1c418f6ee955d47feadbfaa4421d6f9358
+arm32v5-GitCommit: a542a7bc9817e71654aba8feb6b5cb265e8f9976
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: ac3117388507e850afc3e3f3661aa5a67ddb005f
+arm32v6-GitCommit: 4619f8d1d337e99ce34641394b37f13d2086b7fa
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 1c90f843655937f14f4311393f83e999b84a854e
+arm32v7-GitCommit: 167c5ca7501659ccbe426677302f49b1060a2d1c
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d099efc0995072b40690aca7ae12b1153d86d4b8
+arm64v8-GitCommit: cce85f68157251e06d6a328fe092000b55a26725
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 11fa6cd31028cbe8ecd00e34b4714c6cd11005d8
+i386-GitCommit: 6146c81916dc3384c7ac8fe13c5c1fb69f70b80a
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 809376c5217a280406d2f8738655be68f4073638
+mips64le-GitCommit: e152603121edbf1117006ff7d843de5ff26fe864
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 3556e81fab641ab84ead9635e508f5e321a77c35
+ppc64le-GitCommit: 9c6ff55d8efc0ab835a9fe70c660c907ccb1a325
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 2003d909bde49b85d0684909bec5e7cfdec48d67
+s390x-GitCommit: 6b63b93035aa234e8e09843bca168f518db651f6
 
 Tags: 1.33.1-uclibc, 1.33-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/6fce185: Merge pull request https://github.com/docker-library/busybox/pull/104 from infosiftr/buildroot-2021.05
- https://github.com/docker-library/busybox/commit/6270ce0: Update Buildroot to 2021.05