### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,67 +4,67 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-7-jdk-oraclelinux8, 18-ea-7-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-7-jdk-oracle, 18-ea-7-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-7-jdk, 18-ea-7, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-8-jdk-oraclelinux8, 18-ea-8-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-8-jdk-oracle, 18-ea-8-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-8-jdk, 18-ea-8, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-7-jdk-oraclelinux7, 18-ea-7-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-8-jdk-oraclelinux7, 18-ea-8-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-7-jdk-buster, 18-ea-7-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-8-jdk-buster, 18-ea-8-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/buster
 
-Tags: 18-ea-7-jdk-slim-buster, 18-ea-7-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-7-jdk-slim, 18-ea-7-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-8-jdk-slim-buster, 18-ea-8-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-8-jdk-slim, 18-ea-8-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/slim-buster
 
-Tags: 18-ea-7-jdk-windowsservercore-1809, 18-ea-7-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-7-jdk-windowsservercore, 18-ea-7-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-7-jdk, 18-ea-7, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-8-jdk-windowsservercore-1809, 18-ea-8-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-8-jdk-windowsservercore, 18-ea-8-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-8-jdk, 18-ea-8, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-7-jdk-windowsservercore-ltsc2016, 18-ea-7-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-7-jdk-windowsservercore, 18-ea-7-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-7-jdk, 18-ea-7, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-8-jdk-windowsservercore-ltsc2016, 18-ea-8-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-8-jdk-windowsservercore, 18-ea-8-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-8-jdk, 18-ea-8, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-7-jdk-nanoserver-1809, 18-ea-7-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-7-jdk-nanoserver, 18-ea-7-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-8-jdk-nanoserver-1809, 18-ea-8-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-8-jdk-nanoserver, 18-ea-8-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 10eeb5d1855ea6b63303229d237afbe42c75c9e7
+GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17-ea-32-jdk-oraclelinux8, 17-ea-32-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-32-jdk-oracle, 17-ea-32-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-32-jdk, 17-ea-32, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-33-jdk-oraclelinux8, 17-ea-33-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-33-jdk-oracle, 17-ea-33-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
+SharedTags: 17-ea-33-jdk, 17-ea-33, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-32-jdk-oraclelinux7, 17-ea-32-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-ea-33-jdk-oraclelinux7, 17-ea-33-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-32-jdk-buster, 17-ea-32-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-ea-33-jdk-buster, 17-ea-33-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/buster
 
-Tags: 17-ea-32-jdk-slim-buster, 17-ea-32-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-32-jdk-slim, 17-ea-32-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-ea-33-jdk-slim-buster, 17-ea-33-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-33-jdk-slim, 17-ea-33-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/slim-buster
 
 Tags: 17-ea-14-jdk-alpine3.14, 17-ea-14-alpine3.14, 17-ea-jdk-alpine3.14, 17-ea-alpine3.14, 17-jdk-alpine3.14, 17-alpine3.14, 17-ea-14-jdk-alpine, 17-ea-14-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
@@ -77,24 +77,24 @@ Architectures: amd64
 GitCommit: 255fbc7cf6da6d76869b420dd2fe0bc94539b5eb
 Directory: 17/jdk/alpine3.13
 
-Tags: 17-ea-32-jdk-windowsservercore-1809, 17-ea-32-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-32-jdk-windowsservercore, 17-ea-32-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-32-jdk, 17-ea-32, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-33-jdk-windowsservercore-1809, 17-ea-33-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-ea-33-jdk-windowsservercore, 17-ea-33-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-33-jdk, 17-ea-33, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-32-jdk-windowsservercore-ltsc2016, 17-ea-32-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-32-jdk-windowsservercore, 17-ea-32-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-32-jdk, 17-ea-32, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-ea-33-jdk-windowsservercore-ltsc2016, 17-ea-33-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-ea-33-jdk-windowsservercore, 17-ea-33-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-33-jdk, 17-ea-33, 17-ea-jdk, 17-ea, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-32-jdk-nanoserver-1809, 17-ea-32-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-32-jdk-nanoserver, 17-ea-32-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-ea-33-jdk-nanoserver-1809, 17-ea-33-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-ea-33-jdk-nanoserver, 17-ea-33-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: ce46a7a17896d2ba629f28f7b5d28ef41fa5b993
+GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/a63d637: Update 18 to 18-ea+8
- https://github.com/docker-library/openjdk/commit/501e71e: Update 17 to 17-ea+33