### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.0-rc.1, 3.9-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e99ec446e56acac7f57f3e552be70c0421003666
+GitCommit: 01c0a8401843ca403cb90ea627a7ebccefbe755d
 Directory: 3.9-rc/ubuntu
 
 Tags: 3.9.0-rc.1-management, 3.9-rc-management
@@ -16,7 +16,7 @@ Directory: 3.9-rc/ubuntu/management
 
 Tags: 3.9.0-rc.1-alpine, 3.9-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e99ec446e56acac7f57f3e552be70c0421003666
+GitCommit: 01c0a8401843ca403cb90ea627a7ebccefbe755d
 Directory: 3.9-rc/alpine
 
 Tags: 3.9.0-rc.1-management-alpine, 3.9-rc-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/a68d34a: Merge pull request https://github.com/docker-library/rabbitmq/pull/502 from infosiftr/missing
- https://github.com/docker-library/rabbitmq/commit/01c0a84: Error on deprecated RABBITMQ_ERLANG_COOKIE