### PR TITLE
Odoo: update 13.0-15.0 to release 20211018

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: e6d26592e68f0cdad2e391441255761b3638144c
+GitCommit: bb44f3916c974b7586fc278b0664c63e7d989134
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here a re the latest updates for Odoo supported versions.

Thanks.