### PR TITLE
[Haskell] Bump Haskell to use stack 2.7.3

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,17 +4,17 @@ Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
 GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.0.1-buster, 9.0-buster, 9-buster, buster, 9.0.1, 9.0, 9, latest
-GitCommit: af0dc736060a89e40b87cf11af37e434d52bc10b
+GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
 Directory: 9.0/buster
 
 Tags: 9.0.1-stretch, 9.0-stretch, 9-stretch, stretch
-GitCommit: af0dc736060a89e40b87cf11af37e434d52bc10b
+GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
 Directory: 9.0/stretch
 
 Tags: 8.10.4-buster, 8.10-buster, 8-buster, 8.10.4, 8.10, 8
-GitCommit: af0dc736060a89e40b87cf11af37e434d52bc10b
+GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
 Directory: 8.10/buster
 
 Tags: 8.10.4-stretch, 8.10-stretch, 8-stretch
-GitCommit: af0dc736060a89e40b87cf11af37e434d52bc10b
+GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
 Directory: 8.10/stretch


### PR DESCRIPTION
Hi :wave: , just a minor dep bump for Haskell - https://docs.haskellstack.org/en/stable/ChangeLog/#v273 

Oh, this also includes some [dockerfile improvements](https://github.com/haskell/docker-haskell/pull/39) (feedback welcome), but that should not impact users much.