### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,45 +5,45 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.17beta1-buster, 1.17-rc-buster, rc-buster
-SharedTags: 1.17beta1, 1.17-rc, rc
+Tags: 1.17rc1-buster, 1.17-rc-buster, rc-buster
+SharedTags: 1.17rc1, 1.17-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/buster
 
-Tags: 1.17beta1-stretch, 1.17-rc-stretch, rc-stretch
+Tags: 1.17rc1-stretch, 1.17-rc-stretch, rc-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/stretch
 
-Tags: 1.17beta1-alpine3.14, 1.17-rc-alpine3.14, rc-alpine3.14, 1.17beta1-alpine, 1.17-rc-alpine, rc-alpine
+Tags: 1.17rc1-alpine3.14, 1.17-rc-alpine3.14, rc-alpine3.14, 1.17rc1-alpine, 1.17-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/alpine3.14
 
-Tags: 1.17beta1-alpine3.13, 1.17-rc-alpine3.13, rc-alpine3.13
+Tags: 1.17rc1-alpine3.13, 1.17-rc-alpine3.13, rc-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 417ddd2965fd3a98ce8f1061856b9fa4476617c6
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/alpine3.13
 
-Tags: 1.17beta1-windowsservercore-1809, 1.17-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.17beta1-windowsservercore, 1.17-rc-windowsservercore, rc-windowsservercore, 1.17beta1, 1.17-rc, rc
+Tags: 1.17rc1-windowsservercore-1809, 1.17-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.17rc1-windowsservercore, 1.17-rc-windowsservercore, rc-windowsservercore, 1.17rc1, 1.17-rc, rc
 Architectures: windows-amd64
-GitCommit: 94b50ae6a398dced36243c0f9034e168aa1ae833
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17beta1-windowsservercore-ltsc2016, 1.17-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.17beta1-windowsservercore, 1.17-rc-windowsservercore, rc-windowsservercore, 1.17beta1, 1.17-rc, rc
+Tags: 1.17rc1-windowsservercore-ltsc2016, 1.17-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 1.17rc1-windowsservercore, 1.17-rc-windowsservercore, rc-windowsservercore, 1.17rc1, 1.17-rc, rc
 Architectures: windows-amd64
-GitCommit: 94b50ae6a398dced36243c0f9034e168aa1ae833
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.17beta1-nanoserver-1809, 1.17-rc-nanoserver-1809, rc-nanoserver-1809
-SharedTags: 1.17beta1-nanoserver, 1.17-rc-nanoserver, rc-nanoserver
+Tags: 1.17rc1-nanoserver-1809, 1.17-rc-nanoserver-1809, rc-nanoserver-1809
+SharedTags: 1.17rc1-nanoserver, 1.17-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 94b50ae6a398dced36243c0f9034e168aa1ae833
+GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
 Directory: 1.17-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/7f1f587: Update 1.17-rc to 1.17rc1
- https://github.com/docker-library/golang/commit/25b7059: Sort version numbers