### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.48, 2.4, 2, latest, 2.4.48-buster, 2.4-buster, 2-buster, buster
+Tags: 2.4.49, 2.4, 2, latest, 2.4.49-buster, 2.4-buster, 2-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 208fc2ba9a097530bb0b7386b0c2bebacdfb6c5c
+GitCommit: ba836540b5c8a91b8e72a50c660399bb01178a1f
 Directory: 2.4
 
-Tags: 2.4.48-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.48-alpine3.14, 2.4-alpine3.14, 2-alpine3.14, alpine3.14
+Tags: 2.4.49-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.49-alpine3.14, 2.4-alpine3.14, 2-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 208fc2ba9a097530bb0b7386b0c2bebacdfb6c5c
+GitCommit: 524c7ed345423370c6501c424b4694d517fa47c6
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/524c7ed: Update to 2.4.49
- https://github.com/docker-library/httpd/commit/6b536ff: Add Stefan's key in Alpine too (follow-up to https://github.com/docker-library/httpd/pull/199)
- https://github.com/docker-library/httpd/commit/a11f564: Merge pull request https://github.com/docker-library/httpd/pull/199 from sreboot/2.4.49
- https://github.com/docker-library/httpd/commit/ba83654: Update build to 2.4.49 This commit will:   - add missing key hash and details for stefan@eissing.org   - update httpd version to 2.4.49   - update sha256