### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 18-ea-21-jdk-oraclelinux8, 18-ea-21-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-21-jdk-oracle, 18-ea-21-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-21-jdk, 18-ea-21, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-22-jdk-oraclelinux8, 18-ea-22-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-22-jdk-oracle, 18-ea-22-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-22-jdk, 18-ea-22, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-21-jdk-oraclelinux7, 18-ea-21-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-22-jdk-oraclelinux7, 18-ea-22-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-21-jdk-bullseye, 18-ea-21-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
+Tags: 18-ea-22-jdk-bullseye, 18-ea-22-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
 Architectures: amd64, arm64v8
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/bullseye
 
-Tags: 18-ea-21-jdk-slim-bullseye, 18-ea-21-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-21-jdk-slim, 18-ea-21-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-22-jdk-slim-bullseye, 18-ea-22-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-22-jdk-slim, 18-ea-22-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18-ea-21-jdk-buster, 18-ea-21-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-22-jdk-buster, 18-ea-22-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/buster
 
-Tags: 18-ea-21-jdk-slim-buster, 18-ea-21-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
+Tags: 18-ea-22-jdk-slim-buster, 18-ea-22-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/slim-buster
 
 Tags: 18-ea-11-jdk-alpine3.14, 18-ea-11-alpine3.14, 18-ea-jdk-alpine3.14, 18-ea-alpine3.14, 18-jdk-alpine3.14, 18-alpine3.14, 18-ea-11-jdk-alpine, 18-ea-11-alpine, 18-ea-jdk-alpine, 18-ea-alpine, 18-jdk-alpine, 18-alpine
@@ -45,31 +45,31 @@ Architectures: amd64
 GitCommit: 20db9bb3edad42224dcdfa0ea95030c2848851cd
 Directory: 18/jdk/alpine3.13
 
-Tags: 18-ea-21-jdk-windowsservercore-ltsc2022, 18-ea-21-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
-SharedTags: 18-ea-21-jdk-windowsservercore, 18-ea-21-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-21-jdk, 18-ea-21, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-22-jdk-windowsservercore-ltsc2022, 18-ea-22-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
+SharedTags: 18-ea-22-jdk-windowsservercore, 18-ea-22-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-22-jdk, 18-ea-22, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18-ea-21-jdk-windowsservercore-1809, 18-ea-21-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-21-jdk-windowsservercore, 18-ea-21-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-21-jdk, 18-ea-21, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-22-jdk-windowsservercore-1809, 18-ea-22-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-22-jdk-windowsservercore, 18-ea-22-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-22-jdk, 18-ea-22, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-21-jdk-windowsservercore-ltsc2016, 18-ea-21-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-21-jdk-windowsservercore, 18-ea-21-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-21-jdk, 18-ea-21, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-22-jdk-windowsservercore-ltsc2016, 18-ea-22-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-22-jdk-windowsservercore, 18-ea-22-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-22-jdk, 18-ea-22, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-21-jdk-nanoserver-1809, 18-ea-21-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-21-jdk-nanoserver, 18-ea-21-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-22-jdk-nanoserver-1809, 18-ea-22-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-22-jdk-nanoserver, 18-ea-22-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: c2daf6399c18547284d96995c633b0eecefc608f
+GitCommit: 24b4e044af5fb7d1aea5b9ed48cecc62eaf617ac
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/24b4e04: Update 18 to 18-ea+22