### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,40 +1,40 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/6377a52b25e9b7790c7082fbdc3f587069255d27/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/c575437642d2113b7fc1d57901417ee3c5234cc3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 4.9.0-rc1-focal, 4.9-rc-focal
-SharedTags: 4.9.0-rc1, 4.9-rc
+Tags: 5.0.0-rc1-focal, 5.0-rc-focal
+SharedTags: 5.0.0-rc1, 5.0-rc
 Architectures: amd64, arm64v8
-GitCommit: 2e9ea18db4f51698949cbc0416fea3bf89aa1e03
-Directory: 4.9-rc
+GitCommit: 12c2b455fadd9eb4ed2ba491b32370b1854e4fe5
+Directory: 5.0-rc
 
-Tags: 4.9.0-rc1-windowsservercore-1809, 4.9-rc-windowsservercore-1809
-SharedTags: 4.9.0-rc1-windowsservercore, 4.9-rc-windowsservercore, 4.9.0-rc1, 4.9-rc
+Tags: 5.0.0-rc1-windowsservercore-1809, 5.0-rc-windowsservercore-1809
+SharedTags: 5.0.0-rc1-windowsservercore, 5.0-rc-windowsservercore, 5.0.0-rc1, 5.0-rc
 Architectures: windows-amd64
-GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
-Directory: 4.9-rc/windows/windowsservercore-1809
+GitCommit: 12c2b455fadd9eb4ed2ba491b32370b1854e4fe5
+Directory: 5.0-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.9.0-rc1-windowsservercore-ltsc2016, 4.9-rc-windowsservercore-ltsc2016
-SharedTags: 4.9.0-rc1-windowsservercore, 4.9-rc-windowsservercore, 4.9.0-rc1, 4.9-rc
+Tags: 5.0.0-rc1-windowsservercore-ltsc2016, 5.0-rc-windowsservercore-ltsc2016
+SharedTags: 5.0.0-rc1-windowsservercore, 5.0-rc-windowsservercore, 5.0.0-rc1, 5.0-rc
 Architectures: windows-amd64
-GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
-Directory: 4.9-rc/windows/windowsservercore-ltsc2016
+GitCommit: 12c2b455fadd9eb4ed2ba491b32370b1854e4fe5
+Directory: 5.0-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.9.0-rc1-nanoserver-1809, 4.9-rc-nanoserver-1809
-SharedTags: 4.9.0-rc1-nanoserver, 4.9-rc-nanoserver
+Tags: 5.0.0-rc1-nanoserver-1809, 5.0-rc-nanoserver-1809
+SharedTags: 5.0.0-rc1-nanoserver, 5.0-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
-Directory: 4.9-rc/windows/nanoserver-1809
+GitCommit: 12c2b455fadd9eb4ed2ba491b32370b1854e4fe5
+Directory: 5.0-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 4.4.6-bionic, 4.4-bionic, 4-bionic, bionic
 SharedTags: 4.4.6, 4.4, 4, latest
 Architectures: amd64, arm64v8, s390x
-GitCommit: 791d400b9e84a298356b78db01956d98db973b9d
+GitCommit: f14ca0c10b5a76bf41f65127b1b666659e91017e
 Directory: 4.4
 
 Tags: 4.4.6-windowsservercore-1809, 4.4-windowsservercore-1809, 4-windowsservercore-1809, windowsservercore-1809
@@ -61,7 +61,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 4.2.14-bionic, 4.2-bionic
 SharedTags: 4.2.14, 4.2
 Architectures: amd64, arm64v8
-GitCommit: 791d400b9e84a298356b78db01956d98db973b9d
+GitCommit: f14ca0c10b5a76bf41f65127b1b666659e91017e
 Directory: 4.2
 
 Tags: 4.2.14-windowsservercore-1809, 4.2-windowsservercore-1809
@@ -85,29 +85,29 @@ GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
 Directory: 4.2/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 4.0.24-xenial, 4.0-xenial
-SharedTags: 4.0.24, 4.0
+Tags: 4.0.25-xenial, 4.0-xenial
+SharedTags: 4.0.25, 4.0
 Architectures: amd64, arm64v8
-GitCommit: 791d400b9e84a298356b78db01956d98db973b9d
+GitCommit: 724081d1586a930c9b50d6337f086d29968a7389
 Directory: 4.0
 
-Tags: 4.0.24-windowsservercore-1809, 4.0-windowsservercore-1809
-SharedTags: 4.0.24-windowsservercore, 4.0-windowsservercore, 4.0.24, 4.0
+Tags: 4.0.25-windowsservercore-1809, 4.0-windowsservercore-1809
+SharedTags: 4.0.25-windowsservercore, 4.0-windowsservercore, 4.0.25, 4.0
 Architectures: windows-amd64
-GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+GitCommit: 724081d1586a930c9b50d6337f086d29968a7389
 Directory: 4.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.0.24-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016
-SharedTags: 4.0.24-windowsservercore, 4.0-windowsservercore, 4.0.24, 4.0
+Tags: 4.0.25-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016
+SharedTags: 4.0.25-windowsservercore, 4.0-windowsservercore, 4.0.25, 4.0
 Architectures: windows-amd64
-GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+GitCommit: 724081d1586a930c9b50d6337f086d29968a7389
 Directory: 4.0/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 4.0.24-nanoserver-1809, 4.0-nanoserver-1809
-SharedTags: 4.0.24-nanoserver, 4.0-nanoserver
+Tags: 4.0.25-nanoserver-1809, 4.0-nanoserver-1809
+SharedTags: 4.0.25-nanoserver, 4.0-nanoserver
 Architectures: windows-amd64
-GitCommit: dc35ba55761b2f03ce2f79ff3b79783b15e23dae
+GitCommit: 724081d1586a930c9b50d6337f086d29968a7389
 Directory: 4.0/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/38acbae: Update 4.0-rc
- https://github.com/docker-library/mongo/commit/c575437: Fix generate when called with an explicit null version
- https://github.com/docker-library/mongo/commit/12c2b45: Update 5.0-rc to 5.0.0-rc1
- https://github.com/docker-library/mongo/commit/724081d: Update 4.0 to 4.0.25
- https://github.com/docker-library/mongo/commit/f14ca0c: Split ARGs back to two lines; 19.x docker can't handle it
- https://github.com/docker-library/mongo/commit/0740a2c: Merge pull request https://github.com/docker-library/mongo/pull/476 from infosiftr/rcs
- https://github.com/docker-library/mongo/commit/a4a9860: Add RCs more "opportunistically"