### PR TITLE
archlinux: Release 20210613.0.25781

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210606.0.24959
-GitCommit: 394b67466965ceb10d8367b65a34ee8fc7091649
-GitFetch: refs/tags/v20210606.0.24959
+Tags: latest, base, base-20210613.0.25781
+GitCommit: 21697e023043f7b2137d7565daebec4a668a604f
+GitFetch: refs/tags/v20210613.0.25781
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210606.0.24959
-GitCommit: 394b67466965ceb10d8367b65a34ee8fc7091649
-GitFetch: refs/tags/v20210606.0.24959
+Tags: base-devel, base-devel-20210613.0.25781
+GitCommit: 21697e023043f7b2137d7565daebec4a668a604f
+GitFetch: refs/tags/v20210613.0.25781
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks