### PR TITLE
update sapmachine

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,12 +1,12 @@
 Maintainers: Rene Schuenemann <sapmachine@sap.com> (@reshnm), Christian Halstrick <sapmachine@sap.com> (@chalstrick)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: 17, latest
+Tags: 11, 11.0.12
 Architectures: amd64
-GitCommit: 33306feef57cd954cadbbf86c2796edc1e5391f7
-Directory: dockerfiles/official/stable
+GitCommit: 60fd8df23db6501bc6c508f8c87d07e94d36f043
+Directory: dockerfiles/official/11
 
-Tags: 11, 11.0.12, lts
+Tags: 17, latest, lts
 Architectures: amd64
-GitCommit: 4f134f5d589f13b19b6a26931739fed44074ae77
-Directory: dockerfiles/official/lts
+GitCommit: 532baee8c97aee7c85f7b16523aeba4268c0ed96
+Directory: dockerfiles/official/17


### PR DESCRIPTION
There now are two LTS releases of SapMachine supported in parallel. In addition there will be be a short term support release in the future. The directory of the SapMachine repo had to be changed to support this. This change reflects the change and adapts the tags.