### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.9, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 45f48eefd2ee2b9bc32eb653af64f20411121d50
+GitCommit: d38e983d2cf8246046b6dac396d9483c72231223
 Directory: 3.9/ubuntu
 
 Tags: 3.9.9-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.9-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 45f48eefd2ee2b9bc32eb653af64f20411121d50
+GitCommit: d38e983d2cf8246046b6dac396d9483c72231223
 Directory: 3.9/alpine
 
 Tags: 3.9.9-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.24, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a47d2658a1fb8d8b5bd1539c2c627599bbd391cb
+GitCommit: 6f032ec196489ee65888bcd48733bc06442dcd80
 Directory: 3.8/ubuntu
 
 Tags: 3.8.24-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.24-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a47d2658a1fb8d8b5bd1539c2c627599bbd391cb
+GitCommit: 6f032ec196489ee65888bcd48733bc06442dcd80
 Directory: 3.8/alpine
 
 Tags: 3.8.24-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/d38e983: Update 3.9 to otp 24.1.5
- https://github.com/docker-library/rabbitmq/commit/6f032ec: Update 3.8 to otp 24.1.5