### PR TITLE
Bump CouchDB to v3.1.2

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,11 +3,11 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: 4993111e388d203d2200a3dd88449517db548c05
+GitCommit: ee358e62d72bdd72fd69d67ba7fbc80580502270
 
-Tags: latest, 3.1.1, 3.1, 3
+Tags: latest, 3.1.2, 3.1, 3
 Architectures: amd64, arm64v8
-Directory: 3.1.1
+Directory: 3.1.2
 
 Tags: 2.3.1, 2.3, 2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Hey there, this is a security release - please expedite.

Only change since https://github.com/docker-library/official-images/pull/10482 is to move to v3.1.2. We will have a v3.2.0 hopefully next week - if there is other feedback we'd be happy to incorporate it for that release.