### PR TITLE
[varnish] 7.0.0 release

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,16 +1,26 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/e343aa923034760f607ae65cc5f20fa789818ab3/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/6aab92269ce834212ead1279cc28953958c7a34e/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 6.6.1, 6.6, latest
+Tags: fresh, 7.0.0, 7.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: e343aa923034760f607ae65cc5f20fa789818ab3
+GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
 
-Tags: fresh-alpine, 6.6.1-alpine, 6.6-alpine, alpine
+Tags: fresh-alpine, 7.0.0-alpine, 7.0-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: e343aa923034760f607ae65cc5f20fa789818ab3
+GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
+
+Tags: old, 6.6.1, 6.6
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: old/debian
+GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
+
+Tags: old-alpine, 6.6.1-alpine, 6.6-alpine
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: old/alpine
+GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
 
 Tags: stable, 6.0.8, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
the usual Varnish release is out, and this time I kept the previous one around too. This aligns the support logic with upstream (each non-LTS release is supported for one year).