### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.10.1, 4.10, 4, latest
+Tags: 4.10.2, 4.10, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d7b4ff3cc362b94902259b50a5e61f76c43c7b74
+GitCommit: 8b76625d2bfca9e2985a4e236220e3a6e04c7781
 Directory: 4/debian
 
-Tags: 4.10.1-alpine, 4.10-alpine, 4-alpine, alpine
+Tags: 4.10.2-alpine, 4.10-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d7b4ff3cc362b94902259b50a5e61f76c43c7b74
+GitCommit: 8b76625d2bfca9e2985a4e236220e3a6e04c7781
 Directory: 4/alpine
 
 Tags: 3.42.5, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/8b76625: Update to 4.10.2, ghost-cli 1.17.3