### PR TITLE
Update Jetty version to 9.4.44

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,122 +4,122 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.6-jre11-slim
-Architectures: amd64
+Tags: 11.0.6-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
+Architectures: amd64, arm64v8
 Directory: 11.0-jre11-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 11.0.6-jre11
-Architectures: amd64
+Tags: 11.0.6-jre11, 11.0-jre11, 11-jre11
+Architectures: amd64, arm64v8
 Directory: 11.0-jre11
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 11.0.6-jdk16-slim
-Architectures: amd64
-Directory: 11.0-jdk16-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+Tags: 11.0.6-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
+Architectures: amd64, arm64v8
+Directory: 11.0-jdk17-slim
+GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
 
-Tags: 11.0.6, 11.0.6-jdk16
-Architectures: amd64
-Directory: 11.0-jdk16
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+Tags: 11.0.6, 11.0, 11, 11.0.6-jdk17, 11.0-jdk17, 11-jdk17
+Architectures: amd64, arm64v8
+Directory: 11.0-jdk17
+GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
 
-Tags: 11.0.6-jdk11-slim
-Architectures: amd64
+Tags: 11.0.6-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
+Architectures: amd64, arm64v8
 Directory: 11.0-jdk11-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 11.0.6-jdk11
-Architectures: amd64
+Tags: 11.0.6-jdk11, 11.0-jdk11, 11-jdk11
+Architectures: amd64, arm64v8
 Directory: 11.0-jdk11
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 10.0.6-jre11-slim
-Architectures: amd64
+Tags: 10.0.6-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
+Architectures: amd64, arm64v8
 Directory: 10.0-jre11-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 10.0.6-jre11
-Architectures: amd64
+Tags: 10.0.6-jre11, 10.0-jre11, 10-jre11
+Architectures: amd64, arm64v8
 Directory: 10.0-jre11
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 10.0.6-jdk16-slim
-Architectures: amd64
-Directory: 10.0-jdk16-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+Tags: 10.0.6-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
+Architectures: amd64, arm64v8
+Directory: 10.0-jdk17-slim
+GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
 
-Tags: 10.0.6, 10.0.6-jdk16
-Architectures: amd64
-Directory: 10.0-jdk16
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+Tags: 10.0.6, 10.0, 10, 10.0.6-jdk17, 10.0-jdk17, 10-jdk17
+Architectures: amd64, arm64v8
+Directory: 10.0-jdk17
+GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
 
-Tags: 10.0.6-jdk11-slim
-Architectures: amd64
+Tags: 10.0.6-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
+Architectures: amd64, arm64v8
 Directory: 10.0-jdk11-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 10.0.6-jdk11
-Architectures: amd64
+Tags: 10.0.6-jdk11, 10.0-jdk11, 10-jdk11
+Architectures: amd64, arm64v8
 Directory: 10.0-jdk11
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 9.4.43-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.44-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.44-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
-Architectures: amd64
+Tags: 9.4.44-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Architectures: amd64, arm64v8
 Directory: 9.4-jre8-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jre8, 9.4-jre8, 9-jre8
-Architectures: amd64
+Tags: 9.4.44-jre8, 9.4-jre8, 9-jre8
+Architectures: amd64, arm64v8
 Directory: 9.4-jre8
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jdk16-slim, 9.4-jdk16-slim, 9-jdk16-slim
-Architectures: amd64
-Directory: 9.4-jdk16-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+Tags: 9.4.44-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim
+Architectures: amd64, arm64v8
+Directory: 9.4-jdk17-slim
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43, 9.4, 9, 9.4.43-jdk16, 9.4-jdk16, 9-jdk16, latest, jdk16
-Architectures: amd64
-Directory: 9.4-jdk16
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+Tags: 9.4.44, 9.4, 9, 9.4.44-jdk17, 9.4-jdk17, 9-jdk17, latest, jdk17
+Architectures: amd64, arm64v8
+Directory: 9.4-jdk17
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
-Architectures: amd64
+Tags: 9.4.44-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Architectures: amd64, arm64v8
 Directory: 9.4-jdk11-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jdk11, 9.4-jdk11, 9-jdk11
-Architectures: amd64
+Tags: 9.4.44-jdk11, 9.4-jdk11, 9-jdk11
+Architectures: amd64, arm64v8
 Directory: 9.4-jdk11
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
-Architectures: amd64
+Tags: 9.4.44-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Architectures: amd64, arm64v8
 Directory: 9.4-jdk8-slim
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.4.43-jdk8, 9.4-jdk8, 9-jdk8
-Architectures: amd64
+Tags: 9.4.44-jdk8, 9.4-jdk8, 9-jdk8
+Architectures: amd64, arm64v8
 Directory: 9.4-jdk8
-GitCommit: 734954b4f7602caa4f87a06837620b7f5225d583
+GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.3.29-jre8, 9.3-jre8
-Architectures: amd64
+Tags: 9.3.29-jre8, 9.3-jre8, 9.3
+Architectures: amd64, arm64v8
 Directory: 9.3-jre8
-GitCommit: c47212fa6db5547a5090fa409c4ee3913bcc18ce
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
 
-Tags: 9.2.30-jre8, 9.2-jre8
-Architectures: amd64
+Tags: 9.2.30-jre8, 9.2-jre8, 9.2
+Architectures: amd64, arm64v8
 Directory: 9.2-jre8
-GitCommit: 481a3bcb16a8bf0ee11a4b67a4710050e5403064
+GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb


### PR DESCRIPTION

- Upgrade Jetty version to `9.4.44.v20210927`.
- Add more specific tags for the Jetty 10 & 11 images.
- Drop support for images based on JDK16 and add support for JDK17.
- Add support for the `arm64v8` architecture for all images.