### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,45 +4,45 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-6-jdk-oraclelinux8, 18-ea-6-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-6-jdk-oracle, 18-ea-6-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-6-jdk, 18-ea-6, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-7-jdk-oraclelinux8, 18-ea-7-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-7-jdk-oracle, 18-ea-7-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-7-jdk, 18-ea-7, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-6-jdk-oraclelinux7, 18-ea-6-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-7-jdk-oraclelinux7, 18-ea-7-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-6-jdk-buster, 18-ea-6-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-7-jdk-buster, 18-ea-7-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/buster
 
-Tags: 18-ea-6-jdk-slim-buster, 18-ea-6-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-6-jdk-slim, 18-ea-6-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-7-jdk-slim-buster, 18-ea-7-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-7-jdk-slim, 18-ea-7-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/slim-buster
 
-Tags: 18-ea-6-jdk-windowsservercore-1809, 18-ea-6-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-6-jdk-windowsservercore, 18-ea-6-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-6-jdk, 18-ea-6, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-7-jdk-windowsservercore-1809, 18-ea-7-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-7-jdk-windowsservercore, 18-ea-7-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-7-jdk, 18-ea-7, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-6-jdk-windowsservercore-ltsc2016, 18-ea-6-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-6-jdk-windowsservercore, 18-ea-6-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-6-jdk, 18-ea-6, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-7-jdk-windowsservercore-ltsc2016, 18-ea-7-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-7-jdk-windowsservercore, 18-ea-7-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-7-jdk, 18-ea-7, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-6-jdk-nanoserver-1809, 18-ea-6-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-6-jdk-nanoserver, 18-ea-6-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-7-jdk-nanoserver-1809, 18-ea-7-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-7-jdk-nanoserver, 18-ea-7-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 2c704c74bb8c793d9d4709974b600b9f7e1301ac
+GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/10eeb5d: Update 18 to 18-ea+7