### PR TITLE
caddy: v2.4.5 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,51 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/e01e0a10625f95d031411215378b5f790047d990/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/5713f0a131bad5ebb431603215b01d4f24142736/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.4.3-alpine, 2-alpine, alpine
-SharedTags: 2.4.3, 2, latest
+Tags: 2.4.5-alpine, 2-alpine, alpine
+SharedTags: 2.4.5, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/alpine
-GitCommit: 1e2cf7dde14c0cfd3275efdd23f4700ecfc2419f
+GitCommit: 62b2552a99da5dee6a1c204647f0e47ee0a8c0b0
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.4.3-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.4.3-builder, 2-builder, builder
+Tags: 2.4.5-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.4.5-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/builder
-GitCommit: e01e0a10625f95d031411215378b5f790047d990
+GitCommit: 62b2552a99da5dee6a1c204647f0e47ee0a8c0b0
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.4.3-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.4.3-windowsservercore, 2-windowsservercore, windowsservercore, 2.4.3, 2, latest
+Tags: 2.4.5-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.4.5-windowsservercore, 2-windowsservercore, windowsservercore, 2.4.5, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows/1809
-GitCommit: 1e2cf7dde14c0cfd3275efdd23f4700ecfc2419f
+GitCommit: 62b2552a99da5dee6a1c204647f0e47ee0a8c0b0
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.4.3-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.4.3-windowsservercore, 2-windowsservercore, windowsservercore, 2.4.3, 2, latest
+Tags: 2.4.5-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.4.5-windowsservercore, 2-windowsservercore, windowsservercore, 2.4.5, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows/ltsc2016
-GitCommit: 1e2cf7dde14c0cfd3275efdd23f4700ecfc2419f
+GitCommit: 62b2552a99da5dee6a1c204647f0e47ee0a8c0b0
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 
-Tags: 2.4.3-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.4.3-builder, 2-builder, builder
+Tags: 2.4.5-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.4.5-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows-builder/1809
-GitCommit: 1e2cf7dde14c0cfd3275efdd23f4700ecfc2419f
+GitCommit: 5713f0a131bad5ebb431603215b01d4f24142736
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.4.3-builder-windowsservercore-ltsc2016, 2-builder-windowsservercore-ltsc2016, builder-windowsservercore-ltsc2016
-SharedTags: 2.4.3-builder, 2-builder, builder
+Tags: 2.4.5-builder-windowsservercore-ltsc2016, 2-builder-windowsservercore-ltsc2016, builder-windowsservercore-ltsc2016
+SharedTags: 2.4.5-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows-builder/ltsc2016
-GitCommit: 1e2cf7dde14c0cfd3275efdd23f4700ecfc2419f
+GitCommit: 5713f0a131bad5ebb431603215b01d4f24142736
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.4.5

Also bumps xcaddy 0.2.0, Alpine 3.14, and Go 1.17

Signed-off-by: Dave Henderson <dhenderson@gmail.com>