### PR TITLE
Odoo: update 12.0-14.0 to release 20210809

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: b07c4f35b401acec2674a5c570f271684d89c5d0
+GitCommit: 233277f7be894217ae9c3e781862804beb180fb7
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Also, support was added for docker-compose secrets.

Thanks.