### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.8, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 2cd2756ad99c7e5d1ce64d1e50818ab6028e3087
+GitCommit: e51b409bfb2dc4239fd4e80f1ce27ad9b5d01920
 Directory: 3.9/ubuntu
 
 Tags: 3.9.8-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.8-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cd2756ad99c7e5d1ce64d1e50818ab6028e3087
+GitCommit: e51b409bfb2dc4239fd4e80f1ce27ad9b5d01920
 Directory: 3.9/alpine
 
 Tags: 3.9.8-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.23, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 2cd2756ad99c7e5d1ce64d1e50818ab6028e3087
+GitCommit: b7ccbf3166eb10bce14fcbcc889ff66af7500066
 Directory: 3.8/ubuntu
 
 Tags: 3.8.23-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.23-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2cd2756ad99c7e5d1ce64d1e50818ab6028e3087
+GitCommit: b7ccbf3166eb10bce14fcbcc889ff66af7500066
 Directory: 3.8/alpine
 
 Tags: 3.8.23-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e51b409: Update 3.9 to otp 24.1.4
- https://github.com/docker-library/rabbitmq/commit/b7ccbf3: Update 3.8 to otp 24.1.4