### PR TITLE
Update Clear Linux OS to 34860

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 919de92f3ea61be7b1d63e04c401f2bac86f6a78
-GitFetch: refs/tags/clear-linux-34820
+GitCommit: 363680871d42245eab45f031991273402e64a46a
+GitFetch: refs/tags/clear-linux-34860


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34860

@bryteise @mdhorn @phmccarty