### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.21.0, 4.21, 4, latest
+Tags: 4.22.0, 4.22, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 79c91f0e74511e5e7bbea3be157369e14e71e3a2
+GitCommit: 742d137a05e3e4048316d45dafb3b7afe54307cf
 Directory: 4/debian
 
-Tags: 4.21.0-alpine, 4.21-alpine, 4-alpine, alpine
+Tags: 4.22.0-alpine, 4.22-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 79c91f0e74511e5e7bbea3be157369e14e71e3a2
+GitCommit: 742d137a05e3e4048316d45dafb3b7afe54307cf
 Directory: 4/alpine
 
 Tags: 3.42.7, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/742d137: Update to 4.22.0, ghost-cli 1.18.0