### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -5,30 +5,31 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Jamie Anderson (@jamieand),
              Christopher Miller (@mysteriouspants),
              Sumit Tomer (@sktomer),
-             Sean Kelly (@cbgbt)
+             Sean Kelly (@cbgbt),
+             Tanu Rampal (@trampal)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 16cd70fe7971ab0eb4fea0139ede76f9f82cbfc0
+GitCommit: 1ab20d5962c3c160c55007313cf183aebaa4d9c6
 
-Tags: 2.0.20210701.0, 2, latest
+Tags: 2.0.20210721.2, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: c9aea1224a61d049b9be821e147f882ebdd244f9
+amd64-GitCommit: 6690b112365657326d5ff6f3b9e785687804df8f
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 4505286ee22c30ae6404207053f7b6dc03776674
+arm64v8-GitCommit: ceda4fe0a07fdfb35c13ba3b2ef406a72ad16f70
 
-Tags: 2.0.20210701.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20210721.2-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 8cf02b11d3ab0e26f6cad6ca41cb11e2456edc36
+amd64-GitCommit: 1cb9169ce0193baf64a7dc33dc8846734952597a
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: a505906d0b288adbbe727730ce21ea8a95c0fdc6
+arm64v8-GitCommit: e5abdddc53e38c41554c158952ebc85a107d2560
 
-Tags: 2018.03.0.20210521.1, 2018.03, 1
+Tags: 2018.03.0.20210721.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 92faacbbd63cacf5ad059da826c1e1ee9b603f84
+amd64-GitCommit: 5489a282cbdf7501d1137e4373d77a79636a45e4
 
-Tags: 2018.03.0.20210521.1-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20210721.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: c784f486f5974aa5a28038c86700196ebc6e1306
+amd64-GitCommit: 65bc90c3331e6908d445f89c0e140997b251a758


### PR DESCRIPTION
Hello,

We have a new version of Amazon Linux 2018.03 and Amazon Linux 2 that we'd like to have updated in Docker Hub. In addition we're adding my teammate, Tanu (@trampal), to the maintainer's list. Do let me know if there are any issues.

Thanks!
Chris