### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -98,45 +98,45 @@ GitCommit: da09a9b190bc6fe3dd6dab30b1aea6fc6c756f80
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16.0.1-jdk-oraclelinux8, 16.0.1-oraclelinux8, 16.0-jdk-oraclelinux8, 16.0-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 16.0.1-jdk-oracle, 16.0.1-oracle, 16.0-jdk-oracle, 16.0-oracle, 16-jdk-oracle, 16-oracle, jdk-oracle, oracle
-SharedTags: 16.0.1-jdk, 16.0.1, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
+Tags: 16.0.2-jdk-oraclelinux8, 16.0.2-oraclelinux8, 16.0-jdk-oraclelinux8, 16.0-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 16.0.2-jdk-oracle, 16.0.2-oracle, 16.0-jdk-oracle, 16.0-oracle, 16-jdk-oracle, 16-oracle, jdk-oracle, oracle
+SharedTags: 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
 Architectures: amd64, arm64v8
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16.0.1-jdk-oraclelinux7, 16.0.1-oraclelinux7, 16.0-jdk-oraclelinux7, 16.0-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, jdk-oraclelinux7, oraclelinux7
+Tags: 16.0.2-jdk-oraclelinux7, 16.0.2-oraclelinux7, 16.0-jdk-oraclelinux7, 16.0-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16.0.1-jdk-buster, 16.0.1-buster, 16.0-jdk-buster, 16.0-buster, 16-jdk-buster, 16-buster, jdk-buster, buster
+Tags: 16.0.2-jdk-buster, 16.0.2-buster, 16.0-jdk-buster, 16.0-buster, 16-jdk-buster, 16-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/buster
 
-Tags: 16.0.1-jdk-slim-buster, 16.0.1-slim-buster, 16.0-jdk-slim-buster, 16.0-slim-buster, 16-jdk-slim-buster, 16-slim-buster, jdk-slim-buster, slim-buster, 16.0.1-jdk-slim, 16.0.1-slim, 16.0-jdk-slim, 16.0-slim, 16-jdk-slim, 16-slim, jdk-slim, slim
+Tags: 16.0.2-jdk-slim-buster, 16.0.2-slim-buster, 16.0-jdk-slim-buster, 16.0-slim-buster, 16-jdk-slim-buster, 16-slim-buster, jdk-slim-buster, slim-buster, 16.0.2-jdk-slim, 16.0.2-slim, 16.0-jdk-slim, 16.0-slim, 16-jdk-slim, 16-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/slim-buster
 
-Tags: 16.0.1-jdk-windowsservercore-1809, 16.0.1-windowsservercore-1809, 16.0-jdk-windowsservercore-1809, 16.0-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 16.0.1-jdk-windowsservercore, 16.0.1-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16.0.1-jdk, 16.0.1, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
+Tags: 16.0.2-jdk-windowsservercore-1809, 16.0.2-windowsservercore-1809, 16.0-jdk-windowsservercore-1809, 16.0-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16.0.1-jdk-windowsservercore-ltsc2016, 16.0.1-windowsservercore-ltsc2016, 16.0-jdk-windowsservercore-ltsc2016, 16.0-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 16.0.1-jdk-windowsservercore, 16.0.1-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16.0.1-jdk, 16.0.1, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
+Tags: 16.0.2-jdk-windowsservercore-ltsc2016, 16.0.2-windowsservercore-ltsc2016, 16.0-jdk-windowsservercore-ltsc2016, 16.0-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
 Architectures: windows-amd64
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16.0.1-jdk-nanoserver-1809, 16.0.1-nanoserver-1809, 16.0-jdk-nanoserver-1809, 16.0-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 16.0.1-jdk-nanoserver, 16.0.1-nanoserver, 16.0-jdk-nanoserver, 16.0-nanoserver, 16-jdk-nanoserver, 16-nanoserver, jdk-nanoserver, nanoserver
+Tags: 16.0.2-jdk-nanoserver-1809, 16.0.2-nanoserver-1809, 16.0-jdk-nanoserver-1809, 16.0-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 16.0.2-jdk-nanoserver, 16.0.2-nanoserver, 16.0-jdk-nanoserver, 16.0-nanoserver, 16-jdk-nanoserver, 16-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 277bd48c8482ecbc70225442328ef34a7c8ff139
+GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/d443a29: Update 16 to 16.0.2