### PR TITLE
Postgres Remove 9.5 (EOL)

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -53,13 +53,3 @@ Tags: 9.6.22-alpine, 9.6-alpine, 9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 720ab505571bd3eddf0f4b04462cae5b9835f287
 Directory: 9.6/alpine
-
-Tags: 9.5.25, 9.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: b122f60426e69df9d6effbda45fe2ef659c1d4f2
-Directory: 9.5
-
-Tags: 9.5.25-alpine, 9.5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6667795da15f1a2d2791021659f2f766828a4321
-Directory: 9.5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/56eb809: Remove 9.5 (EOL)