### PR TITLE
Bumping JDK11 and JDK8 versions

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -5,56 +5,56 @@ GitRepo: https://github.com/ibmruntimes/semeru-containers.git
 GitFetch: refs/heads/ibm
 
 #-----------------------------openj9 v8 images---------------------------------
-Tags: open-8u302-b08-jdk-focal, open-8-jdk-focal
-SharedTags: open-8u302-b08-jdk, open-8-jdk
+Tags: open-8u312-b07-jdk-focal, open-8-jdk-focal
+SharedTags: open-8u312-b07-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 8/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
-Tags: open-8u302-b08-jdk-centos7, open-8-jdk-centos7
+Tags: open-8u312-b07-jdk-centos7, open-8-jdk-centos7
 Architectures: amd64, ppc64le
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 8/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-8u302-b08-jre-focal, open-8-jre-focal
-SharedTags: open-8u302-b08-jre, open-8-jre
+Tags: open-8u312-b07-jre-focal, open-8-jre-focal
+SharedTags: open-8u312-b07-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 8/jre/ubuntu
 File: Dockerfile.open.releases.full
 
-Tags: open-8u302-b08-jre-centos7, open-8-jre-centos7
+Tags: open-8u312-b07-jre-centos7, open-8-jre-centos7
 Architectures: amd64, ppc64le
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 8/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
-Tags: open-11.0.12_7-jdk-focal, open-11-jdk-focal
-SharedTags: open-11.0.12_7-jdk, open-11-jdk
+Tags: open-11.0.13_8-jdk-focal, open-11-jdk-focal
+SharedTags: open-11.0.13_8-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 11/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.12_7-jdk-centos7, open-11-jdk-centos7
+Tags: open-11.0.13_8-jdk-centos7, open-11-jdk-centos7
 Architectures: amd64, ppc64le
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 11/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.12_7-jre-focal, open-11-jre-focal
-SharedTags: open-11.0.12_7-jre, open-11-jre
+Tags: open-11.0.13_8-jre-focal, open-11-jre-focal
+SharedTags: open-11.0.13_8-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 11/jre/ubuntu
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.12_7-jre-centos7, open-11-jre-centos7
+Tags: open-11.0.13_8-jre-centos7, open-11-jre-centos7
 Architectures: amd64, ppc64le
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 11/jre/centos
 File: Dockerfile.open.releases.full
 
@@ -62,26 +62,26 @@ File: Dockerfile.open.releases.full
 Tags: open-16.0.2_7-jdk-focal, open-16-jdk-focal
 SharedTags: open-16.0.2_7-jdk, open-16-jdk
 Architectures: amd64, ppc64le, s390x
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 16/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-16.0.2_7-jdk-centos7, open-16-jdk-centos7
 Architectures: amd64, ppc64le
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 16/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-16.0.2_7-jre-focal, open-16-jre-focal
 SharedTags: open-16.0.2_7-jre, open-16-jre
 Architectures: amd64, ppc64le, s390x
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 16/jre/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-16.0.2_7-jre-centos7, open-16-jre-centos7
 Architectures: amd64, ppc64le
-GitCommit: a5e772ef095c8d185a4dbcb804e5d4a3c895f71e
+GitCommit: 8ac470fdafa335e8f1b81233cf7fdec1041a9f2a
 Directory: 16/jre/centos
 File: Dockerfile.open.releases.full
 


### PR DESCRIPTION
Updating the JDK11 and JDK8 versions to 11.0.13+8_openj9-0.29.0 and 8u312-b07_openj9-0.29.0 respectively. 

