### PR TITLE
Update wordpress to 5.8.1

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.8.0-apache, 5.8-apache, 5-apache, apache, 5.8.0, 5.8, 5, latest, 5.8.0-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.0-php7.4, 5.8-php7.4, 5-php7.4, php7.4
+Tags: 5.8.1-apache, 5.8-apache, 5-apache, apache, 5.8.1, 5.8, 5, latest, 5.8.1-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.1-php7.4, 5.8-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php7.4/apache
 
-Tags: 5.8.0-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.0-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.8.1-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.1-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php7.4/fpm
 
-Tags: 5.8.0-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.0-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.8.1-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.1-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.8.0-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.0-php7.3, 5.8-php7.3, 5-php7.3, php7.3
+Tags: 5.8.1-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.1-php7.3, 5.8-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php7.3/apache
 
-Tags: 5.8.0-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.8.1-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php7.3/fpm
 
-Tags: 5.8.0-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.8.1-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.8.0-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.0-php8.0, 5.8-php8.0, 5-php8.0, php8.0
+Tags: 5.8.1-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.1-php8.0, 5.8-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php8.0/apache
 
-Tags: 5.8.0-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.8.1-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php8.0/fpm
 
-Tags: 5.8.0-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.8.1-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e98fe75c5a41e2d3f3c4d89f3e6b15e62638147c
+GitCommit: 9954966feffdaf39082609816f896c2e3f75f0db
 Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4
@@ -63,48 +63,3 @@ Tags: cli-2.5.0-php8.0, cli-2.5-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cdb836237e3af7bfd011957316f159c1e81bf29c
 Directory: cli/php8.0/alpine
-
-Tags: beta-5.8.1-RC1-apache, beta-5.8.1-apache, beta-5.8-apache, beta-5-apache, beta-apache, beta-5.8.1-RC1, beta-5.8.1, beta-5.8, beta-5, beta, beta-5.8.1-RC1-php7.4-apache, beta-5.8.1-php7.4-apache, beta-5.8-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.8.1-RC1-php7.4, beta-5.8.1-php7.4, beta-5.8-php7.4, beta-5-php7.4, beta-php7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php7.4/apache
-
-Tags: beta-5.8.1-RC1-fpm, beta-5.8.1-fpm, beta-5.8-fpm, beta-5-fpm, beta-fpm, beta-5.8.1-RC1-php7.4-fpm, beta-5.8.1-php7.4-fpm, beta-5.8-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php7.4/fpm
-
-Tags: beta-5.8.1-RC1-fpm-alpine, beta-5.8.1-fpm-alpine, beta-5.8-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.8.1-RC1-php7.4-fpm-alpine, beta-5.8.1-php7.4-fpm-alpine, beta-5.8-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php7.4/fpm-alpine
-
-Tags: beta-5.8.1-RC1-php7.3-apache, beta-5.8.1-php7.3-apache, beta-5.8-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.8.1-RC1-php7.3, beta-5.8.1-php7.3, beta-5.8-php7.3, beta-5-php7.3, beta-php7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php7.3/apache
-
-Tags: beta-5.8.1-RC1-php7.3-fpm, beta-5.8.1-php7.3-fpm, beta-5.8-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php7.3/fpm
-
-Tags: beta-5.8.1-RC1-php7.3-fpm-alpine, beta-5.8.1-php7.3-fpm-alpine, beta-5.8-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php7.3/fpm-alpine
-
-Tags: beta-5.8.1-RC1-php8.0-apache, beta-5.8.1-php8.0-apache, beta-5.8-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.8.1-RC1-php8.0, beta-5.8.1-php8.0, beta-5.8-php8.0, beta-5-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php8.0/apache
-
-Tags: beta-5.8.1-RC1-php8.0-fpm, beta-5.8.1-php8.0-fpm, beta-5.8-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php8.0/fpm
-
-Tags: beta-5.8.1-RC1-php8.0-fpm-alpine, beta-5.8.1-php8.0-fpm-alpine, beta-5.8-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eaf7449d5aefcb35b23978c3f0d4fd33cea99369
-Directory: beta/php8.0/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/9954966: Update latest to 5.8.1
- https://github.com/docker-library/wordpress/commit/97fb3f5: Update beta to 5.8.1


Or you create a pull request from the docker library bot:
https://github.com/docker-library/official-images/compare/docker-library:master...docker-library-bot:wordpress