### PR TITLE
ubuntu: add riscv64 images and update images

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -6,46 +6,49 @@ GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
 GitCommit: 045a1b4ee981b35a9ffcfd1d4d137cbcd949acfb
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 50b110c15148c069706b155a60d21ecfcbb59de9
+amd64-GitCommit: a967c2b8734c77f7f89449d0b87c2e1eebf8b26e
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0aff0d1e027d57ffbe751dcf9824ed5d4fa08f01
+arm32v7-GitCommit: 44083c5410504d4f9d29bfe858f7d18e6661dd90
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9350774a1f4bee287854325f9a3187edc4f130f2
+arm64v8-GitCommit: 0eb682dd6f580088c25291f21ada8291ff084212
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 415eb486de459136b2fa8e4ae73da1281b9f29a5
+i386-GitCommit: 5d8600ba71374a0f46153263bd62855c49d5226c
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: eea2743574974618b72a93d53b328e5a57aa565f
+ppc64le-GitCommit: 10f4f9269b575b715c17fe3a45d5fb213c62d9a7
+# https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-riscv64
+riscv64-GitFetch: refs/heads/dist-riscv64
+riscv64-GitCommit: ba2eda62d3c01c24967bbebb39c7fc7ab6dfd2f2
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 90212fd19662c782246afd586e629e9520cd7b93
+s390x-GitCommit: 7ee8680c704ad3cbdec238f60bcaccf703db1558
 
-# 20210702 (bionic)
-Tags: 18.04, bionic-20210702, bionic
+# 20210723 (bionic)
+Tags: 18.04, bionic-20210723, bionic
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: bionic
 
-# 20210713 (focal)
-Tags: 20.04, focal-20210713, focal, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+# 20210723 (focal)
+Tags: 20.04, focal-20210723, focal, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: focal
 
-# 20210713 (groovy)
-Tags: 20.10, groovy-20210713, groovy
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+# 20210723 (groovy)
+Tags: 20.10, groovy-20210723, groovy
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: groovy
 
-# 20210711 (hirsute)
-Tags: 21.04, hirsute-20210711, hirsute, rolling
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+# 20210723 (hirsute)
+Tags: 21.04, hirsute-20210723, hirsute, rolling
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: hirsute
 
-# 20210711 (impish)
-Tags: 21.10, impish-20210711, impish, devel
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+# 20210722 (impish)
+Tags: 21.10, impish-20210722, impish, devel
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: impish
 
 # 20191217 (trusty)
@@ -53,7 +56,7 @@ Tags: 14.04, trusty-20191217, trusty
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: trusty
 
-# 20210611 (xenial)
-Tags: 16.04, xenial-20210611, xenial
+# 20210722 (xenial)
+Tags: 16.04, xenial-20210722, xenial
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: xenial


### PR DESCRIPTION
This updates all the Ubuntu images for Xenial and newer to resolve a
recent systemd CVE.