### PR TITLE
Add graalvm image

### DIFF
--- a/library/graalvm
+++ b/library/graalvm
@@ -1,7 +1,7 @@
 Maintainers: Wes Morgan <wmorgan@flur.ee> (@cap10morgan)
 GitRepo: https://github.com/fluree/docker-graalvm.git
 Architectures: amd64, arm64v8
-GitCommit: 4ce5793b9492d2f20841070055bf5f9761582e90
+GitCommit: ec81951e4e73da81d74a5158d30cccd63c105d24
 
 Tags: latest, bullseye-slim, 21.2.0, 21.2, 21, 21-bullseye-slim, 21.2-bullseye-slim, 21.2.0-bullseye-slim
 Directory: bullseye-slim

--- a/library/graalvm
+++ b/library/graalvm
@@ -1,7 +1,7 @@
 Maintainers: Wes Morgan <wmorgan@flur.ee> (@cap10morgan)
 GitRepo: https://github.com/fluree/docker-graalvm.git
 Architectures: amd64, arm64v8
-GitCommit: ec81951e4e73da81d74a5158d30cccd63c105d24
+GitCommit: db3aebbe6ea98642f6275b1eb30da5025a81f791
 
 Tags: latest, bullseye-slim, 21.2.0, 21.2, 21, 21-bullseye-slim, 21.2-bullseye-slim, 21.2.0-bullseye-slim
 Directory: bullseye-slim

--- a/library/graalvm
+++ b/library/graalvm
@@ -1,4 +1,4 @@
-Maintainers: Wes Morgan <wmorgan@flur.ee>
+Maintainers: Wes Morgan <wmorgan@flur.ee> (@cap10morgan)
 GitRepo: https://github.com/fluree/docker-graalvm.git
 Architectures: amd64, arm64v8
 GitCommit: 4ce5793b9492d2f20841070055bf5f9761582e90

--- a/library/graalvm
+++ b/library/graalvm
@@ -1,0 +1,7 @@
+Maintainers: Wes Morgan <wmorgan@flur.ee>
+GitRepo: https://github.com/fluree/docker-graalvm.git
+Architectures: amd64, arm64v8
+GitCommit: 4ce5793b9492d2f20841070055bf5f9761582e90
+
+Tags: latest, bullseye-slim, 21.2.0, 21.2, 21, 21-bullseye-slim, 21.2-bullseye-slim, 21.2.0-bullseye-slim
+Directory: bullseye-slim


### PR DESCRIPTION
This adds a [GraalVM](https://www.graalvm.org) image for building native executables from JVM-based languages. [Their license](https://github.com/oracle/graal/blob/master/LICENSE) permits redistribution of the community edition, which is what this is packaging up.

I asked if the upstream packagers could publish their Docker images as official images, [but they don't seem receptive to that idea](https://github.com/graalvm/container/issues/21). I am already one of the maintainers of the official clojure image, so I'm happy to take this on too. I need it at work anyway.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)