### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,75 +1,75 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/ae10fbf9bae067e11222c34344c9032060ffa997/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/cbd26d92eb01f7212f1fbee822b0042021b6b8a7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev4, 2.5-dev
+Tags: 2.5-dev4, 2.5-dev, 2.5-dev4-buster, 2.5-dev-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.5-rc
 
-Tags: 2.5-dev4-alpine, 2.5-dev-alpine
+Tags: 2.5-dev4-alpine, 2.5-dev-alpine, 2.5-dev4-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.3, 2.4, lts, latest
+Tags: 2.4.3, 2.4, lts, latest, 2.4.3-buster, 2.4-buster, lts-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4
 
-Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine
+Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.3-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4/alpine
 
-Tags: 2.3.13, 2.3
+Tags: 2.3.13, 2.3, 2.3.13-buster, 2.3-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3
 
-Tags: 2.3.13-alpine, 2.3-alpine
+Tags: 2.3.13-alpine, 2.3-alpine, 2.3.13-alpine3.14, 2.3-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3/alpine
 
-Tags: 2.2.16, 2.2
+Tags: 2.2.16, 2.2, 2.2.16-buster, 2.2-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.2
 
-Tags: 2.2.16-alpine, 2.2-alpine
+Tags: 2.2.16-alpine, 2.2-alpine, 2.2.16-alpine3.14, 2.2-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.2/alpine
 
-Tags: 2.0.24, 2.0
+Tags: 2.0.24, 2.0, 2.0.24-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.0
 
-Tags: 2.0.24-alpine, 2.0-alpine
+Tags: 2.0.24-alpine, 2.0-alpine, 2.0.24-alpine3.14, 2.0-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.0/alpine
 
-Tags: 1.8.30, 1.8
+Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 0e7b078d5ff2ed9f29e4223a5d3d38d191818505
 Directory: 1.8
 
-Tags: 1.8.30-alpine, 1.8-alpine
+Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.14, 1.8-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
 Directory: 1.8/alpine
 
-Tags: 1.7.14, 1.7
+Tags: 1.7.14, 1.7, 1.7.14-buster, 1.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
 Directory: 1.7
 
-Tags: 1.7.14-alpine, 1.7-alpine
+Tags: 1.7.14-alpine, 1.7-alpine, 1.7.14-alpine3.12, 1.7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
 Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/21030be: Merge pull request https://github.com/docker-library/haproxy/pull/168 from infosiftr/suite-aliases
- https://github.com/docker-library/haproxy/commit/cbd26d9: Add suite aliases ("alpine3.14", etc)