### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,30 +4,30 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 20.10.7, 20.10, 20, latest
+Tags: 20.10.8, 20.10, 20, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 279ba9c93e8e26a15171645bd511ea8476c4706e
+GitCommit: 75e26edc9ea7fff4aa3212fafa5966f4d6b00022
 Directory: 20.10
 
-Tags: 20.10.7-dind, 20.10-dind, 20-dind, dind
+Tags: 20.10.8-dind, 20.10-dind, 20-dind, dind
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 8baa881aab85f8398d2edbbcc0da4bd1f556dd98
 Directory: 20.10/dind
 
-Tags: 20.10.7-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
+Tags: 20.10.8-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 2ab877f315206028bb9352d86e28c71b25723bf2
+GitCommit: 83e4de3bc2aac346e2f76129b1a3a556c1e1bb95
 Directory: 20.10/dind-rootless
 
-Tags: 20.10.7-git, 20.10-git, 20-git, git
+Tags: 20.10.8-git, 20.10-git, 20-git, git
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 387e351394bfad74bceebf8303c6c8e39c3d4ed4
 Directory: 20.10/git
 
-Tags: 20.10.7-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809, windowsservercore-1809
-SharedTags: 20.10.7-windowsservercore, 20.10-windowsservercore, 20-windowsservercore, windowsservercore
+Tags: 20.10.8-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809, windowsservercore-1809
+SharedTags: 20.10.8-windowsservercore, 20.10-windowsservercore, 20-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 279ba9c93e8e26a15171645bd511ea8476c4706e
+GitCommit: 83e4de3bc2aac346e2f76129b1a3a556c1e1bb95
 Directory: 20.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/0e65005: Merge pull request https://github.com/docker-library/docker/pull/323 from thaJeztah/docker_20.10.8
- https://github.com/docker-library/docker/commit/75e26ed: Add libc6-compat as workaround for non-static ctr binary
- https://github.com/docker-library/docker/commit/83e4de3: Update 20.10 to 20.10.8

cc @thaJeztah 