### PR TITLE
Update node versions

### DIFF
--- a/library/node
+++ b/library/node
@@ -4,42 +4,42 @@ Maintainers: The Node.js Docker Team <https://github.com/nodejs/docker-node> (@n
 GitRepo: https://github.com/nodejs/docker-node.git
 GitFetch: refs/heads/main
 
-Tags: 16-alpine3.11, 16.6-alpine3.11, 16.6.0-alpine3.11, alpine3.11, current-alpine3.11
+Tags: 16-alpine3.11, 16.6-alpine3.11, 16.6.1-alpine3.11, alpine3.11, current-alpine3.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/alpine3.11
 
-Tags: 16-alpine3.12, 16.6-alpine3.12, 16.6.0-alpine3.12, alpine3.12, current-alpine3.12
+Tags: 16-alpine3.12, 16.6-alpine3.12, 16.6.1-alpine3.12, alpine3.12, current-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/alpine3.12
 
-Tags: 16-alpine, 16-alpine3.13, 16.6-alpine, 16.6-alpine3.13, 16.6.0-alpine, 16.6.0-alpine3.13, alpine, alpine3.13, current-alpine, current-alpine3.13
+Tags: 16-alpine, 16-alpine3.13, 16.6-alpine, 16.6-alpine3.13, 16.6.1-alpine, 16.6.1-alpine3.13, alpine, alpine3.13, current-alpine, current-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/alpine3.13
 
-Tags: 16-alpine3.14, 16.6-alpine3.14, 16.6.0-alpine3.14, alpine3.14, current-alpine3.14
+Tags: 16-alpine3.14, 16.6-alpine3.14, 16.6.1-alpine3.14, alpine3.14, current-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/alpine3.14
 
-Tags: 16, 16-buster, 16.6, 16.6-buster, 16.6.0, 16.6.0-buster, buster, current, current-buster, latest
+Tags: 16, 16-buster, 16.6, 16.6-buster, 16.6.1, 16.6.1-buster, buster, current, current-buster, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/buster
 
-Tags: 16-buster-slim, 16-slim, 16.6-buster-slim, 16.6-slim, 16.6.0-buster-slim, 16.6.0-slim, buster-slim, current-buster-slim, current-slim, slim
+Tags: 16-buster-slim, 16-slim, 16.6-buster-slim, 16.6-slim, 16.6.1-buster-slim, 16.6.1-slim, buster-slim, current-buster-slim, current-slim, slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/buster-slim
 
-Tags: 16-stretch, 16.6-stretch, 16.6.0-stretch, current-stretch, stretch
+Tags: 16-stretch, 16.6-stretch, 16.6.1-stretch, current-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/stretch
 
-Tags: 16-stretch-slim, 16.6-stretch-slim, 16.6.0-stretch-slim, current-stretch-slim, stretch-slim
+Tags: 16-stretch-slim, 16.6-stretch-slim, 16.6.1-stretch-slim, current-stretch-slim, stretch-slim
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 16/stretch-slim
@@ -123,4 +123,3 @@ Tags: 12-slim, 12-stretch-slim, 12.22-slim, 12.22-stretch-slim, 12.22.4-slim, 12
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: d1fe16fecfbedc89ad3325021898117bb3031a83
 Directory: 12/stretch-slim
-


### PR DESCRIPTION
Updated node version to [16.6.1](https://github.com/nodejs/node/pull/39631).