### PR TITLE
Adjust rabbitmq tls test to not rely on ENV vars

### DIFF
--- a/test/tests/rabbitmq-tls/rabbitmq-env.conf
+++ b/test/tests/rabbitmq-tls/rabbitmq-env.conf
@@ -1,0 +1,16 @@
+#!/bin/sh
+
+# https://www.rabbitmq.com/clustering-ssl.html
+ERL_SSL_PATH="$(erl -eval 'io:format("~p", [code:lib_dir(ssl, ebin)]),halt().' -noshell)"
+
+sslErlArgs="-pa $ERL_SSL_PATH 
+    -proto_dist inet_tls
+    -ssl_dist_opt server_certfile /certs/combined.pem
+    -ssl_dist_opt server_secure_renegotiate true client_secure_renegotiate true"
+
+SERVER_ADDITIONAL_ERL_ARGS="$sslErlArgs"
+CTL_ERL_ARGS="$sslErlArgs"
+if [ -n "$ERLANG_COOKIE" ]; then
+	SERVER_ADDITIONAL_ERL_ARGS="$SERVER_ADDITIONAL_ERL_ARGS -setcookie $ERLANG_COOKIE"
+	CTL_ERL_ARGS="$CTL_ERL_ARGS -setcookie $ERLANG_COOKIE"
+fi

--- a/test/tests/rabbitmq-tls/rabbitmq.conf
+++ b/test/tests/rabbitmq-tls/rabbitmq.conf
@@ -1,0 +1,7 @@
+loopback_users.guest = false
+listeners.ssl.default = 5671
+ssl_options.cacertfile = /certs/ca.crt
+ssl_options.certfile = /certs/cert.crt
+ssl_options.fail_if_no_peer_cert = true
+ssl_options.keyfile = /certs/private.key
+ssl_options.verify = verify_peer


### PR DESCRIPTION
To fix the tests of 3.9 in https://github.com/docker-library/rabbitmq/pull/467