### PR TITLE
Update Clear Linux OS to 35130

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 8eb2aad3c4399e1b160be6c5952a9cd3294c1dd9
-GitFetch: refs/heads/base-35110
+GitCommit: c6c1b6bfd8150dd4c8e4c20c3556bb7a9651ef03
+GitFetch: refs/heads/base-35130


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35130

@bryteise @mdhorn @phmccarty