### PR TITLE
archlinux: Release 20210808.0.31089

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210725.0.29770
-GitCommit: 57862ad9d9dda77dddc9cc7860347881c425c3ff
-GitFetch: refs/tags/v20210725.0.29770
+Tags: latest, base, base-20210808.0.31089
+GitCommit: cc55709b6dade8788eb8786db3bf2b27ff9fbf1e
+GitFetch: refs/tags/v20210808.0.31089
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210725.0.29770
-GitCommit: 57862ad9d9dda77dddc9cc7860347881c425c3ff
-GitFetch: refs/tags/v20210725.0.29770
+Tags: base-devel, base-devel-20210808.0.31089
+GitCommit: cc55709b6dade8788eb8786db3bf2b27ff9fbf1e
+GitFetch: refs/tags/v20210808.0.31089
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks