### PR TITLE
Update to JRuby 9.3 but keep 9.2 support

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -3,40 +3,49 @@ Maintainers: JRuby Admin <admin@jruby.org> (@jruby),
              Thomas E Enebo <tom.enebo@gmail.com> (@enebo)
 GitRepo: https://github.com/jruby/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: c77be8629e90e0782a41c0ffeb810f02fbf0afc4
+GitCommit: d083a9c13640eba8c135caeefbff3b89350bbede
 
-Tags: latest, 9, 9.2, 9.2.19, 9.2-jre, 9.2-jre8, 9.2.19-jre, 9.2.19-jre8, 9.2.19.0, 9.2.19.0-jre, 9.2.19.0-jre8
+Tags: latest, 9, 9.3, 9.3.0, 9.3-jre, 9.3-jre8, 9.3.0-jre, 9.3.0-jre8, 9.3.0.0, 9.3.0.0-jre, 9.3.0.0-jre8
 Architectures: amd64
-Directory: 9000/jre8
+Directory: 9.3/jre8
 
-Tags: 9-jdk, 9-jdk8, 9.2-jdk, 9.2-jdk8, 9.2.19-jdk, 9.2.19-jdk8, 9.2.19.0-jdk, 9.2.19.0-jdk8
+Tags: 9-jdk, 9-jdk8, 9.3-jdk, 9.3-jdk8, 9.3.0-jdk, 9.3.0-jdk8, 9.3.0.0-jdk, 9.3.0.0-jdk8
 Architectures: amd64
-Directory: 9000/jdk8
+Directory: 9.3/jdk8
+
+Tags: 9.3-jre11, 9.3.0-jre11, 9.3.0.0-jre11
+Architectures: amd64
+Directory: 9.3/jre11
+
+Tags: 9.3-jdk11, 9.3.0-jdk11, 9.3.0.0-jdk11
+Architectures: amd64
+Directory: 9.3/jdk11
+
+Tags: 9.3-jdk17, 9.3.0-jdk17, 9.3.0.0-jdk17
+Architectures: amd64
+Directory: 9.3/jdk17
+
+Tags: 9.2, 9.2.19, 9.2-jre, 9.2-jre8, 9.2.19-jre, 9.2.19-jre8, 9.2.19.0, 9.2.19.0-jre, 9.2.19.0-jre8
+Architectures: amd64
+Directory: 9.2/jre8
+
+Tags: 9.2-jdk, 9.2-jdk8, 9.2.19-jdk, 9.2.19-jdk8, 9.2.19.0-jdk, 9.2.19.0-jdk8
+Architectures: amd64
+Directory: 9.2/jdk8
 
 Tags: 9.2-jre11, 9.2.19-jre11, 9.2.19.0-jre11
 Architectures: amd64
-Directory: 9000/jre11
+Directory: 9.2/jre11
 
 Tags: 9.2-jdk11, 9.2.19-jdk11, 9.2.19.0-jdk11
 Architectures: amd64
-Directory: 9000/jdk11
+Directory: 9.2/jdk11
 
-Tags: 9.2-jdk16, 9.2.19-jdk16, 9.2.19.0-jdk16
+Tags: 9.2-jdk17, 9.2.19-jdk17, 9.2.19.0-jdk17
 Architectures: amd64
-Directory: 9000/jdk16
+Directory: 9.2/jdk17
 
-Tags: 9-onbuild, 9.2-onbuild, 9.2.19-onbuild, 9.2.19.0-onbuild
+Tags: 9.2-onbuild, 9.2.19-onbuild, 9.2.19.0-onbuild
 Architectures: amd64
-Directory: 9000/onbuild-jdk8
+Directory: 9.2/onbuild-jdk8
 
-Tags: 9.1, 9.1.17, 9.1.17.0, 9.1-jre, 9.1.17-jre, 9.1.17.0-jre
-Architectures: amd64
-Directory: 9000/jre
-GitCommit: 8bc3fe27670a851953345182fe12f14f5e708383
-GitFetch: refs/heads/9.1
-
-Tags: 9.1-jdk, 9.1.17-jdk, 9.1.17.0-jdk
-Architectures: amd64
-Directory: 9000/jdk
-GitCommit: 8bc3fe27670a851953345182fe12f14f5e708383
-GitFetch: refs/heads/9.1


### PR DESCRIPTION
JRuby 9.1 support is no longer provided in this config.