### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -39,134 +39,120 @@ GitCommit: 06d4eb1e7ff4a03618a9196c6451eca13d5fb82a
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.9.5-buster, 3.9-buster, 3-buster, buster
-SharedTags: 3.9.5, 3.9, 3, latest
+Tags: 3.9.6-buster, 3.9-buster, 3-buster, buster
+SharedTags: 3.9.6, 3.9, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 761fa01bf5d4023fec5707fa3d9757a9f850e64e
+GitCommit: fe2130938363f307081496dc5930c29c3ef9ddba
 Directory: 3.9/buster
 
-Tags: 3.9.5-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster, 3.9.5-slim, 3.9-slim, 3-slim, slim
+Tags: 3.9.6-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster, 3.9.6-slim, 3.9-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 761fa01bf5d4023fec5707fa3d9757a9f850e64e
+GitCommit: fe2130938363f307081496dc5930c29c3ef9ddba
 Directory: 3.9/buster/slim
 
-Tags: 3.9.5-alpine3.14, 3.9-alpine3.14, 3-alpine3.14, alpine3.14, 3.9.5-alpine, 3.9-alpine, 3-alpine, alpine
+Tags: 3.9.6-alpine3.14, 3.9-alpine3.14, 3-alpine3.14, alpine3.14, 3.9.6-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 761fa01bf5d4023fec5707fa3d9757a9f850e64e
+GitCommit: fe2130938363f307081496dc5930c29c3ef9ddba
 Directory: 3.9/alpine3.14
 
-Tags: 3.9.5-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13
+Tags: 3.9.6-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 761fa01bf5d4023fec5707fa3d9757a9f850e64e
+GitCommit: fe2130938363f307081496dc5930c29c3ef9ddba
 Directory: 3.9/alpine3.13
 
-Tags: 3.9.5-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.9.5-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.5, 3.9, 3, latest
+Tags: 3.9.6-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.9.6-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.6, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 761fa01bf5d4023fec5707fa3d9757a9f850e64e
+GitCommit: fe2130938363f307081496dc5930c29c3ef9ddba
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.9.5-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.9.5-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.5, 3.9, 3, latest
+Tags: 3.9.6-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.9.6-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.6, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 761fa01bf5d4023fec5707fa3d9757a9f850e64e
+GitCommit: fe2130938363f307081496dc5930c29c3ef9ddba
 Directory: 3.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.8.10-buster, 3.8-buster
-SharedTags: 3.8.10, 3.8
+Tags: 3.8.11-buster, 3.8-buster
+SharedTags: 3.8.11, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f3ec6aaf346c8265f01e7918d54fa08d06815f1
+GitCommit: dbf2083938bd54ddb0f8697c177d5ccfc927f20f
 Directory: 3.8/buster
 
-Tags: 3.8.10-slim-buster, 3.8-slim-buster, 3.8.10-slim, 3.8-slim
+Tags: 3.8.11-slim-buster, 3.8-slim-buster, 3.8.11-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f3ec6aaf346c8265f01e7918d54fa08d06815f1
+GitCommit: dbf2083938bd54ddb0f8697c177d5ccfc927f20f
 Directory: 3.8/buster/slim
 
-Tags: 3.8.10-alpine3.14, 3.8-alpine3.14, 3.8.10-alpine, 3.8-alpine
+Tags: 3.8.11-alpine3.14, 3.8-alpine3.14, 3.8.11-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f3ec6aaf346c8265f01e7918d54fa08d06815f1
+GitCommit: dbf2083938bd54ddb0f8697c177d5ccfc927f20f
 Directory: 3.8/alpine3.14
 
-Tags: 3.8.10-alpine3.13, 3.8-alpine3.13
+Tags: 3.8.11-alpine3.13, 3.8-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f3ec6aaf346c8265f01e7918d54fa08d06815f1
+GitCommit: dbf2083938bd54ddb0f8697c177d5ccfc927f20f
 Directory: 3.8/alpine3.13
 
-Tags: 3.8.10-windowsservercore-1809, 3.8-windowsservercore-1809
-SharedTags: 3.8.10-windowsservercore, 3.8-windowsservercore, 3.8.10, 3.8
-Architectures: windows-amd64
-GitCommit: 3f3ec6aaf346c8265f01e7918d54fa08d06815f1
-Directory: 3.8/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 3.8.10-windowsservercore-ltsc2016, 3.8-windowsservercore-ltsc2016
-SharedTags: 3.8.10-windowsservercore, 3.8-windowsservercore, 3.8.10, 3.8
-Architectures: windows-amd64
-GitCommit: 3f3ec6aaf346c8265f01e7918d54fa08d06815f1
-Directory: 3.8/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 3.7.10-buster, 3.7-buster
-SharedTags: 3.7.10, 3.7
+Tags: 3.7.11-buster, 3.7-buster
+SharedTags: 3.7.11, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f7baab397120574829eaaf5295ddf9779b7dc6e
+GitCommit: 0c29e9cf700253291c7f2327537cb1d65f14a428
 Directory: 3.7/buster
 
-Tags: 3.7.10-slim-buster, 3.7-slim-buster, 3.7.10-slim, 3.7-slim
+Tags: 3.7.11-slim-buster, 3.7-slim-buster, 3.7.11-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f7baab397120574829eaaf5295ddf9779b7dc6e
+GitCommit: 0c29e9cf700253291c7f2327537cb1d65f14a428
 Directory: 3.7/buster/slim
 
-Tags: 3.7.10-stretch, 3.7-stretch
+Tags: 3.7.11-stretch, 3.7-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 5f7baab397120574829eaaf5295ddf9779b7dc6e
+GitCommit: 0c29e9cf700253291c7f2327537cb1d65f14a428
 Directory: 3.7/stretch
 
-Tags: 3.7.10-slim-stretch, 3.7-slim-stretch
+Tags: 3.7.11-slim-stretch, 3.7-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 5f7baab397120574829eaaf5295ddf9779b7dc6e
+GitCommit: 0c29e9cf700253291c7f2327537cb1d65f14a428
 Directory: 3.7/stretch/slim
 
-Tags: 3.7.10-alpine3.14, 3.7-alpine3.14, 3.7.10-alpine, 3.7-alpine
+Tags: 3.7.11-alpine3.14, 3.7-alpine3.14, 3.7.11-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f7baab397120574829eaaf5295ddf9779b7dc6e
+GitCommit: 0c29e9cf700253291c7f2327537cb1d65f14a428
 Directory: 3.7/alpine3.14
 
-Tags: 3.7.10-alpine3.13, 3.7-alpine3.13
+Tags: 3.7.11-alpine3.13, 3.7-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f7baab397120574829eaaf5295ddf9779b7dc6e
+GitCommit: 0c29e9cf700253291c7f2327537cb1d65f14a428
 Directory: 3.7/alpine3.13
 
-Tags: 3.6.13-buster, 3.6-buster
-SharedTags: 3.6.13, 3.6
+Tags: 3.6.14-buster, 3.6-buster
+SharedTags: 3.6.14, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6ebf0e1e9ce76d66004057a7d3accce8ee6ab244
+GitCommit: fc33184453f89414b13a87904237fac90778ebeb
 Directory: 3.6/buster
 
-Tags: 3.6.13-slim-buster, 3.6-slim-buster, 3.6.13-slim, 3.6-slim
+Tags: 3.6.14-slim-buster, 3.6-slim-buster, 3.6.14-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6ebf0e1e9ce76d66004057a7d3accce8ee6ab244
+GitCommit: fc33184453f89414b13a87904237fac90778ebeb
 Directory: 3.6/buster/slim
 
-Tags: 3.6.13-stretch, 3.6-stretch
+Tags: 3.6.14-stretch, 3.6-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6ebf0e1e9ce76d66004057a7d3accce8ee6ab244
+GitCommit: fc33184453f89414b13a87904237fac90778ebeb
 Directory: 3.6/stretch
 
-Tags: 3.6.13-slim-stretch, 3.6-slim-stretch
+Tags: 3.6.14-slim-stretch, 3.6-slim-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6ebf0e1e9ce76d66004057a7d3accce8ee6ab244
+GitCommit: fc33184453f89414b13a87904237fac90778ebeb
 Directory: 3.6/stretch/slim
 
-Tags: 3.6.13-alpine3.14, 3.6-alpine3.14, 3.6.13-alpine, 3.6-alpine
+Tags: 3.6.14-alpine3.14, 3.6-alpine3.14, 3.6.14-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebf0e1e9ce76d66004057a7d3accce8ee6ab244
+GitCommit: fc33184453f89414b13a87904237fac90778ebeb
 Directory: 3.6/alpine3.14
 
-Tags: 3.6.13-alpine3.13, 3.6-alpine3.13
+Tags: 3.6.14-alpine3.13, 3.6-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ebf0e1e9ce76d66004057a7d3accce8ee6ab244
+GitCommit: fc33184453f89414b13a87904237fac90778ebeb
 Directory: 3.6/alpine3.13


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/edfbfa1: Merge pull request https://github.com/docker-library/python/pull/623 from Tenzer/version-bumps
- https://github.com/docker-library/python/commit/6166798: Remove Windows Docker images for Python 3.8
- https://github.com/docker-library/python/commit/fc33184: Upgrade 3.6 images to Python 3.6.14
- https://github.com/docker-library/python/commit/0c29e9c: Upgrade 3.7 images to Python 3.7.11
- https://github.com/docker-library/python/commit/dbf2083: Upgrade 3.8 images to Python 3.8.11
- https://github.com/docker-library/python/commit/fe21309: Upgrade 3.9 images to Python 3.9.6