### PR TITLE
archlinux: Release 20211010.0.36274

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20211003.0.35663
-GitCommit: a0eb10330b65dc2163aa70fb118dd6ab37645f03
-GitFetch: refs/tags/v20211003.0.35663
+Tags: latest, base, base-20211010.0.36274
+GitCommit: b867f619a4568ae71795d974f23bbbea07efa92b
+GitFetch: refs/tags/v20211010.0.36274
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20211003.0.35663
-GitCommit: a0eb10330b65dc2163aa70fb118dd6ab37645f03
-GitFetch: refs/tags/v20211003.0.35663
+Tags: base-devel, base-devel-20211010.0.36274
+GitCommit: b867f619a4568ae71795d974f23bbbea07efa92b
+GitFetch: refs/tags/v20211010.0.36274
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks