### PR TITLE
Clarify gpg verification

### DIFF
--- a/README.md
+++ b/README.md
@@ -236,6 +236,7 @@ The purpose in recommending checksum verification is to verify that the artifact
 Below are some examples:
 
 -	**Preferred**: *download over https, PGP key full fingerprint import and `asc` verification, embedded checksum verified.*
+-	**Note:**: verifying the PGP signature of the hash file only is as secure as verifying the signature of the data itself and common practice (given that it's a strong hash)
 
 	```Dockerfile
 	ENV PYTHON_DOWNLOAD_SHA512 (sha512-value-here)


### PR DESCRIPTION
Some docker image developers not understanding what a hash function is have previously told me my installer has to gpg-verify all the tarballs instead of their checksums.

Of course that's nonsense, because then the internet, all distros (including ubuntu) and even blockchains in this world would be broken.

Adding this as a note here should silence this.

Thanks.