### PR TITLE
Update python-hy test to 1.0a3

### DIFF
--- a/test/tests/python-hy/container.cmd
+++ b/test/tests/python-hy/container.cmd
@@ -14,6 +14,7 @@ exit /b 1
 
 rem Hy is complicated, and uses Python's internal AST representation directly, and thus Hy releases usually lag behind a little on major Python releases (and we don't want that to gum up our tests)
 rem see https://github.com/hylang/hy/issues/1111 for example breakage
+rem https://github.com/hylang/hy/pull/2115 -- Python 3.10 + Windows == sad pyreadline
 %python% -c "import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 10) or sys.version_info[0] > 3 or sys.version_info[0] == 2)" || (
 	echo skipping Hy test -- not allowed on Python 2.x or 3.10+ ^(yet!^) >&2
 	rem cheaters gunna cheat
@@ -25,7 +26,8 @@ rem ensure pip does not complain about a new version being available
 set PIP_DISABLE_PIP_VERSION_CHECK=1
 rem or that a new version will no longer work with this python version
 set PIP_NO_PYTHON_VERSION_WARNING=1
-pip install -q "hy==0.20.0" || exit /b %errorlevel%
+rem https://pypi.org/project/hy/#history
+pip install -q "hy==1.0a3" || exit /b %errorlevel%
 
 hy ./container.hy || exit /b %errorlevel%
 

--- a/test/tests/python-hy/container.sh
+++ b/test/tests/python-hy/container.sh
@@ -16,8 +16,8 @@ fi
 
 # Hy is complicated, and uses Python's internal AST representation directly, and thus Hy releases usually lag behind a little on major Python releases (and we don't want that to gum up our tests)
 # see https://github.com/hylang/hy/issues/1111 for example breakage
-if ! "$python" -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 10) or sys.version_info[0] > 3 or sys.version_info[0] == 2)'; then
-	echo >&2 'skipping Hy test -- not allowed on Python 2.x and 3.10+ (yet!)'
+if ! "$python" -c 'import sys; exit((sys.version_info[0] == 3 and sys.version_info[1] >= 11) or sys.version_info[0] > 3 or sys.version_info[0] == 2)'; then
+	echo >&2 'skipping Hy test -- not allowed on Python 2.x and 3.11+ (yet!)'
 	# cheaters gunna cheat
 	cat expected-std-out.txt
 	exit
@@ -27,6 +27,7 @@ fi
 export PIP_DISABLE_PIP_VERSION_CHECK=1
 # or that a new version will no longer work with this python version
 export PIP_NO_PYTHON_VERSION_WARNING=1
-pip install -q 'hy==0.20.0'
+# https://pypi.org/project/hy/#history
+pip install -q 'hy==1.0a3'
 
 hy ./container.hy


### PR DESCRIPTION
Also, now that Python 3.10 is "frozen" (https://pythoninsider.blogspot.com/2021/09/python-3100rc2-is-available.html), allow it to run the tests on Linux.