### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -19,19 +19,19 @@ amd64-GitCommit: 9ac1ecf3a09022407d932c6604e5df6a869505c6
 arm64v8-GitFetch: refs/heads/amzn2-arm64
 arm64v8-GitCommit: dacda51ba31fbbf3fdad88108b3eaf9d6173c2c1
 
-Tags: 2.0.20210813.1-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20211001.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: bc6ebfdaf0d1c3df4d84a6c263b6c41b6b57ebfc
+amd64-GitCommit: 9c71c2fb401041253eabd3bbc64dfec06146f8eb
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 2a36a7eb2f908199f47cb4a712f431eb33f47c20
+arm64v8-GitCommit: 4bdb2a9372e524319ddf9518196de3b372f01929
 
 Tags: 2018.03.0.20211001.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
 amd64-GitCommit: 2a80b9e78bd3857c6277f086df14a95454009e8c
 
-Tags: 2018.03.0.20210721.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20211001.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 65bc90c3331e6908d445f89c0e140997b251a758
+amd64-GitCommit: 10fd6d6c3d0b2da67496a482e294279169e4202d

--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -22,9 +22,9 @@ arm64v8-GitCommit: dacda51ba31fbbf3fdad88108b3eaf9d6173c2c1
 Tags: 2.0.20211001.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 9c71c2fb401041253eabd3bbc64dfec06146f8eb
+amd64-GitCommit: 8fe832ee342779f64c3cac7fad793cba7bc2b635
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 4bdb2a9372e524319ddf9518196de3b372f01929
+arm64v8-GitCommit: 5059f12bce3bf4af18e1b4a405f6317886557b2a
 
 Tags: 2018.03.0.20211001.0, 2018.03, 1
 Architectures: amd64
@@ -34,4 +34,4 @@ amd64-GitCommit: 2a80b9e78bd3857c6277f086df14a95454009e8c
 Tags: 2018.03.0.20211001.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 10fd6d6c3d0b2da67496a482e294279169e4202d
+amd64-GitCommit: 4acfa0e023a60424529b3bb88a1494ed07336091

--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -7,16 +7,17 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Sumit Tomer (@sktomer),
              Sean Kelly (@cbgbt),
              Tanu Rampal (@trampal),
-             Kyle Gosselin-Harris (@kgharris)
+             Kyle Gosselin-Harris (@kgharris),
+             Preston Carpenter (@prcarpen)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 2f83249475d368cf530eb3b1f956425c097bdc4d
+GitCommit: 81ef4b1ec563bea88345a864c7abb98cb4de09da
 
-Tags: 2.0.20210813.1, 2, latest
+Tags: 2.0.20211001.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: e23cdb4dbfd3b72257b02ad7a747a8920a5d65b9
+amd64-GitCommit: 9ac1ecf3a09022407d932c6604e5df6a869505c6
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 88a941fcde35fcf4b87aee22e691842715520746
+arm64v8-GitCommit: dacda51ba31fbbf3fdad88108b3eaf9d6173c2c1
 
 Tags: 2.0.20210813.1-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
@@ -25,10 +26,10 @@ amd64-GitCommit: bc6ebfdaf0d1c3df4d84a6c263b6c41b6b57ebfc
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 2a36a7eb2f908199f47cb4a712f431eb33f47c20
 
-Tags: 2018.03.0.20210721.0, 2018.03, 1
+Tags: 2018.03.0.20211001.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 5489a282cbdf7501d1137e4373d77a79636a45e4
+amd64-GitCommit: 2a80b9e78bd3857c6277f086df14a95454009e8c
 
 Tags: 2018.03.0.20210721.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64


### PR DESCRIPTION
Hello - we have some new docker images.  Please note that included in this fix is a high priority update to our ca-certificates package, so please treat it with some priority.

Thanks!
kylegh