### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/2c7223f5fc2fba18bc8e5cb14896668a5c330ae1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/b9406c480220b6f9577cdf2427abe7ec4bf139ff/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/pypy.git
 
 Tags: 3.7-7.3.5-bullseye, 3.7-7.3-bullseye, 3.7-7-bullseye, 3.7-bullseye, 3-7.3.5-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
 SharedTags: 3.7-7.3.5, 3.7-7.3, 3.7-7, 3.7, 3-7.3.5, 3-7.3, 3-7, 3, latest
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, arm64v8, i386
 GitCommit: 2c7223f5fc2fba18bc8e5cb14896668a5c330ae1
 Directory: 3.7/bullseye
 
 Tags: 3.7-7.3.5-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3-7.3.5-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.7-7.3.5-slim-bullseye, 3.7-7.3-slim-bullseye, 3.7-7-slim-bullseye, 3.7-slim-bullseye, 3-7.3.5-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
-Architectures: amd64, arm64v8, i386, s390x
+Architectures: amd64, arm64v8, i386
 GitCommit: 2c7223f5fc2fba18bc8e5cb14896668a5c330ae1
 Directory: 3.7/slim-bullseye
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/c82a643: Merge pull request https://github.com/docker-library/pypy/pull/58 from infosiftr/libffi6-s390x
- https://github.com/docker-library/pypy/commit/b9406c4: Exclude "s390x" for bullseye+ (due to libffi6 vs libffi7)