### PR TITLE
MariaDB releases 20210707

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,30 +1,30 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/b180797cece7d65e23156fd872368e34d3d2a757/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/098e791b826e6f64f0299560d32f5f102de39938/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 10.6.2-focal, 10.6-focal, rc-focal, 10.6.2, 10.6, rc
+Tags: 10.6.3-focal, 10.6-focal, 10-focal, focal, 10.6.3, 10.6, 10, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 465e597bfa3bd769b5f528df17426bec0724ab12
+GitCommit: 3afe9953898422c1ca6b3986dd6fa255ad10eb70
 Directory: 10.6
 
-Tags: 10.5.11-focal, 10.5-focal, 10-focal, focal, 10.5.11, 10.5, 10, latest
+Tags: 10.5.11-focal, 10.5-focal, 10.5.11, 10.5
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6c466f9551cf73bbaebd02c8f68b058c4e44a40c
+GitCommit: 3afe9953898422c1ca6b3986dd6fa255ad10eb70
 Directory: 10.5
 
 Tags: 10.4.20-focal, 10.4-focal, 10.4.20, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 684d352c819d94e9b914e056655180e2be394819
+GitCommit: 3afe9953898422c1ca6b3986dd6fa255ad10eb70
 Directory: 10.4
 
 Tags: 10.3.30-focal, 10.3-focal, 10.3.30, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 254bc8c6646f75d335325c064905d7288ca24aca
+GitCommit: 3afe9953898422c1ca6b3986dd6fa255ad10eb70
 Directory: 10.3
 
 Tags: 10.2.39-bionic, 10.2-bionic, 10.2.39, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0c4bdac53d22647f39187e8d00d02c5a2e760940
+GitCommit: 3afe9953898422c1ca6b3986dd6fa255ad10eb70
 Directory: 10.2


### PR DESCRIPTION
Hello,

We've done our MariaDB 10.6.3 release. The first stable (GA) release of our 10.6 series.