### PR TITLE
refactor: remove unnecessary tags

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -3,8 +3,8 @@ GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 
 Tags: 2.4.1-buster-slim, 2.4-buster-slim, 2-buster-slim, buster-slim, 2.4.1, 2.4, 2, latest
 Directory: buster/2.4.1
-GitCommit: 5bccd499742f6f05e7ddc970842a1763bdd99cfa
+GitCommit: bfe019bd289169c95503283d73a0fc223576b0ae
 
 Tags: 2.4.1-centos, 2.4-centos, 2-centos, centos
 Directory: centos8/2.4.1
-GitCommit: 5bccd499742f6f05e7ddc970842a1763bdd99cfa
+GitCommit: bfe019bd289169c95503283d73a0fc223576b0ae

--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -8,11 +8,3 @@ GitCommit: 5bccd499742f6f05e7ddc970842a1763bdd99cfa
 Tags: 2.4.1-centos, 2.4-centos, 2-centos, centos
 Directory: centos8/2.4.1
 GitCommit: 5bccd499742f6f05e7ddc970842a1763bdd99cfa
-
-Tags: 2.4.0-buster-slim, 2.4.0
-Directory: buster/2.4.0
-GitCommit: 444f7754822cb3e96cb2b66042d8e87d2227be0b
-
-Tags: 2.4.0-centos
-Directory: centos8/2.4.0
-GitCommit: 444f7754822cb3e96cb2b66042d8e87d2227be0b


### PR DESCRIPTION
## Description

This PR resolves an [old conversation](https://github.com/docker-library/official-images/pull/8551#discussion_r470839830) about removing unnecessary tags from the RethinkDB library definition file.

As the tags will remain available, users will be able to download older tags as well.

## Supporting information

* https://github.com/docker-library/official-images/pull/8551#discussion_r470839830

### Dependencies

N/A