### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev6, 2.5-dev, 2.5-dev6-bullseye, 2.5-dev-bullseye
+Tags: 2.5-dev7, 2.5-dev, 2.5-dev7-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 44e2ce5644bbdfa1b9b2087f72c691586c1d8503
+GitCommit: 4604ebd5fb6f56d5c1db20d06275d057f991b531
 Directory: 2.5-rc
 
-Tags: 2.5-dev6-alpine, 2.5-dev-alpine, 2.5-dev6-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev7-alpine, 2.5-dev-alpine, 2.5-dev7-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 44e2ce5644bbdfa1b9b2087f72c691586c1d8503
+GitCommit: 4604ebd5fb6f56d5c1db20d06275d057f991b531
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.4, 2.4, lts, latest, 2.4.4-bullseye, 2.4-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4604ebd: Update 2.5-rc to 2.5-dev7