### PR TITLE
archlinux: Release 20210926.0.35054

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210829.0.32635
-GitCommit: c5fc33e3a83b74f24aebe6470b8eaba01228eb67
-GitFetch: refs/tags/v20210829.0.32635
+Tags: latest, base, base-20210926.0.35054
+GitCommit: efaee8cf7aac9330b457ab86ce22b903d0bfb1f5
+GitFetch: refs/tags/v20210926.0.35054
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210829.0.32635
-GitCommit: c5fc33e3a83b74f24aebe6470b8eaba01228eb67
-GitFetch: refs/tags/v20210829.0.32635
+Tags: base-devel, base-devel-20210926.0.35054
+GitCommit: efaee8cf7aac9330b457ab86ce22b903d0bfb1f5
+GitFetch: refs/tags/v20210926.0.35054
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks