### PR TITLE
[oraclelinux] Update oraclelinux:7 and oraclelinux:8 for CVE-2021-25217

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c7e35e32366f89bafa4f01f851b44a520ac80b91
+amd64-GitCommit: 8a5f1153d3e770f2e5c01696e50ba68c078384ab
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6d217b04c31eeaed8133ccca9de4f83e9d6ef805
+arm64v8-GitCommit: 79f7824a39dff7c7ef0763748095b51a83dc5573
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/cve/CVE-2021-25217.html> for
details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>