### PR TITLE
Bump Traefik to v2.5.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.5.0-rc2-windowsservercore-1809, 2.5.0-rc2-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809
+Tags: v2.5.0-rc3-windowsservercore-1809, 2.5.0-rc3-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ddec81750aeb6951688061127d7b6ad1feed1d2b
+GitCommit: bf492099829ace471fc6716de77ddfbb1501b1b1
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.0-rc2, 2.5.0-rc2, v2.5, 2.5, brie
+Tags: v2.5.0-rc3, 2.5.0-rc3, v2.5, 2.5, brie
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ddec81750aeb6951688061127d7b6ad1feed1d2b
+GitCommit: bf492099829ace471fc6716de77ddfbb1501b1b1
 Directory: alpine
 
 Tags: v2.4.11-windowsservercore-1809, 2.4.11-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.5.0-rc3](https://github.com/traefik/traefik/releases/tag/v2.5.0-rc3).

/cc @ldez @rtribotte @SantoDE

Cheers
