### PR TITLE
[ros] dashing images using final snapshots

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -113,7 +113,7 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: dashing-ros-core, dashing-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
+GitCommit: 9e11af32454c0ca37c7b9606fac567de66aaae8e
 Directory: ros/dashing/ubuntu/bionic/ros-core
 
 Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
@@ -123,7 +123,7 @@ Directory: ros/dashing/ubuntu/bionic/ros-base
 
 Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
+GitCommit: 9e11af32454c0ca37c7b9606fac567de66aaae8e
 Directory: ros/dashing/ubuntu/bionic/ros1-bridge
 
 


### PR DESCRIPTION
ROS dashing is [reaching EOL](https://discourse.ros.org/t/new-packages-and-patch-release-for-ros-2-dashing-diademata-2021-06-10-final/20875).

This switches the docker images to use the snapshots APT repository before retiring the images