### PR TITLE
NeuroDebian: add ubuntu 21.04 hirsute images

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,6 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: 920deb4853138c8b7fcae4b232c70e82269a3856
+GitCommit: 1e23b9e778a6d38877359febf13a013551a045ae
 
 Tags: xenial, nd16.04
 Directory: dockerfiles/xenial
@@ -25,6 +25,12 @@ Directory: dockerfiles/groovy
 
 Tags: groovy-non-free, nd20.10-non-free
 Directory: dockerfiles/groovy-non-free
+
+Tags: hirsute, nd21.04
+Directory: dockerfiles/hirsute
+
+Tags: hirsute-non-free, nd21.04-non-free
+Directory: dockerfiles/hirsute-non-free
 
 Tags: stretch, nd90
 Directory: dockerfiles/stretch


### PR DESCRIPTION
=== Do not change lines below ===
{
 "chain": [
  "121d7033efd98c99cba48764ae4f85fd6078b786"
 ],
 "cmd": "./gen_dockerfiles",
 "exit": 0,
 "extra_inputs": [],
 "inputs": [],
 "outputs": [],
 "pwd": "."
}
^^^ Do not change lines above ^^^