### PR TITLE
Upgrade Dart to 2.13.3

### DIFF
--- a/library/dart
+++ b/library/dart
@@ -1,7 +1,7 @@
 Maintainers: Alexander Thomas <athom@google.com> (@athomas), Tony Pujals <tonypujals@google.com> (@subfuzion)
 GitRepo: https://github.com/dart-lang/dart-docker.git
 GitFetch: refs/heads/main
-GitCommit: f2f3164323a981adbbcd7393c884509e9504e29e
+GitCommit: b43f5919af3c00e203ceec8b7ff8a41e7aadd7eb
 
-Tags: 2.13.1-sdk, 2.13-sdk, 2-sdk, stable-sdk, sdk, 2.13.1, 2.13, 2, stable, latest, beta-sdk, beta
+Tags: 2.13.3-sdk, 2.13-sdk, 2-sdk, stable-sdk, sdk, 2.13.3, 2.13, 2, stable, latest, beta-sdk, beta
 Directory: stable/buster


### PR DESCRIPTION
Notes:
* 2.13.2 was never published, that's why we're jumping to 2.13.3 directly.
* git was added to the image (dart-lang/dart-docker#26).