### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 6.2.4, 6.2, 6, latest, 6.2.4-buster, 6.2-buster, 6-buster, buster
+Tags: 6.2.5, 6.2, 6, latest, 6.2.5-buster, 6.2-buster, 6-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4422738bea4a9d38971a87fc820525864bb5ff62
+GitCommit: af431c381c3718dbe4d87572f7d3c330a063df8d
 Directory: 6.2
 
-Tags: 6.2.4-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.4-alpine3.14, 6.2-alpine3.14, 6-alpine3.14, alpine3.14
+Tags: 6.2.5-alpine, 6.2-alpine, 6-alpine, alpine, 6.2.5-alpine3.14, 6.2-alpine3.14, 6-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34eedfdcf45cc6b03328f68a67306f0cf77c4a20
+GitCommit: af431c381c3718dbe4d87572f7d3c330a063df8d
 Directory: 6.2/alpine
 
 Tags: 6.0.15, 6.0, 6.0.15-buster, 6.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/af431c3: Update to 6.2.5