### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 44e2ce5644bbdfa1b9b2087f72c691586c1d8503
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.3, 2.4, lts, latest, 2.4.3-bullseye, 2.4-bullseye, lts-bullseye, bullseye
+Tags: 2.4.4, 2.4, lts, latest, 2.4.4-bullseye, 2.4-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
+GitCommit: e01e11b9df6dce3498f0d58f4bb5d0e5f6cd8715
 Directory: 2.4
 
-Tags: 2.4.3-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.3-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
+Tags: 2.4.4-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.4-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: e01e11b9df6dce3498f0d58f4bb5d0e5f6cd8715
 Directory: 2.4/alpine
 
-Tags: 2.3.13, 2.3, 2.3.13-bullseye, 2.3-bullseye
+Tags: 2.3.14, 2.3, 2.3.14-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
+GitCommit: 7b5166d743dffb2388a8f59d59b8c17a761afbb1
 Directory: 2.3
 
-Tags: 2.3.13-alpine, 2.3-alpine, 2.3.13-alpine3.14, 2.3-alpine3.14
+Tags: 2.3.14-alpine, 2.3-alpine, 2.3.14-alpine3.14, 2.3-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: 7b5166d743dffb2388a8f59d59b8c17a761afbb1
 Directory: 2.3/alpine
 
-Tags: 2.2.16, 2.2, 2.2.16-bullseye, 2.2-bullseye
+Tags: 2.2.17, 2.2, 2.2.17-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1ac3ec77f2c0f6aa6faef806fcc60a68f0c98a7
+GitCommit: 6362c8937559905db2345c91fbd29595b5f1a4d6
 Directory: 2.2
 
-Tags: 2.2.16-alpine, 2.2-alpine, 2.2.16-alpine3.14, 2.2-alpine3.14
+Tags: 2.2.17-alpine, 2.2-alpine, 2.2.17-alpine3.14, 2.2-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: 6362c8937559905db2345c91fbd29595b5f1a4d6
 Directory: 2.2/alpine
 
-Tags: 2.0.24, 2.0, 2.0.24-buster, 2.0-buster
+Tags: 2.0.25, 2.0, 2.0.25-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: 30f642f62fdd8b0bee77eaf01a971ffdb4f277cc
 Directory: 2.0
 
-Tags: 2.0.24-alpine, 2.0-alpine, 2.0.24-alpine3.14, 2.0-alpine3.14
+Tags: 2.0.25-alpine, 2.0-alpine, 2.0.25-alpine3.14, 2.0-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5931f79714e7fe67a6fd4969704a9f7c7098502
+GitCommit: 30f642f62fdd8b0bee77eaf01a971ffdb4f277cc
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e01e11b: Update 2.4 to 2.4.4
- https://github.com/docker-library/haproxy/commit/7b5166d: Update 2.3 to 2.3.14
- https://github.com/docker-library/haproxy/commit/6362c89: Update 2.2 to 2.2.17
- https://github.com/docker-library/haproxy/commit/30f642f: Update 2.0 to 2.0.25