### PR TITLE
Groovy 3.0.9 and 4.0.0-beta-1

### DIFF
--- a/library/groovy
+++ b/library/groovy
@@ -4,34 +4,34 @@ GitRepo: https://github.com/groovy/docker-groovy.git
 
 # Groovy 3
 
-Tags: 3.0.8-jdk8, 3.0-jdk8, 3.0.8-jdk, 3.0-jdk, jdk8, jdk
+Tags: 3.0.9-jdk8, 3.0-jdk8, 3.0.9-jdk, 3.0-jdk, jdk8, jdk
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc758151cb38024e32f2bf1d05d672eb589d5872
+GitCommit: 400c5ce5baad6936a4fa3f6a52400345acb0dd9d
 Directory: jdk8
 
-Tags: 3.0.8-jre8, 3.0-jre8, 3.0.8-jre, 3.0-jre, 3.0.8, 3.0, jre8, jre, latest
+Tags: 3.0.9-jre8, 3.0-jre8, 3.0.9-jre, 3.0-jre, 3.0.9, 3.0, jre8, jre, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc758151cb38024e32f2bf1d05d672eb589d5872
+GitCommit: 400c5ce5baad6936a4fa3f6a52400345acb0dd9d
 Directory: jre8
 
-Tags: 3.0.8-jdk11, 3.0-jdk11, jdk11
+Tags: 3.0.9-jdk11, 3.0-jdk11, jdk11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc758151cb38024e32f2bf1d05d672eb589d5872
+GitCommit: 400c5ce5baad6936a4fa3f6a52400345acb0dd9d
 Directory: jdk11
 
-Tags: 3.0.8-jre11, 3.0-jre11, jre11
+Tags: 3.0.9-jre11, 3.0-jre11, jre11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc758151cb38024e32f2bf1d05d672eb589d5872
+GitCommit: 400c5ce5baad6936a4fa3f6a52400345acb0dd9d
 Directory: jre11
 
-Tags: 3.0.8-jdk16, 3.0-jdk16, jdk16
+Tags: 3.0.9-jdk16, 3.0-jdk16, jdk16
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc758151cb38024e32f2bf1d05d672eb589d5872
+GitCommit: 400c5ce5baad6936a4fa3f6a52400345acb0dd9d
 Directory: jdk16
 
-Tags: 3.0.8-jre16, 3.0-jre16, jre16
+Tags: 3.0.9-jre16, 3.0-jre16, jre16
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fc758151cb38024e32f2bf1d05d672eb589d5872
+GitCommit: 400c5ce5baad6936a4fa3f6a52400345acb0dd9d
 Directory: jre16
 
 

--- a/library/groovy
+++ b/library/groovy
@@ -37,38 +37,38 @@ Directory: jre16
 
 # Groovy 4
 
-Tags: 4.0.0-alpha-3-jdk8, 4.0-jdk8, 4.0.0-alpha-3-jdk, 4.0-jdk
+Tags: 4.0.0-beta-1-jdk8, 4.0-jdk8, 4.0.0-beta-1-jdk, 4.0-jdk
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ad50fefc1fc19511003471541a68eba490642bd8
+GitCommit: 368212f8ca90051f5542f9d64523e22bc8130a66
 Directory: jdk8
 
-Tags: 4.0.0-alpha-3-jre8, 4.0-jre8, 4.0.0-alpha-3-jre, 4.0-jre, 4.0.0-alpha-3, 4.0
+Tags: 4.0.0-beta-1-jre8, 4.0-jre8, 4.0.0-beta-1-jre, 4.0-jre, 4.0.0-beta-1, 4.0
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ad50fefc1fc19511003471541a68eba490642bd8
+GitCommit: 368212f8ca90051f5542f9d64523e22bc8130a66
 Directory: jre8
 
-Tags: 4.0.0-alpha-3-jdk11, 4.0-jdk11
+Tags: 4.0.0-beta-1-jdk11, 4.0-jdk11
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ad50fefc1fc19511003471541a68eba490642bd8
+GitCommit: 368212f8ca90051f5542f9d64523e22bc8130a66
 Directory: jdk11
 
-Tags: 4.0.0-alpha-3-jre11, 4.0-jre11
+Tags: 4.0.0-beta-1-jre11, 4.0-jre11
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ad50fefc1fc19511003471541a68eba490642bd8
+GitCommit: 368212f8ca90051f5542f9d64523e22bc8130a66
 Directory: jre11
 
-Tags: 4.0.0-alpha-3-jdk16, 4.0-jdk16
+Tags: 4.0.0-beta-1-jdk16, 4.0-jdk16
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ad50fefc1fc19511003471541a68eba490642bd8
+GitCommit: 368212f8ca90051f5542f9d64523e22bc8130a66
 Directory: jdk16
 
-Tags: 4.0.0-alpha-3-jre16, 4.0-jre16
+Tags: 4.0.0-beta-1-jre16, 4.0-jre16
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ad50fefc1fc19511003471541a68eba490642bd8
+GitCommit: 368212f8ca90051f5542f9d64523e22bc8130a66
 Directory: jre16


### PR DESCRIPTION
Apparently the SKS key servers are now [deprecated](https://central.sonatype.org/publish/requirements/gpg/#distributing-your-public-key) and I was getting the error `gpg: keyserver receive failed: No name`, so I replaced them as well.