### PR TITLE
CouchDB new release v3.2.0

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -3,9 +3,13 @@
 
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
-GitCommit: ee358e62d72bdd72fd69d67ba7fbc80580502270
+GitCommit: c2dc5a84add2d673bce151e0aa8174d09d227d22
 
-Tags: latest, 3.1.2, 3.1, 3
+Tags: latest, 3.2.0, 3.2, 3
+Architectures: amd64, arm64v8
+Directory: 3.2.0
+
+Tags: 3.1.2, 3.1
 Architectures: amd64, arm64v8
 Directory: 3.1.2
 


### PR DESCRIPTION
New CouchDB release. We're keeping 3.1.x alive for this transition for a while.