### PR TITLE
[nats] Release v2.6.2

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -3,6 +3,7 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Waldemar Salinas <wally@synadia.com> (@wallyqs),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
+GitFetch: refs/heads/main
 GitCommit: 3e61fc16a1980576020482c1a1be04e964510e18
 
 Tags: 2.6.2-alpine3.14, 2.6-alpine3.14, 2-alpine3.14, alpine3.14, 2.6.2-alpine, 2.6-alpine, 2-alpine, alpine


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.6.2)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>