### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -8,22 +8,22 @@ GitRepo: https://github.com/docker-library/golang.git
 Tags: 1.17beta1-buster, 1.17-rc-buster, rc-buster
 SharedTags: 1.17beta1, 1.17-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94b50ae6a398dced36243c0f9034e168aa1ae833
+GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
 Directory: 1.17-rc/buster
 
 Tags: 1.17beta1-stretch, 1.17-rc-stretch, rc-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 94b50ae6a398dced36243c0f9034e168aa1ae833
+GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
 Directory: 1.17-rc/stretch
 
 Tags: 1.17beta1-alpine3.14, 1.17-rc-alpine3.14, rc-alpine3.14, 1.17beta1-alpine, 1.17-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f300e60ca19c3b98cfcf01ca112af2ac10104320
+GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
 Directory: 1.17-rc/alpine3.14
 
 Tags: 1.17beta1-alpine3.13, 1.17-rc-alpine3.13, rc-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f300e60ca19c3b98cfcf01ca112af2ac10104320
+GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
 Directory: 1.17-rc/alpine3.13
 
 Tags: 1.17beta1-windowsservercore-1809, 1.17-rc-windowsservercore-1809, rc-windowsservercore-1809
@@ -47,86 +47,86 @@ GitCommit: 94b50ae6a398dced36243c0f9034e168aa1ae833
 Directory: 1.17-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.16.5-buster, 1.16-buster, 1-buster, buster
-SharedTags: 1.16.5, 1.16, 1, latest
+Tags: 1.16.6-buster, 1.16-buster, 1-buster, buster
+SharedTags: 1.16.6, 1.16, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/buster
 
-Tags: 1.16.5-stretch, 1.16-stretch, 1-stretch, stretch
+Tags: 1.16.6-stretch, 1.16-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/stretch
 
-Tags: 1.16.5-alpine3.14, 1.16-alpine3.14, 1-alpine3.14, alpine3.14, 1.16.5-alpine, 1.16-alpine, 1-alpine, alpine
+Tags: 1.16.6-alpine3.14, 1.16-alpine3.14, 1-alpine3.14, alpine3.14, 1.16.6-alpine, 1.16-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f300e60ca19c3b98cfcf01ca112af2ac10104320
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/alpine3.14
 
-Tags: 1.16.5-alpine3.13, 1.16-alpine3.13, 1-alpine3.13, alpine3.13
+Tags: 1.16.6-alpine3.13, 1.16-alpine3.13, 1-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f300e60ca19c3b98cfcf01ca112af2ac10104320
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/alpine3.13
 
-Tags: 1.16.5-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.16.5-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.5, 1.16, 1, latest
+Tags: 1.16.6-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.16.6-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.6, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16.5-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.16.5-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.5, 1.16, 1, latest
+Tags: 1.16.6-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.16.6-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.6, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.16.5-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.16.5-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.16.6-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.16.6-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: b879b60a7d94128c8fb5aea763cf31772495511d
+GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.15.13-buster, 1.15-buster
-SharedTags: 1.15.13, 1.15
+Tags: 1.15.14-buster, 1.15-buster
+SharedTags: 1.15.14, 1.15
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/buster
 
-Tags: 1.15.13-stretch, 1.15-stretch
+Tags: 1.15.14-stretch, 1.15-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/stretch
 
-Tags: 1.15.13-alpine3.14, 1.15-alpine3.14, 1.15.13-alpine, 1.15-alpine
+Tags: 1.15.14-alpine3.14, 1.15-alpine3.14, 1.15.14-alpine, 1.15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f300e60ca19c3b98cfcf01ca112af2ac10104320
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/alpine3.14
 
-Tags: 1.15.13-alpine3.13, 1.15-alpine3.13
+Tags: 1.15.14-alpine3.13, 1.15-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f300e60ca19c3b98cfcf01ca112af2ac10104320
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/alpine3.13
 
-Tags: 1.15.13-windowsservercore-1809, 1.15-windowsservercore-1809
-SharedTags: 1.15.13-windowsservercore, 1.15-windowsservercore, 1.15.13, 1.15
+Tags: 1.15.14-windowsservercore-1809, 1.15-windowsservercore-1809
+SharedTags: 1.15.14-windowsservercore, 1.15-windowsservercore, 1.15.14, 1.15
 Architectures: windows-amd64
-GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.15.13-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
-SharedTags: 1.15.13-windowsservercore, 1.15-windowsservercore, 1.15.13, 1.15
+Tags: 1.15.14-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
+SharedTags: 1.15.14-windowsservercore, 1.15-windowsservercore, 1.15.14, 1.15
 Architectures: windows-amd64
-GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.15.13-nanoserver-1809, 1.15-nanoserver-1809
-SharedTags: 1.15.13-nanoserver, 1.15-nanoserver
+Tags: 1.15.14-nanoserver-1809, 1.15-nanoserver-1809
+SharedTags: 1.15.14-nanoserver, 1.15-nanoserver
 Architectures: windows-amd64
-GitCommit: 74370a4eaf301318abc7257a82bee06ad56f44d0
+GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
 Directory: 1.15/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/54aa949: Update 1.16 to 1.16.6
- https://github.com/docker-library/golang/commit/d23c409: Update 1.15 to 1.15.14
- https://github.com/docker-library/golang/commit/417ddd2: Switch from SKS to Ubuntu keyserver

https://groups.google.com/g/golang-announce/c/n9FxMelZGAQ/m/4ZhvTx0dAQAJ