### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -26,12 +26,12 @@ Directory: 3.0/slim-buster
 
 Tags: 3.0.2-alpine3.14, 3.0-alpine3.14, 3-alpine3.14, alpine3.14, 3.0.2-alpine, 3.0-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 53a12c266a4bd3c1e5ade9907336cf52f694cc6b
 Directory: 3.0/alpine3.14
 
 Tags: 3.0.2-alpine3.13, 3.0-alpine3.13, 3-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 53a12c266a4bd3c1e5ade9907336cf52f694cc6b
 Directory: 3.0/alpine3.13
 
 Tags: 2.7.4-bullseye, 2.7-bullseye, 2-bullseye, 2.7.4, 2.7, 2
@@ -56,12 +56,12 @@ Directory: 2.7/slim-buster
 
 Tags: 2.7.4-alpine3.14, 2.7-alpine3.14, 2-alpine3.14, 2.7.4-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 53a12c266a4bd3c1e5ade9907336cf52f694cc6b
 Directory: 2.7/alpine3.14
 
 Tags: 2.7.4-alpine3.13, 2.7-alpine3.13, 2-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 53a12c266a4bd3c1e5ade9907336cf52f694cc6b
 Directory: 2.7/alpine3.13
 
 Tags: 2.6.8-bullseye, 2.6-bullseye, 2.6.8, 2.6
@@ -86,10 +86,10 @@ Directory: 2.6/slim-buster
 
 Tags: 2.6.8-alpine3.14, 2.6-alpine3.14, 2.6.8-alpine, 2.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e43959905d886946628d89f8e28d276af14a44a0
+GitCommit: 53a12c266a4bd3c1e5ade9907336cf52f694cc6b
 Directory: 2.6/alpine3.14
 
 Tags: 2.6.8-alpine3.13, 2.6-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c5948bcce84b1829a554209c777f0ef6a357dd2
+GitCommit: 53a12c266a4bd3c1e5ade9907336cf52f694cc6b
 Directory: 2.6/alpine3.13


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/4d6eafa: Merge pull request https://github.com/docker-library/ruby/pull/364 from infosiftr/arches
- https://github.com/docker-library/ruby/commit/53a12c2: Use libucontext in 2.7 to fix alpine based builds on arm32v6/7 and s390x
- https://github.com/docker-library/ruby/commit/2caaf19: Merge pull request https://github.com/docker-library/ruby/pull/360 from docker-library/revert-358-confused
- https://github.com/docker-library/ruby/commit/659f4ab: Remove sha256sum from GitHub patch file