### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2c006e5638bca719d537608c08d3f5c48bb53605
 Directory: 2.5-rc/alpine
 
-Tags: 2.4.4, 2.4, lts, latest, 2.4.4-bullseye, 2.4-bullseye, lts-bullseye, bullseye
+Tags: 2.4.7, 2.4, lts, latest, 2.4.7-bullseye, 2.4-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e01e11b9df6dce3498f0d58f4bb5d0e5f6cd8715
+GitCommit: caa9511cd1ae40248aaf542a2c738d745006cbe6
 Directory: 2.4
 
-Tags: 2.4.4-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.4-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
+Tags: 2.4.7-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.7-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e01e11b9df6dce3498f0d58f4bb5d0e5f6cd8715
+GitCommit: caa9511cd1ae40248aaf542a2c738d745006cbe6
 Directory: 2.4/alpine
 
 Tags: 2.3.14, 2.3, 2.3.14-bullseye, 2.3-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/caa9511: Update 2.4 to 2.4.7
- https://github.com/docker-library/haproxy/commit/7f92f51: Update 2.4 to 2.4.6
- https://github.com/docker-library/haproxy/commit/7a791e2: Update 2.4 to 2.4.5