### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
 Directory: cli/php8.0/alpine
 
-Tags: beta-5.8-beta4-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8-beta4, beta-5.8, beta-5, beta, beta-5.8-beta4-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8-beta4-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
+Tags: beta-5.8-RC1-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8-RC1, beta-5.8, beta-5, beta, beta-5.8-RC1-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8-RC1-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php7.4/apache
 
-Tags: beta-5.8-beta4-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8-beta4-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-5.8-RC1-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8-RC1-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php7.4/fpm
 
-Tags: beta-5.8-beta4-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8-beta4-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-5.8-RC1-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8-RC1-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-5.8-beta4-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8-beta4-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
+Tags: beta-5.8-RC1-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8-RC1-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php7.3/apache
 
-Tags: beta-5.8-beta4-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
+Tags: beta-5.8-RC1-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php7.3/fpm
 
-Tags: beta-5.8-beta4-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
+Tags: beta-5.8-RC1-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php7.3/fpm-alpine
 
-Tags: beta-5.8-beta4-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8-beta4-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
+Tags: beta-5.8-RC1-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8-RC1-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php8.0/apache
 
-Tags: beta-5.8-beta4-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-5.8-RC1-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php8.0/fpm
 
-Tags: beta-5.8-beta4-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-5.8-RC1-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 35f4b2751ed7ded4c9462a66346952df4a50e2d0
+GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
 Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/48e14fd: Update beta to 5.8-RC1