### PR TITLE
Fedora 20211001

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -4,7 +4,7 @@ GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 Tags: 33
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/33
-GitCommit: 8062833d074ff75e51c9017d3fd7d3bb0bdadc2d
+GitCommit: 2cb6076825a76904bed22def0bf0de39bd4790ef
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 ppc64le-Directory: ppc64le/
@@ -14,17 +14,29 @@ arm32v7-Directory: armhfp/
 Tags: 34, latest
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/34
-GitCommit: d29b1fabd719afd85a21fecd74f2c2df969e4e49
+GitCommit: 53801b39e17f4d6ba739a79e12281dc55ef37dfd
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 ppc64le-Directory: ppc64le/
 
-Tags: rawhide, 35
-Architectures: amd64, arm64v8, arm32v7
+Tags: 35
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/35
-GitCommit: 533223237dbbfc737bf11a19c31ff7ec69ce5aae
+GitCommit: 4bdeb1ca17027e9945db2d7bca998933abb8de83
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
+s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
+ppc64le-Directory: ppc64le/
+
+Tags: rawhide,36
+Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
+GitFetch: refs/heads/36
+GitCommit: cd67215a79456aefa9eb9507df1edd929e50543b
+amd64-Directory: x86_64/
+arm64v8-Directory: aarch64/
+s390x-Directory: s390x/
+arm32v7-Directory: armhfp/
+ppc64le-Directory: ppc64le/

--- a/library/fedora
+++ b/library/fedora
@@ -1,16 +1,6 @@
 Maintainers: Clement Verna <cverna@fedoraproject.org> (@cverna), Vipul Siddharth <siddharthvipul1@fedoraproject.org> (@siddharthvipul)
 GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 
-Tags: 32
-Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
-GitFetch: refs/heads/32
-GitCommit: ddec1000ce5ba6f6d48b83092baa0931c71463d2
-amd64-Directory: x86_64/
-arm64v8-Directory: aarch64/
-ppc64le-Directory: ppc64le/
-s390x-Directory: s390x/
-arm32v7-Directory: armhfp/
-
 Tags: 33
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/33


### PR DESCRIPTION
Remove Fedora 32 - EOL
Fedora 35 is now in Beta
Fedora 36 is now rawhide