### PR TITLE
[security] Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -84,122 +84,122 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
 Directory: 8.0/alpine3.13/fpm
 
-Tags: 7.4.20-cli-buster, 7.4-cli-buster, 7-cli-buster, 7.4.20-buster, 7.4-buster, 7-buster, 7.4.20-cli, 7.4-cli, 7-cli, 7.4.20, 7.4, 7
+Tags: 7.4.21-cli-buster, 7.4-cli-buster, 7-cli-buster, 7.4.21-buster, 7.4-buster, 7-buster, 7.4.21-cli, 7.4-cli, 7-cli, 7.4.21, 7.4, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/buster/cli
 
-Tags: 7.4.20-apache-buster, 7.4-apache-buster, 7-apache-buster, 7.4.20-apache, 7.4-apache, 7-apache
+Tags: 7.4.21-apache-buster, 7.4-apache-buster, 7-apache-buster, 7.4.21-apache, 7.4-apache, 7-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/buster/apache
 
-Tags: 7.4.20-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, 7.4.20-fpm, 7.4-fpm, 7-fpm
+Tags: 7.4.21-fpm-buster, 7.4-fpm-buster, 7-fpm-buster, 7.4.21-fpm, 7.4-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/buster/fpm
 
-Tags: 7.4.20-zts-buster, 7.4-zts-buster, 7-zts-buster, 7.4.20-zts, 7.4-zts, 7-zts
+Tags: 7.4.21-zts-buster, 7.4-zts-buster, 7-zts-buster, 7.4.21-zts, 7.4-zts, 7-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/buster/zts
 
-Tags: 7.4.20-cli-alpine3.14, 7.4-cli-alpine3.14, 7-cli-alpine3.14, 7.4.20-alpine3.14, 7.4-alpine3.14, 7-alpine3.14, 7.4.20-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, 7.4.20-alpine, 7.4-alpine, 7-alpine
+Tags: 7.4.21-cli-alpine3.14, 7.4-cli-alpine3.14, 7-cli-alpine3.14, 7.4.21-alpine3.14, 7.4-alpine3.14, 7-alpine3.14, 7.4.21-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, 7.4.21-alpine, 7.4-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/alpine3.14/cli
 
-Tags: 7.4.20-fpm-alpine3.14, 7.4-fpm-alpine3.14, 7-fpm-alpine3.14, 7.4.20-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine
+Tags: 7.4.21-fpm-alpine3.14, 7.4-fpm-alpine3.14, 7-fpm-alpine3.14, 7.4.21-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/alpine3.14/fpm
 
-Tags: 7.4.20-zts-alpine3.14, 7.4-zts-alpine3.14, 7-zts-alpine3.14, 7.4.20-zts-alpine, 7.4-zts-alpine, 7-zts-alpine
+Tags: 7.4.21-zts-alpine3.14, 7.4-zts-alpine3.14, 7-zts-alpine3.14, 7.4.21-zts-alpine, 7.4-zts-alpine, 7-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/alpine3.14/zts
 
-Tags: 7.4.20-cli-alpine3.13, 7.4-cli-alpine3.13, 7-cli-alpine3.13, 7.4.20-alpine3.13, 7.4-alpine3.13, 7-alpine3.13
+Tags: 7.4.21-cli-alpine3.13, 7.4-cli-alpine3.13, 7-cli-alpine3.13, 7.4.21-alpine3.13, 7.4-alpine3.13, 7-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/alpine3.13/cli
 
-Tags: 7.4.20-fpm-alpine3.13, 7.4-fpm-alpine3.13, 7-fpm-alpine3.13
+Tags: 7.4.21-fpm-alpine3.13, 7.4-fpm-alpine3.13, 7-fpm-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/alpine3.13/fpm
 
-Tags: 7.4.20-zts-alpine3.13, 7.4-zts-alpine3.13, 7-zts-alpine3.13
+Tags: 7.4.21-zts-alpine3.13, 7.4-zts-alpine3.13, 7-zts-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: 94f1bc256da7cbcf232c05d34717e995ff31c5f6
 Directory: 7.4/alpine3.13/zts
 
-Tags: 7.3.28-cli-buster, 7.3-cli-buster, 7.3.28-buster, 7.3-buster, 7.3.28-cli, 7.3-cli, 7.3.28, 7.3
+Tags: 7.3.29-cli-buster, 7.3-cli-buster, 7.3.29-buster, 7.3-buster, 7.3.29-cli, 7.3-cli, 7.3.29, 7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/buster/cli
 
-Tags: 7.3.28-apache-buster, 7.3-apache-buster, 7.3.28-apache, 7.3-apache
+Tags: 7.3.29-apache-buster, 7.3-apache-buster, 7.3.29-apache, 7.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/buster/apache
 
-Tags: 7.3.28-fpm-buster, 7.3-fpm-buster, 7.3.28-fpm, 7.3-fpm
+Tags: 7.3.29-fpm-buster, 7.3-fpm-buster, 7.3.29-fpm, 7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/buster/fpm
 
-Tags: 7.3.28-zts-buster, 7.3-zts-buster, 7.3.28-zts, 7.3-zts
+Tags: 7.3.29-zts-buster, 7.3-zts-buster, 7.3.29-zts, 7.3-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/buster/zts
 
-Tags: 7.3.28-cli-stretch, 7.3-cli-stretch, 7.3.28-stretch, 7.3-stretch
+Tags: 7.3.29-cli-stretch, 7.3-cli-stretch, 7.3.29-stretch, 7.3-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/stretch/cli
 
-Tags: 7.3.28-apache-stretch, 7.3-apache-stretch
+Tags: 7.3.29-apache-stretch, 7.3-apache-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/stretch/apache
 
-Tags: 7.3.28-fpm-stretch, 7.3-fpm-stretch
+Tags: 7.3.29-fpm-stretch, 7.3-fpm-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/stretch/fpm
 
-Tags: 7.3.28-zts-stretch, 7.3-zts-stretch
+Tags: 7.3.29-zts-stretch, 7.3-zts-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/stretch/zts
 
-Tags: 7.3.28-cli-alpine3.14, 7.3-cli-alpine3.14, 7.3.28-alpine3.14, 7.3-alpine3.14, 7.3.28-cli-alpine, 7.3-cli-alpine, 7.3.28-alpine, 7.3-alpine
+Tags: 7.3.29-cli-alpine3.14, 7.3-cli-alpine3.14, 7.3.29-alpine3.14, 7.3-alpine3.14, 7.3.29-cli-alpine, 7.3-cli-alpine, 7.3.29-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/alpine3.14/cli
 
-Tags: 7.3.28-fpm-alpine3.14, 7.3-fpm-alpine3.14, 7.3.28-fpm-alpine, 7.3-fpm-alpine
+Tags: 7.3.29-fpm-alpine3.14, 7.3-fpm-alpine3.14, 7.3.29-fpm-alpine, 7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/alpine3.14/fpm
 
-Tags: 7.3.28-zts-alpine3.14, 7.3-zts-alpine3.14, 7.3.28-zts-alpine, 7.3-zts-alpine
+Tags: 7.3.29-zts-alpine3.14, 7.3-zts-alpine3.14, 7.3.29-zts-alpine, 7.3-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/alpine3.14/zts
 
-Tags: 7.3.28-cli-alpine3.13, 7.3-cli-alpine3.13, 7.3.28-alpine3.13, 7.3-alpine3.13
+Tags: 7.3.29-cli-alpine3.13, 7.3-cli-alpine3.13, 7.3.29-alpine3.13, 7.3-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/alpine3.13/cli
 
-Tags: 7.3.28-fpm-alpine3.13, 7.3-fpm-alpine3.13
+Tags: 7.3.29-fpm-alpine3.13, 7.3-fpm-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/alpine3.13/fpm
 
-Tags: 7.3.28-zts-alpine3.13, 7.3-zts-alpine3.13
+Tags: 7.3.29-zts-alpine3.13, 7.3-zts-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6da00646d52e29c26491ee25d1ab2e3dcb4cc940
+GitCommit: bf39dd3253b41ba4d64ea39446162f19d158162b
 Directory: 7.3/alpine3.13/zts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/94f1bc2: Update 7.4 to 7.4.21
- https://github.com/docker-library/php/commit/bf39dd3: Update 7.3 to 7.3.29

We need 8.0.8 as well, but https://github.com/php/web-php/pull/413 :disappointed: