### PR TITLE
archlinux: Release 20210627.0.27153

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210620.0.26405
-GitCommit: b22cf69ad3114d0f622637ce22ac9d04e46253ca
-GitFetch: refs/tags/v20210620.0.26405
+Tags: latest, base, base-20210627.0.27153
+GitCommit: aa607ddde6a52c6a8bb0ded75ca85083f2afc6d0
+GitFetch: refs/tags/v20210627.0.27153
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210620.0.26405
-GitCommit: b22cf69ad3114d0f622637ce22ac9d04e46253ca
-GitFetch: refs/tags/v20210620.0.26405
+Tags: base-devel, base-devel-20210627.0.27153
+GitCommit: aa607ddde6a52c6a8bb0ded75ca85083f2afc6d0
+GitFetch: refs/tags/v20210627.0.27153
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks