### PR TITLE
Update Clear Linux OS to 35110

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 89ec5b23516ddc81799aeb66e989fd21bcd679b6
-GitFetch: refs/tags/clear-linux-35090
+GitCommit: 8eb2aad3c4399e1b160be6c5952a9cd3294c1dd9
+GitFetch: refs/heads/base-35110


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35110

@bryteise @mdhorn @phmccarty