### PR TITLE
Haskell bumps + remove stretch support

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,17 +4,9 @@ Maintainers: Peter Salvatore <peter@psftw.com> (@psftw),
 GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.0.1-buster, 9.0-buster, 9-buster, buster, 9.0.1, 9.0, 9, latest
-GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
+GitCommit: f08ade43f48981b87505fbecca852194954fa61b
 Directory: 9.0/buster
 
-Tags: 9.0.1-stretch, 9.0-stretch, 9-stretch, stretch
-GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
-Directory: 9.0/stretch
-
 Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
-GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
+GitCommit: f08ade43f48981b87505fbecca852194954fa61b
 Directory: 8.10/buster
-
-Tags: 8.10.7-stretch, 8.10-stretch, 8-stretch
-GitCommit: 4181ccd382f72959ecb234204fd018b2c203c3fe
-Directory: 8.10/stretch


### PR DESCRIPTION
- Update cabal-install to 3.6.2.0
- Drop support for [debian 9 stretch which latest cabal-install does not
  support](https://github.com/haskell/docker-haskell/issues/48).

Thanks