### PR TITLE
[oraclelinux] update :7, :7-slim, :8, :8-slim

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b8509d63dede08f290333c563e6b354348ed80e9
+amd64-GitCommit: 42466f46acd5dc5a6c43b043a05648e40636804e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 73468d60466918a1479dedf0f3c3f75c76ef240a
+arm64v8-GitCommit: 69ce49d426999b14a510933adcb7fae464ca0d22
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
:7, :7-slim for ELBA-2021-3649 (ca-certificates)

:8, :8-slim for ELSA-2021-3582 (curl: CVE-2021-22922, CVE-2021-22923,
CVE-2021-22924), ELSA-2021-3576 (krb5: CVE-2021-36222, CVE-2021-37750),
ELBA-2021-3573 (ca-certificates)

Errata info:
https://linux.oracle.com/errata/ELBA-2021-3649.html
https://linux.oracle.com/errata/ELSA-2021-3582.html
https://linux.oracle.com/errata/ELSA-2021-3576.html
https://linux.oracle.com/errata/ELBA-2021-3573.html

Signed-off-by: Todd Vierling <todd.vierling@oracle.com>