### PR TITLE
Update Solr to 8.10.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -6,14 +6,24 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
              Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.9.0, 8.9, 8, latest
+Tags: 8.10.0, 8.10, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: a1a59aa9d3ef286fe1e046ddfd168c3c34720660
+GitCommit: c9e67796b9620b9f93973b2667837ae47cc83b8f
+Directory: 8.10
+
+Tags: 8.10.0-slim, 8.10-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: c9e67796b9620b9f93973b2667837ae47cc83b8f
+Directory: 8.10/slim
+
+Tags: 8.9.0, 8.9
+Architectures: amd64, arm64v8
+GitCommit: b786d89646823e5250368cb25fa2f55fdc50ec7e
 Directory: 8.9
 
-Tags: 8.9.0-slim, 8.9-slim, 8-slim, slim
+Tags: 8.9.0-slim, 8.9-slim
 Architectures: amd64, arm64v8
-GitCommit: a1a59aa9d3ef286fe1e046ddfd168c3c34720660
+GitCommit: b786d89646823e5250368cb25fa2f55fdc50ec7e
 Directory: 8.9/slim
 
 Tags: 8.8.2, 8.8


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/r2ae63429d861b1d0c64b32f5e2e086b74fe4cb46f966fdcc9c85267b%40%3Cusers.solr.apache.org%3E) which I'll paste here:

> Solr 8.10.0 Release Highlights:
>
> Backup / restore to / from Amazon S3 (SOLR-15089); included upgrading
> the AWS SDK to v2 (SOLR-15599)
> 
> A new Admin UI screen to interactively design your Solr schema and
> supporting ConfigSet files from sample data (SOLR-15277)
> 
> A new Admin UI screen to manage users, roles, and permissions (SOLR-15527)
> 
> Several enhancements and bug fixes for Solr's Parallel SQL interface,
> included upgrading Apache Calcite to 1.27.0 (SOLR-15460, SOLR-15451,
> SOLR-15456, SOLR-15461, SOLR-15489, SOLR-15475, SOLR-15499,
> SOLR-15570, SOLR-15576, SOLR-9853, SOLR-15579, SOLR-15566)
> 
> A summary of important changes is published in the Solr Reference
> Guide at https://solr.apache.org/guide/8_10/solr-upgrade-notes.html.
> 
> For the most exhaustive list, see the full release notes at
> https://solr.apache.org/8_10_0/changes/Changes.html or by viewing the
> CHANGES.txt file accompanying the distribution.
> 
> Solr's release notes usually don't include Lucene layer changes.
> Lucene's release notes are at
> https://lucene.apache.org/core/8_10_0/changes/Changes.html

There were no docker-solr script updates.  One change to docker-solr documentation.

This PR to official-images has one curious thing in which the git commit hash to 8.9 changed from a1a59aa9d3ef286fe1e046ddfd168c3c34720660 to b786d89646823e5250368cb25fa2f55fdc50ec7e
The rationale is that the older value was a mistake -- it was the commit *in* the PR to docker-solr.  After it was merged, the commit hash on the master branch was something else, now reflected here.  This begs the question -- does Docker Official Images actually _do_ / _verify_ anything with this git hash (apparently not), or is it there just for traceability or something else?