### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/1b93708d724f8d0f84bacd37f19310301daf9387/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/28272a8acf8f601fa571e0aed21cea96ff78001f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 1b93708d724f8d0f84bacd37f19310301daf9387
+GitCommit: 28272a8acf8f601fa571e0aed21cea96ff78001f
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ac59258477f52f6f1a0fca104143e343fe2b84dd
+amd64-GitCommit: 09265c0682d58a784a336319d295704342264860
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 40d5bbcf49c597260abe00e9f35039831151ba9a
+arm32v5-GitCommit: 8362b21b7a5ac842ae8739995a267750fdd9322b
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: e43af5ee987e6a7198a34dce95d694c764ee7585
+arm32v6-GitCommit: 4afc64493e70ef50b80c4a1cb2209df081358622
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 1ca9b3fb29d2de7e9c2f57eceb2d76216181422a
+arm32v7-GitCommit: 52accac26e30fccbcb16f211adcd12f4a1a74479
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1cb20467c0476091743b295c68c5d04890137a4a
+arm64v8-GitCommit: 5d04e31b8d2217fc884f76c702010e9315241ab5
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: cff0e96afe20e91be2bcc62494a1c37094f2a015
+i386-GitCommit: 762982b75e2d05d543e8c877fa2038ecb42c6181
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: da29517ae000304248ec04ed0551f54b8bd9ccf2
+mips64le-GitCommit: e3f73765170cfe654f127b4ff3ea36f212b660a6
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 4256fccfe8faeb7b3ba2d00c7a69e6949ef6db85
+ppc64le-GitCommit: 38c944db2c45f70a2a26039e83f9f52274b1a708
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: b7d6b23f0f37eb7c19a0d363e402449b60aa4349
+riscv64-GitCommit: e08c8f59b1748d4334e352ebb5793cd8dc0bc613
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 05e9b944c030bf78a0e6e9310e6ce8c75b134322
+s390x-GitCommit: ddf0d81b6a67b7218887f665512d0f3b2256b830
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/28272a8: Merge pull request https://github.com/docker-library/busybox/pull/121 from infosiftr/buildroot-2021.08.2
- https://github.com/docker-library/busybox/commit/e124dd4: Update Buildroot to 2021.08.2