### PR TITLE
Update Clear Linux OS to 34900

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 363680871d42245eab45f031991273402e64a46a
-GitFetch: refs/tags/clear-linux-34860
+GitCommit: b510ddebc9baa8d819c1cf8bf42f7309c38c8113
+GitFetch: refs/tags/clear-linux-34900


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34900

@bryteise @mdhorn @phmccarty