### PR TITLE
arangodb 3.7.15

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,13 +1,9 @@
 Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart), Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
 GitRepo: https://github.com/arangodb/arangodb-docker
 
-Tags: 3.6, 3.6.16
-GitCommit: a1a47c9f3f9a437dbefce3e33ac7c57dbc9b15b3
-Directory: alpine/3.6.16
-
-Tags: 3.7, 3.7.14
-GitCommit: 5667472f5348943ccb3ff862e8d9887bab0efdb6
-Directory: alpine/3.7.14
+Tags: 3.7, 3.7.15
+GitCommit: cd9cff3458077a32daaf1d6d31899056c08a07c6
+Directory: alpine/3.7.15
 
 Tags: 3.8, 3.8.1, latest
 GitCommit: 42fc6401e569423cab28e71b0085dc78300caa84


### PR DESCRIPTION
Updated ArangoDB 3.7 to 3.7.15 and removed 3.6 (EoL).