### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -14,27 +14,27 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 34eedfdcf45cc6b03328f68a67306f0cf77c4a20
 Directory: 6.2/alpine
 
-Tags: 6.0.14, 6.0, 6.0.14-buster, 6.0-buster
+Tags: 6.0.15, 6.0, 6.0.15-buster, 6.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 07eb60ebe0d977d5b26fea67f41af73ac1efceb2
+GitCommit: a73df6df17be8294a63e6914fca028984772179a
 Directory: 6.0
 
-Tags: 6.0.14-alpine, 6.0-alpine, 6.0.14-alpine3.14, 6.0-alpine3.14
+Tags: 6.0.15-alpine, 6.0-alpine, 6.0.15-alpine3.14, 6.0-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eedfdcf45cc6b03328f68a67306f0cf77c4a20
+GitCommit: a73df6df17be8294a63e6914fca028984772179a
 Directory: 6.0/alpine
 
-Tags: 5.0.12, 5.0, 5, 5.0.12-buster, 5.0-buster, 5-buster
+Tags: 5.0.13, 5.0, 5, 5.0.13-buster, 5.0-buster, 5-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 147762b57f4d4391ba6cf8fbd1e7590a606643ef
+GitCommit: 6149807771994b753763123cee3b6406ab6745b6
 Directory: 5
 
-Tags: 5.0.12-32bit, 5.0-32bit, 5-32bit, 5.0.12-32bit-buster, 5.0-32bit-buster, 5-32bit-buster
+Tags: 5.0.13-32bit, 5.0-32bit, 5-32bit, 5.0.13-32bit-buster, 5.0-32bit-buster, 5-32bit-buster
 Architectures: amd64
-GitCommit: 147762b57f4d4391ba6cf8fbd1e7590a606643ef
+GitCommit: 6149807771994b753763123cee3b6406ab6745b6
 Directory: 5/32bit
 
-Tags: 5.0.12-alpine, 5.0-alpine, 5-alpine, 5.0.12-alpine3.14, 5.0-alpine3.14, 5-alpine3.14
+Tags: 5.0.13-alpine, 5.0-alpine, 5-alpine, 5.0.13-alpine3.14, 5.0-alpine3.14, 5-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eedfdcf45cc6b03328f68a67306f0cf77c4a20
+GitCommit: 6149807771994b753763123cee3b6406ab6745b6
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/a73df6d: Update to 6.0.15
- https://github.com/docker-library/redis/commit/6149807: Update to 5.0.13