### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,45 +4,45 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.6.1-buster, 1.6-buster, 1-buster, buster
-SharedTags: 1.6.1, 1.6, 1, latest
+Tags: 1.6.2-buster, 1.6-buster, 1-buster, buster
+SharedTags: 1.6.2, 1.6, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 6458311a816406d7b1eb6d37ae92a6e27e32028c
+GitCommit: 16b07a748f97fe67442d7731c6d7714dc8c252cc
 Directory: 1.6/buster
 
-Tags: 1.6.1-alpine3.14, 1.6-alpine3.14, 1-alpine3.14, alpine3.14, 1.6.1-alpine, 1.6-alpine, 1-alpine, alpine
+Tags: 1.6.2-alpine3.14, 1.6-alpine3.14, 1-alpine3.14, alpine3.14, 1.6.2-alpine, 1.6-alpine, 1-alpine, alpine
 Architectures: amd64
-GitCommit: 3aca6cfd86f62b86a323f3d95e2042a613709cac
+GitCommit: 16b07a748f97fe67442d7731c6d7714dc8c252cc
 Directory: 1.6/alpine3.14
 
-Tags: 1.6.1-alpine3.13, 1.6-alpine3.13, 1-alpine3.13, alpine3.13
+Tags: 1.6.2-alpine3.13, 1.6-alpine3.13, 1-alpine3.13, alpine3.13
 Architectures: amd64
-GitCommit: 6458311a816406d7b1eb6d37ae92a6e27e32028c
+GitCommit: 16b07a748f97fe67442d7731c6d7714dc8c252cc
 Directory: 1.6/alpine3.13
 
-Tags: 1.6.1-windowsservercore-1809, 1.6-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.6.1, 1.6, 1, latest
+Tags: 1.6.2-windowsservercore-1809, 1.6-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.6.2, 1.6, 1, latest
 Architectures: windows-amd64
-GitCommit: 6458311a816406d7b1eb6d37ae92a6e27e32028c
+GitCommit: 16b07a748f97fe67442d7731c6d7714dc8c252cc
 Directory: 1.6/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.6.1-windowsservercore-ltsc2016, 1.6-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.6.1, 1.6, 1, latest
+Tags: 1.6.2-windowsservercore-ltsc2016, 1.6-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.6.2, 1.6, 1, latest
 Architectures: windows-amd64
-GitCommit: 6458311a816406d7b1eb6d37ae92a6e27e32028c
+GitCommit: 16b07a748f97fe67442d7731c6d7714dc8c252cc
 Directory: 1.6/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.0.5-buster, 1.0-buster
 SharedTags: 1.0.5, 1.0
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4c770401df0b946da5cf61150bedb05280b218a6
+GitCommit: 2df03ddf2e51147c7973d4e9fa0bb15602930974
 Directory: 1.0/buster
 
 Tags: 1.0.5-stretch, 1.0-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4c770401df0b946da5cf61150bedb05280b218a6
+GitCommit: 2df03ddf2e51147c7973d4e9fa0bb15602930974
 Directory: 1.0/stretch
 
 Tags: 1.0.5-windowsservercore-1809, 1.0-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/16b07a7: Update to 1.6.2
- https://github.com/docker-library/julia/commit/796a90e: Update README
- https://github.com/docker-library/julia/commit/2df03dd: Switch from SKS to Ubuntu keyserver