### PR TITLE
Update Solr to 8.9.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,12 +6,22 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.8.2, 8.8, 8, latest
+Tags: 8.9.0, 8.9, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: a1a59aa9d3ef286fe1e046ddfd168c3c34720660
+Directory: 8.9
+
+Tags: 8.9.0-slim, 8.9-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: a1a59aa9d3ef286fe1e046ddfd168c3c34720660
+Directory: 8.9/slim
+
+Tags: 8.8.2, 8.8
 Architectures: amd64, arm64v8
 GitCommit: 2e73e7067302f889eb42ade28df4adaf3b527d95
 Directory: 8.8
 
-Tags: 8.8.2-slim, 8.8-slim, 8-slim, slim
+Tags: 8.8.2-slim, 8.8-slim
 Architectures: amd64, arm64v8
 GitCommit: 2e73e7067302f889eb42ade28df4adaf3b527d95
 Directory: 8.8/slim


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/r50ecbd4de0c7529df076fd83796035241dff8f7891df1e797d1a0320%40%3Cdev.solr.apache.org%3E) which links to the [release notes](https://solr.apache.org/8_9_0/changes/Changes.html)

Bug Fixes   (15)

 - SOLR-15078: Fix ExpandComponent behavior when expanding on numeric fields to differentiate '0' group from null group
 - SOLR-15149: Better exception handling for LTR model creation errors
 - SOLR-13034: Partial (AKA Atomic) updates could encounter "LazyField" instances in the document cache and not know hot to deal with them when writing the updated doc to the update log.
 - SOLR-15191: Fix JSON Faceting on EnumFieldType if allBuckets, numBuckets or missing is set.
 - SOLR-15457: Fix JSON Faceting on EnumFieldType -- returned values should not be internal ordinals.
 - SOLR-15216: Fix for Invalid Reference to data.followers in Admin UI.
 - SOLR-15273: Fix NullPointerException in StoredFieldsShardResponseProcessor that happened when a field name alias is used for the unique key field in searches with distributed result grouping.
 - SOLR-15384: Zookeeper Status handler /admin/zookeeper/status not queryable from SolrJ
 - SOLR-11921: Move "cursorMark" logic from QueryComponent to SearchHandler so it can work with things like QueryElevationComponent that modify the SortSpec in prepare(), as well as possible custom "search" components other then QueryComponent.
 - SOLR-15317: Correctly handle user principals with whitespace in PKIAuthPlugin
 - SOLR-15383: Solr Zookeeper status page shows green even when some Zookeepers are not serving requests
 - SOLR-11904: Mark ReplicationHandler's polling thread as a Solr server thread so the PKI Interceptor is activated to allow PULL replicas to replicate from security-enabled leaders
 - SOLR-15418: The V2 API threw errors for GET requests to collection handlers like /select.
 - SOLR-15424: Solr replication UI wraps ETA time on top of next line
 - SOLR-15399: IndexFetcher should not issue a local commit for PULL replicas when leader's version is zero