### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/1b76c889fd23ed06cd7411b4ba7a6e92a93fe4ec/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/01825ee7a52ae469fe89e4c83916ce0120a47761/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -23,8 +23,3 @@ Tags: 2.2.19, 2.2, 2
 Architectures: amd64, arm32v7, ppc64le
 GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
 Directory: 2.2
-
-Tags: 2.1.22, 2.1
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
-Directory: 2.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/01825ee: Remove 2.1 (now EOL; see https://cassandra.apache.org/_/download.html)