### PR TITLE
consul: 1.10.0, 1.9.7, 1.8.13

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,25 +1,19 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.10.0-rc2, 1.10.0-beta
+Tags: 1.10.0, 1.10, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 1283c3b4172d1d3f8bca6229da222a3b5932dcc0
+GitCommit: 75971b9b493d8ad1ed2a7d8892a1dace2b54f848
 Directory: 0.X
 
-Tags: 1.9.6, 1.9, latest
+Tags: 1.9.7, 1.9
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 7c120bce6e7543e7aef010a3a47487d5ef2f1770
+GitCommit: 50cd4070084984b3237104bd9494ae45809fd475
 Directory: 0.X
 
-Tags: 1.8.12, 1.8
+Tags: 1.8.13, 1.8
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 953986ec5283713cd2991003e9baa08ad04a8d86
-Directory: 0.X
-
-Tags: 1.7.14, 1.7
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 43b15caac2a3d8f61c9ef57fab8e9eee1a07ca60
+GitCommit: 8e034a419d073ddb09175efcff2d720f7a7bdcec
 Directory: 0.X


### PR DESCRIPTION
Additionally, removes 1.7 and switches 1.10 to be _latest_.