### PR TITLE
eclipse-temurin: add additional JRE architectures

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,20 +7,20 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -28,7 +28,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -36,7 +36,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -57,7 +57,7 @@ File: Dockerfile.releases.full
 Tags: 8u302-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u302-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u302-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 85457d397296c2b988998d8e98fe403df7cdcdc8
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -65,7 +65,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u302-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 85457d397296c2b988998d8e98fe403df7cdcdc8
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -73,29 +73,30 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u302-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 85457d397296c2b988998d8e98fe403df7cdcdc8
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 8/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
+
 
 #------------------------------v11 images---------------------------------
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -103,7 +104,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -111,7 +112,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -119,15 +120,16 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jre-focal, 11-jre-focal
 SharedTags: 11.0.12_7-jre, 11-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: a106577e67528cdea053976a4306a4a1c08323c4
 Directory: 11/jre/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: a106577e67528cdea053976a4306a4a1c08323c4
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
+
 
 #------------------------------v16 images---------------------------------
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
@@ -139,7 +141,7 @@ File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-centos7, 16-jdk-centos7, 16-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: 9c0f0d785455edb2f88383c5ea119121d30c8267
 Directory: 16/jdk/centos
 File: Dockerfile.releases.full
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -120,13 +120,13 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jre-focal, 11-jre-focal
 SharedTags: 11.0.12_7-jre, 11-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a106577e67528cdea053976a4306a4a1c08323c4
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 11/jre/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a106577e67528cdea053976a4306a4a1c08323c4
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
@@ -135,7 +135,7 @@ File: Dockerfile.releases.full
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 9c0f0d785455edb2f88383c5ea119121d30c8267
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -118,14 +118,14 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.12_7-jre-focal, 11-jre-focal
 SharedTags: 11.0.12_7-jre, 11-jre
-Architectures: amd64
-GitCommit: a106577e67528cdea053976a4306a4a1c08323c4
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 11/jre/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jre-centos7, 11-jre-centos7
-Architectures: amd64
-GitCommit: a106577e67528cdea053976a4306a4a1c08323c4
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,20 +7,20 @@ GitRepo: https://github.com/adoptium/containers.git
 Tags: 8u302-b08-jdk-focal, 8-jdk-focal, 8-focal
 SharedTags: 8u302-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 8u302-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -28,7 +28,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jdk-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -36,7 +36,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u302-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -57,7 +57,7 @@ File: Dockerfile.releases.full
 Tags: 8u302-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u302-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u302-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -65,7 +65,7 @@ Constraints: windowsservercore-1809
 Tags: 8u302-b08-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
 SharedTags: 8u302-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u302-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -73,7 +73,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 8u302-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u302-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 8/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -83,20 +83,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.12_7-jdk, 11-jdk, 11
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -104,7 +104,7 @@ Constraints: windowsservercore-1809
 Tags: 11.0.12_7-jdk-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
 SharedTags: 11.0.12_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -112,7 +112,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 11.0.12_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.12_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 38972df75f728378d806ed5f998d1e4902f57305
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -120,13 +120,13 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 11.0.12_7-jre-focal, 11-jre-focal
 SharedTags: 11.0.12_7-jre, 11-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jre/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.12_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
@@ -135,20 +135,20 @@ File: Dockerfile.releases.full
 Tags: 16.0.2_7-jdk-focal, 16-jdk-focal, 16-focal
 SharedTags: 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 02e5d981abee1df9db3c5ac6e799475928e9fbc3
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 16/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-centos7, 16-jdk-centos7, 16-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9c0f0d785455edb2f88383c5ea119121d30c8267
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 16/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 16.0.2_7-jdk-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 16/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
@@ -156,7 +156,7 @@ Constraints: windowsservercore-1809
 Tags: 16.0.2_7-jdk-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
 SharedTags: 16.0.2_7-jdk-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2_7-jdk, 16-jdk, 16, latest
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2016
@@ -164,7 +164,7 @@ Constraints: windowsservercore-ltsc2016
 Tags: 16.0.2_7-jdk-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
 SharedTags: 16.0.2_7-jdk-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
-GitCommit: 94ec04760777535e1ba0374f5ba051eabcf9b2ac
+GitCommit: c611c0d0d5c9efd70a7569a33dd7a46c31dfb06d
 Directory: 16/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Along with some minor housekeeping tasks in the dockerfiles