### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,124 +5,124 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.17.1-bullseye, 1.17-bullseye, 1-bullseye, bullseye
-SharedTags: 1.17.1, 1.17, 1, latest
+Tags: 1.17.2-bullseye, 1.17-bullseye, 1-bullseye, bullseye
+SharedTags: 1.17.2, 1.17, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/bullseye
 
-Tags: 1.17.1-buster, 1.17-buster, 1-buster, buster
+Tags: 1.17.2-buster, 1.17-buster, 1-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/buster
 
-Tags: 1.17.1-stretch, 1.17-stretch, 1-stretch, stretch
+Tags: 1.17.2-stretch, 1.17-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/stretch
 
-Tags: 1.17.1-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14, 1.17.1-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.17.2-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14, 1.17.2-alpine, 1.17-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/alpine3.14
 
-Tags: 1.17.1-alpine3.13, 1.17-alpine3.13, 1-alpine3.13, alpine3.13
+Tags: 1.17.2-alpine3.13, 1.17-alpine3.13, 1-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/alpine3.13
 
-Tags: 1.17.1-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.17.1-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.1, 1.17, 1, latest
+Tags: 1.17.2-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.17.2-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.2, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.17.1-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.17.1-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.1, 1.17, 1, latest
+Tags: 1.17.2-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.17.2-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.2, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17.1-windowsservercore-ltsc2016, 1.17-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.17.1-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.1, 1.17, 1, latest
+Tags: 1.17.2-windowsservercore-ltsc2016, 1.17-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.17.2-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.2, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.17.1-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.17.1-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.2-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.17.2-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.17.1-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.17.1-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.2-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.17.2-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 3f2c52653043f067156ce4f41182c2a758c4c857
+GitCommit: 8c4f2e21fa0194a24288d8c126a5d15b51c221cb
 Directory: 1.17/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.16.8-bullseye, 1.16-bullseye
-SharedTags: 1.16.8, 1.16
+Tags: 1.16.9-bullseye, 1.16-bullseye
+SharedTags: 1.16.9, 1.16
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/bullseye
 
-Tags: 1.16.8-buster, 1.16-buster
+Tags: 1.16.9-buster, 1.16-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/buster
 
-Tags: 1.16.8-stretch, 1.16-stretch
+Tags: 1.16.9-stretch, 1.16-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/stretch
 
-Tags: 1.16.8-alpine3.14, 1.16-alpine3.14, 1.16.8-alpine, 1.16-alpine
+Tags: 1.16.9-alpine3.14, 1.16-alpine3.14, 1.16.9-alpine, 1.16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/alpine3.14
 
-Tags: 1.16.8-alpine3.13, 1.16-alpine3.13
+Tags: 1.16.9-alpine3.13, 1.16-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/alpine3.13
 
-Tags: 1.16.8-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
-SharedTags: 1.16.8-windowsservercore, 1.16-windowsservercore, 1.16.8, 1.16
+Tags: 1.16.9-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
+SharedTags: 1.16.9-windowsservercore, 1.16-windowsservercore, 1.16.9, 1.16
 Architectures: windows-amd64
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.16.8-windowsservercore-1809, 1.16-windowsservercore-1809
-SharedTags: 1.16.8-windowsservercore, 1.16-windowsservercore, 1.16.8, 1.16
+Tags: 1.16.9-windowsservercore-1809, 1.16-windowsservercore-1809
+SharedTags: 1.16.9-windowsservercore, 1.16-windowsservercore, 1.16.9, 1.16
 Architectures: windows-amd64
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16.8-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016
-SharedTags: 1.16.8-windowsservercore, 1.16-windowsservercore, 1.16.8, 1.16
+Tags: 1.16.9-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016
+SharedTags: 1.16.9-windowsservercore, 1.16-windowsservercore, 1.16.9, 1.16
 Architectures: windows-amd64
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.16.8-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
-SharedTags: 1.16.8-nanoserver, 1.16-nanoserver
+Tags: 1.16.9-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
+SharedTags: 1.16.9-nanoserver, 1.16-nanoserver
 Architectures: windows-amd64
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.16.8-nanoserver-1809, 1.16-nanoserver-1809
-SharedTags: 1.16.8-nanoserver, 1.16-nanoserver
+Tags: 1.16.9-nanoserver-1809, 1.16-nanoserver-1809
+SharedTags: 1.16.9-nanoserver, 1.16-nanoserver
 Architectures: windows-amd64
-GitCommit: 3ce9efdffc5c9ba2f018bfc070e7dd2eac2f78aa
+GitCommit: 0deb84e6bcb833d5edb83e1741437cadab44cc22
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/8c4f2e2: Update 1.17 to 1.17.2
- https://github.com/docker-library/golang/commit/0deb84e: Update 1.16 to 1.16.9