### PR TITLE
[varnish] multiarch and alpine support

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,13 +1,18 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/4cfd65e1d3bd4eb9518d8e7590d9fec1de6a50c4/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/32e4b6f9ba7a00d449205c5cff79325309f1d691/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: 6.0, 6.0.8-1, 6.0.8, stable
-Architectures: amd64
-Directory: stable/debian
-GitCommit: 4cfd65e1d3bd4eb9518d8e7590d9fec1de6a50c4
-
-Tags: 6.6, 6.6.1-1, 6.6.1, 6, latest, fresh
-Architectures: amd64
+Tags: fresh, 6.6.1, 6.6, latest
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: 4cfd65e1d3bd4eb9518d8e7590d9fec1de6a50c4
+GitCommit: 32e4b6f9ba7a00d449205c5cff79325309f1d691
+
+Tags: fresh-alpine, 6.6.1-alpine, 6.6-alpine, alpine
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: fresh/alpine
+GitCommit: 32e4b6f9ba7a00d449205c5cff79325309f1d691
+
+Tags: stable, 6.0.8, 6.0
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: stable/debian
+GitCommit: 32e4b6f9ba7a00d449205c5cff79325309f1d691


### PR DESCRIPTION
It changes a few things:

- packages are built in the images rather than merely downloaded
- alpine support has been added (only for the `fresh` image as the `stable` version needs a few extra things unavailable currently)
- since we now build the packages, we should be able to build for all architectures (or close enough)