### PR TITLE
Odoo: update 12.0-14.0 to release 20211006

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 79c66cd4f346a2de6906a05bfeab3f61d3bb0881
+GitCommit: 4f79a47adddee4538ab5d89624e3b6b7c600156f
 
 Tags: 14.0, 14, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

as usual, here are the latest Odoo updates of supported versions.

Thanks.