### PR TITLE
Update Solr to 8.10.1

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/docker-solr/docker-solr/blob/9bd7de97e84615eb9eacc7a243dfc5519153933a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-solr/docker-solr/blob/a44c2584392a5eca8c62c2a39a1841c02b264383/generate-stackbrew-library.sh
 
 Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfbot),
-             Shalin Mangar (@shalinmangar),
-             David Smiley (@dsmiley),
-             Jan Høydahl (@janhoy)
+ Shalin Mangar (@shalinmangar),
+ David Smiley (@dsmiley),
+ Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.10.0, 8.10, 8, latest
+Tags: 8.10.1, 8.10, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: c9e67796b9620b9f93973b2667837ae47cc83b8f
+GitCommit: 34e3cbbf3aa8aebb5aa5dafda01b176e83ed9fb1
 Directory: 8.10
 
-Tags: 8.10.0-slim, 8.10-slim, 8-slim, slim
+Tags: 8.10.1-slim, 8.10-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: c9e67796b9620b9f93973b2667837ae47cc83b8f
+GitCommit: 34e3cbbf3aa8aebb5aa5dafda01b176e83ed9fb1
 Directory: 8.10/slim
 
 Tags: 8.9.0, 8.9


### PR DESCRIPTION
See the [official announcement](https://lists.apache.org/thread.html/rc6cae05006792feba4d49c1b5a14373ec0725028475f94e8faac0bfc%40%3Cusers.solr.apache.org%3E) which links to the [release notes](https://solr.apache.org/docs/8_10_1/changes/Changes.html).

It's a bug-fix release mostly stemming from Lucene.  There are also some dependency updates to address vulnerabilities:

Upgrade httpclient and httpmime to 4.5.13 (SOLR-15269)
Upgrade the following dependencies with vulnerabilities (SOLR-15677)
  - jetty: 9.4.44.v20210927
  - tika: 1.27
  - commons-compress: 1.21
  - netty: 4.1.68.Final
  - fasterxml.jackson: 2.12.3
  - errorprone: 2.9.0
  - gcp-client: 1.32.1
