### PR TITLE
As announced [1], Ubuntu Groovy is EOL

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -3,7 +3,7 @@
 
 Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
 GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
-GitCommit: 045a1b4ee981b35a9ffcfd1d4d137cbcd949acfb
+GitCommit: b247c3fb527caaa74372d5739368a76e3e052fd8
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: a967c2b8734c77f7f89449d0b87c2e1eebf8b26e
@@ -35,11 +35,6 @@ Directory: bionic
 Tags: 20.04, focal-20210723, focal, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: focal
-
-# 20210723 (groovy)
-Tags: 20.10, groovy-20210723, groovy
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-Directory: groovy
 
 # 20210723 (hirsute)
 Tags: 21.04, hirsute-20210723, hirsute, rolling


### PR DESCRIPTION
[1]
https://lists.ubuntu.com/archives/ubuntu-announce/2021-July/000270.html