### PR TITLE
Add API-Firewall official image

### DIFF
--- a/library/api-firewall
+++ b/library/api-firewall
@@ -4,6 +4,5 @@ GitRepo: https://github.com/wallarm/api-firewall.git
 
 Tags: 0.6.7, latest
 Architectures: amd64
-GitCommit: 49f73161392ddd0f9ff76e8c104d5dcccdbf122f
+GitCommit: bfc4069e562ebd9892be0409a1f3e8739fc4f544
 GitFetch: refs/heads/main
-Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -6,3 +6,4 @@ Tags: 0.6.7, latest
 Architectures: amd64
 GitCommit: bfc4069e562ebd9892be0409a1f3e8739fc4f544
 GitFetch: refs/heads/main
+Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -1,8 +1,9 @@
 Maintainers: Ivan Novikov <in@wallarm.com> (@d0znpp), 
              Nikolay Tkachenko (@afr1ka)
-GitRepo: https://github.com/wallarm/api-firewall.git
+GitRepo: https://github.com/wallarm/api-firewall-docker.git
 
 Tags: 0.6.7, latest
 Architectures: amd64
-GitCommit: 9abab2521f63236c782778aaa19a96250f9d69aa
+GitCommit: 8a76dcbef20a07c27d41181f6dc1dbc7c380399f
 GitFetch: refs/heads/main
+Directory: 0.6.7

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -4,6 +4,6 @@ GitRepo: https://github.com/wallarm/api-firewall.git
 
 Tags: 0.6.7, latest
 Architectures: amd64
-GitCommit: bfc4069e562ebd9892be0409a1f3e8739fc4f544
+GitCommit: 49f73161392ddd0f9ff76e8c104d5dcccdbf122f
 GitFetch: refs/heads/main
 Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -3,7 +3,7 @@ Maintainers: Ivan Novikov <in@wallarm.com> (@d0znpp),
 GitRepo: https://github.com/wallarm/api-firewall-docker.git
 
 Tags: 0.6.7, latest
-Architectures: amd64
-GitCommit: 8a76dcbef20a07c27d41181f6dc1dbc7c380399f
+Architectures: amd64, arm64v8, i386
+GitCommit: 1e401622d38c10aedb7056c65bb651168fa08e7e
 GitFetch: refs/heads/main
 Directory: 0.6.7

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -4,6 +4,6 @@ GitRepo: https://github.com/wallarm/api-firewall-docker.git
 
 Tags: 0.6.7, latest
 Architectures: amd64, arm64v8, i386
-GitCommit: 1e401622d38c10aedb7056c65bb651168fa08e7e
+GitCommit: 5cd07f115f16d10095a385a73568a4e60caf278b
 GitFetch: refs/heads/main
 Directory: 0.6.7

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -4,6 +4,5 @@ GitRepo: https://github.com/wallarm/api-firewall.git
 
 Tags: 0.6.7, latest
 Architectures: amd64
-GitCommit: bfc4069e562ebd9892be0409a1f3e8739fc4f544
+GitCommit: 9abab2521f63236c782778aaa19a96250f9d69aa
 GitFetch: refs/heads/main
-Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -2,8 +2,8 @@ Maintainers: Ivan Novikov <in@wallarm.com> (@d0znpp),
              Nikolay Tkachenko (@afr1ka)
 GitRepo: https://github.com/wallarm/api-firewall.git
 
-Tags: 0.6.5, latest
+Tags: 0.6.7, latest
 Architectures: amd64
-GitCommit: f2af792ee8a38e327f274478ac32a8c0eaa4056e
+GitCommit: bfc4069e562ebd9892be0409a1f3e8739fc4f544
 GitFetch: refs/heads/main
 Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -1,0 +1,8 @@
+Maintainers: Ivan Novikov <in@wallarm.com> (@d0znpp), 
+             Nikolay Tkachenko (@afr1ka)
+GitRepo: https://github.com/wallarm/api-firewall.git
+
+Tags: 0.6.5, latest
+Architectures: amd64
+GitCommit: f2af792ee8a38e327f274478ac32a8c0eaa4056e
+Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -4,5 +4,5 @@ GitRepo: https://github.com/wallarm/api-firewall.git
 
 Tags: 0.6.5, latest
 Architectures: amd64
-GitCommit: f2af792ee8a38e327f274478ac32a8c0eaa4056e
+GitCommit: 2986c4c6d163e8e0de02c1740250d9471cc3c806
 Directory: docker

--- a/library/api-firewall
+++ b/library/api-firewall
@@ -4,5 +4,6 @@ GitRepo: https://github.com/wallarm/api-firewall.git
 
 Tags: 0.6.5, latest
 Architectures: amd64
-GitCommit: 2986c4c6d163e8e0de02c1740250d9471cc3c806
+GitCommit: f2af792ee8a38e327f274478ac32a8c0eaa4056e
+GitFetch: refs/heads/main
 Directory: docker


### PR DESCRIPTION
Hello,

We would like to add the [API-Firewall](https://github.com/wallarm/api-firewall) to the official image repository.

Thanks.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/wallarm
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)?
    - https://github.com/wallarm/api-firewall/blob/main/LICENSE - MPL 2.0
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/2074
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)