### PR TITLE
[security] Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev3, 2.5-dev
+Tags: 2.5-dev4, 2.5-dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7807127e2f96d6cd90b8a11e87c41032c58afc62
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.5-rc
 
-Tags: 2.5-dev3-alpine, 2.5-dev-alpine
+Tags: 2.5-dev4-alpine, 2.5-dev-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7807127e2f96d6cd90b8a11e87c41032c58afc62
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.2, 2.4, lts, latest
+Tags: 2.4.3, 2.4, lts, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 973f43b2d1c5c0d57274002e216761c0baedf6c0
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4
 
-Tags: 2.4.2-alpine, 2.4-alpine, lts-alpine, alpine
+Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 973f43b2d1c5c0d57274002e216761c0baedf6c0
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4/alpine
 
-Tags: 2.3.12, 2.3
+Tags: 2.3.13, 2.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2f36ad009f5811f3155d135a6deacc3b789a51cd
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3
 
-Tags: 2.3.12-alpine, 2.3-alpine
+Tags: 2.3.13-alpine, 2.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2f36ad009f5811f3155d135a6deacc3b789a51cd
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3/alpine
 
-Tags: 2.2.15, 2.2
+Tags: 2.2.16, 2.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e6e8aa155660496478b3a348e009935581511c70
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.2
 
-Tags: 2.2.15-alpine, 2.2-alpine
+Tags: 2.2.16-alpine, 2.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e6e8aa155660496478b3a348e009935581511c70
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.2/alpine
 
-Tags: 2.0.23, 2.0
+Tags: 2.0.24, 2.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7fa89477be71cefe9c7f38468d99f85982194c84
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.0
 
-Tags: 2.0.23-alpine, 2.0-alpine
+Tags: 2.0.24-alpine, 2.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7fa89477be71cefe9c7f38468d99f85982194c84
+GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/33404f0: Merge pull request https://github.com/docker-library/haproxy/pull/166 from TimWolla/h2-vuln
- https://github.com/docker-library/haproxy/commit/a5931f7: Security: Update Dockerfiles for new releases