### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.0-rc.2, 3.9-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2ebf4f0eaef98fe92592f76ab19cb2a65ec00396
+GitCommit: 9331f6a8c3f6484d15ff1498f3d82a886f168617
 Directory: 3.9-rc/ubuntu
 
 Tags: 3.9.0-rc.2-management, 3.9-rc-management
@@ -16,7 +16,7 @@ Directory: 3.9-rc/ubuntu/management
 
 Tags: 3.9.0-rc.2-alpine, 3.9-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2ebf4f0eaef98fe92592f76ab19cb2a65ec00396
+GitCommit: 9331f6a8c3f6484d15ff1498f3d82a886f168617
 Directory: 3.9-rc/alpine
 
 Tags: 3.9.0-rc.2-management-alpine, 3.9-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9-rc/alpine/management
 
 Tags: 3.8.19, 3.8, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 67d05697020c3439aa45aaeadc9a23922a21b92c
+GitCommit: 08b58dbec5a970f049fad01ced9480d03ab1c165
 Directory: 3.8/ubuntu
 
 Tags: 3.8.19-management, 3.8-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.19-alpine, 3.8-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67d05697020c3439aa45aaeadc9a23922a21b92c
+GitCommit: 08b58dbec5a970f049fad01ced9480d03ab1c165
 Directory: 3.8/alpine
 
 Tags: 3.8.19-management-alpine, 3.8-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/9331f6a: Update 3.9-rc to otp 24.0.4
- https://github.com/docker-library/rabbitmq/commit/41317fa: Update 3.8-rc to otp 24.0.4
- https://github.com/docker-library/rabbitmq/commit/08b58db: Update 3.8 to otp 24.0.4