### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -118,58 +118,6 @@ GitCommit: 41610205127c2a4f0af64f68b859726993503a89
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 16.0.2-jdk-oraclelinux8, 16.0.2-oraclelinux8, 16.0-jdk-oraclelinux8, 16.0-oraclelinux8, 16-jdk-oraclelinux8, 16-oraclelinux8, 16.0.2-jdk-oracle, 16.0.2-oracle, 16.0-jdk-oracle, 16.0-oracle, 16-jdk-oracle, 16-oracle
-SharedTags: 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16
-Architectures: amd64, arm64v8
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/oraclelinux8
-
-Tags: 16.0.2-jdk-oraclelinux7, 16.0.2-oraclelinux7, 16.0-jdk-oraclelinux7, 16.0-oraclelinux7, 16-jdk-oraclelinux7, 16-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/oraclelinux7
-
-Tags: 16.0.2-jdk-bullseye, 16.0.2-bullseye, 16.0-jdk-bullseye, 16.0-bullseye, 16-jdk-bullseye, 16-bullseye
-Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
-Directory: 16/jdk/bullseye
-
-Tags: 16.0.2-jdk-slim-bullseye, 16.0.2-slim-bullseye, 16.0-jdk-slim-bullseye, 16.0-slim-bullseye, 16-jdk-slim-bullseye, 16-slim-bullseye, 16.0.2-jdk-slim, 16.0.2-slim, 16.0-jdk-slim, 16.0-slim, 16-jdk-slim, 16-slim
-Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
-Directory: 16/jdk/slim-bullseye
-
-Tags: 16.0.2-jdk-buster, 16.0.2-buster, 16.0-jdk-buster, 16.0-buster, 16-jdk-buster, 16-buster
-Architectures: amd64, arm64v8
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/buster
-
-Tags: 16.0.2-jdk-slim-buster, 16.0.2-slim-buster, 16.0-jdk-slim-buster, 16.0-slim-buster, 16-jdk-slim-buster, 16-slim-buster
-Architectures: amd64, arm64v8
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/slim-buster
-
-Tags: 16.0.2-jdk-windowsservercore-1809, 16.0.2-windowsservercore-1809, 16.0-jdk-windowsservercore-1809, 16.0-windowsservercore-1809, 16-jdk-windowsservercore-1809, 16-windowsservercore-1809
-SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16
-Architectures: windows-amd64
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 16.0.2-jdk-windowsservercore-ltsc2016, 16.0.2-windowsservercore-ltsc2016, 16.0-jdk-windowsservercore-ltsc2016, 16.0-windowsservercore-ltsc2016, 16-jdk-windowsservercore-ltsc2016, 16-windowsservercore-ltsc2016
-SharedTags: 16.0.2-jdk-windowsservercore, 16.0.2-windowsservercore, 16.0-jdk-windowsservercore, 16.0-windowsservercore, 16-jdk-windowsservercore, 16-windowsservercore, 16.0.2-jdk, 16.0.2, 16.0-jdk, 16.0, 16-jdk, 16
-Architectures: windows-amd64
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
-Tags: 16.0.2-jdk-nanoserver-1809, 16.0.2-nanoserver-1809, 16.0-jdk-nanoserver-1809, 16.0-nanoserver-1809, 16-jdk-nanoserver-1809, 16-nanoserver-1809
-SharedTags: 16.0.2-jdk-nanoserver, 16.0.2-nanoserver, 16.0-jdk-nanoserver, 16.0-nanoserver, 16-jdk-nanoserver, 16-nanoserver
-Architectures: windows-amd64
-GitCommit: d443a298b6b85cfb8652837b945d9df55b98c20d
-Directory: 16/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
 Tags: 11.0.12-jdk-oraclelinux8, 11.0.12-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.12-jdk-oracle, 11.0.12-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
 GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8620f06: Remove EOL 16 (https://jdk.java.net/16/)

FYI affected maintainers:

- `clojure`: @Quantisan @cap10morgan
- `maven`: @carlossg
- `openjdk`: @tianon @yosifkit
- `tomcat`: @tianon @yosifkit