### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -3,23 +3,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Samuel Karp (@samuelkarp),
              Stewart Smith (@stewartsmith),
              Jamie Anderson (@jamieand),
-             Christopher Miller (@mysteriouspants)
+             Christopher Miller (@mysteriouspants),
+             Sumit Tomer (@sktomer)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: f54c62a58129ae4f47e943aad5c3734c40807bf5
+GitCommit: ec3bea78c4077114c1866aaf10d35dc5004a7b71
 
-Tags: 2.0.20210525.0, 2, latest
+Tags: 2.0.20210617.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 23aa3f990835b6e742f37e1b85df2b8c8894760b
+amd64-GitCommit: a0fca3351cb85df91417b9c0030f5d5f91dfb808
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 3cd81790f0bf30e868a2ac2f7f23edd9034608b4
+arm64v8-GitCommit: c7746089cbbc3e535c045a518896d679edb4b905
 
-Tags: 2.0.20210525.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20210617.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: aef5db273fb6746ed70f5e3c9c8a4ad2a845987a
+amd64-GitCommit: 91a1759eddd8da6439eba7c00f7e97e6a4da1bd1
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 4457fe54bf949f4a2659e97be3eec270a4b75932
+arm64v8-GitCommit: 6ad87cd19ecc5c12fbd0e110f1e382328451d782
 
 Tags: 2018.03.0.20210521.1, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
Hello,

I'm Sumit from Amazon Linux team.
We have a new release for Amazon Linux 2 ready for merge: Amazon Linux 2.20210617.0 Release

Thanks!