### PR TITLE
Bump Traefik to v2.4.12

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: bf492099829ace471fc6716de77ddfbb1501b1b1
 Directory: alpine
 
-Tags: v2.4.11-windowsservercore-1809, 2.4.11-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.12-windowsservercore-1809, 2.4.12-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4c8a1317babfff05ac64efe90b486fe3673d5c0b
+GitCommit: 30021f17f3498849078e823daaaf7089dba02ffb
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.11, 2.4.11, v2.4, 2.4, livarot, latest
+Tags: v2.4.12, 2.4.12, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4c8a1317babfff05ac64efe90b486fe3673d5c0b
+GitCommit: 30021f17f3498849078e823daaaf7089dba02ffb
 Directory: alpine
 
 Tags: v1.7.30-windowsservercore-1809, 1.7.30-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.12](https://github.com/traefik/traefik/releases/tag/v2.4.12).

/cc @ldez @rtribotte @SantoDE

Cheers
