### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,42 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.8.18-beta.1, 3.8-rc
+Tags: 3.8.18, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a740fcd4414566d8abc39386fdd3b2dedff2fba9
-Directory: 3.8-rc/ubuntu
-
-Tags: 3.8.18-beta.1-management, 3.8-rc-management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
-Directory: 3.8-rc/ubuntu/management
-
-Tags: 3.8.18-beta.1-alpine, 3.8-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a740fcd4414566d8abc39386fdd3b2dedff2fba9
-Directory: 3.8-rc/alpine
-
-Tags: 3.8.18-beta.1-management-alpine, 3.8-rc-management-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
-Directory: 3.8-rc/alpine/management
-
-Tags: 3.8.17, 3.8, 3, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d630cc389ee11f88a061a0c35e3aa7a928435293
+GitCommit: 5414666458771b001884ac5c5691bf84b8e6748d
 Directory: 3.8/ubuntu
 
-Tags: 3.8.17-management, 3.8-management, 3-management, management
+Tags: 3.8.18-management, 3.8-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.17-alpine, 3.8-alpine, 3-alpine, alpine
+Tags: 3.8.18-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d630cc389ee11f88a061a0c35e3aa7a928435293
+GitCommit: 5414666458771b001884ac5c5691bf84b8e6748d
 Directory: 3.8/alpine
 
-Tags: 3.8.17-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.8.18-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- docker-library/rabbitmq@ad1824a: Update 3.8-rc to otp 24.0.3
- docker-library/rabbitmq@5414666: Update 3.8 to otp 24.0.3
- docker-library/rabbitmq@226c6de: Update 3.8-rc to 3.8.18-rc.1
- docker-library/rabbitmq@4792573: Update 3.8 to 3.8.18
- docker-library/rabbitmq@59d7871: Merge pull request docker-library/rabbitmq#424 from infosiftr/entrypoint-deprecation
- docker-library/rabbitmq@bc88db1: Merge pull request docker-library/rabbitmq#492 from mkuratczyk/master
- docker-library/rabbitmq@051164d: Switch from SKS to Ubuntu keyserver
- docker-library/rabbitmq@973c614: Add missing `\`
- docker-library/rabbitmq@38ead37: Enable JIT, install g++
- docker-library/rabbitmq@8942a4b: Merge pull request docker-library/rabbitmq#490 from J0WI/alpine-3.14
- docker-library/rabbitmq@59c5913: Alpine 3.14
- docker-library/rabbitmq@2fab209: Add deprecation warnings to "docker-entrypoint.sh"