### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -94,21 +94,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal
 
-Tags: groovy-curl, 20.10-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/groovy/curl
-
-Tags: groovy-scm, 20.10-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: ubuntu/groovy/scm
-
-Tags: groovy, 20.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/groovy
-
 Tags: hirsute-curl, 21.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/10f7101: Remove Ubuntu Groovy (EOL)