### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,6 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
+Tags: 3.8.19-rc.1, 3.8-rc
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 20914d6baab98dead804ee050fe5271cf1098369
+Directory: 3.8-rc/ubuntu
+
+Tags: 3.8.19-rc.1-management, 3.8-rc-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
+Directory: 3.8-rc/ubuntu/management
+
+Tags: 3.8.19-rc.1-alpine, 3.8-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 20914d6baab98dead804ee050fe5271cf1098369
+Directory: 3.8-rc/alpine
+
+Tags: 3.8.19-rc.1-management-alpine, 3.8-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7e63843da6bfb191ddee6dbe3dd7ec0df36ae70b
+Directory: 3.8-rc/alpine/management
+
 Tags: 3.8.18, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 5414666458771b001884ac5c5691bf84b8e6748d


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/20914d6: Update 3.8-rc to 3.8.19-rc.1