### PR TITLE
Bump Traefik to v2.5.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.5.3-windowsservercore-1809, 2.5.3-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
+Tags: v2.5.4-windowsservercore-1809, 2.5.4-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 39417f848e63ab9178c9c197fbc9c35f822446be
+GitCommit: f9d18d1eebcaf805d02bd683f771bcaebb643c44
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.3, 2.5.3, v2.5, 2.5, brie, latest
+Tags: v2.5.4, 2.5.4, v2.5, 2.5, brie, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 39417f848e63ab9178c9c197fbc9c35f822446be
+GitCommit: f9d18d1eebcaf805d02bd683f771bcaebb643c44
 Directory: alpine
 
 Tags: v1.7.33-windowsservercore-1809, 1.7.33-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.5.4](https://github.com/traefik/traefik/releases/tag/v2.5.4).

/cc @ddtmachado @kevinpollet @ldez

Cheers
