### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,14 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.0.2-buster, 3.0-buster, 3-buster, buster, 3.0.2, 3.0, 3, latest
+Tags: 3.0.2-bullseye, 3.0-bullseye, 3-bullseye, bullseye, 3.0.2, 3.0, 3, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+Directory: 3.0/bullseye
+
+Tags: 3.0.2-slim-bullseye, 3.0-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.0.2-slim, 3.0-slim, 3-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+Directory: 3.0/slim-bullseye
+
+Tags: 3.0.2-buster, 3.0-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
 Directory: 3.0/buster
 
-Tags: 3.0.2-slim-buster, 3.0-slim-buster, 3-slim-buster, slim-buster, 3.0.2-slim, 3.0-slim, 3-slim, slim
+Tags: 3.0.2-slim-buster, 3.0-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
 Directory: 3.0/slim-buster
 
 Tags: 3.0.2-alpine3.14, 3.0-alpine3.14, 3-alpine3.14, alpine3.14, 3.0.2-alpine, 3.0-alpine, 3-alpine, alpine
@@ -24,14 +34,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
 Directory: 3.0/alpine3.13
 
-Tags: 2.7.4-buster, 2.7-buster, 2-buster, 2.7.4, 2.7, 2
+Tags: 2.7.4-bullseye, 2.7-bullseye, 2-bullseye, 2.7.4, 2.7, 2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+Directory: 2.7/bullseye
+
+Tags: 2.7.4-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.4-slim, 2.7-slim, 2-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+Directory: 2.7/slim-bullseye
+
+Tags: 2.7.4-buster, 2.7-buster, 2-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
 Directory: 2.7/buster
 
-Tags: 2.7.4-slim-buster, 2.7-slim-buster, 2-slim-buster, 2.7.4-slim, 2.7-slim, 2-slim
+Tags: 2.7.4-slim-buster, 2.7-slim-buster, 2-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
 Directory: 2.7/slim-buster
 
 Tags: 2.7.4-alpine3.14, 2.7-alpine3.14, 2-alpine3.14, 2.7.4-alpine, 2.7-alpine, 2-alpine
@@ -44,29 +64,29 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
 Directory: 2.7/alpine3.13
 
-Tags: 2.6.8-buster, 2.6-buster, 2.6.8, 2.6
+Tags: 2.6.8-bullseye, 2.6-bullseye, 2.6.8, 2.6
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+Directory: 2.6/bullseye
+
+Tags: 2.6.8-slim-bullseye, 2.6-slim-bullseye, 2.6.8-slim, 2.6-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+Directory: 2.6/slim-bullseye
+
+Tags: 2.6.8-buster, 2.6-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
 Directory: 2.6/buster
 
-Tags: 2.6.8-slim-buster, 2.6-slim-buster, 2.6.8-slim, 2.6-slim
+Tags: 2.6.8-slim-buster, 2.6-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
 Directory: 2.6/slim-buster
-
-Tags: 2.6.8-stretch, 2.6-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
-Directory: 2.6/stretch
-
-Tags: 2.6.8-slim-stretch, 2.6-slim-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
-Directory: 2.6/slim-stretch
 
 Tags: 2.6.8-alpine3.14, 2.6-alpine3.14, 2.6.8-alpine, 2.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: e43959905d886946628d89f8e28d276af14a44a0
 Directory: 2.6/alpine3.14
 
 Tags: 2.6.8-alpine3.13, 2.6-alpine3.13


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/301b52c: Merge pull request https://github.com/docker-library/ruby/pull/357 from ojab/add_bullseye
- https://github.com/docker-library/ruby/commit/4916859: Add `bullseye` & `bullseye-slim` versions, drop `stretch` & `stretch-slim`
- https://github.com/docker-library/ruby/commit/fc5c093: Merge pull request https://github.com/docker-library/ruby/pull/358 from infosiftr/confused
- https://github.com/docker-library/ruby/commit/e439599: Update patch file shasum