### PR TITLE
Remove redundant haskell entries

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -18,21 +18,3 @@ Directory: 8.10/buster
 Tags: 8.10.7-stretch, 8.10-stretch, 8-stretch
 GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
 Directory: 8.10/stretch
-
-# to be removed in the future
-
-Tags: 8.10.5-buster, 8.10.5
-GitCommit: 47d2ca30933d9fa81bff1538c035008bb1c0c197
-Directory: 8.10/buster
-
-Tags: 8.10.5-stretch
-GitCommit: 47d2ca30933d9fa81bff1538c035008bb1c0c197
-Directory: 8.10/stretch
-
-Tags: 8.10.6-buster, 8.10.6
-GitCommit: bc860ec5b664fdd12353a46017e407f10045e9b0
-Directory: 8.10/buster
-
-Tags: 8.10.6-stretch
-GitCommit: bc860ec5b664fdd12353a46017e407f10045e9b0
-Directory: 8.10/stretch


### PR DESCRIPTION
These were used temporarily to add missing older versions.

Follows on from #11050.