### PR TITLE
[oraclelinux] Update oraclelinux:8/8-slim for CVE-2021-27218

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6ef2cfe67f1bdf361efaf315ef87bcee28ad76ab
+amd64-GitCommit: 6109f10adcb7eb12dea9e8f4a8c993a1390bcca3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8eaa322e177a75bb7261bca2f57243de9716c7ce
+arm64v8-GitCommit: 07ef1e536086e59227588ffffd68b9c4ad9b11bb
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See <https://linux.oracle.com/errata/ELSA-2021-3058.html>

Signed-off-by: Avi Miller <avi.miller@oracle.com>