### PR TITLE
Odoo: update 12.0-14.0 to release 20210713

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 31fb0a3b34a346778acaa3f47d17d8abf5aa6b18
+GitCommit: 563544203e98e234b52ce19bb3c6357fca6b2c98
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hi,

here are the latest Odoo supported versions.

Thanks a lot.