### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev5, 2.5-dev, 2.5-dev5-bullseye, 2.5-dev-bullseye
+Tags: 2.5-dev6, 2.5-dev, 2.5-dev6-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
+GitCommit: 44e2ce5644bbdfa1b9b2087f72c691586c1d8503
 Directory: 2.5-rc
 
-Tags: 2.5-dev5-alpine, 2.5-dev-alpine, 2.5-dev5-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev6-alpine, 2.5-dev-alpine, 2.5-dev6-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 471471aef48abf9eceffd9bf2e86e46593b25561
+GitCommit: 44e2ce5644bbdfa1b9b2087f72c691586c1d8503
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.3, 2.4, lts, latest, 2.4.3-bullseye, 2.4-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/44e2ce5: Update 2.5-rc to 2.5-dev6