### PR TITLE
Update Clear Linux OS to 34990

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 2dcacc43831a39ac5ab5e289139870bb1f768cfc
-GitFetch: refs/tags/clear-linux-34940
+GitCommit: 639f2d419aa5b63d9a33c9f6b19043b97f97b783
+GitFetch: refs/tags/clear-linux-34990


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 34990

@bryteise @mdhorn @phmccarty