### PR TITLE
Update Jetty versions to 9.4.43, 10.0.6 and 11.0.6

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,115 +4,115 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.5-jre11-slim
+Tags: 11.0.6-jre11-slim
 Architectures: amd64
 Directory: 11.0-jre11-slim
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 11.0.5-jre11
+Tags: 11.0.6-jre11
 Architectures: amd64
 Directory: 11.0-jre11
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 11.0.5-jdk16-slim
+Tags: 11.0.6-jdk16-slim
 Architectures: amd64
 Directory: 11.0-jdk16-slim
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 11.0.5, 11.0.5-jdk16
+Tags: 11.0.6, 11.0.6-jdk16
 Architectures: amd64
 Directory: 11.0-jdk16
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 11.0.5-jdk11-slim
+Tags: 11.0.6-jdk11-slim
 Architectures: amd64
 Directory: 11.0-jdk11-slim
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 11.0.5-jdk11
+Tags: 11.0.6-jdk11
 Architectures: amd64
 Directory: 11.0-jdk11
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 10.0.5-jre11-slim
+Tags: 10.0.6-jre11-slim
 Architectures: amd64
 Directory: 10.0-jre11-slim
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 10.0.5-jre11
+Tags: 10.0.6-jre11
 Architectures: amd64
 Directory: 10.0-jre11
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 10.0.5-jdk16-slim
+Tags: 10.0.6-jdk16-slim
 Architectures: amd64
 Directory: 10.0-jdk16-slim
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 10.0.5, 10.0.5-jdk16
+Tags: 10.0.6, 10.0.6-jdk16
 Architectures: amd64
 Directory: 10.0-jdk16
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 10.0.5-jdk11-slim
+Tags: 10.0.6-jdk11-slim
 Architectures: amd64
 Directory: 10.0-jdk11-slim
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 10.0.5-jdk11
+Tags: 10.0.6-jdk11
 Architectures: amd64
 Directory: 10.0-jdk11
-GitCommit: 729c020b15ed50fd9a8e47aee04ecddbcd6e7b6e
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.43-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.43-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 9.4.43-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64
 Directory: 9.4-jre8-slim
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.43-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64
 Directory: 9.4-jre8
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jdk16-slim, 9.4-jdk16-slim, 9-jdk16-slim
+Tags: 9.4.43-jdk16-slim, 9.4-jdk16-slim, 9-jdk16-slim
 Architectures: amd64
 Directory: 9.4-jdk16-slim
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42, 9.4, 9, 9.4.42-jdk16, 9.4-jdk16, 9-jdk16, latest, jdk16
+Tags: 9.4.43, 9.4, 9, 9.4.43-jdk16, 9.4-jdk16, 9-jdk16, latest, jdk16
 Architectures: amd64
 Directory: 9.4-jdk16
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 9.4.43-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64
 Directory: 9.4-jdk11-slim
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 9.4.43-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64
 Directory: 9.4-jdk11
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 9.4.43-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64
 Directory: 9.4-jdk8-slim
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
-Tags: 9.4.42-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 9.4.43-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64
 Directory: 9.4-jdk8
-GitCommit: c3f894018ed14515bb473355a23a06441ba3890b
+GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
 
 Tags: 9.3.29-jre8, 9.3-jre8
 Architectures: amd64


### PR DESCRIPTION
Update Jetty versions:

`9.4.42` -> `9.4.43`
`10.0.5` -> `10.0.6`
`11.0.5` -> `11.0.6`