### PR TITLE
Bump Traefik to v2.4.11

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: ddec81750aeb6951688061127d7b6ad1feed1d2b
 Directory: alpine
 
-Tags: v2.4.9-windowsservercore-1809, 2.4.9-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.11-windowsservercore-1809, 2.4.11-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 3c9cff0bbd01da83bcf9b73b60e09b9e7f7d8c12
+GitCommit: 4c8a1317babfff05ac64efe90b486fe3673d5c0b
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.9, 2.4.9, v2.4, 2.4, livarot, latest
+Tags: v2.4.11, 2.4.11, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 3c9cff0bbd01da83bcf9b73b60e09b9e7f7d8c12
+GitCommit: 4c8a1317babfff05ac64efe90b486fe3673d5c0b
 Directory: alpine
 
 Tags: v1.7.30-windowsservercore-1809, 1.7.30-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.11](https://github.com/traefik/traefik/releases/tag/v2.4.11).

/cc @ldez @rtribotte @SantoDE

Cheers
