### PR TITLE
21.0.0.6 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 651f2794c93bc454aeae12eda58be1430f731e0e
+GitCommit: 1d2343268a0cbcdf77490c6c8fa607ed1d70c5a6
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -35,23 +35,23 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.5-kernel-slim-java8-openj9
-Directory: releases/21.0.0.5/kernel-slim
+Tags: 21.0.0.6-kernel-slim-java8-openj9
+Directory: releases/21.0.0.6/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.5-kernel-slim-java11-openj9
-Directory: releases/21.0.0.5/kernel-slim
+Tags: 21.0.0.6-kernel-slim-java11-openj9
+Directory: releases/21.0.0.6/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.5-full-java8-openj9
-Directory: releases/21.0.0.5/full
+Tags: 21.0.0.6-full-java8-openj9
+Directory: releases/21.0.0.6/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.5-full-java11-openj9
-Directory: releases/21.0.0.5/full
+Tags: 21.0.0.6-full-java11-openj9
+Directory: releases/21.0.0.6/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 1d2343268a0cbcdf77490c6c8fa607ed1d70c5a6
+GitCommit: af5843fe3f3c594ca0e2dc7e3613d7660d4220e2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -72,25 +72,5 @@ File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 21.0.0.3-full-java11-openj9
 Directory: releases/21.0.0.3/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 20.0.0.12-kernel-slim-java8-openj9
-Directory: releases/20.0.0.12/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 20.0.0.12-kernel-slim-java11-openj9
-Directory: releases/20.0.0.12/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 20.0.0.12-full-java8-openj9
-Directory: releases/20.0.0.12/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 20.0.0.12-full-java11-openj9
-Directory: releases/20.0.0.12/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 1d2343268a0cbcdf77490c6c8fa607ed1d70c5a6
+GitCommit: 17cdd8ad817f7830f0732c95b90843d83f6a4908
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -56,23 +56,5 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 21.0.0.3-full-java11-openj9
 Directory: ga/21.0.0.3/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 20.0.0.12-kernel-java8-ibmjava
-Directory: ga/20.0.0.12/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 20.0.0.12-kernel-java11-openj9
-Directory: ga/20.0.0.12/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 20.0.0.12-full-java8-ibmjava
-Directory: ga/20.0.0.12/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 20.0.0.12-full-java11-openj9
-Directory: ga/20.0.0.12/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 8d30234391a62a3a6b2c32b45801cb5e914781fa
+GitCommit: 1d2343268a0cbcdf77490c6c8fa607ed1d70c5a6
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -23,21 +23,21 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.5-kernel-java8-ibmjava
-Directory: ga/21.0.0.5/kernel
+Tags: 21.0.0.6-kernel-java8-ibmjava
+Directory: ga/21.0.0.6/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.5-kernel-java11-openj9
-Directory: ga/21.0.0.5/kernel
+Tags: 21.0.0.6-kernel-java11-openj9
+Directory: ga/21.0.0.6/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.5-full-java8-ibmjava
-Directory: ga/21.0.0.5/full
+Tags: 21.0.0.6-full-java8-ibmjava
+Directory: ga/21.0.0.6/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.5-full-java11-openj9
-Directory: ga/21.0.0.5/full
+Tags: 21.0.0.6-full-java11-openj9
+Directory: ga/21.0.0.6/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 


### PR DESCRIPTION
Updates to websphere-liberty and open-liberty for the release of 21.0.0.6. This includes removing support for 20.0.0.12.