### PR TITLE
[oraclelinux] update oraclelinux:8 and 8-slim for amd64 and arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fda038ed6d3eca41cac6e6f9950924408b3d7c7d
+amd64-GitCommit: 87eff7192ff886029aba191ba8ce78050507d867
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ac20c0ff31856d307adc49845cd69988f16de168
+arm64v8-GitCommit: c4856a7d8afc0a80f7b06a0a47db4667a81ae1f8
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update image to resolve CVE-2021-20271 and CVE-2021-3520:

See <https://linux.oracle.com/errata/ELSA-2021-2574.html> and
<https://linux.oracle.com/errata/ELSA-2021-2575.html> for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>