### PR TITLE
[security] Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -4,199 +4,199 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.10.0rc1-bullseye, 3.10-rc-bullseye, rc-bullseye
-SharedTags: 3.10.0rc1, 3.10-rc, rc
+Tags: 3.10.0rc2-bullseye, 3.10-rc-bullseye, rc-bullseye
+SharedTags: 3.10.0rc2, 3.10-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/bullseye
 
-Tags: 3.10.0rc1-slim-bullseye, 3.10-rc-slim-bullseye, rc-slim-bullseye, 3.10.0rc1-slim, 3.10-rc-slim, rc-slim
+Tags: 3.10.0rc2-slim-bullseye, 3.10-rc-slim-bullseye, rc-slim-bullseye, 3.10.0rc2-slim, 3.10-rc-slim, rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/bullseye/slim
 
-Tags: 3.10.0rc1-buster, 3.10-rc-buster, rc-buster
+Tags: 3.10.0rc2-buster, 3.10-rc-buster, rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/buster
 
-Tags: 3.10.0rc1-slim-buster, 3.10-rc-slim-buster, rc-slim-buster
+Tags: 3.10.0rc2-slim-buster, 3.10-rc-slim-buster, rc-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/buster/slim
 
-Tags: 3.10.0rc1-alpine3.14, 3.10-rc-alpine3.14, rc-alpine3.14, 3.10.0rc1-alpine, 3.10-rc-alpine, rc-alpine
+Tags: 3.10.0rc2-alpine3.14, 3.10-rc-alpine3.14, rc-alpine3.14, 3.10.0rc2-alpine, 3.10-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/alpine3.14
 
-Tags: 3.10.0rc1-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13
+Tags: 3.10.0rc2-alpine3.13, 3.10-rc-alpine3.13, rc-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/alpine3.13
 
-Tags: 3.10.0rc1-windowsservercore-ltsc2022, 3.10-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 3.10.0rc1-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0rc1, 3.10-rc, rc
+Tags: 3.10.0rc2-windowsservercore-ltsc2022, 3.10-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 3.10.0rc2-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0rc2, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: daf9e7d25e1e7d7c0f3dde48329b12a7fc3ae15e
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.10.0rc1-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 3.10.0rc1-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0rc1, 3.10-rc, rc
+Tags: 3.10.0rc2-windowsservercore-1809, 3.10-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 3.10.0rc2-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0rc2, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.10.0rc1-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 3.10.0rc1-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0rc1, 3.10-rc, rc
+Tags: 3.10.0rc2-windowsservercore-ltsc2016, 3.10-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
+SharedTags: 3.10.0rc2-windowsservercore, 3.10-rc-windowsservercore, rc-windowsservercore, 3.10.0rc2, 3.10-rc, rc
 Architectures: windows-amd64
-GitCommit: f534df63dae90b4baa08631ee9f1ee2d3ff1d825
+GitCommit: 50850bb077be358026bfc240adcbcbc850a5bd33
 Directory: 3.10-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.9.7-bullseye, 3.9-bullseye, 3-bullseye, bullseye
 SharedTags: 3.9.7, 3.9, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/bullseye
 
 Tags: 3.9.7-slim-bullseye, 3.9-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.9.7-slim, 3.9-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/bullseye/slim
 
 Tags: 3.9.7-buster, 3.9-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/buster
 
 Tags: 3.9.7-slim-buster, 3.9-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/buster/slim
 
 Tags: 3.9.7-alpine3.14, 3.9-alpine3.14, 3-alpine3.14, alpine3.14, 3.9.7-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/alpine3.14
 
 Tags: 3.9.7-alpine3.13, 3.9-alpine3.13, 3-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/alpine3.13
 
 Tags: 3.9.7-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.9.7-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.7, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: 5b1611fc4d48f5f9874e98d66656c0d8a92f64ca
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.9.7-windowsservercore-1809, 3.9-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.9.7-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.7, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.9.7-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
 SharedTags: 3.9.7-windowsservercore, 3.9-windowsservercore, 3-windowsservercore, windowsservercore, 3.9.7, 3.9, 3, latest
 Architectures: windows-amd64
-GitCommit: bb70f324485b99613b4d1a279aea61e56768243f
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.9/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
 Tags: 3.8.12-bullseye, 3.8-bullseye
 SharedTags: 3.8.12, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.8/bullseye
 
 Tags: 3.8.12-slim-bullseye, 3.8-slim-bullseye, 3.8.12-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.8/bullseye/slim
 
 Tags: 3.8.12-buster, 3.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.8/buster
 
 Tags: 3.8.12-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.8/buster/slim
 
 Tags: 3.8.12-alpine3.14, 3.8-alpine3.14, 3.8.12-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.8/alpine3.14
 
 Tags: 3.8.12-alpine3.13, 3.8-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05a7a8ad9c1a8bfada3053293224303add892062
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.8/alpine3.13
 
-Tags: 3.7.11-bullseye, 3.7-bullseye
-SharedTags: 3.7.11, 3.7
+Tags: 3.7.12-bullseye, 3.7-bullseye
+SharedTags: 3.7.12, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.7/bullseye
 
-Tags: 3.7.11-slim-bullseye, 3.7-slim-bullseye, 3.7.11-slim, 3.7-slim
+Tags: 3.7.12-slim-bullseye, 3.7-slim-bullseye, 3.7.12-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.7/bullseye/slim
 
-Tags: 3.7.11-buster, 3.7-buster
+Tags: 3.7.12-buster, 3.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b59ce53e3213c9717177fe9a4f25f3e3ffeba56e
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.7/buster
 
-Tags: 3.7.11-slim-buster, 3.7-slim-buster
+Tags: 3.7.12-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b59ce53e3213c9717177fe9a4f25f3e3ffeba56e
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.7/buster/slim
 
-Tags: 3.7.11-alpine3.14, 3.7-alpine3.14, 3.7.11-alpine, 3.7-alpine
+Tags: 3.7.12-alpine3.14, 3.7-alpine3.14, 3.7.12-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b59ce53e3213c9717177fe9a4f25f3e3ffeba56e
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.7/alpine3.14
 
-Tags: 3.7.11-alpine3.13, 3.7-alpine3.13
+Tags: 3.7.12-alpine3.13, 3.7-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b59ce53e3213c9717177fe9a4f25f3e3ffeba56e
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.7/alpine3.13
 
-Tags: 3.6.14-bullseye, 3.6-bullseye
-SharedTags: 3.6.14, 3.6
+Tags: 3.6.15-bullseye, 3.6-bullseye
+SharedTags: 3.6.15, 3.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.6/bullseye
 
-Tags: 3.6.14-slim-bullseye, 3.6-slim-bullseye, 3.6.14-slim, 3.6-slim
+Tags: 3.6.15-slim-bullseye, 3.6-slim-bullseye, 3.6.15-slim, 3.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f154e5d1c8f5b582aa2fd782df880b9cc96bb431
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.6/bullseye/slim
 
-Tags: 3.6.14-buster, 3.6-buster
+Tags: 3.6.15-buster, 3.6-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec760ffc5e62ad800a1dc5b5e280d234d0736a55
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.6/buster
 
-Tags: 3.6.14-slim-buster, 3.6-slim-buster
+Tags: 3.6.15-slim-buster, 3.6-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec760ffc5e62ad800a1dc5b5e280d234d0736a55
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.6/buster/slim
 
-Tags: 3.6.14-alpine3.14, 3.6-alpine3.14, 3.6.14-alpine, 3.6-alpine
+Tags: 3.6.15-alpine3.14, 3.6-alpine3.14, 3.6.15-alpine, 3.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec760ffc5e62ad800a1dc5b5e280d234d0736a55
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.6/alpine3.14
 
-Tags: 3.6.14-alpine3.13, 3.6-alpine3.13
+Tags: 3.6.15-alpine3.13, 3.6-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec760ffc5e62ad800a1dc5b5e280d234d0736a55
+GitCommit: bb68424de76756a2d3dc817f87b1f8640112461f
 Directory: 3.6/alpine3.13


### PR DESCRIPTION
Changes:

- docker-library/python@50850bb: Merge pull request docker-library/python#647 from infosiftr/pin-pip-setuptools
- docker-library/python@bb68424: Pin pip to 21.2.x and setuptools to 57.x
- docker-library/python@57740ba: Update to 3.10.0rc2, pip 21.2.4
- docker-library/python@aaacfe2: Update to 3.6.15, pip 21.2.4
- docker-library/python@7d0f63b: Update to 3.7.12, pip 21.2.4