### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2021-2569

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 87eff7192ff886029aba191ba8ce78050507d867
+amd64-GitCommit: 42888d0bb7536dfa47dc3d8ff629021b9ccb72f4
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c4856a7d8afc0a80f7b06a0a47db4667a81ae1f8
+arm64v8-GitCommit: b7bffd026a456535f5bcb7ca2605a77a6eef4615
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-3541, CVE-2021-3516,
CVE-2021-3517, CVE-2021-3518 and CVE-2021-3537.

See <https://linux.oracle.com/errata/ELSA-2021-2569.html> for details.

Signed-off-by: Avi Miller <avi.miller@oracle.com>