### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.8.1-apache, 5.8-apache, 5-apache, apache, 5.8.1, 5.8, 5, latest, 5.8.1-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.1-php7.4, 5.8-php7.4, 5-php7.4, php7.4
+Tags: 5.8.2-apache, 5.8-apache, 5-apache, apache, 5.8.2, 5.8, 5, latest, 5.8.2-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.2-php7.4, 5.8-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php7.4/apache
 
-Tags: 5.8.1-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.1-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.8.2-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.2-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php7.4/fpm
 
-Tags: 5.8.1-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.1-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.8.2-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.2-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.8.1-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.1-php7.3, 5.8-php7.3, 5-php7.3, php7.3
+Tags: 5.8.2-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.2-php7.3, 5.8-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php7.3/apache
 
-Tags: 5.8.1-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.8.2-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php7.3/fpm
 
-Tags: 5.8.1-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.8.2-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.8.1-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.1-php8.0, 5.8-php8.0, 5-php8.0, php8.0
+Tags: 5.8.2-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.2-php8.0, 5.8-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php8.0/apache
 
-Tags: 5.8.1-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.8.2-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php8.0/fpm
 
-Tags: 5.8.1-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.8.2-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5bbbfa8909232af10ea3fea8b80302a6041a2d04
+GitCommit: 4d82a6aefbe895b0a9f3d809bd2959c2dd1710fd
 Directory: latest/php8.0/fpm-alpine
 
 Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/4d82a6a: Update latest to 5.8.2
- https://github.com/docker-library/wordpress/commit/e643ccc: Update beta to 5.8.2
- https://github.com/docker-library/wordpress/commit/4d988d6: Update beta to 5.8.2-RC1