### PR TITLE
[ros] build final kinetic images using snapshots repository

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: kinetic-ros-core, kinetic-ros-core-xenial
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
+GitCommit: 01be1ebc5941d92304ce7d46c108215ed72ffdf0
 Directory: ros/kinetic/ubuntu/xenial/ros-core
 
 Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic


### PR DESCRIPTION
ROS Kinetic reached [end of life](https://discourse.ros.org/t/kinetic-kame-officially-end-of-life/20394), this PR switches to the snaphots APT repository to build the final images before retiring them