### PR TITLE
Add Rocky Linux as an official Library image

### DIFF
--- a/library/rockylinux
+++ b/library/rockylinux
@@ -3,14 +3,7 @@ GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
 Tags: latest, 8, 8.5
 GitFetch: refs/heads/Rocky-8.5-x86_64
-GitCommit: f8ac86cbf705c95de6fd465a539ff745c22e30bc
+GitCommit: eee13752a34b9195c97d0bce92c05a838484eee8
 arm64v8-GitFetch: refs/heads/Rocky-8.5-aarch64
-arm64v8-GitCommit: 9e8f4812d4d07bfa531e555eda87fa45e38138db
-Architectures: amd64, arm64v8
-
-Tags: 8.4
-GitFetch: refs/heads/Rocky-8.4-x86_64
-GitCommit: 9d5b74c630efd75bb5438c8e0940caa5fb6a3822
-arm64v8-GitFetch: refs/heads/Rocky-8.4-aarch64
-arm64v8-GitCommit: 5722ed46a68e86d74242d5503d76ff0dd092883e
+arm64v8-GitCommit: df726710f2d759478bea1f06946eb168f4cff17a
 Architectures: amd64, arm64v8

--- a/library/rockylinux
+++ b/library/rockylinux
@@ -3,7 +3,7 @@ GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
 Tags: latest, 8, 8.4
 GitFetch: refs/heads/Rocky-8.4-x86_64
-GitCommit: bcdef7f2ad48f32fea61c6133cf44a0e4f3fa4ae
+GitCommit: 3bd70df918de70a34d751e4e5abaac4ef232953a
 arm64v8-GitFetch: refs/heads/Rocky-8.4-aarch64
 arm64v8-GitCommit: 75fdb5083f456817e54fcea4f45faaa36889129a
 Architectures: amd64, arm64v8

--- a/library/rockylinux
+++ b/library/rockylinux
@@ -3,9 +3,9 @@ GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
 Tags: latest, 8, 8.5
 GitFetch: refs/heads/Rocky-8.5-x86_64
-GitCommit: 32c231662afda4fd2d1b030ce2bf74ced0672703
+GitCommit: f8ac86cbf705c95de6fd465a539ff745c22e30bc
 arm64v8-GitFetch: refs/heads/Rocky-8.5-aarch64
-arm64v8-GitCommit: 6764fe1f20baed9c5b6506664941fc41ba258350
+arm64v8-GitCommit: 9e8f4812d4d07bfa531e555eda87fa45e38138db
 Architectures: amd64, arm64v8
 
 Tags: 8.4

--- a/library/rockylinux
+++ b/library/rockylinux
@@ -1,7 +1,14 @@
 Maintainers: The Rocky Linux Foundation <infrastructure@rockylinux.org> (@rocky_linux)
 GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
-Tags: latest, 8, 8.4
+Tags: latest, 8, 8.5
+GitFetch: refs/heads/Rocky-8.5-x86_64
+GitCommit: 32c231662afda4fd2d1b030ce2bf74ced0672703
+arm64v8-GitFetch: refs/heads/Rocky-8.5-aarch64
+arm64v8-GitCommit: 6764fe1f20baed9c5b6506664941fc41ba258350
+Architectures: amd64, arm64v8
+
+Tags: 8.4
 GitFetch: refs/heads/Rocky-8.4-x86_64
 GitCommit: 9d5b74c630efd75bb5438c8e0940caa5fb6a3822
 arm64v8-GitFetch: refs/heads/Rocky-8.4-aarch64

--- a/library/rockylinux
+++ b/library/rockylinux
@@ -3,7 +3,7 @@ GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
 Tags: latest, 8, 8.4
 GitFetch: refs/heads/Rocky-8.4-x86_64
-GitCommit: 3bd70df918de70a34d751e4e5abaac4ef232953a
+GitCommit: 9d5b74c630efd75bb5438c8e0940caa5fb6a3822
 arm64v8-GitFetch: refs/heads/Rocky-8.4-aarch64
-arm64v8-GitCommit: 75fdb5083f456817e54fcea4f45faaa36889129a
+arm64v8-GitCommit: 5722ed46a68e86d74242d5503d76ff0dd092883e
 Architectures: amd64, arm64v8

--- a/library/rockylinux
+++ b/library/rockylinux
@@ -1,0 +1,9 @@
+Maintainers: The Rocky Linux Foundation <infrastructure@rockylinux.org> (@rocky_linux)
+GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
+
+Tags: latest, 8, 8.4
+GitFetch: refs/heads/Rocky-8.4-x86_64
+GitCommit: bcdef7f2ad48f32fea61c6133cf44a0e4f3fa4ae
+arm64v8-GitFetch: refs/heads/Rocky-8.4-aarch64
+arm64v8-GitCommit: 75fdb5083f456817e54fcea4f45faaa36889129a
+Architectures: amd64, arm64v8


### PR DESCRIPTION
Hi all,

We'd like to add Rocky Linux into the official image library for Docker Hub.

Thank you for your consideration!

I messed up my previous git history and just started fresh. Apologies for the confusion. Previous PR here: https://github.com/docker-library/official-images/pull/10983

Best,
Neil

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - base distribution
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/2047
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] ~~existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)~~
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)