### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,30 +4,30 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2021-04-27
-Tags: 11.1.0, 11.1, 11, latest, 11.1.0-bullseye, 11.1-bullseye, 11-bullseye, bullseye
+# Last Modified: 2021-07-28
+Tags: 11.2.0, 11.2, 11, latest, 11.2.0-bullseye, 11.2-bullseye, 11-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5937a0b39e55c174007c2b9c2f363cdd2142818
+GitCommit: c2c4e3ac9245fa9e5789512969cf3209e0c56136
 Directory: 11
-# Docker EOL: 2022-10-27
+# Docker EOL: 2023-01-28
 
 # Last Modified: 2021-04-08
 Tags: 10.3.0, 10.3, 10, 10.3.0-buster, 10.3-buster, 10-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5937a0b39e55c174007c2b9c2f363cdd2142818
+GitCommit: a49434c14bb5fd8aa7d1d66b366195bbafea4e7e
 Directory: 10
 # Docker EOL: 2022-10-08
 
 # Last Modified: 2021-06-01
 Tags: 9.4.0, 9.4, 9, 9.4.0-buster, 9.4-buster, 9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2c4cae395157000ce7b0f89ea47268f66f320bb1
+GitCommit: a49434c14bb5fd8aa7d1d66b366195bbafea4e7e
 Directory: 9
 # Docker EOL: 2022-12-01
 
 # Last Modified: 2021-05-14
 Tags: 8.5.0, 8.5, 8, 8.5.0-buster, 8.5-buster, 8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 93a66921c867fd54e7672e852a8aec4619fbc6de
+GitCommit: a49434c14bb5fd8aa7d1d66b366195bbafea4e7e
 Directory: 8
 # Docker EOL: 2022-11-14


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/c2c4e3a: Update 11 to 11.2.0
- https://github.com/docker-library/gcc/commit/a49434c: Switch from SKS to Ubuntu keyserver