### PR TITLE
Add Grafana image

### DIFF
--- a/library/grafana
+++ b/library/grafana
@@ -1,0 +1,14 @@
+# this file is generated via https://github.com/grafana/grafana-docker-official/blob/2be51dd606d8c52062f1499b6090f278f7ad084c/generate-stackbrew-library.sh
+
+Maintainers: Torkel Ödegaard <torkel@grafana.com> (@torkelo)
+GitRepo: https://github.com/docker-library/grafana.git
+
+Tags: 8.1.2
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: ba014f25b5b7f7f6ad4aa164860ad17aff2bacfd
+Directory: 8
+
+Tags: 7.5.10
+Architectures: amd64, arm32, arm64v8
+GitCommit: ba014f25b5b7f7f6ad4aa164860ad17aff2bacfd
+Directory: 7


### PR DESCRIPTION
# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream? 
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well? Top 90 most popular project on GitHub 
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)

This image is similar to how elasticsearch/kibana is configured in that it's basing the image on our upstream image. This is preferable as the image publish step is after a long build & integration test process that validates the image & build, so would be good to just re-use the same image.  https://github.com/grafana/grafana-docker-official

The upstream Dockerfile is at:  https://github.com/grafana/grafana/blob/main/packaging/docker/Dockerfile

