### PR TITLE
Remove "dbm" and "gdbm" from Ruby 3.1 standard libraries

### DIFF
--- a/test/tests/ruby-standard-libs/container.rb
+++ b/test/tests/ruby-standard-libs/container.rb
@@ -166,6 +166,12 @@ if rubyVersion >= Gem::Version.create('3.0')
 	# https://bugs.ruby-lang.org/issues/17303
 	stdlib.delete('webrick')
 end
+if rubyVersion >= Gem::Version.create('3.1')
+	# https://github.com/ruby/ruby/pull/4525
+	stdlib.delete('dbm')
+	# https://github.com/ruby/ruby/pull/4526
+	stdlib.delete('gdbm')
+end
 
 result = 'ok'
 stdlib.each do |lib|


### PR DESCRIPTION
https://github.com/docker-library/ruby/pull/367#issuecomment-964377451

> Looks like both `dbm` and `gdbm` have been removed in this release :disappointed:
> 
> (It's very strange that they didn't put that in the release notes anywhere :see_no_evil:)
> 
> Receipts:
> 
> - https://github.com/ruby/ruby/pull/4525
> - https://github.com/ruby/ruby/pull/4526
> - https://github.com/ruby/ruby/pull/4619