### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.4, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: b0ab6c9cfa2a46eeb4c242cc0ef9b1c60399c6c8
+GitCommit: fa2f5ed3589f24f37d4448fa0428150884bc0db2
 Directory: 3.9/ubuntu
 
 Tags: 3.9.4-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.4-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b0ab6c9cfa2a46eeb4c242cc0ef9b1c60399c6c8
+GitCommit: fa2f5ed3589f24f37d4448fa0428150884bc0db2
 Directory: 3.9/alpine
 
 Tags: 3.9.4-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.21, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 51d22c8d4eb548af158cea5a5c5f7ddf55d5cc1f
+GitCommit: b6abcc8293d34c13594d04767c3123cc961968a9
 Directory: 3.8/ubuntu
 
 Tags: 3.8.21-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.21-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 51d22c8d4eb548af158cea5a5c5f7ddf55d5cc1f
+GitCommit: b6abcc8293d34c13594d04767c3123cc961968a9
 Directory: 3.8/alpine
 
 Tags: 3.8.21-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/606b799: Update 3.9-rc to openssl 1.1.1l
- https://github.com/docker-library/rabbitmq/commit/fa2f5ed: Update 3.9 to openssl 1.1.1l
- https://github.com/docker-library/rabbitmq/commit/5bca855: Update 3.8-rc to openssl 1.1.1l
- https://github.com/docker-library/rabbitmq/commit/b6abcc8: Update 3.8 to openssl 1.1.1l