### PR TITLE
Update Clear Linux OS to 34930

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 363680871d42245eab45f031991273402e64a46a
-GitFetch: refs/tags/clear-linux-34860
+GitCommit: 08a13d8f4799a60e1ecf170148b7868a886b0d96
+GitFetch: refs/tags/clear-linux-34930


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34930

@bryteise @mdhorn @phmccarty