### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.25, 8.0, 8, latest
-GitCommit: a09a716a88ce34a17e16df3f8b091066d90e6f34
+Tags: 8.0.26, 8.0, 8, latest
+GitCommit: c506174eab8ae160f56483e8d72410f8f1e1470f
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.34, 5.7, 5
-GitCommit: b11f06b0d202e7b0f97b000e158fc4fc869d2194
+Tags: 5.7.35, 5.7, 5
+GitCommit: 9e91c13e4147ab680e620d06fb16b505d6ea6bd1
 Directory: 5.7
 File: Dockerfile.debian
 
 Tags: 5.6.51, 5.6
-GitCommit: 43ee7daebca3af6cb13ae3032b2a4e6f642c7233
+GitCommit: d60655b1b42f677c315d5fe2ca0e87126ca921f5
 Directory: 5.6
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/c506174: Update 8.0 to 8.0.26, debian 8.0.26-1debian10
- https://github.com/docker-library/mysql/commit/9e91c13: Update 5.7 to 5.7.35, debian 5.7.35-1debian10
- https://github.com/docker-library/mysql/commit/d60655b: Switch from SKS to Ubuntu keyserver