### PR TITLE
Odoo: update 12.0-14.0 to release 20210728

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 42923bb50cf7d908ec2a0da1c93d24403be713e8
+GitCommit: b07c4f35b401acec2674a5c570f271684d89c5d0
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,


as usual, here are the latest Odoo updates for supported versions.

Thanks