### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev12, 2.5-dev, 2.5-dev12-bullseye, 2.5-dev-bullseye
+Tags: 2.5-dev13, 2.5-dev, 2.5-dev13-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ceb49f539a491923f8bf852aa9880df90c884c9
+GitCommit: 27ecbd03c584c5120e13f837df8df57ecfe82584
 Directory: 2.5-rc
 
-Tags: 2.5-dev12-alpine, 2.5-dev-alpine, 2.5-dev12-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev13-alpine, 2.5-dev-alpine, 2.5-dev13-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ceb49f539a491923f8bf852aa9880df90c884c9
+GitCommit: 27ecbd03c584c5120e13f837df8df57ecfe82584
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.8, 2.4, lts, latest, 2.4.8-bullseye, 2.4-bullseye, lts-bullseye, bullseye
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 71dbe58808bd40dcd3da787888efaac6dba4ca23
 Directory: 2.3/alpine
 
-Tags: 2.2.17, 2.2, 2.2.17-bullseye, 2.2-bullseye
+Tags: 2.2.18, 2.2, 2.2.18-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 82898014efd86e3f712bf937d40232fc23cae475
 Directory: 2.2
 
-Tags: 2.2.17-alpine, 2.2-alpine, 2.2.17-alpine3.14, 2.2-alpine3.14
+Tags: 2.2.18-alpine, 2.2-alpine, 2.2.18-alpine3.14, 2.2-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 82898014efd86e3f712bf937d40232fc23cae475
 Directory: 2.2/alpine
 
 Tags: 2.0.25, 2.0, 2.0.25-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/27ecbd0: Update 2.5-rc to 2.5-dev13
- https://github.com/docker-library/haproxy/commit/8289801: Update 2.2 to 2.2.18