### PR TITLE
Update MediaWiki

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,35 +2,35 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 51105612d2e1168f1b0545f47951847d63fb9613
+GitCommit: b19002eb9ee59f3e1856307b39b0d0303f16e962
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.36.1, 1.36, stable, latest
+Tags: 1.36.2, 1.36, stable, latest
 Directory: 1.36/apache
 
-Tags: 1.36.1-fpm, 1.36-fpm, stable-fpm
+Tags: 1.36.2-fpm, 1.36-fpm, stable-fpm
 Directory: 1.36/fpm
 
-Tags: 1.36.1-fpm-alpine, 1.36-fpm-alpine, stable-fpm-alpine
+Tags: 1.36.2-fpm-alpine, 1.36-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.36/fpm-alpine
 
-Tags: 1.35.3, 1.35, lts, legacy
+Tags: 1.35.4, 1.35, lts, legacy
 Directory: 1.35/apache
 
-Tags: 1.35.3-fpm, 1.35-fpm, lts-fpm, legacy-fpm
+Tags: 1.35.4-fpm, 1.35-fpm, lts-fpm, legacy-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.3-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacy-fpm-alpline
+Tags: 1.35.4-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacy-fpm-alpline
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 
-Tags: 1.31.15, 1.31, legacylts
+Tags: 1.31.16, 1.31, legacylts
 Directory: 1.31/apache
 
-Tags: 1.31.15-fpm, 1.31-fpm, legacylts-fpm
+Tags: 1.31.16-fpm, 1.31-fpm, legacylts-fpm
 Directory: 1.31/fpm
 
-Tags: 1.31.15-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.31.16-fpm-alpine, 1.31-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.31/fpm-alpine


### PR DESCRIPTION
Updates to 1.31.16, 1.35.4 & 1.36.2 security releases.

https://github.com/wikimedia/mediawiki-docker/pull/101

Note: MediaWiki 1.31 is EOL now, so a few days after these versions are published I'll send another PR to remove those tags.