### PR TITLE
archlinux: Release 20210711.0.28748

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210704.0.28149
-GitCommit: 48f5284ce032808cfbc9cd43e111bebe37bc13ad
-GitFetch: refs/tags/v20210704.0.28149
+Tags: latest, base, base-20210711.0.28748
+GitCommit: 7f8b5d1af75044049a9e950ec3131d22857b1e86
+GitFetch: refs/tags/v20210711.0.28748
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210704.0.28149
-GitCommit: 48f5284ce032808cfbc9cd43e111bebe37bc13ad
-GitFetch: refs/tags/v20210704.0.28149
+Tags: base-devel, base-devel-20210711.0.28748
+GitCommit: 7f8b5d1af75044049a9e950ec3131d22857b1e86
+GitFetch: refs/tags/v20210711.0.28748
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks