### PR TITLE
Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/httpd/blob/38a58221d725d54686d6113f12efbd3fa97ef3e6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/httpd/blob/cab17d54f9e0070c672326a555996d94922b486e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.51, 2.4, 2, latest, 2.4.51-buster, 2.4-buster, 2-buster, buster
+Tags: 2.4.51, 2.4, 2, latest, 2.4.51-bullseye, 2.4-bullseye, 2-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d89a55e9e5742bebd10fddf83ffb07f2df4d7a0
+GitCommit: cab17d54f9e0070c672326a555996d94922b486e
 Directory: 2.4
 
 Tags: 2.4.51-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.51-alpine3.14, 2.4-alpine3.14, 2-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d89a55e9e5742bebd10fddf83ffb07f2df4d7a0
+GitCommit: cab17d54f9e0070c672326a555996d94922b486e
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/5f92ab1: Merge pull request https://github.com/docker-library/httpd/pull/204 from infosiftr/bullseye
- https://github.com/docker-library/httpd/commit/cab17d5: Update to Debian Bullseye
- https://github.com/docker-library/httpd/commit/2fdf867: Merge pull request https://github.com/docker-library/httpd/pull/202 from infosiftr/alpine-deps
- https://github.com/docker-library/httpd/commit/a9e7ecc: Move Alpine "runtime" deps to match Debian better