### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -63,3 +63,48 @@ Tags: cli-2.5.0-php8.0, cli-2.5-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
 Directory: cli/php8.0/alpine
+
+Tags: beta-5.8-beta1-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8-beta1, beta-5.8, beta-5, beta, beta-5.8-beta1-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8-beta1-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php7.4/apache
+
+Tags: beta-5.8-beta1-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8-beta1-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php7.4/fpm
+
+Tags: beta-5.8-beta1-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8-beta1-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php7.4/fpm-alpine
+
+Tags: beta-5.8-beta1-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8-beta1-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php7.3/apache
+
+Tags: beta-5.8-beta1-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php7.3/fpm
+
+Tags: beta-5.8-beta1-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php7.3/fpm-alpine
+
+Tags: beta-5.8-beta1-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8-beta1-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php8.0/apache
+
+Tags: beta-5.8-beta1-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php8.0/fpm
+
+Tags: beta-5.8-beta1-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ba94129af1c4d5b1497aad9a2128ea154e87b7e3
+Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/ba94129: Update beta to 5.8-beta1