### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev10, 2.5-dev, 2.5-dev10-bullseye, 2.5-dev-bullseye
+Tags: 2.5-dev11, 2.5-dev, 2.5-dev11-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: baee9f3e5ba1bb274afb7933b950af9fb44b32cd
+GitCommit: 2cf366810d1ad6f2e89d29c249d2c859e213290a
 Directory: 2.5-rc
 
-Tags: 2.5-dev10-alpine, 2.5-dev-alpine, 2.5-dev10-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev11-alpine, 2.5-dev-alpine, 2.5-dev11-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: baee9f3e5ba1bb274afb7933b950af9fb44b32cd
+GitCommit: 2cf366810d1ad6f2e89d29c249d2c859e213290a
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.7, 2.4, lts, latest, 2.4.7-bullseye, 2.4-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2cf3668: Update 2.5-rc to 2.5-dev11