### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev1, 2.5-dev
+Tags: 2.5-dev2, 2.5-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d87e27dd90273fe213f7d468516ad192e959f086
+GitCommit: 0234c30ab794a26ee90ec93401da019d93b49f72
 Directory: 2.5-rc
 
-Tags: 2.5-dev1-alpine, 2.5-dev-alpine
+Tags: 2.5-dev2-alpine, 2.5-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d87e27dd90273fe213f7d468516ad192e959f086
+GitCommit: 0234c30ab794a26ee90ec93401da019d93b49f72
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.2, 2.4, lts, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/0234c30: Update 2.5-rc to 2.5-dev2