### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,24 +34,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2f36ad009f5811f3155d135a6deacc3b789a51cd
 Directory: 2.3/alpine
 
-Tags: 2.2.14, 2.2
+Tags: 2.2.15, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 99d68b7d5b3ec68cdfcb7e0cef173e054d491bcb
+GitCommit: e6e8aa155660496478b3a348e009935581511c70
 Directory: 2.2
 
-Tags: 2.2.14-alpine, 2.2-alpine
+Tags: 2.2.15-alpine, 2.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
+GitCommit: e6e8aa155660496478b3a348e009935581511c70
 Directory: 2.2/alpine
 
-Tags: 2.0.22, 2.0
+Tags: 2.0.23, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a67c29391a51f0fa90c0256b35b5c27d8bc598ce
+GitCommit: 7fa89477be71cefe9c7f38468d99f85982194c84
 Directory: 2.0
 
-Tags: 2.0.22-alpine, 2.0-alpine
+Tags: 2.0.23-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
+GitCommit: 7fa89477be71cefe9c7f38468d99f85982194c84
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e6e8aa1: Update 2.2 to 2.2.15
- https://github.com/docker-library/haproxy/commit/7fa8947: Update 2.0 to 2.0.23