### PR TITLE
[ros] retire ROS Kinetic images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -2,33 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: kinetic
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: kinetic-ros-core, kinetic-ros-core-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 01be1ebc5941d92304ce7d46c108215ed72ffdf0
-Directory: ros/kinetic/ubuntu/xenial/ros-core
-
-Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/kinetic/ubuntu/xenial/ros-base
-
-Tags: kinetic-robot, kinetic-robot-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/kinetic/ubuntu/xenial/robot
-
-Tags: kinetic-perception, kinetic-perception-xenial
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/kinetic/ubuntu/xenial/perception
-
-
-################################################################################
 # Release: melodic
 
 ########################################


### PR DESCRIPTION
Follow-up of https://github.com/docker-library/official-images/pull/10444