### PR TITLE
Add OpenJDK + Eclipse OpenJ9 images from IBM Semeru Runtimes

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -1,0 +1,87 @@
+# IBM Semeru Runtimes official Docker images.
+
+Maintainers: Surya Narkedimilli <snarkedi@in.ibm.com> (@narkedi)
+GitRepo: https://github.com/ibmruntimes/semeru-containers.git
+GitFetch: refs/heads/ibm
+
+#-----------------------------openj9 v8 images---------------------------------
+Tags: open-8u302-b08-jdk-focal, open-8-jdk-focal
+SharedTags: open-8u302-b08-jdk, open-8-jdk
+Architectures: amd64, ppc64le, s390x
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 8/jdk/ubuntu
+File: Dockerfile.open.releases.full
+
+Tags: open-8u302-b08-jdk-centos7, open-8-jdk-centos7
+Architectures: amd64, ppc64le
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 8/jdk/centos
+File: Dockerfile.open.releases.full
+
+Tags: open-8u302-b08-jre-focal, open-8-jre-focal
+SharedTags: open-8u302-b08-jre, open-8-jre
+Architectures: amd64, ppc64le, s390x
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 8/jre/ubuntu
+File: Dockerfile.open.releases.full
+
+Tags: open-8u302-b08-jre-centos7, open-8-jre-centos7
+Architectures: amd64, ppc64le
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 8/jre/centos
+File: Dockerfile.open.releases.full
+
+#-----------------------------openj9 v11 images---------------------------------
+Tags: open-11.0.12_7-jdk-focal, open-11-jdk-focal
+SharedTags: open-11.0.12_7-jdk, open-11-jdk
+Architectures: amd64, ppc64le, s390x
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 11/jdk/ubuntu
+File: Dockerfile.open.releases.full
+
+Tags: open-11.0.12_7-jdk-centos7, open-11-jdk-centos7
+Architectures: amd64, ppc64le
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 11/jdk/centos
+File: Dockerfile.open.releases.full
+
+Tags: open-11.0.12_7-jre-focal, open-11-jre-focal
+SharedTags: open-11.0.12_7-jre, open-11-jre
+Architectures: amd64, ppc64le, s390x
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 11/jre/ubuntu
+File: Dockerfile.open.releases.full
+
+Tags: open-11.0.12_7-jre-centos7, open-11-jre-centos7
+Architectures: amd64, ppc64le
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 11/jre/centos
+File: Dockerfile.open.releases.full
+
+#-----------------------------openj9 v16 images---------------------------------
+Tags: open-16.0.2_7-jdk-focal, open-16-jdk-focal
+SharedTags: open-16.0.2_7-jdk, open-16-jdk
+Architectures: amd64, ppc64le, s390x
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 16/jdk/ubuntu
+File: Dockerfile.open.releases.full
+
+Tags: open-16.0.2_7-jdk-centos7, open-16-jdk-centos7
+Architectures: amd64, ppc64le
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 16/jdk/centos
+File: Dockerfile.open.releases.full
+
+Tags: open-16.0.2_7-jre-focal, open-16-jre-focal
+SharedTags: open-16.0.2_7-jre, open-16-jre
+Architectures: amd64, ppc64le, s390x
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 16/jre/ubuntu
+File: Dockerfile.open.releases.full
+
+Tags: open-16.0.2_7-jre-centos7, open-16-jre-centos7
+Architectures: amd64, ppc64le
+GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+Directory: 16/jre/centos
+File: Dockerfile.open.releases.full
+

--- a/test/config.sh
+++ b/test/config.sh
@@ -19,6 +19,7 @@ testAlias+=(
 	[adoptopenjdk]='openjdk'
 	[eclipse-temurin]='openjdk'
 	[sapmachine]='openjdk'
+	[ibm-semeru-runtimes]='openjdk'
 
 	[jruby]='ruby'
 	[pypy]='python'


### PR DESCRIPTION
This request is to add the OpenJDK+ Eclipse OpenJ9 images to the official Docker images.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - IBM
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - language stack
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/2017
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)