### PR TITLE
Bump Traefik to v2.5.0-rc6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.5.0-rc5-windowsservercore-1809, 2.5.0-rc5-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809
+Tags: v2.5.0-rc6-windowsservercore-1809, 2.5.0-rc6-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 12c45824c07644abb315508f20c4e77c83b0fa28
+GitCommit: 03801f145800769a5965bb4b155b9f3d9ba8a2db
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.0-rc5, 2.5.0-rc5, v2.5, 2.5, brie
+Tags: v2.5.0-rc6, 2.5.0-rc6, v2.5, 2.5, brie
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 12c45824c07644abb315508f20c4e77c83b0fa28
+GitCommit: 03801f145800769a5965bb4b155b9f3d9ba8a2db
 Directory: alpine
 
 Tags: v2.4.13-windowsservercore-1809, 2.4.13-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.5.0-rc6](https://github.com/traefik/traefik/releases/tag/v2.5.0-rc6).

/cc @ddtmachado @mpl @jbdoumenjou

Cheers
