### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/65d69325ad741cea6dee20781c1faaab2e003d87/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/4f766db54f5179aca1a841e4036d6d6746ac79d9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -85,12 +85,12 @@ GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal/curl
 
 Tags: focal-scm, 20.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: ubuntu/focal/scm
 
 Tags: focal, 20.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/4f766db: Exclude upper variants on focal+riscv64 (missing mercurial and likely others)
- https://github.com/docker-library/buildpack-deps/commit/26988f0: Remove more traces of "jessie" (EOL)