### PR TITLE
actions: auto cancel builds if user pushes another commit

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -10,6 +10,11 @@ defaults:
 env:
   # https://github.com/docker-library/bashbrew/issues/10
   GIT_LFS_SKIP_SMUDGE: 1
+  
+# Cancel existing runs if user makes another push
+concurrency:
+  group: "${{ github.ref }}"
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
 

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -11,9 +11,9 @@ env:
   # https://github.com/docker-library/bashbrew/issues/10
   GIT_LFS_SKIP_SMUDGE: 1
   
-# Cancel existing runs if user makes another push
+# cancel existing runs if user makes another push
 concurrency:
-  group: "${{ github.ref }}"
+  group: ${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:


### PR DESCRIPTION
Currently, if a user pushes several commits to a PR the CI will try to build each commit. This wastes both time and resources.

This PR adds a task that will cancel any other builds for the same PR.