### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -11,17 +11,17 @@ Directory: 2.5-rc
 
 Tags: 2.5-dev0-alpine, 2.5-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.0, 2.4, lts, latest
+Tags: 2.4.1, 2.4, lts, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+GitCommit: 8cac7162fb3fb4431208d98c2cd9c63d1897421f
 Directory: 2.4
 
-Tags: 2.4.0-alpine, 2.4-alpine, lts-alpine, alpine
+Tags: 2.4.1-alpine, 2.4-alpine, lts-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae10fbf9bae067e11222c34344c9032060ffa997
+GitCommit: 8cac7162fb3fb4431208d98c2cd9c63d1897421f
 Directory: 2.4/alpine
 
 Tags: 2.3.10, 2.3
@@ -31,7 +31,7 @@ Directory: 2.3
 
 Tags: 2.3.10-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
+GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 2.3/alpine
 
 Tags: 2.2.14, 2.2
@@ -41,7 +41,7 @@ Directory: 2.2
 
 Tags: 2.2.14-alpine, 2.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 99d68b7d5b3ec68cdfcb7e0cef173e054d491bcb
+GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 2.2/alpine
 
 Tags: 2.0.22, 2.0
@@ -51,7 +51,7 @@ Directory: 2.0
 
 Tags: 2.0.22-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a67c29391a51f0fa90c0256b35b5c27d8bc598ce
+GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8
@@ -61,7 +61,7 @@ Directory: 1.8
 
 Tags: 1.8.30-alpine, 1.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e7b078d5ff2ed9f29e4223a5d3d38d191818505
+GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 1.8/alpine
 
 Tags: 1.7.14, 1.7


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8cac716: Update 2.4 to 2.4.1
- https://github.com/docker-library/haproxy/commit/8751639: Merge pull request https://github.com/docker-library/haproxy/pull/161 from J0WI/alpine-3.14
- https://github.com/docker-library/haproxy/commit/8f43326: Alpine 3.14