### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,40 +1,40 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/55844dac0137f947755a0d89d65565d703d1c7ad/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/ee376bb09bd69b1773a780fda1d777a4f15d84ca/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Jérôme Petazzoni <jerome.petazzoni@gmail.com> (@jpetazzo)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 55844dac0137f947755a0d89d65565d703d1c7ad
+GitCommit: ee376bb09bd69b1773a780fda1d777a4f15d84ca
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0a3fcfc05b6d1ddac8a929cbc57def698f0765f6
+amd64-GitCommit: 6166a8226f7213354cc1b743477c1eabc0cb00e0
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 9e59a8d467b333676cc8e29a7964979f5fd3569b
+arm32v5-GitCommit: 71e0511daed23bab5bc5cdb7ecd87d779284b672
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: bbd00c7ef3923434ee36f10a740ba1e040688999
+arm32v6-GitCommit: 23bdbda32966927cb767941cd26d0cade5f0a671
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: ffb106006f4fbf8b38f0039ff7483a877c2416b5
+arm32v7-GitCommit: 9160d44a37fd2a653370769c627a3cf559ca38de
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 3c905f13b4a494760c31ee2fda21e1c240b17ae3
+arm64v8-GitCommit: 5d36d403791795e49f7f540d57ec4ff9fdb721ad
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 0bfd0bc19d92136a5b1cac1782b4bee461130ac8
+i386-GitCommit: 27e5a24147bf09acd19483656c06e2a462b3d4d5
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: da00702daf24fab7c6aa28440aff2c6f21fe8993
+mips64le-GitCommit: 3f54934d089f5538993dafc9df2a7f9e92c5a793
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 1fb5c5ee49036bdd783be4edb804f62ad14cb51e
+ppc64le-GitCommit: 56d398fca85a7318776aa420e9e5e5b16ca56cab
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: ee3ed8fad6f09cccb2c6e2cb32418b71f0146d29
+riscv64-GitCommit: db3b4ad8775b7cc3ecd8b3329922680e0870fb30
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: b003537d059328b0137b0972606c955dd17ffd93
+s390x-GitCommit: c0197ee123b106844eec3d23759a245a5c150eb1
 
 Tags: 1.33.1-uclibc, 1.33-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/ee376bb: Merge pull request https://github.com/docker-library/busybox/pull/116 from J0WI/bullseye
- https://github.com/docker-library/busybox/commit/a1441e4: Debian Bullseye
- https://github.com/docker-library/busybox/commit/f169360: Merge pull request https://github.com/docker-library/busybox/pull/114 from infosiftr/buildroot-2021.08
- https://github.com/docker-library/busybox/commit/6b3cc33: Update Buildroot to 2021.08
- https://github.com/docker-library/busybox/commit/8b56971: Merge pull request https://github.com/docker-library/busybox/pull/115 from infosiftr/musl-getconf.c
- https://github.com/docker-library/busybox/commit/a52ec13: Download musl getconf.c from GitHub mirror instead