### PR TITLE
Add eclipse-temurin openjdk official docker image

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -12,7 +12,7 @@ Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver, 8u302-b08-jdk, 8-jdk, 8
+SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
 GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 8/jdk/windows/nanoserver-1809
@@ -45,7 +45,7 @@ Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver, 11.0.12_7-jdk, 11-jdk, 11
+SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
 GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 11/jdk/windows/nanoserver-1809
@@ -70,31 +70,31 @@ Constraints: windowsservercore-ltsc2016
 
 
 #------------------------------v16 images---------------------------------
-Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal, hotspot-focal
-SharedTags: 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
+SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809, hotspot-nanoserver-1809
-SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver, hotspot-nanoserver, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
 GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, hotspot-windowsservercore-1809
-SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, hotspot-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
 GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
-SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, hotspot-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
 GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/windows/windowsservercore-ltsc2016

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -1,28 +1,79 @@
-# Eclipse Temurin OpenJDK images provided by the Eclipse Foundation
+# Eclipse Temurin OpenJDK images provided by the Eclipse Foundation.
 
 Maintainers: George Adams <george.adams@microsoft.com> (@gdams)
 GitRepo: https://github.com/adoptium/containers.git
 
-#----------------------------- v8 images---------------------------------
+#------------------------------v8 images---------------------------------
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
-Architectures: amd64
-GitCommit: 733485c47b0072af9b15542a2d0a68e46f1fd986
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
-#----------------------------- v11 images---------------------------------
+Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
+Architectures: windows-amd64
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+Directory: 8/jdk/windows/windowsservercore-1809
+File: Dockerfile.releases.full
+Constraints: windowsservercore-1809
+
+Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
+Architectures: windows-amd64
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+Directory: 8/jdk/windows/windowsservercore-ltsc2016
+File: Dockerfile.releases.full
+Constraints: windowsservercore-ltsc2016
+
+
+#------------------------------v11 images---------------------------------
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
-Architectures: amd64
-GitCommit: 733485c47b0072af9b15542a2d0a68e46f1fd986
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
-#----------------------------- v16 images---------------------------------
-Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal, focal
-SharedTags: 16.0.2_7-jdk, 16-jdk, 16, jdk, latest
-Architectures: amd64
-GitCommit: 733485c47b0072af9b15542a2d0a68e46f1fd986
+Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
+Architectures: windows-amd64
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+Directory: 11/jdk/windows/windowsservercore-1809
+File: Dockerfile.releases.full
+Constraints: windowsservercore-1809
+
+Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
+Architectures: windows-amd64
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+Directory: 11/jdk/windows/windowsservercore-ltsc2016
+File: Dockerfile.releases.full
+Constraints: windowsservercore-ltsc2016
+
+
+#------------------------------v16 images---------------------------------
+Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal, hotspot-focal
+SharedTags: 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
+
+Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, hotspot-windowsservercore-1809
+SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, hotspot-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Architectures: windows-amd64
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+Directory: 16/jdk/windows/windowsservercore-1809
+File: Dockerfile.releases.full
+Constraints: windowsservercore-1809
+
+Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
+SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, hotspot-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Architectures: windows-amd64
+GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+Directory: 16/jdk/windows/windowsservercore-ltsc2016
+File: Dockerfile.releases.full
+Constraints: windowsservercore-ltsc2016
+

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -11,14 +11,6 @@ GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
-Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
-Directory: 8/jdk/windows/nanoserver-1809
-File: Dockerfile.releases.full
-Constraints: nanoserver-1809, windowsservercore-1809
-
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
@@ -35,6 +27,14 @@ Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
 
+Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Architectures: windows-amd64
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+Directory: 8/jdk/windows/nanoserver-1809
+File: Dockerfile.releases.full
+Constraints: nanoserver-1809, windowsservercore-1809
+
 
 #------------------------------v11 images---------------------------------
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
@@ -43,14 +43,6 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
-
-Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
-Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
-Directory: 11/jdk/windows/nanoserver-1809
-File: Dockerfile.releases.full
-Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
@@ -68,6 +60,14 @@ Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
 
+Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Architectures: windows-amd64
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+Directory: 11/jdk/windows/nanoserver-1809
+File: Dockerfile.releases.full
+Constraints: nanoserver-1809, windowsservercore-1809
+
 
 #------------------------------v16 images---------------------------------
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
@@ -76,14 +76,6 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
-
-Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
-Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
-Directory: 16/jdk/windows/nanoserver-1809
-File: Dockerfile.releases.full
-Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
@@ -100,4 +92,12 @@ GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
+
+Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
+Architectures: windows-amd64
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+Directory: 16/jdk/windows/nanoserver-1809
+File: Dockerfile.releases.full
+Constraints: nanoserver-1809, windowsservercore-1809
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -1,6 +1,6 @@
 # Eclipse Temurin OpenJDK images provided by the Eclipse Foundation
 
-Maintainers: George Adams <george.adams@microsoft.com> (@gdams_)
+Maintainers: George Adams <george.adams@microsoft.com> (@gdams)
 GitRepo: https://github.com/adoptium/containers.git
 
 #----------------------------- v8 images---------------------------------

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,20 +7,20 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -28,7 +28,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -36,7 +36,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -45,21 +45,21 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -67,7 +67,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -75,7 +75,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -85,20 +85,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-centos7, 16-jdk-centos7, 16-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 16/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -106,7 +106,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -114,7 +114,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,14 +7,14 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +22,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -30,7 +30,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -40,14 +40,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -55,7 +55,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -63,7 +63,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -73,14 +73,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -88,7 +88,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -96,7 +96,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
+GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -1,0 +1,28 @@
+# Eclipse Temurin OpenJDK images provided by the Eclipse Foundation
+
+Maintainers: George Adams <george.adams@microsoft.com> (@gdams_)
+GitRepo: https://github.com/adoptium/containers.git
+
+#----------------------------- v8 images---------------------------------
+Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
+SharedTags: 8u302-b08-jdk, 8-jdk, 8
+Architectures: amd64
+GitCommit: 733485c47b0072af9b15542a2d0a68e46f1fd986
+Directory: 8/jdk/ubuntu
+File: Dockerfile.releases.full
+
+#----------------------------- v11 images---------------------------------
+Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
+SharedTags: 11.0.12_7-jdk, 11-jdk, 11
+Architectures: amd64
+GitCommit: 733485c47b0072af9b15542a2d0a68e46f1fd986
+Directory: 11/jdk/ubuntu
+File: Dockerfile.releases.full
+
+#----------------------------- v16 images---------------------------------
+Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal, focal
+SharedTags: 16.0.2_7-jdk, 16-jdk, 16, jdk, latest
+Architectures: amd64
+GitCommit: 733485c47b0072af9b15542a2d0a68e46f1fd986
+Directory: 16/jdk/ubuntu
+File: Dockerfile.releases.full

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,20 +7,20 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -28,7 +28,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -36,7 +36,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -46,20 +46,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -67,7 +67,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -75,7 +75,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -85,20 +85,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-centos7, 16-jdk-centos7, 16-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 16/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -106,7 +106,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -114,7 +114,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: f01e2df4062823b3290d65500cf13f47c9ad7c1c
+GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,14 +7,20 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 8/jdk/ubuntu
+File: Dockerfile.releases.full
+
+Tags: 8u302-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +28,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -30,7 +36,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -40,14 +46,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 11/jdk/ubuntu
+File: Dockerfile.releases.full
+
+Tags: 11.0.12_7-jdk-centos7, 11-jdk-centos7, 11-centos7
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -55,7 +67,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -63,7 +75,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -73,14 +85,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 16/jdk/ubuntu
+File: Dockerfile.releases.full
+
+Tags: 16.0.2_7-jdk-centos7, 16-jdk-centos7, 16-centos7
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
+Directory: 16/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -88,7 +106,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -96,7 +114,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 769743b69736f8c726f545145927b3139b299678
+GitCommit: bdb263d9eec4f46d60550be822b2174b53af2e90
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,14 +7,14 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -22,7 +22,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -30,7 +30,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -40,14 +40,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -55,7 +55,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -63,7 +63,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -73,14 +73,14 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -88,7 +88,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -96,7 +96,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,14 +7,14 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +22,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -30,7 +30,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -40,14 +40,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -55,7 +55,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -63,7 +63,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -73,14 +73,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -88,7 +88,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -96,7 +96,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: cf6127df5d6e3c2f284ef604a4a3860f918fb95b
+GitCommit: 769743b69736f8c726f545145927b3139b299678
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,14 +7,14 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +22,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -30,7 +30,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -40,14 +40,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -55,7 +55,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -63,7 +63,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -73,14 +73,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -88,7 +88,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -96,7 +96,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 2895eed8066bac01fa6b9eb622e2bee8829d72f4
+GitCommit: 4217fed29a839d45c26c1dbdb6fd713e14106467
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,14 +7,22 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
+
+Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver, 8u302-b08-jdk, 8-jdk, 8
+Architectures: windows-amd64
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+Directory: 8/jdk/windows/nanoserver-1809
+File: Dockerfile.releases.full
+Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -22,7 +30,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -32,14 +40,22 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
+
+Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver, 11.0.12_7-jdk, 11-jdk, 11
+Architectures: windows-amd64
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+Directory: 11/jdk/windows/nanoserver-1809
+File: Dockerfile.releases.full
+Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -47,7 +63,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -57,14 +73,22 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal, hotspot-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
+
+Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809, hotspot-nanoserver-1809
+SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver, hotspot-nanoserver, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
+Architectures: windows-amd64
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
+Directory: 16/jdk/windows/nanoserver-1809
+File: Dockerfile.releases.full
+Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, hotspot-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, hotspot-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -72,7 +96,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, hotspot-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, hotspot-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, hotspot, latest
 Architectures: windows-amd64
-GitCommit: 074f4950c925da3da7e42c7223957c7d65626cd7
+GitCommit: 2f3ab31a0cde57caef5d839128c79033e85edc15
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016

--- a/test/config.sh
+++ b/test/config.sh
@@ -17,6 +17,7 @@ imageTests[:onbuild]+='
 testAlias+=(
 	[amazoncorretto]='openjdk'
 	[adoptopenjdk]='openjdk'
+	[eclipse-temurin]='openjdk'
 	[sapmachine]='openjdk'
 	[iojs]='node'
 	[jruby]='ruby'


### PR DESCRIPTION
The AdoptOpenJDK project has moved to the Eclipse Foundation and rebranded. Going forwards the binaries will be released by the Eclipse Temurin project.

This PR is the starting point to get the official repo created. Please let me know what else is needed?

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long) https://github.com/docker-library/docs/pull/2008
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~
- [x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)