### PR TITLE
[varnish] keep package files around

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,11 +1,11 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/b4396ad550ffa073bf1e3ceff4ae0ebfcd7023bb/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/efa8f60de4abc4f388343bcc4088c2564aa89be7/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 7.0.0, 7.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: b4396ad550ffa073bf1e3ceff4ae0ebfcd7023bb
+GitCommit: efa8f60de4abc4f388343bcc4088c2564aa89be7
 
 Tags: fresh-alpine, 7.0.0-alpine, 7.0-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -15,7 +15,7 @@ GitCommit: b4396ad550ffa073bf1e3ceff4ae0ebfcd7023bb
 Tags: old, 6.6.1, 6.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
+GitCommit: efa8f60de4abc4f388343bcc4088c2564aa89be7
 
 Tags: old-alpine, 6.6.1-alpine, 6.6-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -25,4 +25,4 @@ GitCommit: b0c5d6439a4abf5c628214de96a54438344012de
 Tags: stable, 6.0.8, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/debian
-GitCommit: e343aa923034760f607ae65cc5f20fa789818ab3
+GitCommit: efa8f60de4abc4f388343bcc4088c2564aa89be7


### PR DESCRIPTION
  Keeping one the created packages install is costly, so we do the next
  best thing and keep them around, letting the user install them if they
  really want it.
  
  See for more info https://github.com/varnish/docker-varnish/commit/efa8f60de4abc4f388343bcc4088c2564aa89be7