### PR TITLE
Release Couchbase Server 7.0.0 (EE and CE)

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,65 +1,22 @@
 Maintainers: Couchbase Docker Team <docker@couchbase.com> (@cb-robot)
 GitRepo: https://github.com/couchbase/docker
 
-Tags: 7.0.0-beta, enterprise-7.0.0-beta
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/7.0.0-beta
+Tags: latest, enterprise, 7.0.0, enterprise-7.0.0
+GitCommit: a4a4b016732b4ea3a42ea115f481c66ba69b980d
+Directory: enterprise/couchbase-server/7.0.0
 
-Tags: community-7.0.0-beta
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: community/couchbase-server/7.0.0-beta
+Tags: community, community-7.0.0
+GitCommit: a4a4b016732b4ea3a42ea115f481c66ba69b980d
+Directory: community/couchbase-server/7.0.0
 
-Tags: latest, enterprise, 6.6.2, enterprise-6.6.2
+Tags: 6.6.2, enterprise-6.6.2
 GitCommit: 4d5b6101c73d4efe75d2288107f6fe00b1deeff5
 Directory: enterprise/couchbase-server/6.6.2
 
-Tags: community, community-6.6.0
+Tags: community-6.6.0
 GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
 Directory: community/couchbase-server/6.6.0
 
 Tags: 6.0.5, enterprise-6.0.5
 GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
 Directory: enterprise/couchbase-server/6.0.5
-
-# One-off updates of older versions as we have updated the
-# Ubuntu base image version to address security vulnerabilities
-
-Tags: 6.6.1, enterprise-6.6.1
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.6.1
-
-Tags: 6.6.0, enterprise-6.6.0
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.6.0
-
-Tags: 6.5.1, enterprise-6.5.1
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.5.1
-
-Tags: 6.5.0, enterprise-6.5.0
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.5.0
-
-Tags: 6.0.4, enterprise-6.0.4
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.0.4
-
-Tags: 6.0.3, enterprise-6.0.3
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.0.3
-
-Tags: 6.0.2, enterprise-6.0.2
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.0.2
-
-Tags: 6.0.1, enterprise-6.0.1
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: enterprise/couchbase-server/6.0.1
-
-Tags: community-6.5.1
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: community/couchbase-server/6.5.1
-
-Tags: community-6.5.0
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
-Directory: community/couchbase-server/6.5.1


### PR DESCRIPTION
Our official GA date is Thursday, July 28. If this change could be pushed live Tuesday or Wednesday we'd really appreciate it.