### PR TITLE
Odoo: update 13.0-15.0 to release 20211029

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: bb44f3916c974b7586fc278b0664c63e7d989134
+GitCommit: fb468f57e06ce2bd1111c0cdca34fc96087bb0b5
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo.

The temporary patch was removed thanks to this fix: odoo/odoo@248762c80fb

Thanks