### PR TITLE
Bump Traefik to v2.5.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.5.1-windowsservercore-1809, 2.5.1-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
+Tags: v2.5.2-windowsservercore-1809, 2.5.2-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e7276179b92d6a3774416a1044a588df3439721f
+GitCommit: 26f817dd97af4070e842cf79d675f15ef29bb2e3
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.1, 2.5.1, v2.5, 2.5, brie, latest
+Tags: v2.5.2, 2.5.2, v2.5, 2.5, brie, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e7276179b92d6a3774416a1044a588df3439721f
+GitCommit: 26f817dd97af4070e842cf79d675f15ef29bb2e3
 Directory: alpine
 
 Tags: v1.7.30-windowsservercore-1809, 1.7.30-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.5.2](https://github.com/traefik/traefik/releases/tag/v2.5.2).

/cc @ddtmachado @mpl @juliens

Cheers
