### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.16.0, 4.16, 4, latest
+Tags: 4.17.1, 4.17, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba23bf322ca1894329d70b94f80d996d2ce2070a
+GitCommit: 4b869701b36e1ae18a81a2117cbbfa539cd3fd16
 Directory: 4/debian
 
-Tags: 4.16.0-alpine, 4.16-alpine, 4-alpine, alpine
+Tags: 4.17.1-alpine, 4.17-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: ba23bf322ca1894329d70b94f80d996d2ce2070a
+GitCommit: 4b869701b36e1ae18a81a2117cbbfa539cd3fd16
 Directory: 4/alpine
 
 Tags: 3.42.6, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4b86970: Update to 4.17.1, ghost-cli 1.17.3
- https://github.com/docker-library/ghost/commit/70b47b8: Update to 4.17.0, ghost-cli 1.17.3