### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.7.0-beta4-buster, 1.7.0-buster, 1.7-buster, 1.7-rc-buster
-SharedTags: 1.7.0-beta4, 1.7.0, 1.7, 1.7-rc
+Tags: 1.7.0-rc1-buster, 1.7.0-buster, 1.7-buster, 1.7-rc-buster
+SharedTags: 1.7.0-rc1, 1.7.0, 1.7, 1.7-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 5a430868c3fdca37e7a8c852b3a96fbeacb95d0f
+GitCommit: e73f498ea1d7214e64c4771eca529ffd880dad58
 Directory: 1.7-rc/buster
 
-Tags: 1.7.0-beta4-alpine3.14, 1.7.0-alpine3.14, 1.7-alpine3.14, 1.7-rc-alpine3.14, 1.7.0-beta4-alpine, 1.7.0-alpine, 1.7-alpine, 1.7-rc-alpine
+Tags: 1.7.0-rc1-alpine3.14, 1.7.0-alpine3.14, 1.7-alpine3.14, 1.7-rc-alpine3.14, 1.7.0-rc1-alpine, 1.7.0-alpine, 1.7-alpine, 1.7-rc-alpine
 Architectures: amd64
-GitCommit: 241c1d647e6f03cc0e669ade8057bfa2a0164948
+GitCommit: e73f498ea1d7214e64c4771eca529ffd880dad58
 Directory: 1.7-rc/alpine3.14
 
-Tags: 1.7.0-beta4-windowsservercore-ltsc2022, 1.7.0-windowsservercore-ltsc2022, 1.7-windowsservercore-ltsc2022, 1.7-rc-windowsservercore-ltsc2022
-SharedTags: 1.7.0-beta4, 1.7.0, 1.7, 1.7-rc
+Tags: 1.7.0-rc1-windowsservercore-ltsc2022, 1.7.0-windowsservercore-ltsc2022, 1.7-windowsservercore-ltsc2022, 1.7-rc-windowsservercore-ltsc2022
+SharedTags: 1.7.0-rc1, 1.7.0, 1.7, 1.7-rc
 Architectures: windows-amd64
-GitCommit: f1b28468460fce290b8d32c20faedafe6c9c041e
+GitCommit: e73f498ea1d7214e64c4771eca529ffd880dad58
 Directory: 1.7-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.7.0-beta4-windowsservercore-1809, 1.7.0-windowsservercore-1809, 1.7-windowsservercore-1809, 1.7-rc-windowsservercore-1809
-SharedTags: 1.7.0-beta4, 1.7.0, 1.7, 1.7-rc
+Tags: 1.7.0-rc1-windowsservercore-1809, 1.7.0-windowsservercore-1809, 1.7-windowsservercore-1809, 1.7-rc-windowsservercore-1809
+SharedTags: 1.7.0-rc1, 1.7.0, 1.7, 1.7-rc
 Architectures: windows-amd64
-GitCommit: 5a430868c3fdca37e7a8c852b3a96fbeacb95d0f
+GitCommit: e73f498ea1d7214e64c4771eca529ffd880dad58
 Directory: 1.7-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.7.0-beta4-windowsservercore-ltsc2016, 1.7.0-windowsservercore-ltsc2016, 1.7-windowsservercore-ltsc2016, 1.7-rc-windowsservercore-ltsc2016
-SharedTags: 1.7.0-beta4, 1.7.0, 1.7, 1.7-rc
+Tags: 1.7.0-rc1-windowsservercore-ltsc2016, 1.7.0-windowsservercore-ltsc2016, 1.7-windowsservercore-ltsc2016, 1.7-rc-windowsservercore-ltsc2016
+SharedTags: 1.7.0-rc1, 1.7.0, 1.7, 1.7-rc
 Architectures: windows-amd64
-GitCommit: 5a430868c3fdca37e7a8c852b3a96fbeacb95d0f
+GitCommit: e73f498ea1d7214e64c4771eca529ffd880dad58
 Directory: 1.7-rc/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/e73f498: Update to 1.7.0-rc1
- https://github.com/docker-library/julia/commit/82b9730: Adjust update.sh to error out if we expect to find a musl build and it's missing