### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev4, 2.5-dev, 2.5-dev4-buster, 2.5-dev-buster
+Tags: 2.5-dev5, 2.5-dev, 2.5-dev5-buster, 2.5-dev-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: 471471aef48abf9eceffd9bf2e86e46593b25561
 Directory: 2.5-rc
 
-Tags: 2.5-dev4-alpine, 2.5-dev-alpine, 2.5-dev4-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev5-alpine, 2.5-dev-alpine, 2.5-dev5-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: 471471aef48abf9eceffd9bf2e86e46593b25561
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.3, 2.4, lts, latest, 2.4.3-buster, 2.4-buster, lts-buster, buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/471471a: Update 2.5-rc to 2.5-dev5