### PR TITLE
archlinux: Release 20210815.0.31571

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210808.0.31089
-GitCommit: cc55709b6dade8788eb8786db3bf2b27ff9fbf1e
-GitFetch: refs/tags/v20210808.0.31089
+Tags: latest, base, base-20210815.0.31571
+GitCommit: e7ccd22d57c784a1962aad905234002a2c5aa2f1
+GitFetch: refs/tags/v20210815.0.31571
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210808.0.31089
-GitCommit: cc55709b6dade8788eb8786db3bf2b27ff9fbf1e
-GitFetch: refs/tags/v20210808.0.31089
+Tags: base-devel, base-devel-20210815.0.31571
+GitCommit: e7ccd22d57c784a1962aad905234002a2c5aa2f1
+GitFetch: refs/tags/v20210815.0.31571
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks