### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,25 +1,20 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/01825ee7a52ae469fe89e4c83916ce0120a47761/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/9ad4840f08a292dfb22e17b0410d6960b6b5e5d2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0.0, 4.0, 4, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 74d6b84828dbd2668a51a66b492e9aded9e07c40
+Tags: 4.0.1, 4.0, 4, latest
+Architectures: amd64
+GitCommit: f58183960ff693e4ec0c28f9f85453d69f646243
 Directory: 4.0
 
 Tags: 3.11.11, 3.11, 3
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 6d2a0503c7778dd48d3ef718d8d44d38c149a208
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 9e67d08a5990ba44b8464d7773f1bbbfaae834e4
 Directory: 3.11
 
 Tags: 3.0.25, 3.0
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: abdbbc043a9e41601fdc9f4e44bffaac46e1192f
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 9e67d08a5990ba44b8464d7773f1bbbfaae834e4
 Directory: 3.0
-
-Tags: 2.2.19, 2.2, 2
-Architectures: amd64, arm32v7, ppc64le
-GitCommit: 701846b06c0e6eb2c15c6ee8f3c2ed33df52a9aa
-Directory: 2.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/f581839: Update 4.0 to 4.0.1
- https://github.com/docker-library/cassandra/commit/9ad4840: Remove 2.2 (EOL)
- https://github.com/docker-library/cassandra/commit/ac9860f: Merge pull request https://github.com/docker-library/cassandra/pull/238 from infosiftr/eclipse-temurin
- https://github.com/docker-library/cassandra/commit/9e67d08: Switch to Eclipse Temurin