### PR TITLE
Bump Traefik to v1.7.31

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,21 +13,21 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 39417f848e63ab9178c9c197fbc9c35f822446be
 Directory: alpine
 
-Tags: v1.7.30-windowsservercore-1809, 1.7.30-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.31-windowsservercore-1809, 1.7.31-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 7d554807d47ad41f0cc622b107504cb338fed7c5
+GitCommit: 4de2bf351a36c29f3a9458d5ed86c2bc2affed24
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.30-alpine, 1.7.30-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.31-alpine, 1.7.31-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 7d554807d47ad41f0cc622b107504cb338fed7c5
+GitCommit: 4de2bf351a36c29f3a9458d5ed86c2bc2affed24
 Directory: alpine
 
-Tags: v1.7.30, 1.7.30, v1.7, 1.7, maroilles
+Tags: v1.7.31, 1.7.31, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 7d554807d47ad41f0cc622b107504cb338fed7c5
+GitCommit: 4de2bf351a36c29f3a9458d5ed86c2bc2affed24
 Directory: scratch


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v1.7.31](https://github.com/traefik/traefik/releases/tag/v1.7.31).

/cc @ddtmachado @kevinpollet @jbdoumenjou

Cheers
