### PR TITLE
Update Clear Linux OS to 34820

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: b04cf9aae4da1156fd7834432da845857cac36ac
-GitFetch: refs/tags/clear-linux-34810
+GitCommit: 919de92f3ea61be7b1d63e04c401f2bac86f6a78
+GitFetch: refs/tags/clear-linux-34820


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34820

@bryteise @mdhorn @phmccarty