### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,40 +1,40 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/ba8de1363a5bff92c31876539715b88d7dee5f54/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/55844dac0137f947755a0d89d65565d703d1c7ad/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: ba8de1363a5bff92c31876539715b88d7dee5f54
+GitCommit: 55844dac0137f947755a0d89d65565d703d1c7ad
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2bcc4bf56c2a4594aa31feb8b42d5eab76d168bb
+amd64-GitCommit: 0a3fcfc05b6d1ddac8a929cbc57def698f0765f6
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: a542a7bc9817e71654aba8feb6b5cb265e8f9976
+arm32v5-GitCommit: 9e59a8d467b333676cc8e29a7964979f5fd3569b
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 4619f8d1d337e99ce34641394b37f13d2086b7fa
+arm32v6-GitCommit: bbd00c7ef3923434ee36f10a740ba1e040688999
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 167c5ca7501659ccbe426677302f49b1060a2d1c
+arm32v7-GitCommit: ffb106006f4fbf8b38f0039ff7483a877c2416b5
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cce85f68157251e06d6a328fe092000b55a26725
+arm64v8-GitCommit: 3c905f13b4a494760c31ee2fda21e1c240b17ae3
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 6146c81916dc3384c7ac8fe13c5c1fb69f70b80a
+i386-GitCommit: 0bfd0bc19d92136a5b1cac1782b4bee461130ac8
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: e152603121edbf1117006ff7d843de5ff26fe864
+mips64le-GitCommit: da00702daf24fab7c6aa28440aff2c6f21fe8993
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 9c6ff55d8efc0ab835a9fe70c660c907ccb1a325
+ppc64le-GitCommit: 1fb5c5ee49036bdd783be4edb804f62ad14cb51e
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 87ee88572c15dfbca78263ca2118fd4afd9d3cc2
+riscv64-GitCommit: ee3ed8fad6f09cccb2c6e2cb32418b71f0146d29
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 6b63b93035aa234e8e09843bca168f518db651f6
+s390x-GitCommit: b003537d059328b0137b0972606c955dd17ffd93
 
 Tags: 1.33.1-uclibc, 1.33-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64
@@ -60,3 +60,28 @@ mips64le-Directory: stable/uclibc
 ppc64le-Directory: stable/glibc
 riscv64-Directory: stable/uclibc
 s390x-Directory: stable/glibc
+
+Tags: 1.34.0-uclibc, 1.34-uclibc, unstable-uclibc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64
+Directory: unstable/uclibc
+
+Tags: 1.34.0-glibc, 1.34-glibc, unstable-glibc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: unstable/glibc
+
+Tags: 1.34.0-musl, 1.34-musl, unstable-musl
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: unstable/musl
+
+Tags: 1.34.0, 1.34, unstable
+Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
+amd64-Directory: unstable/uclibc
+arm32v5-Directory: unstable/uclibc
+arm32v6-Directory: unstable/musl
+arm32v7-Directory: unstable/uclibc
+arm64v8-Directory: unstable/uclibc
+i386-Directory: unstable/uclibc
+mips64le-Directory: unstable/uclibc
+ppc64le-Directory: unstable/glibc
+riscv64-Directory: unstable/uclibc
+s390x-Directory: unstable/glibc


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/55844da: Merge pull request https://github.com/docker-library/busybox/pull/112 from infosiftr/mips
- https://github.com/docker-library/busybox/commit/82c3cf0: Add patch for MIPS compilation failure
- https://github.com/docker-library/busybox/commit/350ed43: Merge pull request https://github.com/docker-library/busybox/pull/111 from infosiftr/1.34.0
- https://github.com/docker-library/busybox/commit/d7f0f0f: Update unstable to 1.34.0
- https://github.com/docker-library/busybox/commit/d38e4bb: Merge pull request https://github.com/docker-library/busybox/pull/108 from infosiftr/buildroot-2021.05.1
- https://github.com/docker-library/busybox/commit/4da0e13: Update Buildroot to 2021.05.1