### PR TITLE
Bump couchdb commit to fix builds, drop 3.0.x support

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,15 +3,11 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: e3ca492e13f65ffd72593ac3d7c43c737787e2b2
+GitCommit: 4993111e388d203d2200a3dd88449517db548c05
 
 Tags: latest, 3.1.1, 3.1, 3
 Architectures: amd64, arm64v8
 Directory: 3.1.1
-
-Tags: 3.0.1, 3.0
-Architectures: amd64, arm64v8
-Directory: 3.0.1
 
 Tags: 2.3.1, 2.3, 2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Our binary repositories moved when bintray was shut down; this just reflects the new install process.