### PR TITLE
Update Jetty versions to 10.0.7, 11.0.7, and 9.3.30

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,65 +4,65 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.6-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
+Tags: 11.0.7-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jre11-slim
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 11.0.6-jre11, 11.0-jre11, 11-jre11
+Tags: 11.0.7-jre11, 11.0-jre11, 11-jre11
 Architectures: amd64, arm64v8
 Directory: 11.0-jre11
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 11.0.6-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
+Tags: 11.0.7-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk17-slim
-GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 11.0.6, 11.0, 11, 11.0.6-jdk17, 11.0-jdk17, 11-jdk17
+Tags: 11.0.7, 11.0, 11, 11.0.7-jdk17, 11.0-jdk17, 11-jdk17
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk17
-GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 11.0.6-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
+Tags: 11.0.7-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk11-slim
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 11.0.6-jdk11, 11.0-jdk11, 11-jdk11
+Tags: 11.0.7-jdk11, 11.0-jdk11, 11-jdk11
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk11
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 10.0.6-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
+Tags: 10.0.7-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jre11-slim
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 10.0.6-jre11, 10.0-jre11, 10-jre11
+Tags: 10.0.7-jre11, 10.0-jre11, 10-jre11
 Architectures: amd64, arm64v8
 Directory: 10.0-jre11
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 10.0.6-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
+Tags: 10.0.7-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk17-slim
-GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 10.0.6, 10.0, 10, 10.0.6-jdk17, 10.0-jdk17, 10-jdk17
+Tags: 10.0.7, 10.0, 10, 10.0.7-jdk17, 10.0-jdk17, 10-jdk17
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk17
-GitCommit: 6059de7092f0d4b53a9b583803fbf0972be7710a
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 10.0.6-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
+Tags: 10.0.7-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk11-slim
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
-Tags: 10.0.6-jdk11, 10.0-jdk11, 10-jdk11
+Tags: 10.0.7-jdk11, 10.0-jdk11, 10-jdk11
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk11
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
 Tags: 9.4.44-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
@@ -114,10 +114,10 @@ Architectures: amd64, arm64v8
 Directory: 9.4-jdk8
 GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
 
-Tags: 9.3.29-jre8, 9.3-jre8, 9.3
+Tags: 9.3.30-jre8, 9.3-jre8, 9.3
 Architectures: amd64, arm64v8
 Directory: 9.3-jre8
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
 
 Tags: 9.2.30-jre8, 9.2-jre8, 9.2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update jetty versions with new releases 10.0.7, 11.0.7, and 9.3.30