### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -8,9 +8,9 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Sean Kelly (@cbgbt),
              Tanu Rampal (@trampal),
              Kyle Gosselin-Harris (@kgharris),
-             Preston Carpenter (@prcarpen)
+             Preston Carpenter (@timidger)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 81ef4b1ec563bea88345a864c7abb98cb4de09da
+GitCommit: d7cc3212c8c5e3690db6094fb47a8af47d747774
 
 Tags: 2.0.20211005.0, 2, latest
 Architectures: amd64, arm64v8
@@ -26,12 +26,12 @@ amd64-GitCommit: 88795b1b01976327b8be552342f1106f47c3c155
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 74076f50bc5a992c8ffe4b0e6ab4ff26578aba9b
 
-Tags: 2018.03.0.20211001.0, 2018.03, 1
+Tags: 2018.03.0.20211015.1, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 2a80b9e78bd3857c6277f086df14a95454009e8c
+amd64-GitCommit: 6439ad492e98f0a1b225199e8170506a1c3ac889
 
-Tags: 2018.03.0.20211001.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20211015.1-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 4acfa0e023a60424529b3bb88a1494ed07336091
+amd64-GitCommit: bd1b726ab8cc9dedc7732608e8247525dd977c4d


### PR DESCRIPTION
Hello,

We have a new release of Amazon Linux 2018.03. This update includes an updated version of OpenSSL. Additionally it updates Preston's alias to be his Github username.

Thanks!