### PR TITLE
mariadb releases 20210806 with s390x

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -5,12 +5,12 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.6.4-focal, 10.6-focal, 10-focal, focal, 10.6.4, 10.6, 10, latest
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
 Directory: 10.6
 
 Tags: 10.5.12-focal, 10.5-focal, 10.5.12, 10.5
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
 Directory: 10.5
 


### PR DESCRIPTION
s390x was missed in the release.

Sorry for missing this new architecture in the last PR.