### PR TITLE
maven: remove openjdk-16 and adoptopenjdk

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -6,11 +6,6 @@ Architectures: amd64, arm64v8
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
 Directory: openjdk-11
 
-Tags: 3.8.3-jdk-11-openj9, 3.8-jdk-11-openj9, 3-jdk-11-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-11-openj9
-
 Tags: 3.8.3-jdk-11-slim, 3.8-jdk-11-slim, 3-jdk-11-slim
 Architectures: amd64, arm64v8
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
@@ -20,11 +15,6 @@ Tags: 3.8.3-jdk-8, 3.8-jdk-8, 3-jdk-8
 Architectures: amd64, arm64v8
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
 Directory: openjdk-8
-
-Tags: 3.8.3-jdk-8-openj9, 3.8-jdk-8-openj9, 3-jdk-8-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-8-openj9
 
 Tags: 3.8.3-jdk-8-slim, 3.8-jdk-8-slim, 3-jdk-8-slim
 Architectures: amd64, arm64v8
@@ -40,16 +30,6 @@ Tags: 3.8.3-openjdk-11-slim, 3.8-openjdk-11-slim, 3-openjdk-11-slim
 Architectures: amd64, arm64v8
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
 Directory: openjdk-11-slim
-
-Tags: 3.8.3-openjdk-16, 3.8-openjdk-16, 3-openjdk-16
-Architectures: amd64, arm64v8
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: openjdk-16
-
-Tags: 3.8.3-openjdk-16-slim, 3.8-openjdk-16-slim, 3-openjdk-16-slim
-Architectures: amd64, arm64v8
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: openjdk-16-slim
 
 Tags: 3.8.3-openjdk-17, 3.8.3, 3.8.3-openjdk, 3.8-openjdk-17, 3.8, 3.8-openjdk, 3-openjdk-17, 3, latest, 3-openjdk, openjdk
 Architectures: amd64, arm64v8
@@ -71,53 +51,13 @@ Architectures: amd64, arm64v8
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
 Directory: openjdk-8-slim
 
-Tags: 3.8.3-adoptopenjdk-11, 3.8-adoptopenjdk-11, 3-adoptopenjdk-11
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-11
-
-Tags: 3.8.3-adoptopenjdk-11-openj9, 3.8-adoptopenjdk-11-openj9, 3-adoptopenjdk-11-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-11-openj9
-
-Tags: 3.8.3-adoptopenjdk-15, 3.8.3-adoptopenjdk, 3.8-adoptopenjdk-15, 3.8-adoptopenjdk, 3-adoptopenjdk-15, 3-adoptopenjdk, adoptopenjdk
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-15
-
-Tags: 3.8.3-adoptopenjdk-15-openj9, 3.8-adoptopenjdk-15-openj9, 3-adoptopenjdk-15-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-15-openj9
-
-Tags: 3.8.3-adoptopenjdk-16, 3.8-adoptopenjdk-16, 3-adoptopenjdk-16
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-16
-
-Tags: 3.8.3-adoptopenjdk-16-openj9, 3.8-adoptopenjdk-16-openj9, 3-adoptopenjdk-16-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-16-openj9
-
-Tags: 3.8.3-adoptopenjdk-8, 3.8-adoptopenjdk-8, 3-adoptopenjdk-8
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-8
-
-Tags: 3.8.3-adoptopenjdk-8-openj9, 3.8-adoptopenjdk-8-openj9, 3-adoptopenjdk-8-openj9
-Architectures: amd64, ppc64le, s390x
-GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
-Directory: adoptopenjdk-8-openj9
-
 Tags: 3.8.3-eclipse-temurin-11, 3.8-eclipse-temurin-11, 3-eclipse-temurin-11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
 Directory: eclipse-temurin-11
 
 Tags: 3.8.3-eclipse-temurin-16, 3.8-eclipse-temurin-16, 3-eclipse-temurin-16
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 4612a489002a4d33b6e43b0a1c0c424861672127
 Directory: eclipse-temurin-16
 


### PR DESCRIPTION
removed from library

openj9 is no longer available either