### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,39 +4,39 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.9.0, 3.9, 3, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
+Tags: 3.9.1, 3.9, 3, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 58d11af3f891678cc40a41197713e6e82c55598c
 Directory: 3.9/ubuntu
 
-Tags: 3.9.0-management, 3.9-management, 3-management, management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Tags: 3.9.1-management, 3.9-management, 3-management, management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/ubuntu/management
 
-Tags: 3.9.0-alpine, 3.9-alpine, 3-alpine, alpine
+Tags: 3.9.1-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
+GitCommit: 58d11af3f891678cc40a41197713e6e82c55598c
 Directory: 3.9/alpine
 
-Tags: 3.9.0-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.9.1-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/alpine/management
 
 Tags: 3.8.19, 3.8
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 08b58dbec5a970f049fad01ced9480d03ab1c165
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: edc5592ff434850b95cb68d35611db7282939793
 Directory: 3.8/ubuntu
 
 Tags: 3.8.19-management, 3.8-management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 0d1c84a50aa69305b2fa3e98632a206d3d2a3f9f
 Directory: 3.8/ubuntu/management
 
 Tags: 3.8.19-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 08b58dbec5a970f049fad01ced9480d03ab1c165
+GitCommit: edc5592ff434850b95cb68d35611db7282939793
 Directory: 3.8/alpine
 
 Tags: 3.8.19-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- docker-library/rabbitmq@58d11af: Update 3.9 to 3.9.1
- docker-library/rabbitmq@2b02eea: Update 3.9-rc to otp 24.0.5
- docker-library/rabbitmq@e4dab02: Update 3.9 to otp 24.0.5
- docker-library/rabbitmq@c3ccabb: Update 3.8-rc to otp 24.0.5
- docker-library/rabbitmq@edc5592: Update 3.8 to otp 24.0.5