### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.6.5, 4.6, 4, latest
+Tags: 4.6.6, 4.6, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4410785268b9bfdf3b38419058c0f29d0a525fc9
+GitCommit: b0308244a0690b19cbb8e9c58ab7b30dda410e6e
 Directory: 4/debian
 
-Tags: 4.6.5-alpine, 4.6-alpine, 4-alpine, alpine
+Tags: 4.6.6-alpine, 4.6-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4410785268b9bfdf3b38419058c0f29d0a525fc9
+GitCommit: b0308244a0690b19cbb8e9c58ab7b30dda410e6e
 Directory: 4/alpine
 
 Tags: 3.42.5, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/b030824: Update to 4.6.6, ghost-cli 1.17.3