### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,72 +4,72 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev8, 2.5-dev, 2.5-dev8-bullseye, 2.5-dev-bullseye
+Tags: 2.5-dev9, 2.5-dev, 2.5-dev9-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c006e5638bca719d537608c08d3f5c48bb53605
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.5-rc
 
-Tags: 2.5-dev8-alpine, 2.5-dev-alpine, 2.5-dev8-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev9-alpine, 2.5-dev-alpine, 2.5-dev9-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2c006e5638bca719d537608c08d3f5c48bb53605
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.7, 2.4, lts, latest, 2.4.7-bullseye, 2.4-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: caa9511cd1ae40248aaf542a2c738d745006cbe6
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.4
 
 Tags: 2.4.7-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.7-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: caa9511cd1ae40248aaf542a2c738d745006cbe6
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.4/alpine
 
 Tags: 2.3.14, 2.3, 2.3.14-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7b5166d743dffb2388a8f59d59b8c17a761afbb1
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.3
 
 Tags: 2.3.14-alpine, 2.3-alpine, 2.3.14-alpine3.14, 2.3-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b5166d743dffb2388a8f59d59b8c17a761afbb1
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.3/alpine
 
 Tags: 2.2.17, 2.2, 2.2.17-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6362c8937559905db2345c91fbd29595b5f1a4d6
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.2
 
 Tags: 2.2.17-alpine, 2.2-alpine, 2.2.17-alpine3.14, 2.2-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6362c8937559905db2345c91fbd29595b5f1a4d6
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.2/alpine
 
 Tags: 2.0.25, 2.0, 2.0.25-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 30f642f62fdd8b0bee77eaf01a971ffdb4f277cc
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.0
 
 Tags: 2.0.25-alpine, 2.0-alpine, 2.0.25-alpine3.14, 2.0-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 30f642f62fdd8b0bee77eaf01a971ffdb4f277cc
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e7b078d5ff2ed9f29e4223a5d3d38d191818505
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 1.8
 
 Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.14, 1.8-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8f4332673f7c2b2b3b42a9760e8ba0936968b7c7
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 1.8/alpine
 
 Tags: 1.7.14, 1.7, 1.7.14-buster, 1.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 1.7
 
 Tags: 1.7.14-alpine, 1.7-alpine, 1.7.14-alpine3.12, 1.7-alpine3.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2991130ba47e26edd1e0eb32239c3a4a7b579aa6
+GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ba58714: Merge pull request https://github.com/docker-library/haproxy/pull/171 from xsak/master
- https://github.com/docker-library/haproxy/commit/47dd63f: Create HOME directory for haproxy user
- https://github.com/docker-library/haproxy/commit/29a2b73: Update 2.5-rc to 2.5-dev9