### PR TITLE
Add new "ruby-native-extension" test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -236,6 +236,7 @@ imageTests+=(
 		ruby-bundler
 		ruby-nonroot
 		ruby-binstubs
+		ruby-native-extension
 	'
 	[rust]='
 		rust-hello-world

--- a/test/tests/ruby-native-extension/expected-std-out.txt
+++ b/test/tests/ruby-native-extension/expected-std-out.txt
@@ -1,0 +1,1 @@
+it works

--- a/test/tests/ruby-native-extension/run.sh
+++ b/test/tests/ruby-native-extension/run.sh
@@ -1,0 +1,44 @@
+#!/bin/bash
+set -eo pipefail
+
+dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
+
+image="$1"
+
+buildDepsImage="$image"
+if ! docker run --rm --entrypoint sh "$image" -c 'command -v gcc' > /dev/null; then
+	buildDepsImage="$("$dir/../image-name.sh" librarytest/ruby-native-extension "$image")"
+
+	os="$(docker run --rm --entrypoint sh "$image" -c '. /etc/os-release && echo "$ID"')"
+	case "$os" in
+		alpine)
+			"$dir/../docker-build.sh" "$dir" "$buildDepsImage" <<-EOD
+				FROM $image
+				RUN apk add --no-cache gcc make musl-dev
+			EOD
+			;;
+
+		*) # must be Debian slim variants (no gcc but not Alpine)
+			"$dir/../docker-build.sh" "$dir" "$buildDepsImage" <<-EOD
+				FROM $image
+				RUN set -eux; \
+					apt-get update; \
+					apt-get install -y --no-install-recommends gcc make libc6-dev; \
+					rm -rf /var/lib/apt/lists/*
+			EOD
+			;;
+	esac
+fi
+
+docker run --interactive --rm --entrypoint sh "$buildDepsImage" -eu <<-'EOSH'
+	if command -v jruby > /dev/null; then
+		platform='jruby'
+	else
+		platform='ruby'
+	fi
+	gem install bcrypt \
+		--version 3.1.16 \
+		--platform "$platform" \
+		--silent
+	ruby -e 'require "bcrypt"; print "it works\n"'
+EOSH


### PR DESCRIPTION
This test explicitly forces compilation of the `bcrypt` extension to validate that doing so works correctly.

See https://github.com/docker-library/ruby/issues/365 and https://github.com/docker-library/ruby/pull/366, especially https://github.com/docker-library/ruby/pull/366#issuecomment-953387277.