### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/ac338f3112ad10269fc2d21d9104570454ca064b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/d83080b4f20d310638ea412049f8313e562eff0f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -66,105 +66,105 @@ GitCommit: 48b669921a105090c2e227f308596752fb04f453
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17-jdk-oraclelinux8, 17-oraclelinux8, 17-jdk-oracle, 17-oracle
-SharedTags: 17-jdk, 17
+Tags: 17-jdk-oraclelinux8, 17-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 17-jdk-oracle, 17-oracle, jdk-oracle, oracle
+SharedTags: 17-jdk, 17, jdk, latest
 Architectures: amd64, arm64v8
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/oraclelinux8
 
-Tags: 17-jdk-oraclelinux7, 17-oraclelinux7
+Tags: 17-jdk-oraclelinux7, 17-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/oraclelinux7
 
-Tags: 17-jdk-bullseye, 17-bullseye
+Tags: 17-jdk-bullseye, 17-bullseye, jdk-bullseye, bullseye
 Architectures: amd64, arm64v8
 GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
 Directory: 17/jdk/bullseye
 
-Tags: 17-jdk-slim-bullseye, 17-slim-bullseye, 17-jdk-slim, 17-slim
+Tags: 17-jdk-slim-bullseye, 17-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 17-jdk-slim, 17-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
 GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
 Directory: 17/jdk/slim-bullseye
 
-Tags: 17-jdk-buster, 17-buster
+Tags: 17-jdk-buster, 17-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/buster
 
-Tags: 17-jdk-slim-buster, 17-slim-buster
+Tags: 17-jdk-slim-buster, 17-slim-buster, jdk-slim-buster, slim-buster
 Architectures: amd64, arm64v8
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/slim-buster
 
-Tags: 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17-jdk-windowsservercore, 17-windowsservercore, 17-jdk, 17
+Tags: 17-jdk-windowsservercore-1809, 17-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 17-jdk-windowsservercore, 17-windowsservercore, jdk-windowsservercore, windowsservercore, 17-jdk, 17, jdk, latest
 Architectures: windows-amd64
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016
-SharedTags: 17-jdk-windowsservercore, 17-windowsservercore, 17-jdk, 17
+Tags: 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 17-jdk-windowsservercore, 17-windowsservercore, jdk-windowsservercore, windowsservercore, 17-jdk, 17, jdk, latest
 Architectures: windows-amd64
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17-jdk-nanoserver, 17-nanoserver
+Tags: 17-jdk-nanoserver-1809, 17-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 17-jdk-nanoserver, 17-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: 766a81815f22ddeda16b4fd82f6bd9786007a7ec
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16.0.2-jdk-oraclelinux8, 16.0.2-oraclelinux8, 16.0-jdk-oraclelinux8, 16.0-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 16.0.2-jdk-oracle, 16.0.2-oracle, 16.0-jdk-oracle, 16.0-oracle, 16-jdk-oracle, 16-oracle, jdk-oracle, oracle
-SharedTags: 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
+Tags: 16.0.2-jdk-oraclelinux8, 16.0.2-oraclelinux8, 16.0-jdk-oraclelinux8, 16.0-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16.0.2-jdk-oracle, 16.0.2-oracle, 16.0-jdk-oracle, 16.0-oracle, 16-jdk-oracle, 16-oracle
+SharedTags: 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16
 Architectures: amd64, arm64v8
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/oraclelinux8
 
-Tags: 16.0.2-jdk-oraclelinux7, 16.0.2-oraclelinux7, 16.0-jdk-oraclelinux7, 16.0-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7, jdk-oraclelinux7, oraclelinux7
+Tags: 16.0.2-jdk-oraclelinux7, 16.0.2-oraclelinux7, 16.0-jdk-oraclelinux7, 16.0-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/oraclelinux7
 
-Tags: 16.0.2-jdk-bullseye, 16.0.2-bullseye, 16.0-jdk-bullseye, 16.0-bullseye, 16-jdk-bullseye, 16-bullseye, jdk-bullseye, bullseye
+Tags: 16.0.2-jdk-bullseye, 16.0.2-bullseye, 16.0-jdk-bullseye, 16.0-bullseye, 16-jdk-bullseye, 16-bullseye
 Architectures: amd64, arm64v8
 GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
 Directory: 16/jdk/bullseye
 
-Tags: 16.0.2-jdk-slim-bullseye, 16.0.2-slim-bullseye, 16.0-jdk-slim-bullseye, 16.0-slim-bullseye, 16-jdk-slim-bullseye, 16-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 16.0.2-jdk-slim, 16.0.2-slim, 16.0-jdk-slim, 16.0-slim, 16-jdk-slim, 16-slim, jdk-slim, slim
+Tags: 16.0.2-jdk-slim-bullseye, 16.0.2-slim-bullseye, 16.0-jdk-slim-bullseye, 16.0-slim-bullseye, 16-jdk-slim-bullseye, 16-slim-bullseye, 16.0.2-jdk-slim, 16.0.2-slim, 16.0-jdk-slim, 16.0-slim, 16-jdk-slim, 16-slim
 Architectures: amd64, arm64v8
 GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
 Directory: 16/jdk/slim-bullseye
 
-Tags: 16.0.2-jdk-buster, 16.0.2-buster, 16.0-jdk-buster, 16.0-buster, 16-jdk-buster, 16-buster, jdk-buster, buster
+Tags: 16.0.2-jdk-buster, 16.0.2-buster, 16.0-jdk-buster, 16.0-buster, 16-jdk-buster, 16-buster
 Architectures: amd64, arm64v8
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/buster
 
-Tags: 16.0.2-jdk-slim-buster, 16.0.2-slim-buster, 16.0-jdk-slim-buster, 16.0-slim-buster, 16-jdk-slim-buster, 16-slim-buster, jdk-slim-buster, slim-buster
+Tags: 16.0.2-jdk-slim-buster, 16.0.2-slim-buster, 16.0-jdk-slim-buster, 16.0-slim-buster, 16-jdk-slim-buster, 16-slim-buster
 Architectures: amd64, arm64v8
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/slim-buster
 
-Tags: 16.0.2-jdk-windowsservercore-1809, 16.0.2-windowsservercore-1809, 16.0-jdk-windowsservercore-1809, 16.0-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
+Tags: 16.0.2-jdk-windowsservercore-1809, 16.0.2-windowsservercore-1809, 16.0-jdk-windowsservercore-1809, 16.0-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
+SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16
 Architectures: windows-amd64
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 16.0.2-jdk-windowsservercore-ltsc2016, 16.0.2-windowsservercore-ltsc2016, 16.0-jdk-windowsservercore-ltsc2016, 16.0-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, jdk-windowsservercore, windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16, jdk, latest
+Tags: 16.0.2-jdk-windowsservercore-ltsc2016, 16.0.2-windowsservercore-ltsc2016, 16.0-jdk-windowsservercore-ltsc2016, 16.0-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
+SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16
 Architectures: windows-amd64
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 16.0.2-jdk-nanoserver-1809, 16.0.2-nanoserver-1809, 16.0-jdk-nanoserver-1809, 16.0-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 16.0.2-jdk-nanoserver, 16.0.2-nanoserver, 16.0-jdk-nanoserver, 16.0-nanoserver, 16-jdk-nanoserver, 16-nanoserver, jdk-nanoserver, nanoserver
+Tags: 16.0.2-jdk-nanoserver-1809, 16.0.2-nanoserver-1809, 16.0-jdk-nanoserver-1809, 16.0-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
+SharedTags: 16.0.2-jdk-nanoserver, 16.0.2-nanoserver, 16.0-jdk-nanoserver, 16.0-nanoserver, 16-jdk-nanoserver, 16-nanoserver
 Architectures: windows-amd64
 GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
 Directory: 16/jdk/windows/nanoserver-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/d83080b: Update latest to 17, which is now GA: http://jdk.java.net/17/