### PR TITLE
update fluentd to v1.14.0

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,13 +3,13 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Alpine images
-Tags: v1.9.1-1.0, v1.9-1, latest
+Tags: v1.14.0-1.0, v1.14-1, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: b9cb2826b85900f960e256b2426a033e7cacfd6c
-Directory: v1.9/alpine
+GitCommit: a9e4cee765c7aaf7876d6fe3282aa565dbcdc2a4
+Directory: v1.14/alpine
 
 # Debian images
-Tags: v1.9.1-debian-1.0, v1.9-debian-1
+Tags: v1.14.0-debian-1.0, v1.14-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9cb2826b85900f960e256b2426a033e7cacfd6c
-Directory: v1.9/debian
+GitCommit: a9e4cee765c7aaf7876d6fe3282aa565dbcdc2a4
+Directory: v1.14/debian


### PR DESCRIPTION
Update to the latest stable version.

Signed-off-by: Hiroshi Hatake <hatake@calyptia.com>