### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.13.4
+Tags: 7.14.0
 Architectures: amd64, arm64v8
-GitCommit: 714d1fc8c2dfbe13b5b139a8b5591ebeedfd744b
+GitCommit: e818b5e40773c96618b3b60202519072f7fba521
 Directory: 7
 
-Tags: 6.8.17
+Tags: 6.8.18
 Architectures: amd64
-GitCommit: 122b0fc17af3034d581534d6fb751be2a3788d10
+GitCommit: c834683526fe79e051f595e738e26b39a33b22db
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.13.4
+Tags: 7.14.0
 Architectures: amd64, arm64v8
-GitCommit: c7c2bd622e117b7149057f6e5ea62ae60a5817ef
+GitCommit: 80e00e461a6aad29ce2d8acd1bd6c21828c98812
 Directory: 7
 
-Tags: 6.8.17
+Tags: 6.8.18
 Architectures: amd64
-GitCommit: e4ae56677ce14520cbfd443b9b0ae567ef4e1376
+GitCommit: cff36ad1ea430335a6ceccb4a2f6beaad710551f
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.13.4
+Tags: 7.14.0
 Architectures: amd64, arm64v8
-GitCommit: cae93ca9913f1606eefc15a1f25c6c301ba5c5b5
+GitCommit: 458cc387b0320cef6170dc8532b6695fd3daebff
 Directory: 7
 
-Tags: 6.8.17
+Tags: 6.8.18
 Architectures: amd64
-GitCommit: 75364496903069961088ee6f84f0e32481340524
+GitCommit: b33a53e022f25be3395791b247227247642a6504
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/c834683: Update to 6.8.18
- https://github.com/docker-library/elasticsearch/commit/e818b5e: Update to 7.14.0

logstash:
- https://github.com/docker-library/logstash/commit/b33a53e: Update to 6.8.18
- https://github.com/docker-library/logstash/commit/458cc38: Update to 7.14.0

kibana:
- https://github.com/docker-library/kibana/commit/cff36ad: Update to 6.8.18
- https://github.com/docker-library/kibana/commit/80e00e4: Update to 7.14.0

---

Upstream diffs:

- https://github.com/elastic/dockerfiles/compare/v7.13.4..v7.14.0?w=1
- https://github.com/elastic/dockerfiles/compare/v6.8.17..v6.8.18