### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,67 +4,67 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-5-jdk-oraclelinux8, 18-ea-5-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-5-jdk-oracle, 18-ea-5-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-5-jdk, 18-ea-5, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-6-jdk-oraclelinux8, 18-ea-6-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-6-jdk-oracle, 18-ea-6-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-6-jdk, 18-ea-6, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-5-jdk-oraclelinux7, 18-ea-5-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-6-jdk-oraclelinux7, 18-ea-6-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-5-jdk-buster, 18-ea-5-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-6-jdk-buster, 18-ea-6-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/buster
 
-Tags: 18-ea-5-jdk-slim-buster, 18-ea-5-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-5-jdk-slim, 18-ea-5-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-6-jdk-slim-buster, 18-ea-6-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-6-jdk-slim, 18-ea-6-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/slim-buster
 
-Tags: 18-ea-5-jdk-windowsservercore-1809, 18-ea-5-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-5-jdk-windowsservercore, 18-ea-5-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-5-jdk, 18-ea-5, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-6-jdk-windowsservercore-1809, 18-ea-6-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-6-jdk-windowsservercore, 18-ea-6-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-6-jdk, 18-ea-6, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-5-jdk-windowsservercore-ltsc2016, 18-ea-5-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-5-jdk-windowsservercore, 18-ea-5-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-5-jdk, 18-ea-5, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-6-jdk-windowsservercore-ltsc2016, 18-ea-6-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-6-jdk-windowsservercore, 18-ea-6-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-6-jdk, 18-ea-6, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-5-jdk-nanoserver-1809, 18-ea-5-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-5-jdk-nanoserver, 18-ea-5-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-6-jdk-nanoserver-1809, 18-ea-6-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-6-jdk-nanoserver, 18-ea-6-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 608f26c5ea63ca34070b439c904cb94a30f6b0c1
+GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17-ea-30-jdk-oraclelinux8, 17-ea-30-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-30-jdk-oracle, 17-ea-30-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-30-jdk, 17-ea-30, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-31-jdk-oraclelinux8, 17-ea-31-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-31-jdk-oracle, 17-ea-31-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-31-jdk, 17-ea-31, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-30-jdk-oraclelinux7, 17-ea-30-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-31-jdk-oraclelinux7, 17-ea-31-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-30-jdk-buster, 17-ea-30-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-31-jdk-buster, 17-ea-31-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/buster
 
-Tags: 17-ea-30-jdk-slim-buster, 17-ea-30-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-30-jdk-slim, 17-ea-30-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-31-jdk-slim-buster, 17-ea-31-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-31-jdk-slim, 17-ea-31-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-14-jdk-alpine3.14, 17-ea-14-alpine3.14, 17-ea-jdk-alpine3.14, 17-ea-alpine3.14, 17-jdk-alpine3.14, 17-alpine3.14, 17-ea-14-jdk-alpine, 17-ea-14-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -77,24 +77,24 @@ Architectures: amd64
 GitCommit: 255fbc7cf6da6d76869b420dd2fe0bc94539b5eb
 Directory: 17/jdk/alpine3.13
 
-Tags: 17-ea-30-jdk-windowsservercore-1809, 17-ea-30-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-30-jdk-windowsservercore, 17-ea-30-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-30-jdk, 17-ea-30, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-31-jdk-windowsservercore-1809, 17-ea-31-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-31-jdk-windowsservercore, 17-ea-31-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-31-jdk, 17-ea-31, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-30-jdk-windowsservercore-ltsc2016, 17-ea-30-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-30-jdk-windowsservercore, 17-ea-30-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-30-jdk, 17-ea-30, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-31-jdk-windowsservercore-ltsc2016, 17-ea-31-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-31-jdk-windowsservercore, 17-ea-31-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-31-jdk, 17-ea-31, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-30-jdk-nanoserver-1809, 17-ea-30-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-30-jdk-nanoserver, 17-ea-30-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-31-jdk-nanoserver-1809, 17-ea-31-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-31-jdk-nanoserver, 17-ea-31-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 0502ca2f6ef871ecd470a2b7e2b43477257b1684
+GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/2c704c7: Update 18 to 18-ea+6
- https://github.com/docker-library/openjdk/commit/da09a9b: Update 17 to 17-ea+31