### PR TITLE
[security] Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -49,80 +49,80 @@ GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.9.6-bullseye, 3.9-bullseye, 3-bullseye, bullseye
-SharedTags: 3.9.6, 3.9, 3, latest
+Tags: 3.9.7-bullseye, 3.9-bullseye, 3-bullseye, bullseye
+SharedTags: 3.9.7, 3.9, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/bullseye
 
-Tags: 3.9.6-slim-bullseye, 3.9-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.9.6-slim, 3.9-slim, 3-slim, slim
+Tags: 3.9.7-slim-bullseye, 3.9-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.9.7-slim, 3.9-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/bullseye/slim
 
-Tags: 3.9.6-buster, 3.9-buster, 3-buster, buster
+Tags: 3.9.7-buster, 3.9-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9c6007b87f2fa537c8c923fc67a93640e0cb503e
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/buster
 
-Tags: 3.9.6-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.9.7-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9c6007b87f2fa537c8c923fc67a93640e0cb503e
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/buster/slim
 
-Tags: 3.9.6-alpine3.14, 3.9-alpine3.14, 3-alpine3.14, alpine3.14, 3.9.6-alpine, 3.9-alpine, 3-alpine, alpine
+Tags: 3.9.7-alpine3.14, 3.9-alpine3.14, 3-alpine3.14, alpine3.14, 3.9.7-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c6007b87f2fa537c8c923fc67a93640e0cb503e
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/alpine3.14
 
-Tags: 3.9.6-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13
+Tags: 3.9.7-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c6007b87f2fa537c8c923fc67a93640e0cb503e
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/alpine3.13
 
-Tags: 3.9.6-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.9.6-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.6, 3.9, 3, latest
+Tags: 3.9.7-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.9.7-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.7, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 9c6007b87f2fa537c8c923fc67a93640e0cb503e
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.9.6-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.9.6-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.6, 3.9, 3, latest
+Tags: 3.9.7-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 3.9.7-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.7, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 9c6007b87f2fa537c8c923fc67a93640e0cb503e
+GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
 Directory: 3.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 3.8.11-bullseye, 3.8-bullseye
-SharedTags: 3.8.11, 3.8
+Tags: 3.8.12-bullseye, 3.8-bullseye
+SharedTags: 3.8.12, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
 Directory: 3.8/bullseye
 
-Tags: 3.8.11-slim-bullseye, 3.8-slim-bullseye, 3.8.11-slim, 3.8-slim
+Tags: 3.8.12-slim-bullseye, 3.8-slim-bullseye, 3.8.12-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
 Directory: 3.8/bullseye/slim
 
-Tags: 3.8.11-buster, 3.8-buster
+Tags: 3.8.12-buster, 3.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 670a51bde142663856c29c3ef85efcebde0aec6d
+GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
 Directory: 3.8/buster
 
-Tags: 3.8.11-slim-buster, 3.8-slim-buster
+Tags: 3.8.12-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 670a51bde142663856c29c3ef85efcebde0aec6d
+GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
 Directory: 3.8/buster/slim
 
-Tags: 3.8.11-alpine3.14, 3.8-alpine3.14, 3.8.11-alpine, 3.8-alpine
+Tags: 3.8.12-alpine3.14, 3.8-alpine3.14, 3.8.12-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 670a51bde142663856c29c3ef85efcebde0aec6d
+GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
 Directory: 3.8/alpine3.14
 
-Tags: 3.8.11-alpine3.13, 3.8-alpine3.13
+Tags: 3.8.12-alpine3.13, 3.8-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 670a51bde142663856c29c3ef85efcebde0aec6d
+GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
 Directory: 3.8/alpine3.13
 
 Tags: 3.7.11-bullseye, 3.7-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/bb70f32: Update to 3.9.7, pip 21.2.4
- https://github.com/docker-library/python/commit/05a7a8a: Update to 3.8.12, pip 21.2.4

https://pythoninsider.blogspot.com/2021/08/python-397-and-3812-are-now-available.html