### PR TITLE
[oraclelinux] Update oraclelinux:8 and 8-slim for CVE-2021-33910

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 42888d0bb7536dfa47dc3d8ff629021b9ccb72f4
+amd64-GitCommit: 6ef2cfe67f1bdf361efaf315ef87bcee28ad76ab
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b7bffd026a456535f5bcb7ca2605a77a6eef4615
+arm64v8-GitCommit: 8eaa322e177a75bb7261bca2f57243de9716c7ce
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/errata/ELSA-2021-2717.html> for info.

Signed-off-by: Avi Miller <avi.miller@oracle.com>