### PR TITLE
alpine: bump 3.14.2 for openssl security fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.14.1, 3.14, 3, latest
+Tags: 3.14.2, 3.14, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.14
-GitCommit: 571b69f12f4a3891f48b308ed9611e018cc862f7
+GitCommit: 6046c206b93945695d9c3efedcafe629a327fd85
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
- CVE-2021-3711
- CVE-2021-3712