### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/memcached/blob/3d73fde6c55bbd705b4c41fdf0a4ea57d2e3b9a1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/memcached/blob/98b1361ab4f197b881a96145e0cc6ba605fbf46d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -10,6 +10,6 @@ GitCommit: e0b2a7e2288f313824b2e860d6225d3fd018a7f7
 Directory: debian
 
 Tags: 1.6.12-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.12-alpine3.14, 1.6-alpine3.14, 1-alpine3.14, alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2f7d163ec21401699a4f87e6e293b2ed45227598
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/98b1361: Add another issue link
- https://github.com/docker-library/memcached/commit/8785640: Remove arm32v6 from the Architectures list (for now)

See https://github.com/docker-library/memcached/issues/69, https://github.com/memcached/memcached/issues/799