### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -73,33 +73,3 @@ Tags: 2.6.7-alpine3.12, 2.6-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
 Directory: 2.6/alpine3.12
-
-Tags: 2.5.9-buster, 2.5-buster, 2.5.9, 2.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
-Directory: 2.5/buster
-
-Tags: 2.5.9-slim-buster, 2.5-slim-buster, 2.5.9-slim, 2.5-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
-Directory: 2.5/buster/slim
-
-Tags: 2.5.9-stretch, 2.5-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
-Directory: 2.5/stretch
-
-Tags: 2.5.9-slim-stretch, 2.5-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
-Directory: 2.5/stretch/slim
-
-Tags: 2.5.9-alpine3.13, 2.5-alpine3.13, 2.5.9-alpine, 2.5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
-Directory: 2.5/alpine3.13
-
-Tags: 2.5.9-alpine3.12, 2.5-alpine3.12
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3904524e5d9e538b33525a602a4bcb7618aff8b6
-Directory: 2.5/alpine3.12


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/6fe76a8: Remove 2.5 (EOL)