### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -6,16 +6,10 @@ GitRepo: https://github.com/docker-library/httpd.git
 
 Tags: 2.4.48, 2.4, 2, latest, 2.4.48-buster, 2.4-buster, 2-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6d68525ac47c0474d3d74269b2669104c1d867dd
+GitCommit: 208fc2ba9a097530bb0b7386b0c2bebacdfb6c5c
 Directory: 2.4
 
 Tags: 2.4.48-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.48-alpine3.14, 2.4-alpine3.14, 2-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6d68525ac47c0474d3d74269b2669104c1d867dd
-Directory: 2.4/alpine
-
-# temporary one-time backfill of "alpine3.13" aliases
-Tags: 2.4.48-alpine3.13, 2.4-alpine3.13, 2-alpine3.13, alpine3.13
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8835b23f748f80bcec510c14b68c84bc37767cdb
+GitCommit: 208fc2ba9a097530bb0b7386b0c2bebacdfb6c5c
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/e99b051: Merge pull request https://github.com/docker-library/httpd/pull/196 from infosiftr/downloads.apache.org
- https://github.com/docker-library/httpd/commit/208fc2b: Add/use downloads.apache.org (www-us.apache.org seems to be having a sad)