### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.9.3, 3.9, 3, latest
+Tags: 3.9.4, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: cd44d4e7a4335ae137c1723772e2a777f0466d67
+GitCommit: b0ab6c9cfa2a46eeb4c242cc0ef9b1c60399c6c8
 Directory: 3.9/ubuntu
 
-Tags: 3.9.3-management, 3.9-management, 3-management, management
+Tags: 3.9.4-management, 3.9-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/ubuntu/management
 
-Tags: 3.9.3-alpine, 3.9-alpine, 3-alpine, alpine
+Tags: 3.9.4-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd44d4e7a4335ae137c1723772e2a777f0466d67
+GitCommit: b0ab6c9cfa2a46eeb4c242cc0ef9b1c60399c6c8
 Directory: 3.9/alpine
 
-Tags: 3.9.3-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.9.4-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/b0ab6c9: Merge pull request https://github.com/docker-library/rabbitmq/pull/519 from infosiftr/upstream-envs
- https://github.com/docker-library/rabbitmq/commit/6f686e5: Update 3.9 to 3.9.4
- https://github.com/docker-library/rabbitmq/commit/3dc2705: Allow upstream-supported environment variables without error