### PR TITLE
Build arm64v8 images for openjdk-8

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -8,27 +8,21 @@ Tags: latest
 Directory: target/openjdk-11-slim-bullseye/latest
 
 Tags: openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.6-buster
-Architectures: amd64
 Directory: target/openjdk-8-buster/lein
 
 Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.6-slim-buster
-Architectures: amd64
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
-Architectures: amd64
 Directory: target/openjdk-8-buster/boot
 
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
-Architectures: amd64
 Directory: target/openjdk-8-slim-buster/boot
 
 Tags: openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.967-buster
-Architectures: amd64
 Directory: target/openjdk-8-buster/tools-deps
 
 Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.967-slim-buster
-Architectures: amd64
 Directory: target/openjdk-8-slim-buster/tools-deps
 
 Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.6-buster, lein-buster, lein-2.9.6-buster

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: a522fe073231eeac9863571aa3e15e932e336aa1
+GitCommit: 5478f42e8108c3199bcab80ed223c499c12004bd
 
 Tags: latest
 Directory: target/openjdk-11-slim-bullseye/latest

--- a/library/clojure
+++ b/library/clojure
@@ -2,15 +2,15 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 5478f42e8108c3199bcab80ed223c499c12004bd
+GitCommit: 1007ea06a9f4a571f33f31846a78c0ee5c8f88fd
 
 Tags: latest
 Directory: target/openjdk-11-slim-bullseye/latest
 
-Tags: openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.6-buster
+Tags: openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.7-buster
 Directory: target/openjdk-8-buster/lein
 
-Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.6-slim-buster
+Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.7-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
@@ -25,10 +25,10 @@ Directory: target/openjdk-8-buster/tools-deps
 Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.967-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.6-buster, lein-buster, lein-2.9.6-buster
+Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.7-buster, lein-buster, lein-2.9.7-buster
 Directory: target/openjdk-11-buster/lein
 
-Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.6-slim-buster, slim-buster, lein-slim-buster, lein-2.9.6-slim-buster
+Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.7-slim-buster, slim-buster, lein-slim-buster, lein-2.9.7-slim-buster
 Directory: target/openjdk-11-slim-buster/lein
 
 Tags: openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
@@ -43,10 +43,10 @@ Directory: target/openjdk-11-buster/tools-deps
 Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.967-slim-buster, tools-deps-1.10.3.967-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.6-slim-buster
+Tags: openjdk-16-slim-buster, openjdk-16-lein-slim-buster, openjdk-16-lein-2.9.7-slim-buster
 Directory: target/openjdk-16-slim-buster/lein
 
-Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.6-buster
+Tags: openjdk-16-buster, openjdk-16-lein-buster, openjdk-16-lein-2.9.7-buster
 Directory: target/openjdk-16-buster/lein
 
 Tags: openjdk-16-boot-slim-buster, openjdk-16-boot-2.8.3-slim-buster
@@ -61,10 +61,10 @@ Directory: target/openjdk-16-slim-buster/tools-deps
 Tags: openjdk-16-tools-deps-buster, openjdk-16-tools-deps-1.10.3.967-buster
 Directory: target/openjdk-16-buster/tools-deps
 
-Tags: openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.6-slim-buster
+Tags: openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.7-slim-buster
 Directory: target/openjdk-17-slim-buster/lein
 
-Tags: openjdk-17-buster, openjdk-17-lein-buster, openjdk-17-lein-2.9.6-buster
+Tags: openjdk-17-buster, openjdk-17-lein-buster, openjdk-17-lein-2.9.7-buster
 Directory: target/openjdk-17-buster/lein
 
 Tags: openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster
@@ -79,10 +79,10 @@ Directory: target/openjdk-17-slim-buster/tools-deps
 Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.967-buster
 Directory: target/openjdk-17-buster/tools-deps
 
-Tags: openjdk-18-slim-buster, openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.6-slim-buster
+Tags: openjdk-18-slim-buster, openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.7-slim-buster
 Directory: target/openjdk-18-slim-buster/lein
 
-Tags: openjdk-18-buster, openjdk-18-lein-buster, openjdk-18-lein-2.9.6-buster
+Tags: openjdk-18-buster, openjdk-18-lein-buster, openjdk-18-lein-2.9.7-buster
 Directory: target/openjdk-18-buster/lein
 
 Tags: openjdk-18-boot-slim-buster, openjdk-18-boot-2.8.3-slim-buster
@@ -97,11 +97,11 @@ Directory: target/openjdk-18-slim-buster/tools-deps
 Tags: openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.10.3.967-buster
 Directory: target/openjdk-18-buster/tools-deps
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.6, openjdk-8-bullseye, openjdk-8-lein-bullseye, openjdk-8-lein-2.9.6-bullseye
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.7, openjdk-8-bullseye, openjdk-8-lein-bullseye, openjdk-8-lein-2.9.7-bullseye
 Architectures: amd64
 Directory: target/openjdk-8-bullseye/lein
 
-Tags: openjdk-8-slim-bullseye, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.6-slim-bullseye
+Tags: openjdk-8-slim-bullseye, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.7-slim-bullseye
 Architectures: amd64
 Directory: target/openjdk-8-slim-bullseye/lein
 
@@ -121,10 +121,10 @@ Tags: openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.10.3.967-slim-b
 Architectures: amd64
 Directory: target/openjdk-8-slim-bullseye/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.6, lein, lein-2.9.6, openjdk-11-bullseye, openjdk-11-lein-bullseye, openjdk-11-lein-2.9.6-bullseye, lein-bullseye, lein-2.9.6-bullseye
+Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.7, lein, lein-2.9.7, openjdk-11-bullseye, openjdk-11-lein-bullseye, openjdk-11-lein-2.9.7-bullseye, lein-bullseye, lein-2.9.7-bullseye
 Directory: target/openjdk-11-bullseye/lein
 
-Tags: openjdk-11-lein-slim-bullseye, openjdk-11-slim-bullseye, openjdk-11-lein-2.9.6-slim-bullseye, slim-bullseye, lein-slim-bullseye, lein-2.9.6-slim-bullseye
+Tags: openjdk-11-lein-slim-bullseye, openjdk-11-slim-bullseye, openjdk-11-lein-2.9.7-slim-bullseye, slim-bullseye, lein-slim-bullseye, lein-2.9.7-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/lein
 
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-bullseye, openjdk-11-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
@@ -139,10 +139,10 @@ Directory: target/openjdk-11-bullseye/tools-deps
 Tags: openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.10.3.967-slim-bullseye, tools-deps-1.10.3.967-slim-bullseye, tools-deps-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/tools-deps
 
-Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.6, openjdk-16-slim-bullseye, openjdk-16-lein-slim-bullseye, openjdk-16-lein-2.9.6-slim-bullseye
+Tags: openjdk-16, openjdk-16-lein, openjdk-16-lein-2.9.7, openjdk-16-slim-bullseye, openjdk-16-lein-slim-bullseye, openjdk-16-lein-2.9.7-slim-bullseye
 Directory: target/openjdk-16-slim-bullseye/lein
 
-Tags: openjdk-16-bullseye, openjdk-16-lein-bullseye, openjdk-16-lein-2.9.6-bullseye
+Tags: openjdk-16-bullseye, openjdk-16-lein-bullseye, openjdk-16-lein-2.9.7-bullseye
 Directory: target/openjdk-16-bullseye/lein
 
 Tags: openjdk-16-boot, openjdk-16-boot-2.8.3, openjdk-16-boot-slim-bullseye, openjdk-16-boot-2.8.3-slim-bullseye
@@ -157,10 +157,10 @@ Directory: target/openjdk-16-slim-bullseye/tools-deps
 Tags: openjdk-16-tools-deps-bullseye, openjdk-16-tools-deps-1.10.3.967-bullseye
 Directory: target/openjdk-16-bullseye/tools-deps
 
-Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.6, openjdk-17-slim-bullseye, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.6-slim-bullseye
+Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.7, openjdk-17-slim-bullseye, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.7-slim-bullseye
 Directory: target/openjdk-17-slim-bullseye/lein
 
-Tags: openjdk-17-bullseye, openjdk-17-lein-bullseye, openjdk-17-lein-2.9.6-bullseye
+Tags: openjdk-17-bullseye, openjdk-17-lein-bullseye, openjdk-17-lein-2.9.7-bullseye
 Directory: target/openjdk-17-bullseye/lein
 
 Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-bullseye, openjdk-17-boot-2.8.3-slim-bullseye
@@ -175,10 +175,10 @@ Directory: target/openjdk-17-slim-bullseye/tools-deps
 Tags: openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.967-bullseye
 Directory: target/openjdk-17-bullseye/tools-deps
 
-Tags: openjdk-18, openjdk-18-lein, openjdk-18-lein-2.9.6, openjdk-18-slim-bullseye, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.6-slim-bullseye
+Tags: openjdk-18, openjdk-18-lein, openjdk-18-lein-2.9.7, openjdk-18-slim-bullseye, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.7-slim-bullseye
 Directory: target/openjdk-18-slim-bullseye/lein
 
-Tags: openjdk-18-bullseye, openjdk-18-lein-bullseye, openjdk-18-lein-2.9.6-bullseye
+Tags: openjdk-18-bullseye, openjdk-18-lein-bullseye, openjdk-18-lein-2.9.7-bullseye
 Directory: target/openjdk-18-bullseye/lein
 
 Tags: openjdk-18-boot, openjdk-18-boot-2.8.3, openjdk-18-boot-slim-bullseye, openjdk-18-boot-2.8.3-slim-bullseye
@@ -193,7 +193,7 @@ Directory: target/openjdk-18-slim-bullseye/tools-deps
 Tags: openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.10.3.967-bullseye
 Directory: target/openjdk-18-bullseye/tools-deps
 
-Tags: openjdk-18-alpine, openjdk-18-lein-alpine, openjdk-18-lein-2.9.6-alpine
+Tags: openjdk-18-alpine, openjdk-18-lein-alpine, openjdk-18-lein-2.9.7-alpine
 Architectures: amd64
 Directory: target/openjdk-18-alpine/lein
 


### PR DESCRIPTION
I think these didn't used to be available upstream, but they are now listed in https://github.com/docker-library/official-images/blob/master/library/openjdk