### PR TITLE
[security] Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.15.0, 4.15, 4, latest
+Tags: 4.15.1, 4.15, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 55d673e6116840feae0cd46e97fdd06dacd590f2
+GitCommit: 79a69bfc5d49b3eb9c64cfa9342b3d9ed9ebb626
 Directory: 4/debian
 
-Tags: 4.15.0-alpine, 4.15-alpine, 4-alpine, alpine
+Tags: 4.15.1-alpine, 4.15-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 55d673e6116840feae0cd46e97fdd06dacd590f2
+GitCommit: 79a69bfc5d49b3eb9c64cfa9342b3d9ed9ebb626
 Directory: 4/alpine
 
-Tags: 3.42.5, 3.42, 3
+Tags: 3.42.6, 3.42, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5f8c4895e23dc9ee4281aea85ee7f1093a4fbf0c
+GitCommit: 8c2d7b00336cf5f2b5b7b49f14d674ee01f6b507
 Directory: 3/debian
 
-Tags: 3.42.5-alpine, 3.42-alpine, 3-alpine
+Tags: 3.42.6-alpine, 3.42-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 5f8c4895e23dc9ee4281aea85ee7f1093a4fbf0c
+GitCommit: 8c2d7b00336cf5f2b5b7b49f14d674ee01f6b507
 Directory: 3/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/8c2d7b0: Update to 3.42.6, ghost-cli 1.17.3
- https://github.com/docker-library/ghost/commit/79a69bf: Update to 4.15.1, ghost-cli 1.17.3