### PR TITLE
Update joomla to multi versions

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -1,34 +1,65 @@
-# this file is generated via https://github.com/joomla-docker/docker-joomla/blob/6874f569cbc6202f3fe84ed067305c803a6e1ab7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/joomla-docker/docker-joomla/blob/ee137cbaebee5425cb84a113d559c4c8c26c1c0b/generate-stackbrew-library.sh
 
-Maintainers: Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
+Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.org> (@Llewellynvdm),
+             Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 3.10.1-apache, 3.10-apache, 3-apache, apache, 3.10.1, 3.10, 3, latest, 3.10.1-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache, php7.3-apache, 3.10.1-php7.3, 3.10-php7.3, 3-php7.3, php7.3
+Tags: 4.0.2-php7.4-apache, 4.0-php7.4-apache, 4-php7.4-apache, php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4f73d3abf8c943c5371a095d45cada713db8c786
-Directory: php7.3/apache
+GitCommit: 2c56389172e05c05365b7192af3d8a76bbf77bdf
+Directory: 4.0/php7.4/apache
 
-Tags: 3.10.1-fpm, 3.10-fpm, 3-fpm, fpm, 3.10.1-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm, php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4f73d3abf8c943c5371a095d45cada713db8c786
-Directory: php7.3/fpm
-
-Tags: 3.10.1-fpm-alpine, 3.10-fpm-alpine, 3-fpm-alpine, fpm-alpine, 3.10.1-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 4.0.2-php7.4-fpm-alpine, 4.0-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4f73d3abf8c943c5371a095d45cada713db8c786
-Directory: php7.3/fpm-alpine
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 4.0/php7.4/fpm-alpine
 
-Tags: 3.10.1-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache, php7.4-apache, 3.10.1-php7.4, 3.10-php7.4, 3-php7.4, php7.4
+Tags: 4.0.2-php7.4-fpm, 4.0-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4f73d3abf8c943c5371a095d45cada713db8c786
-Directory: php7.4/apache
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 4.0/php7.4/fpm
 
-Tags: 3.10.1-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm, php7.4-fpm
+Tags: 4.0.2, 4.0, 4, latest, 4.0.2-apache, 4.0-apache, 4-apache, apache, 4.0.2-php8.0, 4.0-php8.0, 4-php8.0, php8.0, 4.0.2-php8.0-apache, 4.0-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4f73d3abf8c943c5371a095d45cada713db8c786
-Directory: php7.4/fpm
+GitCommit: 2c56389172e05c05365b7192af3d8a76bbf77bdf
+Directory: 4.0/php8.0/apache
 
-Tags: 3.10.1-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 4.0.2-php8.0-fpm-alpine, 4.0-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4f73d3abf8c943c5371a095d45cada713db8c786
-Directory: php7.4/fpm-alpine
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 4.0/php8.0/fpm-alpine
+
+Tags: 4.0.2-php8.0-fpm, 4.0-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 4.0/php8.0/fpm
+
+Tags: 3.10.1-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2c56389172e05c05365b7192af3d8a76bbf77bdf
+Directory: 3.10/php7.3/apache
+
+Tags: 3.10.1-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 3.10/php7.3/fpm-alpine
+
+Tags: 3.10.1-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 3.10/php7.3/fpm
+
+Tags: 3.10.1, 3.10, 3, 3.10.1-apache, 3.10-apache, 3-apache, 3.10.1-php7.4, 3.10-php7.4, 3-php7.4, 3.10.1-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2c56389172e05c05365b7192af3d8a76bbf77bdf
+Directory: 3.10/php7.4/apache
+
+Tags: 3.10.1-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 3.10/php7.4/fpm-alpine
+
+Tags: 3.10.1-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 1504169114168d08deab0512760fbd8248bc97fd
+Directory: 3.10/php7.4/fpm


### PR DESCRIPTION
Changes:

- https://github.com/joomla-docker/docker-joomla/commit/2c56389: fixed a2enmod rewrite
- https://github.com/joomla-docker/docker-joomla/commit/44935d6: adds the verfy templating workflow
- https://github.com/joomla-docker/docker-joomla/commit/ee137cb: changes the whole generate-stackbrew-library.sh to now make use of the new versions.json architecture
- https://github.com/joomla-docker/docker-joomla/commit/1504169: adds all the new folders and docker image files
- https://github.com/joomla-docker/docker-joomla/commit/7e756fc: adds the maintainers.json
- https://github.com/joomla-docker/docker-joomla/commit/8a35ac1: changes the update file to now run the versions.sh and apply-templates.sh on update
- https://github.com/joomla-docker/docker-joomla/commit/44e24ec: adds the new versions-helper file untill we have a better API
- https://github.com/joomla-docker/docker-joomla/commit/6bbb8ab: adds the new apply-templates script
- https://github.com/joomla-docker/docker-joomla/commit/0131227: adds the new versions builder script
- https://github.com/joomla-docker/docker-joomla/commit/19a8746: adds the new docker template
- https://github.com/joomla-docker/docker-joomla/commit/48a8877: removed the old docker templates
- https://github.com/joomla-docker/docker-joomla/commit/14dc1b8: adds gitignore for jq and other
- https://github.com/joomla-docker/docker-joomla/commit/11062e0: removes the old file structure of the images