### PR TITLE
archlinux: Release 20210718.0.29333

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210711.0.28748
-GitCommit: 7f8b5d1af75044049a9e950ec3131d22857b1e86
-GitFetch: refs/tags/v20210711.0.28748
+Tags: latest, base, base-20210718.0.29333
+GitCommit: df58cede32dad342c61aae956d858a9ab0d673d4
+GitFetch: refs/tags/v20210718.0.29333
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210711.0.28748
-GitCommit: 7f8b5d1af75044049a9e950ec3131d22857b1e86
-GitFetch: refs/tags/v20210711.0.28748
+Tags: base-devel, base-devel-20210718.0.29333
+GitCommit: df58cede32dad342c61aae956d858a9ab0d673d4
+GitFetch: refs/tags/v20210718.0.29333
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks