### PR TITLE
kong: add arm64 to alpine image

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -6,7 +6,7 @@ Tags: 2.5.0-alpine, 2.5.0, 2.5, alpine, latest
 GitCommit: ff3efa2c53e785e655a9c7de24c8111a373900cb
 GitFetch: refs/tags/2.5.0
 Directory: alpine
-Architectures: amd64
+Architectures: amd64, arm64v8
 
 Tags: 2.5.0-ubuntu, 2.5-ubuntu, ubuntu
 GitCommit: ff3efa2c53e785e655a9c7de24c8111a373900cb


### PR DESCRIPTION
Label got accidentally dropped in the 2.5 release process. A sibling PR will be opened in automation to ensure this doesn't occur again.