### PR TITLE
Update mongo-express for CVE-2021-21422

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -5,10 +5,10 @@ GitRepo: https://github.com/mongo-express/mongo-express-docker.git
 
 
 GitCommit: 26e7ea94e4d222de7d52531caee52149ac093c26
-Tags: 1.0.0-alpha.4, 1.0.0-alpha, 1.0, latest
+Tags: 1.0.0-alpha.4, 1.0.0-alpha, latest
 Architectures: amd64, arm64v8
 
 
 GitCommit: 4b43fe8a1206434cb32a006cd155dd71462f092f
-Tags: 0.54.0, 0.54, latest
+Tags: 0.54.0, 0.54
 Architectures: amd64, arm64v8

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -2,7 +2,13 @@
 
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
-GitCommit: 4b43fe8a1206434cb32a006cd155dd71462f092f
 
+
+GitCommit: 26e7ea94e4d222de7d52531caee52149ac093c26
+Tags: 1.0.0-alpha.4, 1.0.0-alpha, 1.0, latest
+Architectures: amd64, arm64v8
+
+
+GitCommit: 4b43fe8a1206434cb32a006cd155dd71462f092f
 Tags: 0.54.0, 0.54, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Hello,
We've fixed a security vulnerability in mongo-express and need the mongo-express image being updated to publish security advisory.
Also for connecting to mongo, from now only connection string is valid.

These changes are not automatic since I wanted to keep the old tags as well.