### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -9,7 +9,7 @@ Architectures: amd64, arm64v8
 GitCommit: ade24e9202c209408df15dc88959020313b67773
 Directory: 7.14
 
-Tags: 6.8.19
+Tags: 6.8.20
 Architectures: amd64
-GitCommit: 12452b4a9bdb05e32082ec9ea3d68ac11336df9e
+GitCommit: 7c27790b5084246183270861bc4d450dd80301d2
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -9,7 +9,7 @@ Architectures: amd64, arm64v8
 GitCommit: 93b1fa087fd940757b530511d868fdc7931149de
 Directory: 7.14
 
-Tags: 6.8.19
+Tags: 6.8.20
 Architectures: amd64
-GitCommit: 5cb47fd09dfb83cc484a779cc61ba6abf97f63b2
+GitCommit: 61d8511e32cd477ab0ba3af1e4256b9f1c8358b7
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -9,7 +9,7 @@ Architectures: amd64, arm64v8
 GitCommit: c77765eaeb758ec15bc9525a44eff05eecc884aa
 Directory: 7.14
 
-Tags: 6.8.19
+Tags: 6.8.20
 Architectures: amd64
-GitCommit: 6f3408c8f635558443a440f459211b7e68aeb8e6
+GitCommit: 5bcca98c9dc32e7f2311c2e90d557ee669ae1db8
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/7c27790: Update to 6.8.20

logstash:
- https://github.com/docker-library/logstash/commit/5bcca98: Update to 6.8.20

kibana:
- https://github.com/docker-library/kibana/commit/61d8511: Update to 6.8.20