### PR TITLE
MariaDB releases 20211108

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,30 +1,35 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/098e791b826e6f64f0299560d32f5f102de39938/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/c75ff03efb6527d6c6ce06839867a06b6fa9387d/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 10.6.4-focal, 10.6-focal, 10-focal, focal, 10.6.4, 10.6, 10, latest
+Tags: 10.7.1-focal, 10.7-focal, 10.7.1, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
+GitCommit: d4efdb8951f606fe2837e9cc4db37225a5b7a621
+Directory: 10.7
+
+Tags: 10.6.5-focal, 10.6-focal, 10-focal, focal, 10.6.5, 10.6, 10, latest
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: d711333929498046f354e14430cbe65e4767fc63
 Directory: 10.6
 
-Tags: 10.5.12-focal, 10.5-focal, 10.5.12, 10.5
+Tags: 10.5.13-focal, 10.5-focal, 10.5.13, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
+GitCommit: 8414e4ff9ebff49f28148a860d85131e11c049c6
 Directory: 10.5
 
-Tags: 10.4.21-focal, 10.4-focal, 10.4.21, 10.4
+Tags: 10.4.22-focal, 10.4-focal, 10.4.22, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
+GitCommit: 435a47c85a80be384524051f23cc3e8f132c31ff
 Directory: 10.4
 
-Tags: 10.3.31-focal, 10.3-focal, 10.3.31, 10.3
+Tags: 10.3.32-focal, 10.3-focal, 10.3.32, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
+GitCommit: a98e19f16db72ff1f6148cd797a0cb53dacacef3
 Directory: 10.3
 
-Tags: 10.2.40-bionic, 10.2-bionic, 10.2.40, 10.2
+Tags: 10.2.41-bionic, 10.2-bionic, 10.2.41, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 60caa9ea5c46b985ac6a7ebc93564a29791fca08
+GitCommit: 9c804d5875d9faa880133b7720fdf7ccf35d6393
 Directory: 10.2


### PR DESCRIPTION
Hi,

We've done our 10.7.1 RC release and our 10.6.5, 10.5.13, 10.4.22, 10.3.32, and 10.2.41 maintenance releases.