### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d87e27dd90273fe213f7d468516ad192e959f086
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.1, 2.4, lts, latest
+Tags: 2.4.2, 2.4, lts, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8cac7162fb3fb4431208d98c2cd9c63d1897421f
+GitCommit: 973f43b2d1c5c0d57274002e216761c0baedf6c0
 Directory: 2.4
 
-Tags: 2.4.1-alpine, 2.4-alpine, lts-alpine, alpine
+Tags: 2.4.2-alpine, 2.4-alpine, lts-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8cac7162fb3fb4431208d98c2cd9c63d1897421f
+GitCommit: 973f43b2d1c5c0d57274002e216761c0baedf6c0
 Directory: 2.4/alpine
 
-Tags: 2.3.10, 2.3
+Tags: 2.3.12, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: db9335048c43b78fb4daec1ac9d7d171fc209d78
+GitCommit: 2f36ad009f5811f3155d135a6deacc3b789a51cd
 Directory: 2.3
 
-Tags: 2.3.10-alpine, 2.3-alpine
+Tags: 2.3.12-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
+GitCommit: 2f36ad009f5811f3155d135a6deacc3b789a51cd
 Directory: 2.3/alpine
 
 Tags: 2.2.14, 2.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/973f43b: Update 2.4 to 2.4.2