### PR TITLE
eclipse-mosquitto 2.0.12

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,12 +1,12 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: 17bbca22fb5dc57bfdc83ac60be67e34208825fd
+GitCommit: 9afeeb1a568470871511a78de6b5927010ede1f5
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 2.0.11, 2.0, 2, latest
+Tags: 2.0.12, 2.0, 2, latest
 Directory: docker/2.0
 
-Tags: 2.0.11-openssl, 2.0-openssl, 2-openssl, openssl
+Tags: 2.0.12-openssl, 2.0-openssl, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
 Tags: 1.6.15, 1.6


### PR DESCRIPTION
Also:
* Bump Alpine version to 3.14
* Remove self compiled cJSON - this is included in alpine:3.14
* Bump libwebsockets to 4.2.1