### PR TITLE
Update joomla

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -3,32 +3,32 @@
 Maintainers: Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 3.9.28-apache, 3.9-apache, 3-apache, apache, 3.9.28, 3.9, 3, latest, 3.9.28-php7.3-apache, 3.9-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.9.28-php7.3, 3.9-php7.3, 3-php7.3, php7.3
+Tags: 3.10.0-apache, 3.10-apache, 3-apache, apache, 3.10.0, 3.10, 3, latest, 3.10.0-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.10.0-php7.3, 3.10-php7.3, 3-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633c331dc9186adbf4f9db6486dca7bc0adc240
+GitCommit: 7d3cec34d348137c16751298528bced4ba504160
 Directory: php7.3/apache
 
-Tags: 3.9.28-fpm, 3.9-fpm, 3-fpm, fpm, 3.9.28-php7.3-fpm, 3.9-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
+Tags: 3.10.0-fpm, 3.10-fpm, 3-fpm, fpm, 3.10.0-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633c331dc9186adbf4f9db6486dca7bc0adc240
+GitCommit: 7d3cec34d348137c16751298528bced4ba504160
 Directory: php7.3/fpm
 
-Tags: 3.9.28-fpm-alpine, 3.9-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.9.28-php7.3-fpm-alpine, 3.9-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 3.10.0-fpm-alpine, 3.10-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.10.0-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b633c331dc9186adbf4f9db6486dca7bc0adc240
+GitCommit: 7d3cec34d348137c16751298528bced4ba504160
 Directory: php7.3/fpm-alpine
 
-Tags: 3.9.28-php7.4-apache, 3.9-php7.4-apache, 3-php7.4-apache, php7.4-apache, 3.9.28-php7.4, 3.9-php7.4, 3-php7.4, php7.4
+Tags: 3.10.0-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache, php7.4-apache, 3.10.0-php7.4, 3.10-php7.4, 3-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633c331dc9186adbf4f9db6486dca7bc0adc240
+GitCommit: 7d3cec34d348137c16751298528bced4ba504160
 Directory: php7.4/apache
 
-Tags: 3.9.28-php7.4-fpm, 3.9-php7.4-fpm, 3-php7.4-fpm, php7.4-fpm
+Tags: 3.10.0-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633c331dc9186adbf4f9db6486dca7bc0adc240
+GitCommit: 7d3cec34d348137c16751298528bced4ba504160
 Directory: php7.4/fpm
 
-Tags: 3.9.28-php7.4-fpm-alpine, 3.9-php7.4-fpm-alpine, 3-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 3.10.0-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b633c331dc9186adbf4f9db6486dca7bc0adc240
+GitCommit: 7d3cec34d348137c16751298528bced4ba504160
 Directory: php7.4/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/joomla-docker/docker-joomla/commit/7d3cec3: Joomla 3.10.0 Stable (https://github.com/joomla-docker/docker-joomla/pull/122)