### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -29,21 +29,21 @@ Directory: 1.17-rc/alpine3.13
 Tags: 1.17rc1-windowsservercore-1809, 1.17-rc-windowsservercore-1809, rc-windowsservercore-1809
 SharedTags: 1.17rc1-windowsservercore, 1.17-rc-windowsservercore, rc-windowsservercore, 1.17rc1, 1.17-rc, rc
 Architectures: windows-amd64
-GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.17-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 1.17rc1-windowsservercore-ltsc2016, 1.17-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
 SharedTags: 1.17rc1-windowsservercore, 1.17-rc-windowsservercore, rc-windowsservercore, 1.17rc1, 1.17-rc, rc
 Architectures: windows-amd64
-GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.17-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.17rc1-nanoserver-1809, 1.17-rc-nanoserver-1809, rc-nanoserver-1809
 SharedTags: 1.17rc1-nanoserver, 1.17-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 7f1f587018139127c0dc71bc276ca7b0609847f4
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.17-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -71,21 +71,21 @@ Directory: 1.16/alpine3.13
 Tags: 1.16.6-windowsservercore-1809, 1.16-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
 SharedTags: 1.16.6-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.6, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 1.16.6-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 1.16.6-windowsservercore, 1.16-windowsservercore, 1-windowsservercore, windowsservercore, 1.16.6, 1.16, 1, latest
 Architectures: windows-amd64
-GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.16/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.16.6-nanoserver-1809, 1.16-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
 SharedTags: 1.16.6-nanoserver, 1.16-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 54aa949c354b1e14cb636539f401b0e58ca76927
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -113,20 +113,20 @@ Directory: 1.15/alpine3.13
 Tags: 1.15.14-windowsservercore-1809, 1.15-windowsservercore-1809
 SharedTags: 1.15.14-windowsservercore, 1.15-windowsservercore, 1.15.14, 1.15
 Architectures: windows-amd64
-GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.15/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 1.15.14-windowsservercore-ltsc2016, 1.15-windowsservercore-ltsc2016
 SharedTags: 1.15.14-windowsservercore, 1.15-windowsservercore, 1.15.14, 1.15
 Architectures: windows-amd64
-GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.15/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 1.15.14-nanoserver-1809, 1.15-nanoserver-1809
 SharedTags: 1.15.14-nanoserver, 1.15-nanoserver
 Architectures: windows-amd64
-GitCommit: d23c409d5096cd3e6b18d977e1f70473e2726461
+GitCommit: 272431aeb4d1e2235a36d1aa64e76f0977a720cc
 Directory: 1.15/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/91fcb9a: Merge pull request https://github.com/docker-library/golang/pull/377 from infosiftr/go-1.17-windows
- https://github.com/docker-library/golang/commit/272431a: For Go 1.17+, move the Windows install to C:\Program Files\Go