### PR TITLE
[oraclelinux] update 7, 7-slim, 8, 8-slim for amd64 and arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 42466f46acd5dc5a6c43b043a05648e40636804e
+amd64-GitCommit: 743952decf40b7800d887935fdb262edcf9d9904
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 69ce49d426999b14a510933adcb7fae464ca0d22
+arm64v8-GitCommit: 0507bc97351a0451e7e736929cf852347e5857e0
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates the following fixes/updates:

ELBA-2021-3790: tzdata-2021c (all tags/archs)
CVE-2021-23840 and CVE-2021-23841: openssl-1.0.2k (7/7-slim)
CVE-2016-4658: libxml2 (7/7-slim)

Refs:

https://linux.oracle.com/errata/ELBA-2021-3790.html
https://linux.oracle.com/errata/ELSA-2021-3798.html
https://linux.oracle.com/errata/ELSA-2021-3810.html

Signed-off-by: Avi Miller <avi.miller@oracle.com>