### PR TITLE
Update develop to 1.9.2rc1

### DIFF
--- a/library/eggdrop
+++ b/library/eggdrop
@@ -3,7 +3,7 @@ GitRepo: https://github.com/eggheads/eggdrop-docker.git
 
 Tags: develop
 Architectures: arm32v6, arm64v8, amd64
-GitCommit: 8d3bb9a0a2f35b45d50b82e9c7dd7a5af66e4c9a
+GitCommit: f067a3393434028c1f1bf785a9c4ca062d477acc
 Directory: develop
 
 Tags: 1.8, 1.8.4
@@ -15,8 +15,3 @@ Tags: 1.9, 1.9.1, stable, latest
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 5444df31406ef15da9fa7e6b742d093179f66d60
 Directory: 1.9
-
-Tags: 1.9-libs, 1.9.1-libs
-Architectures: amd64, arm32v6, arm64v8
-GitCommit: 5444df31406ef15da9fa7e6b742d093179f66d60
-Directory: 1.9-libs

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -6,11 +6,6 @@ Architectures: arm32v6, arm64v8, amd64
 GitCommit: f067a3393434028c1f1bf785a9c4ca062d477acc
 Directory: develop
 
-Tags: 1.8, 1.8.4
-Architectures: amd64
-GitCommit: 14411e45f599536a86d9f023c0fa09f3dd2f5454
-Directory: 1.8
-
 Tags: 1.9, 1.9.1, stable, latest
 Architectures: amd64, arm32v6, arm64v8
 GitCommit: 5444df31406ef15da9fa7e6b742d093179f66d60

--- a/library/eggdrop
+++ b/library/eggdrop
@@ -13,5 +13,10 @@ Directory: 1.8
 
 Tags: 1.9, 1.9.1, stable, latest
 Architectures: amd64, arm32v6, arm64v8
-GitCommit: eb6827278e290bc9ae5d443adfac3ca153d1c459
+GitCommit: 5444df31406ef15da9fa7e6b742d093179f66d60
 Directory: 1.9
+
+Tags: 1.9-libs, 1.9.1-libs
+Architectures: amd64, arm32v6, arm64v8
+GitCommit: 5444df31406ef15da9fa7e6b742d093179f66d60
+Directory: 1.9-libs


### PR DESCRIPTION
- Remove 1.8 version
- Update 1.9 to 1.9.2
- Remove "heavy" version