### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,45 +4,45 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-8-jdk-oraclelinux8, 18-ea-8-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-8-jdk-oracle, 18-ea-8-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-8-jdk, 18-ea-8, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-9-jdk-oraclelinux8, 18-ea-9-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-9-jdk-oracle, 18-ea-9-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-9-jdk, 18-ea-9, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-8-jdk-oraclelinux7, 18-ea-8-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-9-jdk-oraclelinux7, 18-ea-9-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-8-jdk-buster, 18-ea-8-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-9-jdk-buster, 18-ea-9-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/buster
 
-Tags: 18-ea-8-jdk-slim-buster, 18-ea-8-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-8-jdk-slim, 18-ea-8-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-9-jdk-slim-buster, 18-ea-9-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-9-jdk-slim, 18-ea-9-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/slim-buster
 
-Tags: 18-ea-8-jdk-windowsservercore-1809, 18-ea-8-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-8-jdk-windowsservercore, 18-ea-8-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-8-jdk, 18-ea-8, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-9-jdk-windowsservercore-1809, 18-ea-9-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-9-jdk-windowsservercore, 18-ea-9-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-9-jdk, 18-ea-9, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-8-jdk-windowsservercore-ltsc2016, 18-ea-8-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-8-jdk-windowsservercore, 18-ea-8-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-8-jdk, 18-ea-8, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-9-jdk-windowsservercore-ltsc2016, 18-ea-9-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-9-jdk-windowsservercore, 18-ea-9-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-9-jdk, 18-ea-9, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-8-jdk-nanoserver-1809, 18-ea-8-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-8-jdk-nanoserver, 18-ea-8-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-9-jdk-nanoserver-1809, 18-ea-9-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-9-jdk-nanoserver, 18-ea-9-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: a63d637823f2e16ff01ee3691a65e67589df3046
+GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/b00ee0e: Update 18 to 18-ea+9