### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,45 +4,45 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-10-jdk-oraclelinux8, 18-ea-10-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-10-jdk-oracle, 18-ea-10-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-10-jdk, 18-ea-10, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-11-jdk-oraclelinux8, 18-ea-11-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-11-jdk-oracle, 18-ea-11-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-11-jdk, 18-ea-11, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-10-jdk-oraclelinux7, 18-ea-10-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-11-jdk-oraclelinux7, 18-ea-11-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-10-jdk-buster, 18-ea-10-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-11-jdk-buster, 18-ea-11-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/buster
 
-Tags: 18-ea-10-jdk-slim-buster, 18-ea-10-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-10-jdk-slim, 18-ea-10-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-11-jdk-slim-buster, 18-ea-11-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster, 18-ea-11-jdk-slim, 18-ea-11-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/slim-buster
 
-Tags: 18-ea-10-jdk-windowsservercore-1809, 18-ea-10-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-10-jdk-windowsservercore, 18-ea-10-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-10-jdk, 18-ea-10, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-11-jdk-windowsservercore-1809, 18-ea-11-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-11-jdk-windowsservercore, 18-ea-11-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-11-jdk, 18-ea-11, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-10-jdk-windowsservercore-ltsc2016, 18-ea-10-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-10-jdk-windowsservercore, 18-ea-10-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-10-jdk, 18-ea-10, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-11-jdk-windowsservercore-ltsc2016, 18-ea-11-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-11-jdk-windowsservercore, 18-ea-11-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-11-jdk, 18-ea-11, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-10-jdk-nanoserver-1809, 18-ea-10-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-10-jdk-nanoserver, 18-ea-10-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-11-jdk-nanoserver-1809, 18-ea-11-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-11-jdk-nanoserver, 18-ea-11-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 581aba7e0651e15f2e6ae356202335022a636703
+GitCommit: 28f60bfbb1e86733637b8054e86c4c32bafb4e69
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/28f60bf: Update 18 to 18-ea+11