### PR TITLE
[nats] Release v2.5.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -3,31 +3,31 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Waldemar Salinas <wally@synadia.com> (@wallyqs),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 86cdad679af541e9f4a3bb536d8de9624399e668
+GitCommit: c9521f936fbd32881a65083d948a935a277b918c
 
-Tags: 2.4.0-alpine3.14, 2.4-alpine3.14, 2-alpine3.14, alpine3.14, 2.4.0-alpine, 2.4-alpine, 2-alpine, alpine
+Tags: 2.5.0-alpine3.14, 2.5-alpine3.14, 2-alpine3.14, alpine3.14, 2.5.0-alpine, 2.5-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.4.0/alpine3.14
+Directory: 2.5.0/alpine3.14
 
-Tags: 2.4.0-scratch, 2.4-scratch, 2-scratch, scratch, 2.4.0-linux, 2.4-linux, 2-linux, linux
-SharedTags: 2.4.0, 2.4, 2, latest
+Tags: 2.5.0-scratch, 2.5-scratch, 2-scratch, scratch, 2.5.0-linux, 2.5-linux, 2-linux, linux
+SharedTags: 2.5.0, 2.5, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.4.0/scratch
+Directory: 2.5.0/scratch
 
-Tags: 2.4.0-windowsservercore-1809, 2.4-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.4.0-windowsservercore, 2.4-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.5.0-windowsservercore-1809, 2.5-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.5.0-windowsservercore, 2.5-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.4.0/windowsservercore-1809
+Directory: 2.5.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.4.0-nanoserver-1809, 2.4-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.4.0-nanoserver, 2.4-nanoserver, 2-nanoserver, nanoserver, 2.4.0, 2.4, 2, latest
+Tags: 2.5.0-nanoserver-1809, 2.5-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.5.0-nanoserver, 2.5-nanoserver, 2-nanoserver, nanoserver, 2.5.0, 2.5, 2, latest
 Architectures: windows-amd64
-Directory: 2.4.0/nanoserver-1809
+Directory: 2.5.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.4.0-windowsservercore-ltsc2016, 2.4-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.4.0-windowsservercore, 2.4-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.5.0-windowsservercore-ltsc2016, 2.5-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.5.0-windowsservercore, 2.5-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.4.0/windowsservercore-ltsc2016
+Directory: 2.5.0/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.5.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>