### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,80 +1,80 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/90892b68142fcc5ffab5e4658f52219cf450d698/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/6898578de00125ce6e9efd306c92b6ffd29aaa4e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 14rc1, 14rc1-bullseye
+Tags: 14.0, 14, latest, 14.0-bullseye, 14-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c3bf1dd3aadab4cce10fdd8eac069080339093a1
+GitCommit: db430ccd715678b60d7c7b9a0fee577991998837
 Directory: 14/bullseye
 
-Tags: 14rc1-alpine, 14rc1-alpine3.14
+Tags: 14.0-alpine, 14-alpine, alpine, 14.0-alpine3.14, 14-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3bf1dd3aadab4cce10fdd8eac069080339093a1
+GitCommit: db430ccd715678b60d7c7b9a0fee577991998837
 Directory: 14/alpine
 
-Tags: 13.4, 13, latest, 13.4-bullseye, 13-bullseye, bullseye
+Tags: 13.4, 13, 13.4-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d50c412c4e1da9b37966a19a1141d167eeaf056f
+GitCommit: 7d027c7fc38292e1d423c7a89fab6aa9e5ebed00
 Directory: 13/bullseye
 
-Tags: 13.4-alpine, 13-alpine, alpine, 13.4-alpine3.14, 13-alpine3.14, alpine3.14
+Tags: 13.4-alpine, 13-alpine, 13.4-alpine3.14, 13-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7f5f6da5a1976bfd2c6d989e20cef080d0d9c68f
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 13/alpine
 
 Tags: 12.8, 12, 12.8-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d50c412c4e1da9b37966a19a1141d167eeaf056f
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 12/bullseye
 
 Tags: 12.8-alpine, 12-alpine, 12.8-alpine3.14, 12-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf175692c137b00938f480b3ae1babae0999e05e
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 12/alpine
 
 Tags: 11.13-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d50c412c4e1da9b37966a19a1141d167eeaf056f
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 11/bullseye
 
 Tags: 11.13, 11, 11.13-stretch, 11-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 415040d370e989dd3e6010bcdee5ba2440273598
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 11/stretch
 
 Tags: 11.13-alpine, 11-alpine, 11.13-alpine3.14, 11-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 415040d370e989dd3e6010bcdee5ba2440273598
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 11/alpine
 
 Tags: 10.18-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d50c412c4e1da9b37966a19a1141d167eeaf056f
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 10/bullseye
 
 Tags: 10.18, 10, 10.18-stretch, 10-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: a7a749d0ce8b8cd54c5545f6d9489d755af00659
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 10/stretch
 
 Tags: 10.18-alpine, 10-alpine, 10.18-alpine3.14, 10-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a7a749d0ce8b8cd54c5545f6d9489d755af00659
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 10/alpine
 
 Tags: 9.6.23-bullseye, 9.6-bullseye, 9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d50c412c4e1da9b37966a19a1141d167eeaf056f
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 9.6/bullseye
 
 Tags: 9.6.23, 9.6, 9, 9.6.23-stretch, 9.6-stretch, 9-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 32d0897216bfa477c70688b960e5a95651df8992
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 9.6/stretch
 
 Tags: 9.6.23-alpine, 9.6-alpine, 9-alpine, 9.6.23-alpine3.14, 9.6-alpine3.14, 9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32d0897216bfa477c70688b960e5a95651df8992
+GitCommit: ab940cbb923af99e2c7cf0e0ba5305bc6815aecc
 Directory: 9.6/alpine


### PR DESCRIPTION
Changes:

- docker-library/postgres@48a0a36: Merge pull request docker-library/postgres#892 from infosiftr/move-latest
- docker-library/postgres@6898578: Move latest to 14
- docker-library/postgres@db430cc: Update 14 to 14.0, bullseye 14.0-1.pgdg110+1
- docker-library/postgres@7d027c7: Update 13 to bullseye 13.4-4.pgdg110+1
- docker-library/postgres@471fee5: Merge pull request docker-library/postgres#888 from infosiftr/bullseye-nss-wrapper
- docker-library/postgres@ab940cb: Fix "libnss-wrapper" usage on bullseye