### PR TITLE
archlinux: Release 20211003.0.35663

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20210926.0.35054
-GitCommit: efaee8cf7aac9330b457ab86ce22b903d0bfb1f5
-GitFetch: refs/tags/v20210926.0.35054
+Tags: latest, base, base-20211003.0.35663
+GitCommit: a0eb10330b65dc2163aa70fb118dd6ab37645f03
+GitFetch: refs/tags/v20211003.0.35663
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20210926.0.35054
-GitCommit: efaee8cf7aac9330b457ab86ce22b903d0bfb1f5
-GitFetch: refs/tags/v20210926.0.35054
+Tags: base-devel, base-devel-20211003.0.35663
+GitCommit: a0eb10330b65dc2163aa70fb118dd6ab37645f03
+GitFetch: refs/tags/v20211003.0.35663
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks