### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -46,55 +46,45 @@ GitCommit: b00ee0ef38e6cc40049b893d3eb6695c6a493b9a
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17-ea-33-jdk-oraclelinux8, 17-ea-33-oraclelinux8, 17-ea-jdk-oraclelinux8, 17-ea-oraclelinux8, 17-jdk-oraclelinux8, 17-oraclelinux8, 17-ea-33-jdk-oracle, 17-ea-33-oracle, 17-ea-jdk-oracle, 17-ea-oracle, 17-jdk-oracle, 17-oracle
-SharedTags: 17-ea-33-jdk, 17-ea-33, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-jdk-oraclelinux8, 17-oraclelinux8, 17-jdk-oracle, 17-oracle
+SharedTags: 17-jdk, 17
 Architectures: amd64, arm64v8
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-ea-33-jdk-oraclelinux7, 17-ea-33-oraclelinux7, 17-ea-jdk-oraclelinux7, 17-ea-oraclelinux7, 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-jdk-oraclelinux7, 17-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-ea-33-jdk-buster, 17-ea-33-buster, 17-ea-jdk-buster, 17-ea-buster, 17-jdk-buster, 17-buster
+Tags: 17-jdk-buster, 17-buster
 Architectures: amd64, arm64v8
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/buster
 
-Tags: 17-ea-33-jdk-slim-buster, 17-ea-33-slim-buster, 17-ea-jdk-slim-buster, 17-ea-slim-buster, 17-jdk-slim-buster, 17-slim-buster, 17-ea-33-jdk-slim, 17-ea-33-slim, 17-ea-jdk-slim, 17-ea-slim, 17-jdk-slim, 17-slim
+Tags: 17-jdk-slim-buster, 17-slim-buster, 17-jdk-slim, 17-slim
 Architectures: amd64, arm64v8
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/slim-buster
 
-Tags: 17-ea-14-jdk-alpine3.14, 17-ea-14-alpine3.14, 17-ea-jdk-alpine3.14, 17-ea-alpine3.14, 17-jdk-alpine3.14, 17-alpine3.14, 17-ea-14-jdk-alpine, 17-ea-14-alpine, 17-ea-jdk-alpine, 17-ea-alpine, 17-jdk-alpine, 17-alpine
-Architectures: amd64
-GitCommit: d4ff1d2ba6fadeee6a97970420be717827e0b968
-Directory: 17/jdk/alpine3.14
-
-Tags: 17-ea-14-jdk-alpine3.13, 17-ea-14-alpine3.13, 17-ea-jdk-alpine3.13, 17-ea-alpine3.13, 17-jdk-alpine3.13, 17-alpine3.13
-Architectures: amd64
-GitCommit: 255fbc7cf6da6d76869b420dd2fe0bc94539b5eb
-Directory: 17/jdk/alpine3.13
-
-Tags: 17-ea-33-jdk-windowsservercore-1809, 17-ea-33-windowsservercore-1809, 17-ea-jdk-windowsservercore-1809, 17-ea-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-ea-33-jdk-windowsservercore, 17-ea-33-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-33-jdk, 17-ea-33, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17-jdk-windowsservercore, 17-windowsservercore, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-ea-33-jdk-windowsservercore-ltsc2016, 17-ea-33-windowsservercore-ltsc2016, 17-ea-jdk-windowsservercore-ltsc2016, 17-ea-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-ea-33-jdk-windowsservercore, 17-ea-33-windowsservercore, 17-ea-jdk-windowsservercore, 17-ea-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17-ea-33-jdk, 17-ea-33, 17-ea-jdk, 17-ea, 17-jdk, 17
+Tags: 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
+SharedTags: 17-jdk-windowsservercore, 17-windowsservercore, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-ea-33-jdk-nanoserver-1809, 17-ea-33-nanoserver-1809, 17-ea-jdk-nanoserver-1809, 17-ea-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-ea-33-jdk-nanoserver, 17-ea-33-nanoserver, 17-ea-jdk-nanoserver, 17-ea-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 501e71e2ada878d2e129b42ea6ebc19a7c286504
+GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/766a818: Update 17 to 17

(http://jdk.java.net/17/ -- this is Release Candidate, which is why `latest` doesn't update yet)