### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0-rc1, 4.0
+Tags: 4.0-rc2, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: f00a725cc0189ef166ac1d893227651bd81a6996
+GitCommit: 08bea513f803c366493d823aa81a81d73e21c93f
 Directory: 4.0
 
 Tags: 3.11.10, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 03bef93db2ff4b5a3cbc954618f08c44ddcb7568
+GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
 Directory: 3.11
 
 Tags: 3.0.24, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 03bef93db2ff4b5a3cbc954618f08c44ddcb7568
+GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
 Directory: 3.0
 
 Tags: 2.2.19, 2.2, 2
 Architectures: amd64, arm32v7, ppc64le
-GitCommit: 03bef93db2ff4b5a3cbc954618f08c44ddcb7568
+GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
 Directory: 2.2
 
 Tags: 2.1.22, 2.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 03bef93db2ff4b5a3cbc954618f08c44ddcb7568
+GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
 Directory: 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/08bea51: Update 4.0 to 4.0-rc2
- https://github.com/docker-library/cassandra/commit/6d31171: Switch from SKS to Ubuntu keyserver