### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.7, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 1fe17ee8b4bad429992f4c67301db7125f2a631e
+GitCommit: bf1387720b58d9c3930fb8424061f656361bbc08
 Directory: 3.9/ubuntu
 
 Tags: 3.9.7-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.7-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1fe17ee8b4bad429992f4c67301db7125f2a631e
+GitCommit: bf1387720b58d9c3930fb8424061f656361bbc08
 Directory: 3.9/alpine
 
 Tags: 3.9.7-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.23, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 5ce5b2a7d1463cd1f11b44776bc49ce0a8cb63da
+GitCommit: f92bb2eeea0720132212e35fc619a955a6280c8f
 Directory: 3.8/ubuntu
 
 Tags: 3.8.23-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.23-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ce5b2a7d1463cd1f11b44776bc49ce0a8cb63da
+GitCommit: f92bb2eeea0720132212e35fc619a955a6280c8f
 Directory: 3.8/alpine
 
 Tags: 3.8.23-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/bf13877: Update 3.9 to otp 24.1.2
- https://github.com/docker-library/rabbitmq/commit/f92bb2e: Update 3.8 to otp 24.1.2