### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -4,262 +4,262 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 8.1.0RC3-cli-bullseye, 8.1-rc-cli-bullseye, 8.1.0RC3-bullseye, 8.1-rc-bullseye, 8.1.0RC3-cli, 8.1-rc-cli, 8.1.0RC3, 8.1-rc
+Tags: 8.1.0RC4-cli-bullseye, 8.1-rc-cli-bullseye, 8.1.0RC4-bullseye, 8.1-rc-bullseye, 8.1.0RC4-cli, 8.1-rc-cli, 8.1.0RC4, 8.1-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/bullseye/cli
 
-Tags: 8.1.0RC3-apache-bullseye, 8.1-rc-apache-bullseye, 8.1.0RC3-apache, 8.1-rc-apache
+Tags: 8.1.0RC4-apache-bullseye, 8.1-rc-apache-bullseye, 8.1.0RC4-apache, 8.1-rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/bullseye/apache
 
-Tags: 8.1.0RC3-fpm-bullseye, 8.1-rc-fpm-bullseye, 8.1.0RC3-fpm, 8.1-rc-fpm
+Tags: 8.1.0RC4-fpm-bullseye, 8.1-rc-fpm-bullseye, 8.1.0RC4-fpm, 8.1-rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/bullseye/fpm
 
-Tags: 8.1.0RC3-zts-bullseye, 8.1-rc-zts-bullseye, 8.1.0RC3-zts, 8.1-rc-zts
+Tags: 8.1.0RC4-zts-bullseye, 8.1-rc-zts-bullseye, 8.1.0RC4-zts, 8.1-rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/bullseye/zts
 
-Tags: 8.1.0RC3-cli-buster, 8.1-rc-cli-buster, 8.1.0RC3-buster, 8.1-rc-buster
+Tags: 8.1.0RC4-cli-buster, 8.1-rc-cli-buster, 8.1.0RC4-buster, 8.1-rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/buster/cli
 
-Tags: 8.1.0RC3-apache-buster, 8.1-rc-apache-buster
+Tags: 8.1.0RC4-apache-buster, 8.1-rc-apache-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/buster/apache
 
-Tags: 8.1.0RC3-fpm-buster, 8.1-rc-fpm-buster
+Tags: 8.1.0RC4-fpm-buster, 8.1-rc-fpm-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/buster/fpm
 
-Tags: 8.1.0RC3-zts-buster, 8.1-rc-zts-buster
+Tags: 8.1.0RC4-zts-buster, 8.1-rc-zts-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/buster/zts
 
-Tags: 8.1.0RC3-cli-alpine3.14, 8.1-rc-cli-alpine3.14, 8.1.0RC3-alpine3.14, 8.1-rc-alpine3.14, 8.1.0RC3-cli-alpine, 8.1-rc-cli-alpine, 8.1.0RC3-alpine, 8.1-rc-alpine
+Tags: 8.1.0RC4-cli-alpine3.14, 8.1-rc-cli-alpine3.14, 8.1.0RC4-alpine3.14, 8.1-rc-alpine3.14, 8.1.0RC4-cli-alpine, 8.1-rc-cli-alpine, 8.1.0RC4-alpine, 8.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/alpine3.14/cli
 
-Tags: 8.1.0RC3-fpm-alpine3.14, 8.1-rc-fpm-alpine3.14, 8.1.0RC3-fpm-alpine, 8.1-rc-fpm-alpine
+Tags: 8.1.0RC4-fpm-alpine3.14, 8.1-rc-fpm-alpine3.14, 8.1.0RC4-fpm-alpine, 8.1-rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/alpine3.14/fpm
 
-Tags: 8.1.0RC3-cli-alpine3.13, 8.1-rc-cli-alpine3.13, 8.1.0RC3-alpine3.13, 8.1-rc-alpine3.13
+Tags: 8.1.0RC4-cli-alpine3.13, 8.1-rc-cli-alpine3.13, 8.1.0RC4-alpine3.13, 8.1-rc-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/alpine3.13/cli
 
-Tags: 8.1.0RC3-fpm-alpine3.13, 8.1-rc-fpm-alpine3.13
+Tags: 8.1.0RC4-fpm-alpine3.13, 8.1-rc-fpm-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 104c2a74f0ba960f55019ffda06e04c1edcef80b
+GitCommit: 505d8665003831f1babe32c3a60b878da58da8bc
 Directory: 8.1-rc/alpine3.13/fpm
 
 Tags: 8.0.11-cli-bullseye, 8.0-cli-bullseye, 8-cli-bullseye, cli-bullseye, 8.0.11-bullseye, 8.0-bullseye, 8-bullseye, bullseye, 8.0.11-cli, 8.0-cli, 8-cli, cli, 8.0.11, 8.0, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/bullseye/cli
 
 Tags: 8.0.11-apache-bullseye, 8.0-apache-bullseye, 8-apache-bullseye, apache-bullseye, 8.0.11-apache, 8.0-apache, 8-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/bullseye/apache
 
 Tags: 8.0.11-fpm-bullseye, 8.0-fpm-bullseye, 8-fpm-bullseye, fpm-bullseye, 8.0.11-fpm, 8.0-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/bullseye/fpm
 
 Tags: 8.0.11-zts-bullseye, 8.0-zts-bullseye, 8-zts-bullseye, zts-bullseye, 8.0.11-zts, 8.0-zts, 8-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/bullseye/zts
 
 Tags: 8.0.11-cli-buster, 8.0-cli-buster, 8-cli-buster, cli-buster, 8.0.11-buster, 8.0-buster, 8-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/buster/cli
 
 Tags: 8.0.11-apache-buster, 8.0-apache-buster, 8-apache-buster, apache-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/buster/apache
 
 Tags: 8.0.11-fpm-buster, 8.0-fpm-buster, 8-fpm-buster, fpm-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/buster/fpm
 
 Tags: 8.0.11-zts-buster, 8.0-zts-buster, 8-zts-buster, zts-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/buster/zts
 
 Tags: 8.0.11-cli-alpine3.14, 8.0-cli-alpine3.14, 8-cli-alpine3.14, cli-alpine3.14, 8.0.11-alpine3.14, 8.0-alpine3.14, 8-alpine3.14, alpine3.14, 8.0.11-cli-alpine, 8.0-cli-alpine, 8-cli-alpine, cli-alpine, 8.0.11-alpine, 8.0-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/alpine3.14/cli
 
 Tags: 8.0.11-fpm-alpine3.14, 8.0-fpm-alpine3.14, 8-fpm-alpine3.14, fpm-alpine3.14, 8.0.11-fpm-alpine, 8.0-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/alpine3.14/fpm
 
 Tags: 8.0.11-cli-alpine3.13, 8.0-cli-alpine3.13, 8-cli-alpine3.13, cli-alpine3.13, 8.0.11-alpine3.13, 8.0-alpine3.13, 8-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/alpine3.13/cli
 
 Tags: 8.0.11-fpm-alpine3.13, 8.0-fpm-alpine3.13, 8-fpm-alpine3.13, fpm-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d98db4cebcdf5ff776e2d0b9bf4a5b482f4e657
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 8.0/alpine3.13/fpm
 
 Tags: 7.4.24-cli-bullseye, 7.4-cli-bullseye, 7-cli-bullseye, 7.4.24-bullseye, 7.4-bullseye, 7-bullseye, 7.4.24-cli, 7.4-cli, 7-cli, 7.4.24, 7.4, 7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/bullseye/cli
 
 Tags: 7.4.24-apache-bullseye, 7.4-apache-bullseye, 7-apache-bullseye, 7.4.24-apache, 7.4-apache, 7-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/bullseye/apache
 
 Tags: 7.4.24-fpm-bullseye, 7.4-fpm-bullseye, 7-fpm-bullseye, 7.4.24-fpm, 7.4-fpm, 7-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/bullseye/fpm
 
 Tags: 7.4.24-zts-bullseye, 7.4-zts-bullseye, 7-zts-bullseye, 7.4.24-zts, 7.4-zts, 7-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/bullseye/zts
 
 Tags: 7.4.24-cli-buster, 7.4-cli-buster, 7-cli-buster, 7.4.24-buster, 7.4-buster, 7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/buster/cli
 
 Tags: 7.4.24-apache-buster, 7.4-apache-buster, 7-apache-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/buster/apache
 
 Tags: 7.4.24-fpm-buster, 7.4-fpm-buster, 7-fpm-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/buster/fpm
 
 Tags: 7.4.24-zts-buster, 7.4-zts-buster, 7-zts-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/buster/zts
 
 Tags: 7.4.24-cli-alpine3.14, 7.4-cli-alpine3.14, 7-cli-alpine3.14, 7.4.24-alpine3.14, 7.4-alpine3.14, 7-alpine3.14, 7.4.24-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, 7.4.24-alpine, 7.4-alpine, 7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/alpine3.14/cli
 
 Tags: 7.4.24-fpm-alpine3.14, 7.4-fpm-alpine3.14, 7-fpm-alpine3.14, 7.4.24-fpm-alpine, 7.4-fpm-alpine, 7-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/alpine3.14/fpm
 
 Tags: 7.4.24-zts-alpine3.14, 7.4-zts-alpine3.14, 7-zts-alpine3.14, 7.4.24-zts-alpine, 7.4-zts-alpine, 7-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/alpine3.14/zts
 
 Tags: 7.4.24-cli-alpine3.13, 7.4-cli-alpine3.13, 7-cli-alpine3.13, 7.4.24-alpine3.13, 7.4-alpine3.13, 7-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/alpine3.13/cli
 
 Tags: 7.4.24-fpm-alpine3.13, 7.4-fpm-alpine3.13, 7-fpm-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/alpine3.13/fpm
 
 Tags: 7.4.24-zts-alpine3.13, 7.4-zts-alpine3.13, 7-zts-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 41d3146c41fc26fc6768a44a75ab59f6a392f28e
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.4/alpine3.13/zts
 
 Tags: 7.3.31-cli-bullseye, 7.3-cli-bullseye, 7.3.31-bullseye, 7.3-bullseye, 7.3.31-cli, 7.3-cli, 7.3.31, 7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/bullseye/cli
 
 Tags: 7.3.31-apache-bullseye, 7.3-apache-bullseye, 7.3.31-apache, 7.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/bullseye/apache
 
 Tags: 7.3.31-fpm-bullseye, 7.3-fpm-bullseye, 7.3.31-fpm, 7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/bullseye/fpm
 
 Tags: 7.3.31-zts-bullseye, 7.3-zts-bullseye, 7.3.31-zts, 7.3-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/bullseye/zts
 
 Tags: 7.3.31-cli-buster, 7.3-cli-buster, 7.3.31-buster, 7.3-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/buster/cli
 
 Tags: 7.3.31-apache-buster, 7.3-apache-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/buster/apache
 
 Tags: 7.3.31-fpm-buster, 7.3-fpm-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/buster/fpm
 
 Tags: 7.3.31-zts-buster, 7.3-zts-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/buster/zts
 
 Tags: 7.3.31-cli-alpine3.14, 7.3-cli-alpine3.14, 7.3.31-alpine3.14, 7.3-alpine3.14, 7.3.31-cli-alpine, 7.3-cli-alpine, 7.3.31-alpine, 7.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/alpine3.14/cli
 
 Tags: 7.3.31-fpm-alpine3.14, 7.3-fpm-alpine3.14, 7.3.31-fpm-alpine, 7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/alpine3.14/fpm
 
 Tags: 7.3.31-zts-alpine3.14, 7.3-zts-alpine3.14, 7.3.31-zts-alpine, 7.3-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/alpine3.14/zts
 
 Tags: 7.3.31-cli-alpine3.13, 7.3-cli-alpine3.13, 7.3.31-alpine3.13, 7.3-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/alpine3.13/cli
 
 Tags: 7.3.31-fpm-alpine3.13, 7.3-fpm-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/alpine3.13/fpm
 
 Tags: 7.3.31-zts-alpine3.13, 7.3-zts-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 369384a82dbaf964f5b24919fafc16a43cc6280d
+GitCommit: 15ddd64eb28016277ff2da21a13282b745277f9e
 Directory: 7.3/alpine3.13/zts


### PR DESCRIPTION
Changes:

- docker-library/php@505d866: Update 8.1-rc to 8.1.0RC4
- docker-library/php@15ddd64: Merge pull request docker-library/php#1213 from infosiftr/strip-ext
- docker-library/php@d7f4627: Merge pull request docker-library/php#1212 from infosiftr/find-perm
- docker-library/php@b2c6b85: Add stripping to installed extensions
- docker-library/php@6e558df: Fix "find -perm" syntax (and ignore "strip" failures but not "find" failures)
- docker-library/php@1e6fd3b: Merge pull request docker-library/php#1208 from infosiftr/extra-extra
- docker-library/php@6d7ea20: Merge PHP_EXTRA_* into the places they're used