### PR TITLE
arangodb 3.8.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -9,6 +9,6 @@ Tags: 3.7, 3.7.14
 GitCommit: 5667472f5348943ccb3ff862e8d9887bab0efdb6
 Directory: alpine/3.7.14
 
-Tags: 3.8, 3.8.0, latest
-GitCommit: 47656513d1c73c368046e151c697fb85f0eca8cc
-Directory: alpine/3.8.0
+Tags: 3.8, 3.8.1, latest
+GitCommit: 42fc6401e569423cab28e71b0085dc78300caa84
+Directory: alpine/3.8.1


### PR DESCRIPTION
Updated ArangoDB 3.8 to 3.8.1.