### PR TITLE
alpine: security bump 3.11.12, 3.12.8, 3.13.6

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -26,10 +26,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.13.5, 3.13
+Tags: 3.13.6, 3.13
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.13
-GitCommit: 37579d92b9faa70398240431bc46720242faa5e5
+GitCommit: 97bdddbacbe7f7fa6165ed2bdfa86d7d0ab43420
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -38,10 +38,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.7, 3.12
+Tags: 3.12.8, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: 8b8051f1c11daff18ada363488e145af9e201802
+GitCommit: d9f83182075b7e627dfbea4f86f7f8134c48a5a5
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -50,10 +50,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.11, 3.11
+Tags: 3.11.12, 3.11
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: 2cd76fb18830708f4af5a6927c3aa40867a4e8bb
+GitCommit: 48093276e3960aeccc4db369c11ea0460b90f349
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Fixes the following issues:

apk-tools:
- CVE-2021-36159

openssl:
- CVE-2021-3711
- CVE-2021-3712