### PR TITLE
archlinux: Release 20210704.0.28149

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210627.0.27153
-GitCommit: aa607ddde6a52c6a8bb0ded75ca85083f2afc6d0
-GitFetch: refs/tags/v20210627.0.27153
+Tags: latest, base, base-20210704.0.28149
+GitCommit: 48f5284ce032808cfbc9cd43e111bebe37bc13ad
+GitFetch: refs/tags/v20210704.0.28149
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210627.0.27153
-GitCommit: aa607ddde6a52c6a8bb0ded75ca85083f2afc6d0
-GitFetch: refs/tags/v20210627.0.27153
+Tags: base-devel, base-devel-20210704.0.28149
+GitCommit: 48f5284ce032808cfbc9cd43e111bebe37bc13ad
+GitFetch: refs/tags/v20210704.0.28149
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks