### PR TITLE
notary update

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,6 +1,6 @@
 Maintainers: Justin Cormack (@justincormack)
 GitRepo: https://github.com/docker/notary-official-images.git
-GitCommit: 278bbe63ea6bfb67974fe969c77e02049fe47ab7
+GitCommit: fe7543aa8fc466423578b726570192028bbb818c
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: server-0.6.1-2, server


### PR DESCRIPTION
Notary as been failing to build in the docker official images
CI since Alpine replaced go1.12.8 with 1.12.10 (because of
CVE-2019-16276).

This replaces it with the latest in the tree as greping for
exact version isn't part of the Dockerfile now.

FYI: @justincormack