### PR TITLE
Update rocket.chat

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/53135ee4ce97bf647ed6c5b2326328d539cbe5f8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/79d4e000c93b6d26f8a8956935017ddbf9d9e89f/generate-stackbrew-library.sh
 
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 3.15.1, 3.15, 3, latest
-GitCommit: 2d2b9be110be03050cc9b47fa9b11a0b07f53a1b
+Tags: 3.16.2, 3.16, 3, latest
+GitCommit: 74d96d6cae29412ee6e2c7446c1b3b6f9e18ed15
+Directory: 3.16
+
+Tags: 3.15.3, 3.15
+GitCommit: 74d96d6cae29412ee6e2c7446c1b3b6f9e18ed15
 Directory: 3.15
 
 Tags: 3.14.5, 3.14
 GitCommit: 2d2b9be110be03050cc9b47fa9b11a0b07f53a1b
 Directory: 3.14
-
-Tags: 3.13.5, 3.13
-GitCommit: 05c37cfd9ffdd2ee54b274b949742a539760c9f9
-Directory: 3.13
 
 Tags: 2.4.14, 2.4, 2
 GitCommit: 8c163b1c5a8e077280d8dc2301ba75dfbfd52d32


### PR DESCRIPTION
I'm having issues building on my machine due to missing Node gpg keys, but since Node published a version recently (https://github.com/docker-library/official-images/pull/10489) I don't expect this to be a real issue...