### PR TITLE
Friendica Release 2021.09 | Wrong Commit

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -5,17 +5,17 @@ GitRepo: https://github.com/friendica/docker.git
 
 Tags: 2021.09-apache, apache, stable-apache, 2021.09, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9fe43ec2fb78aef998f8611834006a026b1e281d
+GitCommit: 7881472f579f506458f445ce1db3ce655eb91a5d
 Directory: 2021.09/apache
 
 Tags: 2021.09-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9fe43ec2fb78aef998f8611834006a026b1e281d
+GitCommit: 7881472f579f506458f445ce1db3ce655eb91a5d
 Directory: 2021.09/fpm
 
 Tags: 2021.09-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9fe43ec2fb78aef998f8611834006a026b1e281d
+GitCommit: 7881472f579f506458f445ce1db3ce655eb91a5d
 Directory: 2021.09/fpm-alpine
 
 Tags: 2021.12-dev-apache, dev-apache, 2021.12-dev, dev


### PR DESCRIPTION
I accidentally used a wrong commit for the Friendica Release 2021.09, so at least the SHA256 wasn't right ;-)

Thanks to this check finding it: https://doi-janky.infosiftr.net/job/multiarch/job/amd64/job/friendica/126/console