### PR TITLE
[varnish] simplify the script setup

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,16 +1,16 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/6aab92269ce834212ead1279cc28953958c7a34e/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/b4396ad550ffa073bf1e3ceff4ae0ebfcd7023bb/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 7.0.0, 7.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
+GitCommit: b4396ad550ffa073bf1e3ceff4ae0ebfcd7023bb
 
 Tags: fresh-alpine, 7.0.0-alpine, 7.0-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
+GitCommit: b4396ad550ffa073bf1e3ceff4ae0ebfcd7023bb
 
 Tags: old, 6.6.1, 6.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
Because the default workdir doesn't involve the hostname anymore, we
don't need any trickery to force it.