### PR TITLE
Update tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -16,7 +16,7 @@ Directory: 10.0/jdk16/openjdk-slim-buster
 
 Tags: 10.0.8-jdk16-corretto, 10.0-jdk16-corretto, 10-jdk16-corretto
 Architectures: amd64, arm64v8
-GitCommit: af5cd35d87d6084f39604981ca408ef981e55fd7
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 10.0/jdk16/corretto
 
 Tags: 10.0.8-jdk11-openjdk-buster, 10.0-jdk11-openjdk-buster, 10-jdk11-openjdk-buster, 10.0.8-jdk11-openjdk, 10.0-jdk11-openjdk, 10-jdk11-openjdk, 10.0.8-jdk11, 10.0-jdk11, 10-jdk11, 10.0.8, 10.0, 10
@@ -41,7 +41,7 @@ Directory: 10.0/jdk11/adoptopenjdk-openj9
 
 Tags: 10.0.8-jdk11-corretto, 10.0-jdk11-corretto, 10-jdk11-corretto
 Architectures: amd64, arm64v8
-GitCommit: af5cd35d87d6084f39604981ca408ef981e55fd7
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 10.0/jdk11/corretto
 
 Tags: 10.0.8-jdk8-openjdk-buster, 10.0-jdk8-openjdk-buster, 10-jdk8-openjdk-buster, 10.0.8-jdk8-openjdk, 10.0-jdk8-openjdk, 10-jdk8-openjdk, 10.0.8-jdk8, 10.0-jdk8, 10-jdk8
@@ -66,7 +66,7 @@ Directory: 10.0/jdk8/adoptopenjdk-openj9
 
 Tags: 10.0.8-jdk8-corretto, 10.0-jdk8-corretto, 10-jdk8-corretto
 Architectures: amd64, arm64v8
-GitCommit: af5cd35d87d6084f39604981ca408ef981e55fd7
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 10.0/jdk8/corretto
 
 Tags: 9.0.50-jdk16-openjdk-buster, 9.0-jdk16-openjdk-buster, 9-jdk16-openjdk-buster, jdk16-openjdk-buster, 9.0.50-jdk16-openjdk, 9.0-jdk16-openjdk, 9-jdk16-openjdk, jdk16-openjdk, 9.0.50-jdk16, 9.0-jdk16, 9-jdk16, jdk16
@@ -81,7 +81,7 @@ Directory: 9.0/jdk16/openjdk-slim-buster
 
 Tags: 9.0.50-jdk16-corretto, 9.0-jdk16-corretto, 9-jdk16-corretto, jdk16-corretto
 Architectures: amd64, arm64v8
-GitCommit: debd24dbfcf6122ee9ee73c95f60488d752d2c2d
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 9.0/jdk16/corretto
 
 Tags: 9.0.50-jdk11-openjdk-buster, 9.0-jdk11-openjdk-buster, 9-jdk11-openjdk-buster, jdk11-openjdk-buster, 9.0.50-jdk11-openjdk, 9.0-jdk11-openjdk, 9-jdk11-openjdk, jdk11-openjdk, 9.0.50-jdk11, 9.0-jdk11, 9-jdk11, jdk11, 9.0.50, 9.0, 9, latest
@@ -106,7 +106,7 @@ Directory: 9.0/jdk11/adoptopenjdk-openj9
 
 Tags: 9.0.50-jdk11-corretto, 9.0-jdk11-corretto, 9-jdk11-corretto, jdk11-corretto
 Architectures: amd64, arm64v8
-GitCommit: debd24dbfcf6122ee9ee73c95f60488d752d2c2d
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 9.0/jdk11/corretto
 
 Tags: 9.0.50-jdk8-openjdk-buster, 9.0-jdk8-openjdk-buster, 9-jdk8-openjdk-buster, jdk8-openjdk-buster, 9.0.50-jdk8-openjdk, 9.0-jdk8-openjdk, 9-jdk8-openjdk, jdk8-openjdk, 9.0.50-jdk8, 9.0-jdk8, 9-jdk8, jdk8
@@ -131,7 +131,7 @@ Directory: 9.0/jdk8/adoptopenjdk-openj9
 
 Tags: 9.0.50-jdk8-corretto, 9.0-jdk8-corretto, 9-jdk8-corretto, jdk8-corretto
 Architectures: amd64, arm64v8
-GitCommit: debd24dbfcf6122ee9ee73c95f60488d752d2c2d
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 9.0/jdk8/corretto
 
 Tags: 8.5.68-jdk16-openjdk-buster, 8.5-jdk16-openjdk-buster, 8-jdk16-openjdk-buster, 8.5.68-jdk16-openjdk, 8.5-jdk16-openjdk, 8-jdk16-openjdk, 8.5.68-jdk16, 8.5-jdk16, 8-jdk16
@@ -146,7 +146,7 @@ Directory: 8.5/jdk16/openjdk-slim-buster
 
 Tags: 8.5.68-jdk16-corretto, 8.5-jdk16-corretto, 8-jdk16-corretto
 Architectures: amd64, arm64v8
-GitCommit: 26129e8db171231dc9e4e2b49f71571e46ca8a30
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 8.5/jdk16/corretto
 
 Tags: 8.5.68-jdk11-openjdk-buster, 8.5-jdk11-openjdk-buster, 8-jdk11-openjdk-buster, 8.5.68-jdk11-openjdk, 8.5-jdk11-openjdk, 8-jdk11-openjdk, 8.5.68-jdk11, 8.5-jdk11, 8-jdk11
@@ -171,7 +171,7 @@ Directory: 8.5/jdk11/adoptopenjdk-openj9
 
 Tags: 8.5.68-jdk11-corretto, 8.5-jdk11-corretto, 8-jdk11-corretto
 Architectures: amd64, arm64v8
-GitCommit: 26129e8db171231dc9e4e2b49f71571e46ca8a30
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 8.5/jdk11/corretto
 
 Tags: 8.5.68-jdk8-openjdk-buster, 8.5-jdk8-openjdk-buster, 8-jdk8-openjdk-buster, 8.5.68-jdk8-openjdk, 8.5-jdk8-openjdk, 8-jdk8-openjdk, 8.5.68-jdk8, 8.5-jdk8, 8-jdk8, 8.5.68, 8.5, 8
@@ -196,7 +196,7 @@ Directory: 8.5/jdk8/adoptopenjdk-openj9
 
 Tags: 8.5.68-jdk8-corretto, 8.5-jdk8-corretto, 8-jdk8-corretto
 Architectures: amd64, arm64v8
-GitCommit: 26129e8db171231dc9e4e2b49f71571e46ca8a30
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 8.5/jdk8/corretto
 
 Tags: 7.0.109-jdk8-openjdk-buster, 7.0-jdk8-openjdk-buster, 7-jdk8-openjdk-buster, 7.0.109-jdk8-openjdk, 7.0-jdk8-openjdk, 7-jdk8-openjdk, 7.0.109-jdk8, 7.0-jdk8, 7-jdk8, 7.0.109, 7.0, 7
@@ -221,5 +221,5 @@ Directory: 7/jdk8/adoptopenjdk-openj9
 
 Tags: 7.0.109-jdk8-corretto, 7.0-jdk8-corretto, 7-jdk8-corretto
 Architectures: amd64, arm64v8
-GitCommit: 26129e8db171231dc9e4e2b49f71571e46ca8a30
+GitCommit: 9adc8cfd8ba3cbeae809e4319ae483be49e11366
 Directory: 7/jdk8/corretto


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/tomcat/commit/9adc8cf: Use OpenSSL 1.1 for Corretto images (https://github.com/docker-library/tomcat/pull/234)