### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,30 +1,30 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/c191e1ac6c2fe9973c7ac1f106d395d03ed05eba/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/74d6b84828dbd2668a51a66b492e9aded9e07c40/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0-rc2, 4.0
+Tags: 4.0.0, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 08bea513f803c366493d823aa81a81d73e21c93f
+GitCommit: 74d6b84828dbd2668a51a66b492e9aded9e07c40
 Directory: 4.0
 
-Tags: 3.11.10, 3.11, 3, latest
+Tags: 3.11.10, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
+GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
 Directory: 3.11
 
 Tags: 3.0.24, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
+GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
 Directory: 3.0
 
 Tags: 2.2.19, 2.2, 2
 Architectures: amd64, arm32v7, ppc64le
-GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
+GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
 Directory: 2.2
 
 Tags: 2.1.22, 2.1
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6d3117157c726a7d3a8667f56e6fb046cfe18106
+GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
 Directory: 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/e893a07: Merge pull request https://github.com/docker-library/cassandra/pull/235 from emerkle826/4.0-gpg
- https://github.com/docker-library/cassandra/commit/74d6b84: Bump to 4.0.0 GA
- https://github.com/docker-library/cassandra/commit/701846b: Add missing Cassandra GPG keys for 4.0