### PR TITLE
Update clojure images for various new upstreams

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -200,28 +200,37 @@ Tags: openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.10.3.967-bullseye
 Directory: target/openjdk-18-bullseye/tools-deps
 
 Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.6-alpine
+Architectures: amd64
 Directory: target/openjdk-16-alpine/lein
 
 Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
+Architectures: amd64
 Directory: target/openjdk-16-alpine/boot
 
 Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.3.967-alpine
+Architectures: amd64
 Directory: target/openjdk-16-alpine/tools-deps
 
 Tags: openjdk-17-alpine, openjdk-17-lein-alpine, openjdk-17-lein-2.9.6-alpine
+Architectures: amd64
 Directory: target/openjdk-17-alpine/lein
 
 Tags: openjdk-17-boot-alpine, openjdk-17-boot-2.8.3-alpine
+Architectures: amd64
 Directory: target/openjdk-17-alpine/boot
 
 Tags: openjdk-17-tools-deps-alpine, openjdk-17-tools-deps-1.10.3.967-alpine
+Architectures: amd64
 Directory: target/openjdk-17-alpine/tools-deps
 
 Tags: openjdk-18-alpine, openjdk-18-lein-alpine, openjdk-18-lein-2.9.6-alpine
+Architectures: amd64
 Directory: target/openjdk-18-alpine/lein
 
 Tags: openjdk-18-boot-alpine, openjdk-18-boot-2.8.3-alpine
+Architectures: amd64
 Directory: target/openjdk-18-alpine/boot
 
 Tags: openjdk-18-tools-deps-alpine, openjdk-18-tools-deps-1.10.3.967-alpine
+Architectures: amd64
 Directory: target/openjdk-18-alpine/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 6f24ea5a9cfe6916fd5597d25e37b7b362cbec89
+GitCommit: a522fe073231eeac9863571aa3e15e932e336aa1
 
 Tags: latest
 Directory: target/openjdk-11-slim-bullseye/latest
@@ -198,30 +198,6 @@ Directory: target/openjdk-18-slim-bullseye/tools-deps
 
 Tags: openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.10.3.967-bullseye
 Directory: target/openjdk-18-bullseye/tools-deps
-
-Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.6-alpine
-Architectures: amd64
-Directory: target/openjdk-16-alpine/lein
-
-Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
-Architectures: amd64
-Directory: target/openjdk-16-alpine/boot
-
-Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.3.967-alpine
-Architectures: amd64
-Directory: target/openjdk-16-alpine/tools-deps
-
-Tags: openjdk-17-alpine, openjdk-17-lein-alpine, openjdk-17-lein-2.9.6-alpine
-Architectures: amd64
-Directory: target/openjdk-17-alpine/lein
-
-Tags: openjdk-17-boot-alpine, openjdk-17-boot-2.8.3-alpine
-Architectures: amd64
-Directory: target/openjdk-17-alpine/boot
-
-Tags: openjdk-17-tools-deps-alpine, openjdk-17-tools-deps-1.10.3.967-alpine
-Architectures: amd64
-Directory: target/openjdk-17-alpine/tools-deps
 
 Tags: openjdk-18-alpine, openjdk-18-lein-alpine, openjdk-18-lein-2.9.6-alpine
 Architectures: amd64

--- a/library/clojure
+++ b/library/clojure
@@ -2,12 +2,12 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: f651209e1815a9dc5382ad7d40f5e5058ab01c66
+GitCommit: 6f24ea5a9cfe6916fd5597d25e37b7b362cbec89
 
 Tags: latest
-Directory: target/openjdk-11-slim-buster/latest
+Directory: target/openjdk-11-slim-bullseye/latest
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.6, openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.6-buster
+Tags: openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.6-buster
 Architectures: amd64
 Directory: target/openjdk-8-buster/lein
 
@@ -15,7 +15,7 @@ Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.6-sl
 Architectures: amd64
 Directory: target/openjdk-8-slim-buster/lein
 
-Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
+Tags: openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
 Architectures: amd64
 Directory: target/openjdk-8-buster/boot
 
@@ -23,82 +23,205 @@ Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Architectures: amd64
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.943, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.943-buster
+Tags: openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.967-buster
 Architectures: amd64
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.943-slim-buster
+Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.967-slim-buster
 Architectures: amd64
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.6, lein, lein-2.9.6, openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.6-buster, lein-buster, lein-2.9.6-buster
+Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.6-buster, lein-buster, lein-2.9.6-buster
 Directory: target/openjdk-11-buster/lein
 
 Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.6-slim-buster, slim-buster, lein-slim-buster, lein-2.9.6-slim-buster
 Directory: target/openjdk-11-slim-buster/lein
 
-Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
+Tags: openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
 Directory: target/openjdk-11-buster/boot
 
 Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.943, tools-deps, tools-deps-1.10.3.943, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.943-buster, tools-deps-buster, tools-deps-1.10.3.943-buster
+Tags: openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.967-buster, tools-deps-buster, tools-deps-1.10.3.967-buster
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.943-slim-buster, tools-deps-1.10.3.943-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.967-slim-buster, tools-deps-1.10.3.967-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.6, openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.6-slim-buster
+Tags: openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.6-slim-buster
 Directory: target/openjdk-16-slim-buster/lein
 
 Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.6-buster
 Directory: target/openjdk-16-buster/lein
 
-Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
+Tags: openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
 Directory: target/openjdk-16-slim-buster/boot
 
 Tags: openjdk-16-boot-buster, openjdk-16-boot-2.8.3-buster
 Directory: target/openjdk-16-buster/boot
 
-Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.3.943, openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.3.943-slim-buster
+Tags: openjdk-16-tools-deps-slim-buster, openjdk-16-tools-deps-1.10.3.967-slim-buster
 Directory: target/openjdk-16-slim-buster/tools-deps
 
-Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.3.943-buster
+Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.3.967-buster
 Directory: target/openjdk-16-buster/tools-deps
 
-Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.6, openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.6-slim-buster
+Tags: openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.6-slim-buster
 Directory: target/openjdk-17-slim-buster/lein
 
 Tags: openjdk-17-buster, openjdk-17-lein-buster, openjdk-17-lein-2.9.6-buster
 Directory: target/openjdk-17-buster/lein
 
-Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster
+Tags: openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster
 Directory: target/openjdk-17-slim-buster/boot
 
 Tags: openjdk-17-boot-buster, openjdk-17-boot-2.8.3-buster
 Directory: target/openjdk-17-buster/boot
 
-Tags: openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.943, openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.943-slim-buster
+Tags: openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.967-slim-buster
 Directory: target/openjdk-17-slim-buster/tools-deps
 
-Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.943-buster
+Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.967-buster
 Directory: target/openjdk-17-buster/tools-deps
 
-Tags: openjdk-18, openjdk-18-lein, openjdk-18-lein-2.9.6, openjdk-18-slim-buster, openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.6-slim-buster
+Tags: openjdk-18-slim-buster, openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.6-slim-buster
 Directory: target/openjdk-18-slim-buster/lein
 
 Tags: openjdk-18-buster, openjdk-18-lein-buster, openjdk-18-lein-2.9.6-buster
 Directory: target/openjdk-18-buster/lein
 
-Tags: openjdk-18-boot, openjdk-18-boot-2.8.3, openjdk-18-boot-slim-buster, openjdk-18-boot-2.8.3-slim-buster
+Tags: openjdk-18-boot-slim-buster, openjdk-18-boot-2.8.3-slim-buster
 Directory: target/openjdk-18-slim-buster/boot
 
 Tags: openjdk-18-boot-buster, openjdk-18-boot-2.8.3-buster
 Directory: target/openjdk-18-buster/boot
 
-Tags: openjdk-18-tools-deps, openjdk-18-tools-deps-1.10.3.943, openjdk-18-tools-deps-slim-buster, openjdk-18-tools-deps-1.10.3.943-slim-buster
+Tags: openjdk-18-tools-deps-slim-buster, openjdk-18-tools-deps-1.10.3.967-slim-buster
 Directory: target/openjdk-18-slim-buster/tools-deps
 
-Tags: openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.10.3.943-buster
+Tags: openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.10.3.967-buster
 Directory: target/openjdk-18-buster/tools-deps
+
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.6, openjdk-8-bullseye, openjdk-8-lein-bullseye, openjdk-8-lein-2.9.6-bullseye
+Architectures: amd64
+Directory: target/openjdk-8-bullseye/lein
+
+Tags: openjdk-8-slim-bullseye, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.6-slim-bullseye
+Architectures: amd64
+Directory: target/openjdk-8-slim-bullseye/lein
+
+Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-bullseye, openjdk-8-boot-2.8.3-bullseye
+Architectures: amd64
+Directory: target/openjdk-8-bullseye/boot
+
+Tags: openjdk-8-boot-slim-bullseye, openjdk-8-boot-2.8.3-slim-bullseye
+Architectures: amd64
+Directory: target/openjdk-8-slim-bullseye/boot
+
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.967, openjdk-8-tools-deps-bullseye, openjdk-8-tools-deps-1.10.3.967-bullseye
+Architectures: amd64
+Directory: target/openjdk-8-bullseye/tools-deps
+
+Tags: openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.10.3.967-slim-bullseye
+Architectures: amd64
+Directory: target/openjdk-8-slim-bullseye/tools-deps
+
+Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.6, lein, lein-2.9.6, openjdk-11-bullseye, openjdk-11-lein-bullseye, openjdk-11-lein-2.9.6-bullseye, lein-bullseye, lein-2.9.6-bullseye
+Directory: target/openjdk-11-bullseye/lein
+
+Tags: openjdk-11-lein-slim-bullseye, openjdk-11-slim-bullseye, openjdk-11-lein-2.9.6-slim-bullseye, slim-bullseye, lein-slim-bullseye, lein-2.9.6-slim-bullseye
+Directory: target/openjdk-11-slim-bullseye/lein
+
+Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-bullseye, openjdk-11-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
+Directory: target/openjdk-11-bullseye/boot
+
+Tags: openjdk-11-boot-slim-bullseye, openjdk-11-boot-2.8.3-slim-bullseye, boot-slim-bullseye, boot-2.8.3-slim-bullseye
+Directory: target/openjdk-11-slim-bullseye/boot
+
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.967, tools-deps, tools-deps-1.10.3.967, openjdk-11-tools-deps-bullseye, openjdk-11-tools-deps-1.10.3.967-bullseye, tools-deps-bullseye, tools-deps-1.10.3.967-bullseye
+Directory: target/openjdk-11-bullseye/tools-deps
+
+Tags: openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.10.3.967-slim-bullseye, tools-deps-1.10.3.967-slim-bullseye, tools-deps-slim-bullseye
+Directory: target/openjdk-11-slim-bullseye/tools-deps
+
+Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.6, openjdk-16-slim-bullseye, openjdk-16-lein-slim-bullseye, openjdk-16-lein-2.9.6-slim-bullseye
+Directory: target/openjdk-16-slim-bullseye/lein
+
+Tags: openjdk-16-bullseye, openjdk-16-lein-bullseye, openjdk-16-lein-2.9.6-bullseye
+Directory: target/openjdk-16-bullseye/lein
+
+Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-bullseye, openjdk-16-boot-2.8.3-slim-bullseye
+Directory: target/openjdk-16-slim-bullseye/boot
+
+Tags: openjdk-16-boot-bullseye, openjdk-16-boot-2.8.3-bullseye
+Directory: target/openjdk-16-bullseye/boot
+
+Tags: openjdk-16-tools-deps, openjdk-16-tools-deps-1.10.3.967, openjdk-16-tools-deps-slim-bullseye, openjdk-16-tools-deps-1.10.3.967-slim-bullseye
+Directory: target/openjdk-16-slim-bullseye/tools-deps
+
+Tags: openjdk-16-tools-deps-bullseye, openjdk-16-tools-deps-1.10.3.967-bullseye
+Directory: target/openjdk-16-bullseye/tools-deps
+
+Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.6, openjdk-17-slim-bullseye, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.6-slim-bullseye
+Directory: target/openjdk-17-slim-bullseye/lein
+
+Tags: openjdk-17-bullseye, openjdk-17-lein-bullseye, openjdk-17-lein-2.9.6-bullseye
+Directory: target/openjdk-17-bullseye/lein
+
+Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-bullseye, openjdk-17-boot-2.8.3-slim-bullseye
+Directory: target/openjdk-17-slim-bullseye/boot
+
+Tags: openjdk-17-boot-bullseye, openjdk-17-boot-2.8.3-bullseye
+Directory: target/openjdk-17-bullseye/boot
+
+Tags: openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.967, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.967-slim-bullseye
+Directory: target/openjdk-17-slim-bullseye/tools-deps
+
+Tags: openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.967-bullseye
+Directory: target/openjdk-17-bullseye/tools-deps
+
+Tags: openjdk-18, openjdk-18-lein, openjdk-18-lein-2.9.6, openjdk-18-slim-bullseye, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.6-slim-bullseye
+Directory: target/openjdk-18-slim-bullseye/lein
+
+Tags: openjdk-18-bullseye, openjdk-18-lein-bullseye, openjdk-18-lein-2.9.6-bullseye
+Directory: target/openjdk-18-bullseye/lein
+
+Tags: openjdk-18-boot, openjdk-18-boot-2.8.3, openjdk-18-boot-slim-bullseye, openjdk-18-boot-2.8.3-slim-bullseye
+Directory: target/openjdk-18-slim-bullseye/boot
+
+Tags: openjdk-18-boot-bullseye, openjdk-18-boot-2.8.3-bullseye
+Directory: target/openjdk-18-bullseye/boot
+
+Tags: openjdk-18-tools-deps, openjdk-18-tools-deps-1.10.3.967, openjdk-18-tools-deps-slim-bullseye, openjdk-18-tools-deps-1.10.3.967-slim-bullseye
+Directory: target/openjdk-18-slim-bullseye/tools-deps
+
+Tags: openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.10.3.967-bullseye
+Directory: target/openjdk-18-bullseye/tools-deps
+
+Tags: openjdk-16-alpine, openjdk-16-lein-alpine, openjdk-16-lein-2.9.6-alpine
+Directory: target/openjdk-16-alpine/lein
+
+Tags: openjdk-16-boot-alpine, openjdk-16-boot-2.8.3-alpine
+Directory: target/openjdk-16-alpine/boot
+
+Tags: openjdk-16-tools-deps-alpine, openjdk-16-tools-deps-1.10.3.967-alpine
+Directory: target/openjdk-16-alpine/tools-deps
+
+Tags: openjdk-17-alpine, openjdk-17-lein-alpine, openjdk-17-lein-2.9.6-alpine
+Directory: target/openjdk-17-alpine/lein
+
+Tags: openjdk-17-boot-alpine, openjdk-17-boot-2.8.3-alpine
+Directory: target/openjdk-17-alpine/boot
+
+Tags: openjdk-17-tools-deps-alpine, openjdk-17-tools-deps-1.10.3.967-alpine
+Directory: target/openjdk-17-alpine/tools-deps
+
+Tags: openjdk-18-alpine, openjdk-18-lein-alpine, openjdk-18-lein-2.9.6-alpine
+Directory: target/openjdk-18-alpine/lein
+
+Tags: openjdk-18-boot-alpine, openjdk-18-boot-2.8.3-alpine
+Directory: target/openjdk-18-alpine/boot
+
+Tags: openjdk-18-tools-deps-alpine, openjdk-18-tools-deps-1.10.3.967-alpine
+Directory: target/openjdk-18-alpine/tools-deps


### PR DESCRIPTION
- tools-deps 1.10.3.967 was released
- openjdk released Debian bullseye-based images
- openjdk released Alpine-based images for JDKs 16, 17, & 18