### PR TITLE
[oraclelinux] Updating oraclelinux:7 and 7-slim for CVE-2020-28196

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8a5f1153d3e770f2e5c01696e50ba68c078384ab
+amd64-GitCommit: fda038ed6d3eca41cac6e6f9950924408b3d7c7d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 79f7824a39dff7c7ef0763748095b51a83dc5573
+arm64v8-GitCommit: ac20c0ff31856d307adc49845cd69988f16de168
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/errata/ELSA-2021-9294.html> for
release information.

Signed-off-by: Avi Miller <avi.miller@oracle.com>