### PR TITLE
Update Clear Linux OS to 34940

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 08a13d8f4799a60e1ecf170148b7868a886b0d96
-GitFetch: refs/tags/clear-linux-34930
+GitCommit: 2dcacc43831a39ac5ab5e289139870bb1f768cfc
+GitFetch: refs/tags/clear-linux-34940


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34940

@bryteise @mdhorn @phmccarty