### PR TITLE
maven: amazoncorretto-17

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -146,6 +146,11 @@ Architectures: amd64, arm64v8
 GitCommit: 0a7b1ef030687a5d95ce3e7567a4c279ab87dc81
 Directory: amazoncorretto-16
 
+Tags: 3.8.2-amazoncorretto-17, 3.8-amazoncorretto-17, 3-amazoncorretto-17
+Architectures: amd64, arm64v8
+GitCommit: 09bbbf942bef1b62cb64692966d4ec829dff24ba
+Directory: amazoncorretto-17
+
 Tags: 3.8.2-amazoncorretto-8, 3.8-amazoncorretto-8, 3-amazoncorretto-8
 Architectures: amd64, arm64v8
 GitCommit: 0a7b1ef030687a5d95ce3e7567a4c279ab87dc81


### PR DESCRIPTION
Latest release of maven amazoncorretto-17 by @carlossg referencing commit https://github.com/carlossg/docker-maven/commit/09bbbf942bef1b62cb64692966d4ec829dff24ba.