### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1e80d29e88b34cf1a7230325d6d5ff66424b4262
 Directory: 2.4/alpine
 
-Tags: 2.3.14, 2.3, 2.3.14-bullseye, 2.3-bullseye
+Tags: 2.3.15, 2.3, 2.3.15-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 71dbe58808bd40dcd3da787888efaac6dba4ca23
 Directory: 2.3
 
-Tags: 2.3.14-alpine, 2.3-alpine, 2.3.14-alpine3.14, 2.3-alpine3.14
+Tags: 2.3.15-alpine, 2.3-alpine, 2.3.15-alpine3.14, 2.3-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 71dbe58808bd40dcd3da787888efaac6dba4ca23
 Directory: 2.3/alpine
 
 Tags: 2.2.17, 2.2, 2.2.17-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/71dbe58: Update 2.3 to 2.3.15