### PR TITLE
InfluxDB v1.9.3 Enterprise-only release

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -1,6 +1,6 @@
 Maintainers: Cody Shepherd (@codyshepherd), Daniel Moran <dmoran@influxdata.com> (@danxmoran)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 952c4a9c85fe9ccfe954222e8aa8eb268d785bce
+GitCommit: c29f3dbf7ccb63ed94cd9639f46bf2b488fbe634
 
 Tags: 1.7, 1.7.11
 Architectures: amd64, arm32v7, arm64v8
@@ -40,16 +40,16 @@ Directory: influxdb/1.8/meta
 Tags: 1.8-meta-alpine, 1.8.6-meta-alpine, meta-alpine
 Directory: influxdb/1.8/meta/alpine
 
-Tags: 1.9-data, 1.9.2-data
+Tags: 1.9-data, 1.9.3-data
 Directory: influxdb/1.9/data
 
-Tags: 1.9-data-alpine, 1.9.2-data-alpine
+Tags: 1.9-data-alpine, 1.9.3-data-alpine
 Directory: influxdb/1.9/data/alpine
 
-Tags: 1.9-meta, 1.9.2-meta
+Tags: 1.9-meta, 1.9.3-meta
 Directory: influxdb/1.9/meta
 
-Tags: 1.9-meta-alpine, 1.9.2-meta-alpine
+Tags: 1.9-meta-alpine, 1.9.3-meta-alpine
 Directory: influxdb/1.9/meta/alpine
 
 Tags: 2.0, 2.0.7, latest


### PR DESCRIPTION
Release of Docker images for Enterprise-only InfluxDB v1.9.3 release.