### PR TITLE
[oraclelinux] Updating 7, 7-slim 8 and 8-slim for ELBA-2021-4003

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 743952decf40b7800d887935fdb262edcf9d9904
+amd64-GitCommit: 03f1e8a1c1b4814ae20536cb130954b36e812959
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0507bc97351a0451e7e736929cf852347e5857e0
+arm64v8-GitCommit: 742edd5a557ca06ea3cd6e225892aa351ee32436
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for rebase to tzdata-2021e.

See https://linux.oracle.com/errata/ELBA-2021-4003.html for details.

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com