### PR TITLE
Bump Traefik to v2.4.14

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 03801f145800769a5965bb4b155b9f3d9ba8a2db
 Directory: alpine
 
-Tags: v2.4.13-windowsservercore-1809, 2.4.13-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
+Tags: v2.4.14-windowsservercore-1809, 2.4.14-windowsservercore-1809, v2.4-windowsservercore-1809, 2.4-windowsservercore-1809, livarot-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ae84d69ecdfbcfeb37a1d727060bcb73db71a213
+GitCommit: f89fbe18d125560d8542224f60c82569a65ceba8
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.4.13, 2.4.13, v2.4, 2.4, livarot, latest
+Tags: v2.4.14, 2.4.14, v2.4, 2.4, livarot, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ae84d69ecdfbcfeb37a1d727060bcb73db71a213
+GitCommit: f89fbe18d125560d8542224f60c82569a65ceba8
 Directory: alpine
 
 Tags: v1.7.30-windowsservercore-1809, 1.7.30-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.4.14](https://github.com/traefik/traefik/releases/tag/v2.4.14).

/cc @ddtmachado @mpl @ldez

Cheers
