### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2021-4057, ELSA-2021-4059, ELSA-2021-4060

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: adf03872e334fdb7ee980e5f0084002b7cd53440
+amd64-GitCommit: 2d8bb73d502264da7502b5fcabd0891783179639
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9647a7ef7ed110c0e051f636390d9c770adb12e5
+arm64v8-GitCommit: bb501f6263a627985787b712d23e615f6c7eaa79
 
 Tags: 8.4, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-3733, CVE-2021-33928, CVE-2021-33929, CVE-2021-33930, CVE-2021-33938, CVE-2021-22946 and CVE-2021-22947.

See https://linux.oracle.com/errata/ELSA-2021-4057.html,  https://linux.oracle.com/errata/ELSA-2021-4059.html and https://linux.oracle.com/errata/ELSA-2021-4060.html for details.

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com