### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -51,60 +51,60 @@ Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
+GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
 Directory: cli/php7.4/alpine
 
 Tags: cli-2.5.0-php7.3, cli-2.5-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
+GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
 Directory: cli/php7.3/alpine
 
 Tags: cli-2.5.0-php8.0, cli-2.5-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9300bc2999791d515b3dabdd7cd820f3dca8eebb
+GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
 Directory: cli/php8.0/alpine
 
-Tags: beta-5.8-beta2-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8-beta2, beta-5.8, beta-5, beta, beta-5.8-beta2-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8-beta2-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
+Tags: beta-5.8-beta3-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8-beta3, beta-5.8, beta-5, beta, beta-5.8-beta3-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8-beta3-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php7.4/apache
 
-Tags: beta-5.8-beta2-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8-beta2-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-5.8-beta3-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8-beta3-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php7.4/fpm
 
-Tags: beta-5.8-beta2-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8-beta2-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-5.8-beta3-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8-beta3-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-5.8-beta2-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8-beta2-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
+Tags: beta-5.8-beta3-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8-beta3-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php7.3/apache
 
-Tags: beta-5.8-beta2-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
+Tags: beta-5.8-beta3-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php7.3/fpm
 
-Tags: beta-5.8-beta2-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
+Tags: beta-5.8-beta3-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php7.3/fpm-alpine
 
-Tags: beta-5.8-beta2-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8-beta2-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
+Tags: beta-5.8-beta3-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8-beta3-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php8.0/apache
 
-Tags: beta-5.8-beta2-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-5.8-beta3-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php8.0/fpm
 
-Tags: beta-5.8-beta2-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-5.8-beta3-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 599ed2943c34b5282e3b11536443289e77657e7b
+GitCommit: d459db5d0a0ff8b9b58e9b0790822026da7f1c84
 Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/d459db5: Update beta to 5.8-beta3
- https://github.com/docker-library/wordpress/commit/f5e96ef: Switch from SKS to Ubuntu keyserver