### PR TITLE
archlinux: Release 20211024.0.37588

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20211017.0.36769
-GitCommit: afe05134d6cf1c805a1de5e56546fe958d1a48af
-GitFetch: refs/tags/v20211017.0.36769
+Tags: latest, base, base-20211024.0.37588
+GitCommit: 72e5f804d292b7ef23473694cb4f2f54f5168e4c
+GitFetch: refs/tags/v20211024.0.37588
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20211017.0.36769
-GitCommit: afe05134d6cf1c805a1de5e56546fe958d1a48af
-GitFetch: refs/tags/v20211017.0.36769
+Tags: base-devel, base-devel-20211024.0.37588
+GitCommit: 72e5f804d292b7ef23473694cb4f2f54f5168e4c
+GitFetch: refs/tags/v20211024.0.37588
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks