### PR TITLE
[ros] retire dashing images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -106,28 +106,6 @@ Directory: ros/noetic/debian/buster/perception
 
 
 ################################################################################
-# Release: dashing
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: dashing-ros-core, dashing-ros-core-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 9e11af32454c0ca37c7b9606fac567de66aaae8e
-Directory: ros/dashing/ubuntu/bionic/ros-core
-
-Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/dashing/ubuntu/bionic/ros-base
-
-Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 9e11af32454c0ca37c7b9606fac567de66aaae8e
-Directory: ros/dashing/ubuntu/bionic/ros1-bridge
-
-
-################################################################################
 # Release: foxy
 
 ########################################


### PR DESCRIPTION
Follow-up of https://github.com/docker-library/official-images/pull/10343