### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,6 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.18-beta.1, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: a740fcd4414566d8abc39386fdd3b2dedff2fba9
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.18-beta.1-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.18-beta.1-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a740fcd4414566d8abc39386fdd3b2dedff2fba9
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.18-beta.1-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.17, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d630cc389ee11f88a061a0c35e3aa7a928435293


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/a740fcd: Update 3.8-rc to 3.8.18-beta.1