### PR TITLE
MariaDB releases 20210623

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,25 +6,25 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.6.2-focal, 10.6-focal, rc-focal, 10.6.2, 10.6, rc
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d9b652b4ce1e36f39abd8d302d4908617447d77
+GitCommit: 465e597bfa3bd769b5f528df17426bec0724ab12
 Directory: 10.6
 
-Tags: 10.5.10-focal, 10.5-focal, 10-focal, focal, 10.5.10, 10.5, 10, latest
+Tags: 10.5.11-focal, 10.5-focal, 10-focal, focal, 10.5.11, 10.5, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 710e0cd9d9197becc954e9a4c572cb97dd1d07a8
+GitCommit: 6c466f9551cf73bbaebd02c8f68b058c4e44a40c
 Directory: 10.5
 
-Tags: 10.4.19-focal, 10.4-focal, 10.4.19, 10.4
+Tags: 10.4.20-focal, 10.4-focal, 10.4.20, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 710e0cd9d9197becc954e9a4c572cb97dd1d07a8
+GitCommit: 684d352c819d94e9b914e056655180e2be394819
 Directory: 10.4
 
-Tags: 10.3.29-focal, 10.3-focal, 10.3.29, 10.3
+Tags: 10.3.30-focal, 10.3-focal, 10.3.30, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 710e0cd9d9197becc954e9a4c572cb97dd1d07a8
+GitCommit: 254bc8c6646f75d335325c064905d7288ca24aca
 Directory: 10.3
 
-Tags: 10.2.38-bionic, 10.2-bionic, 10.2.38, 10.2
+Tags: 10.2.39-bionic, 10.2-bionic, 10.2.39, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 710e0cd9d9197becc954e9a4c572cb97dd1d07a8
+GitCommit: 0c4bdac53d22647f39187e8d00d02c5a2e760940
 Directory: 10.2


### PR DESCRIPTION
Hi,

We've done our 10.5.11, 10.4.20, 10.3.30, and 10.2.39 maintenance releases.