### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -2,23 +2,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Frédérick Lefebvre (@fred-lefebvre),
              Samuel Karp (@samuelkarp),
              Stewart Smith (@stewartsmith),
-             Jamie Anderson (@jamieand)
+             Jamie Anderson (@jamieand),
+             Christopher Miller (@mysteriouspants)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: fe9fa575014a79d219bf41e8ec60b933faa58d91
+GitCommit: f54c62a58129ae4f47e943aad5c3734c40807bf5
 
-Tags: 2.0.20210421.0, 2, latest
+Tags: 2.0.20210525.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 05450487e7d8b1ac1b6d269ccde98690214dae45
+amd64-GitCommit: 23aa3f990835b6e742f37e1b85df2b8c8894760b
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 95c948469d64aa3c5e3758c92bce70d4719dc04b
+arm64v8-GitCommit: 3cd81790f0bf30e868a2ac2f7f23edd9034608b4
 
-Tags: 2.0.20210421.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20210525.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: e72cb97b74ee2fd1208659acfc9918416f107312
+amd64-GitCommit: aef5db273fb6746ed70f5e3c9c8a4ad2a845987a
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 0f4368397c145df45cb1273b37c86ab088889d10
+arm64v8-GitCommit: 4457fe54bf949f4a2659e97be3eec270a4b75932
 
 Tags: 2018.03.0.20210521.1, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
Hello,

We have a new release of Amazon Linux 2.0's container images. Someone previously on the maintainers list will be commenting here soon so you know this is from the Amazon Linux team.

Thanks!