### PR TITLE
Update Clear Linux OS to 34810

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: cd26ac0c0a9a1f236df0379cbcaad8831b2f7c3c
-GitFetch: refs/tags/clear-linux-34790
+GitCommit: b04cf9aae4da1156fd7834432da845857cac36ac
+GitFetch: refs/tags/clear-linux-34810


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34810

@bryteise @mdhorn @phmccarty