### PR TITLE
Updates for the release of 21.0.0.9

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 3314e0761eab88e38d67af9aa5d678eadec09043
+GitCommit: c0b16e39ba0d342f2d818ec0ece7ebade5b2ba63
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -35,23 +35,23 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.8-kernel-slim-java8-openj9
-Directory: releases/21.0.0.8/kernel-slim
+Tags: 21.0.0.9-kernel-slim-java8-openj9
+Directory: releases/21.0.0.9/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.8-kernel-slim-java11-openj9
-Directory: releases/21.0.0.8/kernel-slim
+Tags: 21.0.0.9-kernel-slim-java11-openj9
+Directory: releases/21.0.0.9/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.8-full-java8-openj9
-Directory: releases/21.0.0.8/full
+Tags: 21.0.0.9-full-java8-openj9
+Directory: releases/21.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk8
 
-Tags: 21.0.0.8-full-java11-openj9
-Directory: releases/21.0.0.8/full
+Tags: 21.0.0.9-full-java11-openj9
+Directory: releases/21.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
@@ -72,25 +72,5 @@ File: Dockerfile.ubuntu.adoptopenjdk8
 
 Tags: 21.0.0.6-full-java11-openj9
 Directory: releases/21.0.0.6/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 21.0.0.3-kernel-slim-java8-openj9
-Directory: releases/21.0.0.3/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 21.0.0.3-kernel-slim-java11-openj9
-Directory: releases/21.0.0.3/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 21.0.0.3-full-java8-openj9
-Directory: releases/21.0.0.3/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk8
-
-Tags: 21.0.0.3-full-java11-openj9
-Directory: releases/21.0.0.3/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 7a88c5cbca4d18015ee9ebb006633d998537c36e
+GitCommit: 11a30fa86e6aba0f81deecc54d0b83f8b39f322c
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: kernel
@@ -23,21 +23,21 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.8-kernel-java8-ibmjava
-Directory: ga/21.0.0.8/kernel
+Tags: 21.0.0.9-kernel-java8-ibmjava
+Directory: ga/21.0.0.9/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.8-kernel-java11-openj9
-Directory: ga/21.0.0.8/kernel
+Tags: 21.0.0.9-kernel-java11-openj9
+Directory: ga/21.0.0.9/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
-Tags: 21.0.0.8-full-java8-ibmjava
-Directory: ga/21.0.0.8/full
+Tags: 21.0.0.9-full-java8-ibmjava
+Directory: ga/21.0.0.9/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.8-full-java11-openj9
-Directory: ga/21.0.0.8/full
+Tags: 21.0.0.9-full-java11-openj9
+Directory: ga/21.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11
 
@@ -56,23 +56,5 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 21.0.0.6-full-java11-openj9
 Directory: ga/21.0.0.6/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 21.0.0.3-kernel-java8-ibmjava
-Directory: ga/21.0.0.3/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 21.0.0.3-kernel-java11-openj9
-Directory: ga/21.0.0.3/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.adoptopenjdk11
-
-Tags: 21.0.0.3-full-java8-ibmjava
-Directory: ga/21.0.0.3/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 21.0.0.3-full-java11-openj9
-Directory: ga/21.0.0.3/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.adoptopenjdk11


### PR DESCRIPTION
Updates for both open-liberty and websphere-liberty for the 21.0.0.9 release. This includes dropping 21.0.0.3.