### PR TITLE
Some bumps for Haskell

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,17 +4,35 @@ Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
 GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.0.1-buster, 9.0-buster, 9-buster, buster, 9.0.1, 9.0, 9, latest
-GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
+GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
 Directory: 9.0/buster
 
 Tags: 9.0.1-stretch, 9.0-stretch, 9-stretch, stretch
-GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
+GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
 Directory: 9.0/stretch
 
-Tags: 8.10.4-buster, 8.10-buster, 8-buster, 8.10.4, 8.10, 8
-GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
+Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
+GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
 Directory: 8.10/buster
 
-Tags: 8.10.4-stretch, 8.10-stretch, 8-stretch
-GitCommit: d9bf04e3d561c3ccef4528bbe74d1c89552c6d35
+Tags: 8.10.7-stretch, 8.10-stretch, 8-stretch
+GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
+Directory: 8.10/stretch
+
+# to be removed in the future
+
+Tags: 8.10.5-buster, 8.10.5
+GitCommit: 47d2ca30933d9fa81bff1538c035008bb1c0c197
+Directory: 8.10/buster
+
+Tags: 8.10.5-stretch
+GitCommit: 47d2ca30933d9fa81bff1538c035008bb1c0c197
+Directory: 8.10/stretch
+
+Tags: 8.10.6-buster, 8.10.6
+GitCommit: bc860ec5b664fdd12353a46017e407f10045e9b0
+Directory: 8.10/buster
+
+Tags: 8.10.6-stretch
+GitCommit: bc860ec5b664fdd12353a46017e407f10045e9b0
 Directory: 8.10/stretch


### PR DESCRIPTION
:wave: The Haskell images have been a [bit stuck on installing some dependencies](https://github.com/haskell/docker-haskell/issues/45) via debian packaging, which seems to be dead at this point.

This includes changes to switch away from the debian packaging and [directly install the haskell compiler and the cabal build tool](https://github.com/haskell/docker-haskell/pull/46). We are also now doing sha256 verification on top of the gpg verify step. With this done, it includes the missing version bumps as well.

I'm assuming each of these commits will be applied independently and the versions released? (or I might need multiple stacked PRs?)

cc @psftw 