### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/74d6b84828dbd2668a51a66b492e9aded9e07c40/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/1b76c889fd23ed06cd7411b4ba7a6e92a93fe4ec/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -9,14 +9,14 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 74d6b84828dbd2668a51a66b492e9aded9e07c40
 Directory: 4.0
 
-Tags: 3.11.10, 3.11, 3
+Tags: 3.11.11, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
+GitCommit: 6d2a0503c7778dd48d3ef718d8d44d38c149a208
 Directory: 3.11
 
-Tags: 3.0.24, 3.0
+Tags: 3.0.25, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
+GitCommit: abdbbc043a9e41601fdc9f4e44bffaac46e1192f
 Directory: 3.0
 
 Tags: 2.2.19, 2.2, 2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/6d2a050: Update 3.11 to 3.11.11
- https://github.com/docker-library/cassandra/commit/abdbbc0: Update 3.0 to 3.0.25
- https://github.com/docker-library/cassandra/commit/1b76c88: Exclude riscv64