### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-19-jdk-oraclelinux8, 18-ea-19-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-19-jdk-oracle, 18-ea-19-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-19-jdk, 18-ea-19, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-20-jdk-oraclelinux8, 18-ea-20-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-20-jdk-oracle, 18-ea-20-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-20-jdk, 18-ea-20, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-19-jdk-oraclelinux7, 18-ea-19-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-20-jdk-oraclelinux7, 18-ea-20-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-19-jdk-bullseye, 18-ea-19-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
+Tags: 18-ea-20-jdk-bullseye, 18-ea-20-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/bullseye
 
-Tags: 18-ea-19-jdk-slim-bullseye, 18-ea-19-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-19-jdk-slim, 18-ea-19-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-20-jdk-slim-bullseye, 18-ea-20-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-20-jdk-slim, 18-ea-20-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18-ea-19-jdk-buster, 18-ea-19-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-20-jdk-buster, 18-ea-20-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/buster
 
-Tags: 18-ea-19-jdk-slim-buster, 18-ea-19-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
+Tags: 18-ea-20-jdk-slim-buster, 18-ea-20-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/slim-buster
 
 Tags: 18-ea-11-jdk-alpine3.14, 18-ea-11-alpine3.14, 18-ea-jdk-alpine3.14, 18-ea-alpine3.14, 18-jdk-alpine3.14, 18-alpine3.14, 18-ea-11-jdk-alpine, 18-ea-11-alpine, 18-ea-jdk-alpine, 18-ea-alpine, 18-jdk-alpine, 18-alpine
@@ -45,24 +45,24 @@ Architectures: amd64
 GitCommit: 20db9bb3edad42224dcdfa0ea95030c2848851cd
 Directory: 18/jdk/alpine3.13
 
-Tags: 18-ea-19-jdk-windowsservercore-1809, 18-ea-19-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-19-jdk-windowsservercore, 18-ea-19-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-19-jdk, 18-ea-19, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-20-jdk-windowsservercore-1809, 18-ea-20-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-20-jdk-windowsservercore, 18-ea-20-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-20-jdk, 18-ea-20, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-19-jdk-windowsservercore-ltsc2016, 18-ea-19-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-19-jdk-windowsservercore, 18-ea-19-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-19-jdk, 18-ea-19, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-20-jdk-windowsservercore-ltsc2016, 18-ea-20-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-20-jdk-windowsservercore, 18-ea-20-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-20-jdk, 18-ea-20, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-19-jdk-nanoserver-1809, 18-ea-19-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-19-jdk-nanoserver, 18-ea-19-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-20-jdk-nanoserver-1809, 18-ea-20-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-20-jdk-nanoserver, 18-ea-20-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 8693e60fb789ebe456e55c5d65aa8fd2e790fb01
+GitCommit: a81efb7fb8455ed013347813f0b5e592e57bfb39
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -118,190 +118,190 @@ GitCommit: 41610205127c2a4f0af64f68b859726993503a89
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.12-jdk-oraclelinux8, 11.0.12-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.12-jdk-oracle, 11.0.12-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
+Tags: 11.0.13-jdk-oraclelinux8, 11.0.13-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.13-jdk-oracle, 11.0.13-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/oraclelinux8
 
-Tags: 11.0.12-jdk-oraclelinux7, 11.0.12-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
+Tags: 11.0.13-jdk-oraclelinux7, 11.0.13-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/oraclelinux7
 
-Tags: 11.0.12-jdk-bullseye, 11.0.12-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
-SharedTags: 11.0.12-jdk, 11.0.12, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.13-jdk-bullseye, 11.0.13-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
+SharedTags: 11.0.13-jdk, 11.0.13, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/bullseye
 
-Tags: 11.0.12-jdk-slim-bullseye, 11.0.12-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.12-jdk-slim, 11.0.12-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.13-jdk-slim-bullseye, 11.0.13-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.13-jdk-slim, 11.0.13-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/slim-bullseye
 
-Tags: 11.0.12-jdk-buster, 11.0.12-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
+Tags: 11.0.13-jdk-buster, 11.0.13-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 Architectures: amd64, arm64v8
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/buster
 
-Tags: 11.0.12-jdk-slim-buster, 11.0.12-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
+Tags: 11.0.13-jdk-slim-buster, 11.0.13-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/slim-buster
 
-Tags: 11.0.12-jdk-windowsservercore-1809, 11.0.12-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.12-jdk-windowsservercore, 11.0.12-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12-jdk, 11.0.12, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.13-jdk-windowsservercore-1809, 11.0.13-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.13-jdk-windowsservercore, 11.0.13-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.13-jdk, 11.0.13, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.12-jdk-windowsservercore-ltsc2016, 11.0.12-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.12-jdk-windowsservercore, 11.0.12-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.12-jdk, 11.0.12, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.13-jdk-windowsservercore-ltsc2016, 11.0.13-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
+SharedTags: 11.0.13-jdk-windowsservercore, 11.0.13-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.13-jdk, 11.0.13, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.12-jdk-nanoserver-1809, 11.0.12-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.12-jdk-nanoserver, 11.0.12-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.13-jdk-nanoserver-1809, 11.0.13-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.13-jdk-nanoserver, 11.0.13-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.12-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
-SharedTags: 11.0.12-jre, 11.0-jre, 11-jre
+Tags: 11.0.13-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
+SharedTags: 11.0.13-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/bullseye
 
-Tags: 11.0.12-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.12-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.13-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.13-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/slim-bullseye
 
-Tags: 11.0.12-jre-buster, 11.0-jre-buster, 11-jre-buster
+Tags: 11.0.13-jre-buster, 11.0-jre-buster, 11-jre-buster
 Architectures: amd64, arm64v8
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/buster
 
-Tags: 11.0.12-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
+Tags: 11.0.13-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/slim-buster
 
-Tags: 11.0.12-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.12-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.12-jre, 11.0-jre, 11-jre
+Tags: 11.0.13-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.13-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.13-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.12-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.12-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.12-jre, 11.0-jre, 11-jre
+Tags: 11.0.13-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
+SharedTags: 11.0.13-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.13-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 11.0.12-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.12-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.13-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.13-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 6c18f690c35e42950119a92d2edd854a869745c5
+GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u302-jdk-oraclelinux8, 8u302-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u302-jdk-oracle, 8u302-oracle, 8-jdk-oracle, 8-oracle
+Tags: 8u312-jdk-oraclelinux8, 8u312-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u312-jdk-oracle, 8u312-oracle, 8-jdk-oracle, 8-oracle
 Architectures: amd64, arm64v8
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/oraclelinux8
 
-Tags: 8u302-jdk-oraclelinux7, 8u302-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
+Tags: 8u312-jdk-oraclelinux7, 8u312-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/oraclelinux7
 
-Tags: 8u302-jdk-bullseye, 8u302-bullseye, 8-jdk-bullseye, 8-bullseye
-SharedTags: 8u302-jdk, 8u302, 8-jdk, 8
+Tags: 8u312-jdk-bullseye, 8u312-bullseye, 8-jdk-bullseye, 8-bullseye
+SharedTags: 8u312-jdk, 8u312, 8-jdk, 8
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/bullseye
 
-Tags: 8u302-jdk-slim-bullseye, 8u302-slim-bullseye, 8-jdk-slim-bullseye, 8-slim-bullseye, 8u302-jdk-slim, 8u302-slim, 8-jdk-slim, 8-slim
+Tags: 8u312-jdk-slim-bullseye, 8u312-slim-bullseye, 8-jdk-slim-bullseye, 8-slim-bullseye, 8u312-jdk-slim, 8u312-slim, 8-jdk-slim, 8-slim
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/slim-bullseye
 
-Tags: 8u302-jdk-buster, 8u302-buster, 8-jdk-buster, 8-buster
+Tags: 8u312-jdk-buster, 8u312-buster, 8-jdk-buster, 8-buster
 Architectures: amd64, arm64v8
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/buster
 
-Tags: 8u302-jdk-slim-buster, 8u302-slim-buster, 8-jdk-slim-buster, 8-slim-buster
+Tags: 8u312-jdk-slim-buster, 8u312-slim-buster, 8-jdk-slim-buster, 8-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/slim-buster
 
-Tags: 8u302-jdk-windowsservercore-1809, 8u302-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u302-jdk-windowsservercore, 8u302-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-jdk, 8u302, 8-jdk, 8
+Tags: 8u312-jdk-windowsservercore-1809, 8u312-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u312-jdk-windowsservercore, 8u312-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u312-jdk, 8u312, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u302-jdk-windowsservercore-ltsc2016, 8u302-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u302-jdk-windowsservercore, 8u302-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u302-jdk, 8u302, 8-jdk, 8
+Tags: 8u312-jdk-windowsservercore-ltsc2016, 8u312-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
+SharedTags: 8u312-jdk-windowsservercore, 8u312-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u312-jdk, 8u312, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u302-jdk-nanoserver-1809, 8u302-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u302-jdk-nanoserver, 8u302-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u312-jdk-nanoserver-1809, 8u312-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u312-jdk-nanoserver, 8u312-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u302-jre-bullseye, 8-jre-bullseye
-SharedTags: 8u302-jre, 8-jre
+Tags: 8u312-jre-bullseye, 8-jre-bullseye
+SharedTags: 8u312-jre, 8-jre
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/bullseye
 
-Tags: 8u302-jre-slim-bullseye, 8-jre-slim-bullseye, 8u302-jre-slim, 8-jre-slim
+Tags: 8u312-jre-slim-bullseye, 8-jre-slim-bullseye, 8u312-jre-slim, 8-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: ac338f3112ad10269fc2d21d9104570454ca064b
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/slim-bullseye
 
-Tags: 8u302-jre-buster, 8-jre-buster
+Tags: 8u312-jre-buster, 8-jre-buster
 Architectures: amd64, arm64v8
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/buster
 
-Tags: 8u302-jre-slim-buster, 8-jre-slim-buster
+Tags: 8u312-jre-slim-buster, 8-jre-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/slim-buster
 
-Tags: 8u302-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u302-jre-windowsservercore, 8-jre-windowsservercore, 8u302-jre, 8-jre
+Tags: 8u312-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u312-jre-windowsservercore, 8-jre-windowsservercore, 8u312-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u302-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u302-jre-windowsservercore, 8-jre-windowsservercore, 8u302-jre, 8-jre
+Tags: 8u312-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
+SharedTags: 8u312-jre-windowsservercore, 8-jre-windowsservercore, 8u312-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 8u302-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u302-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u312-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u312-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 81dd4c4c6dac783f6a0996a665984d52e3d69211
+GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/a81efb7: Update 18 to 18-ea+20
- https://github.com/docker-library/openjdk/commit/3ce4449: Update 8 to 8u312
- https://github.com/docker-library/openjdk/commit/61bfbb3: Update 11 to 11.0.13
- https://github.com/docker-library/openjdk/commit/8620f06: Remove EOL 16 (https://jdk.java.net/16/)