### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,25 +4,67 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 17-ea-25-jdk-oraclelinux8, 17-ea-25-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-25-jdk-oracle, 17-ea-25-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-25-jdk, 17-ea-25, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 18-ea-1-jdk-oraclelinux8, 18-ea-1-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-1-jdk-oracle, 18-ea-1-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-1-jdk, 18-ea-1, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/oraclelinux8
+
+Tags: 18-ea-1-jdk-oraclelinux7, 18-ea-1-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Architectures: amd64, arm64v8
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/oraclelinux7
+
+Tags: 18-ea-1-jdk-buster, 18-ea-1-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Architectures: amd64, arm64v8
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/buster
+
+Tags: 18-ea-1-jdk-slim-buster, 18-ea-1-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-1-jdk-slim, 18-ea-1-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Architectures: amd64, arm64v8
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/slim-buster
+
+Tags: 18-ea-1-jdk-windowsservercore-1809, 18-ea-1-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-1-jdk-windowsservercore, 18-ea-1-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-1-jdk, 18-ea-1, 18-ea-jdk, 18-ea, 18-jdk, 18
+Architectures: windows-amd64
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 18-ea-1-jdk-windowsservercore-ltsc2016, 18-ea-1-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-1-jdk-windowsservercore, 18-ea-1-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-1-jdk, 18-ea-1, 18-ea-jdk, 18-ea, 18-jdk, 18
+Architectures: windows-amd64
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/windows/windowsservercore-ltsc2016
+Constraints: windowsservercore-ltsc2016
+
+Tags: 18-ea-1-jdk-nanoserver-1809, 18-ea-1-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-1-jdk-nanoserver, 18-ea-1-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Architectures: windows-amd64
+GitCommit: c1413741bbd213f62e3d203b03dcd558c65e3fdf
+Directory: 18/jdk/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
+
+Tags: 17-ea-26-jdk-oraclelinux8, 17-ea-26-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-26-jdk-oracle, 17-ea-26-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-26-jdk, 17-ea-26, 17-ea-jdk, 17-ea, 17-jdk, 17
+Architectures: amd64, arm64v8
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-25-jdk-oraclelinux7, 17-ea-25-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-26-jdk-oraclelinux7, 17-ea-26-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-25-jdk-buster, 17-ea-25-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-26-jdk-buster, 17-ea-26-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/buster
 
-Tags: 17-ea-25-jdk-slim-buster, 17-ea-25-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-25-jdk-slim, 17-ea-25-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-26-jdk-slim-buster, 17-ea-26-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-26-jdk-slim, 17-ea-26-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-14-jdk-alpine3.13, 17-ea-14-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13, 17-ea-14-jdk-alpine, 17-ea-14-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -35,24 +77,24 @@ Architectures: amd64
 GitCommit: 255fbc7cf6da6d76869b420dd2fe0bc94539b5eb
 Directory: 17/jdk/alpine3.12
 
-Tags: 17-ea-25-jdk-windowsservercore-1809, 17-ea-25-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-25-jdk-windowsservercore, 17-ea-25-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-25-jdk, 17-ea-25, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-26-jdk-windowsservercore-1809, 17-ea-26-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-26-jdk-windowsservercore, 17-ea-26-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-26-jdk, 17-ea-26, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-25-jdk-windowsservercore-ltsc2016, 17-ea-25-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-25-jdk-windowsservercore, 17-ea-25-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-25-jdk, 17-ea-25, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-26-jdk-windowsservercore-ltsc2016, 17-ea-26-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-26-jdk-windowsservercore, 17-ea-26-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-26-jdk, 17-ea-26, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-25-jdk-nanoserver-1809, 17-ea-25-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-25-jdk-nanoserver, 17-ea-25-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-26-jdk-nanoserver-1809, 17-ea-26-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-26-jdk-nanoserver, 17-ea-26-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 45e05473d1b545373bd1174083d74e0b53d0aa35
+GitCommit: f493ea72c2473d2d56bbf863cfe86bc8131620f2
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/ae4617e: Adjust version.sh to be more reliable by not piping `cat` to `grep`
- https://github.com/docker-library/openjdk/commit/97ecba6: Merge pull request https://github.com/docker-library/openjdk/pull/459 from infosiftr/18-ea
- https://github.com/docker-library/openjdk/commit/c141374: Add jdk 18 early access
- https://github.com/docker-library/openjdk/commit/f493ea7: Update 17 to 17-ea+26