### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,105 +6,105 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.7.2-apache, 5.7-apache, 5-apache, apache, 5.7.2, 5.7, 5, latest, 5.7.2-php7.4-apache, 5.7-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.7.2-php7.4, 5.7-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php7.4/apache
 
 Tags: 5.7.2-fpm, 5.7-fpm, 5-fpm, fpm, 5.7.2-php7.4-fpm, 5.7-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php7.4/fpm
 
 Tags: 5.7.2-fpm-alpine, 5.7-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.7.2-php7.4-fpm-alpine, 5.7-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php7.4/fpm-alpine
 
 Tags: 5.7.2-php7.3-apache, 5.7-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.7.2-php7.3, 5.7-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php7.3/apache
 
 Tags: 5.7.2-php7.3-fpm, 5.7-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php7.3/fpm
 
 Tags: 5.7.2-php7.3-fpm-alpine, 5.7-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php7.3/fpm-alpine
 
 Tags: 5.7.2-php8.0-apache, 5.7-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.7.2-php8.0, 5.7-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php8.0/apache
 
 Tags: 5.7.2-php8.0-fpm, 5.7-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php8.0/fpm
 
 Tags: 5.7.2-php8.0-fpm-alpine, 5.7-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1d90641dc2075168fe59df2f02502df068cc5531
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: cli/php7.4/alpine
 
 Tags: cli-2.5.0-php7.3, cli-2.5-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: cli/php7.3/alpine
 
 Tags: cli-2.5.0-php8.0, cli-2.5-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f5e96ef8fe64860a81eac80766c06e1fe1554e4e
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: cli/php8.0/alpine
 
 Tags: beta-5.8-RC1-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8-RC1, beta-5.8, beta-5, beta, beta-5.8-RC1-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8-RC1-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php7.4/apache
 
 Tags: beta-5.8-RC1-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8-RC1-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php7.4/fpm
 
 Tags: beta-5.8-RC1-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8-RC1-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php7.4/fpm-alpine
 
 Tags: beta-5.8-RC1-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8-RC1-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php7.3/apache
 
 Tags: beta-5.8-RC1-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php7.3/fpm
 
 Tags: beta-5.8-RC1-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php7.3/fpm-alpine
 
 Tags: beta-5.8-RC1-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8-RC1-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php8.0/apache
 
 Tags: beta-5.8-RC1-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php8.0/fpm
 
 Tags: beta-5.8-RC1-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 48e14fd936409bea7d9c963f2a2337ffbc990581
+GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/c2f5d90: Merge pull request https://github.com/docker-library/wordpress/pull/620 from infosiftr/imagick-php-8
- https://github.com/docker-library/wordpress/commit/cdb8362: Update imagick for PHP 8 support