### PR TITLE
Replace uses of "tac|tac|grep -q" with "grep > /dev/null"

### DIFF
--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -35,8 +35,8 @@ _request() {
 # Check that /ghost/ redirects to setup (the image is unconfigured by default)
 ghostVersion="$(docker inspect --format '{{range .Config.Env}}{{ . }}{{"\n"}}{{end}}' "$serverImage" | awk -F= '$1 == "GHOST_VERSION" { print $2 }')"
 case "$ghostVersion" in
-	2.*) _request GET '/ghost/api/v2/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
-	3.*) _request GET '/ghost/api/v3/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
-	4.*) _request GET '/ghost/api/v4/admin/authentication/setup/' |tac|tac| grep -q 'status":false' ;;
+	2.*) _request GET '/ghost/api/v2/admin/authentication/setup/' | grep 'status":false' > /dev/null ;;
+	3.*) _request GET '/ghost/api/v3/admin/authentication/setup/' | grep 'status":false' > /dev/null ;;
+	4.*) _request GET '/ghost/api/v4/admin/authentication/setup/' | grep 'status":false' > /dev/null ;;
 	*) echo "no tests for version ${ghostVersion}" && exit 1 ;;
 esac

--- a/test/tests/haproxy-basics/run.sh
+++ b/test/tests/haproxy-basics/run.sh
@@ -48,5 +48,5 @@ _request() {
 . "$dir/../../retry.sh" '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'
 
 # Check that we can request / (which is proxying example.com)
-_request GET http '/' |tac|tac| grep -q '<h1>Example Domain</h1>'
-_request GET https '/' |tac|tac| grep -q '<h1>Example Domain</h1>'
+_request GET http '/' | grep '<h1>Example Domain</h1>' > /dev/null
+_request GET https '/' | grep '<h1>Example Domain</h1>' > /dev/null

--- a/test/tests/monica-apache-run/run.sh
+++ b/test/tests/monica-apache-run/run.sh
@@ -41,5 +41,4 @@ _request() {
 . "$dir/../../retry.sh" --tries 30 '_request GET / --output /dev/null'
 
 # Check that we can request / and that it contains the pattern "Welcome" somewhere
-_request GET '/' |tac|tac| grep -iq "Welcome"
-# (without "|tac|tac|" we get "broken pipe" since "grep" closes the pipe before "curl" is done reading it)
+_request GET '/' | grep -i "Welcome" > /dev/null

--- a/test/tests/monica-fpm-run/run.sh
+++ b/test/tests/monica-fpm-run/run.sh
@@ -61,5 +61,4 @@ fcgi-request() {
 . "$dir/../../retry.sh" --tries 30 'fcgi-request GET /index.php' > /dev/null 2>&1
 
 # Check that we can request /register and that it contains the pattern "Welcome" somewhere
-fcgi-request GET '/index.php' register |tac|tac| grep -iq "Welcome"
-# (without "|tac|tac|" we get "broken pipe" since "grep" closes the pipe before "curl" is done reading it)
+fcgi-request GET '/index.php' register | grep -i "Welcome" > /dev/null

--- a/test/tests/nextcloud-apache-run/run.sh
+++ b/test/tests/nextcloud-apache-run/run.sh
@@ -34,5 +34,4 @@ _request() {
 
 # Check that we can request / and that it contains the pattern "Finish setup" somewhere
 # <input type="submit" class="primary" value="Finish setup" data-finishing="Finishing …">
-_request GET '/' |tac|tac| grep -iq "Finish setup"
-# (without "|tac|tac|" we get "broken pipe" since "grep" closes the pipe before "curl" is done reading it)
+_request GET '/' | grep -i "Finish setup" > /dev/null

--- a/test/tests/nextcloud-fpm-run/run.sh
+++ b/test/tests/nextcloud-fpm-run/run.sh
@@ -44,5 +44,4 @@ fcgi-request() {
 
 # Check that we can request / and that it contains the pattern "Finish setup" somewhere
 # <input type="submit" class="primary" value="Finish setup" data-finishing="Finishing …">
-fcgi-request GET '/index.php' |tac|tac| grep -iq "Finish setup"
-# (without "|tac|tac|" we get "broken pipe" since "grep" closes the pipe before "curl" is done reading it)
+fcgi-request GET '/index.php' | grep -i "Finish setup" > /dev/null

--- a/test/tests/redmine-basics/run.sh
+++ b/test/tests/redmine-basics/run.sh
@@ -34,7 +34,7 @@ _request() {
 . "$dir/../../retry.sh" --tries 40 '_request GET / --output /dev/null'
 
 # Check that / include the text "Redmine" somewhere
-_request GET '/' |tac|tac| grep -q Redmine
+_request GET '/' | grep Redmine > /dev/null
 
 # Check that /account/register include the text "Password" somewhere
-_request GET '/account/register' |tac|tac| grep -q Password
+_request GET '/account/register' | grep Password > /dev/null

--- a/test/tests/spiped-basics/run.sh
+++ b/test/tests/spiped-basics/run.sh
@@ -55,4 +55,4 @@ _request() {
 . "$dir/../../retry.sh" '[ "$(_request GET / --output /dev/null || echo $?)" != 7 ]'
 
 # Check that we can request / (which is proxying example.com)
-_request GET http '/' |tac|tac| grep -q '<h1>Example Domain</h1>'
+_request GET http '/' | grep '<h1>Example Domain</h1>' > /dev/null

--- a/test/tests/wordpress-apache-run/run.sh
+++ b/test/tests/wordpress-apache-run/run.sh
@@ -42,5 +42,4 @@ _request() {
 
 # Check that we can request / and that it contains the word "setup" somewhere
 # <form id="setup" method="post" action="?step=1"><label class='screen-reader-text' for='language'>Select a default language</label>
-_request GET '/' |tac|tac| grep -iq setup
-# (without "|tac|tac|" we get "broken pipe" since "grep" closes the pipe before "curl" is done reading it)
+_request GET '/' | grep -i setup > /dev/null

--- a/test/tests/wordpress-fpm-run/run.sh
+++ b/test/tests/wordpress-fpm-run/run.sh
@@ -52,5 +52,4 @@ fcgi-request() {
 
 # index.php redirects to wp-admin/install.php, check that it contains the word "setup" somewhere
 # <form id="setup" method="post" action="?step=1"><label class='screen-reader-text' for='language'>Select a default language</label>
-fcgi-request GET '/wp-admin/install.php' |tac|tac| grep -iq setup
-# (without "|tac|tac|" we get "broken pipe" since "grep" closes the pipe before "curl" is done reading it)
+fcgi-request GET '/wp-admin/install.php' | grep -i setup > /dev/null

--- a/test/tests/zookeeper-basics/run.sh
+++ b/test/tests/zookeeper-basics/run.sh
@@ -24,4 +24,4 @@ zkCli() {
 . "$dir/../../retry.sh" --tries "$ZOOKEEPER_TEST_TRIES" --sleep "$ZOOKEEPER_TEST_SLEEP" zkCli ls /
 
 # List and check Zookeeper root
-zkCli ls / |tac|tac| grep -q '^\[zookeeper\]$'
+zkCli ls / | grep '^\[zookeeper\]$' > /dev/null


### PR DESCRIPTION
There are too many times/places this workaround doesn't fully work anymore. :disappointed: