### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -13,3 +13,9 @@ Tags: 2.4.48-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.48-alpine3.14, 2.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6d68525ac47c0474d3d74269b2669104c1d867dd
 Directory: 2.4/alpine
+
+# temporary one-time backfill of "alpine3.13" aliases
+Tags: 2.4.48-alpine3.13, 2.4-alpine3.13, 2-alpine3.13, alpine3.13
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8835b23f748f80bcec510c14b68c84bc37767cdb
+Directory: 2.4/alpine

--- a/library/httpd
+++ b/library/httpd
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/httpd/blob/b3146c0dc0d3831077a28df82348c5afed4d9ea7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/httpd/blob/38a58221d725d54686d6113f12efbd3fa97ef3e6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.48, 2.4, 2, latest
+Tags: 2.4.48, 2.4, 2, latest, 2.4.48-buster, 2.4-buster, 2-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8835b23f748f80bcec510c14b68c84bc37767cdb
+GitCommit: 6d68525ac47c0474d3d74269b2669104c1d867dd
 Directory: 2.4
 
-Tags: 2.4.48-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.4.48-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.48-alpine3.14, 2.4-alpine3.14, 2-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 46340f4c78fa6b0ba66e814f0aef3ada6c1f535f
+GitCommit: 6d68525ac47c0474d3d74269b2669104c1d867dd
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- docker-library/httpd@5ed28f3: Merge pull request docker-library/httpd#186 from infosiftr/suite-aliases
- docker-library/httpd@38a5822: Add suite aliases ("alpine3.14", etc)
- docker-library/httpd@6d68525: Switch from SKS to Ubuntu keyserver

(also, temporary `alpine3.13` aliases backfill)

Refs https://github.com/docker-library/httpd/issues/185