### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -15,8 +15,8 @@ GitCommit: 30d7b9bf7663c96fcd888bd75e9aaa547a808a23
 Directory: 20.10/dind
 
 Tags: 20.10.7-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
-Architectures: amd64
-GitCommit: 279ba9c93e8e26a15171645bd511ea8476c4706e
+Architectures: amd64, arm64v8
+GitCommit: 2ab877f315206028bb9352d86e28c71b25723bf2
 Directory: 20.10/dind-rootless
 
 Tags: 20.10.7-git, 20.10-git, 20-git, git


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/bd0faef: Merge pull request https://github.com/docker-library/docker/pull/315 from infosiftr/arm64-rootless-extras
- https://github.com/docker-library/docker/commit/2a72a42: Update README
- https://github.com/docker-library/docker/commit/2ab877f: Enable rootless-extras on arm64 for 20.10+