### PR TITLE
Bump Traefik to v2.4.9

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.4.8-windowsservercore-1809, 2.4.8-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.9-windowsservercore-1809, 2.4.9-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
+GitCommit: 3c9cff0bbd01da83bcf9b73b60e09b9e7f7d8c12
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.8, 2.4.8, v2.4, 2.4, livarot, latest
+Tags: v2.4.9, 2.4.9, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c704f6f1db80e36ed01040d5da27d753f2a03ad1
+GitCommit: 3c9cff0bbd01da83bcf9b73b60e09b9e7f7d8c12
 Directory: alpine
 
 Tags: v1.7.30-windowsservercore-1809, 1.7.30-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.9](https://github.com/traefik/traefik/releases/tag/v2.4.9).

/cc @ldez @rtribotte @SantoDE

Cheers
