### PR TITLE
Odoo: update 12.0-14.0 to release 20210609

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 6d95b778cfdd0673e1571f962a4aac70f67a685e
+GitCommit: aa6f1bb98f9e23746d958fce2158683df904cfce
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported releases.

Thanks