### PR TITLE
eclipse-mosquitto: Fix issue with libwebsockets http2 support.

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,6 +1,6 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 5217863b8b210f22df81c6b95d1eb89ed4af9b50
+GitCommit: 17bbca22fb5dc57bfdc83ac60be67e34208825fd
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: 2.0.11, 2.0, 2, latest


### PR DESCRIPTION
Disable http2 support in the compiled libwebsockets, it causes problems in some situations.