### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev5, 2.5-dev, 2.5-dev5-buster, 2.5-dev-buster
+Tags: 2.5-dev5, 2.5-dev, 2.5-dev5-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 471471aef48abf9eceffd9bf2e86e46593b25561
+GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
 Directory: 2.5-rc
 
 Tags: 2.5-dev5-alpine, 2.5-dev-alpine, 2.5-dev5-alpine3.14, 2.5-dev-alpine3.14
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 471471aef48abf9eceffd9bf2e86e46593b25561
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.3, 2.4, lts, latest, 2.4.3-buster, 2.4-buster, lts-buster, buster
+Tags: 2.4.3, 2.4, lts, latest, 2.4.3-bullseye, 2.4-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
 Directory: 2.4
 
 Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.3-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
@@ -24,9 +24,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.4/alpine
 
-Tags: 2.3.13, 2.3, 2.3.13-buster, 2.3-buster
+Tags: 2.3.13, 2.3, 2.3.13-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
 Directory: 2.3
 
 Tags: 2.3.13-alpine, 2.3-alpine, 2.3.13-alpine3.14, 2.3-alpine3.14
@@ -34,9 +34,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
 Directory: 2.3/alpine
 
-Tags: 2.2.16, 2.2, 2.2.16-buster, 2.2-buster
+Tags: 2.2.16, 2.2, 2.2.16-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
 Directory: 2.2
 
 Tags: 2.2.16-alpine, 2.2-alpine, 2.2.16-alpine3.14, 2.2-alpine3.14


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c39b1a0: Merge pull request https://github.com/docker-library/haproxy/pull/167 from TimWolla/bullseye
- https://github.com/docker-library/haproxy/commit/f1ac3ec: Update to debian:bullseye-slim for 2.2+