### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,77 +4,77 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 14.0, 14, latest, 14.0-bullseye, 14-bullseye, bullseye
+Tags: 14.1, 14, latest, 14.1-bullseye, 14-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: d29fb5f3e41a7e98c297766f984040de47d87991
 Directory: 14/bullseye
 
-Tags: 14.0-alpine, 14-alpine, alpine, 14.0-alpine3.14, 14-alpine3.14, alpine3.14
+Tags: 14.1-alpine, 14-alpine, alpine, 14.1-alpine3.14, 14-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: d29fb5f3e41a7e98c297766f984040de47d87991
 Directory: 14/alpine
 
-Tags: 13.4, 13, 13.4-bullseye, 13-bullseye
+Tags: 13.5, 13, 13.5-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: 97da1af84373d90ad9742880ba5153bb4ff82514
 Directory: 13/bullseye
 
-Tags: 13.4-alpine, 13-alpine, 13.4-alpine3.14, 13-alpine3.14
+Tags: 13.5-alpine, 13-alpine, 13.5-alpine3.14, 13-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: 97da1af84373d90ad9742880ba5153bb4ff82514
 Directory: 13/alpine
 
-Tags: 12.8, 12, 12.8-bullseye, 12-bullseye
+Tags: 12.9, 12, 12.9-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: f8a5afdb15a6ae0efa15d1f397aea2f519fd0f9d
 Directory: 12/bullseye
 
-Tags: 12.8-alpine, 12-alpine, 12.8-alpine3.14, 12-alpine3.14
+Tags: 12.9-alpine, 12-alpine, 12.9-alpine3.14, 12-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: f8a5afdb15a6ae0efa15d1f397aea2f519fd0f9d
 Directory: 12/alpine
 
-Tags: 11.13-bullseye, 11-bullseye
+Tags: 11.14-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: b5b5a2f0b30010568f0ca807065cbc7bf0506f22
 Directory: 11/bullseye
 
-Tags: 11.13, 11, 11.13-stretch, 11-stretch
+Tags: 11.14, 11, 11.14-stretch, 11-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: b5b5a2f0b30010568f0ca807065cbc7bf0506f22
 Directory: 11/stretch
 
-Tags: 11.13-alpine, 11-alpine, 11.13-alpine3.14, 11-alpine3.14
+Tags: 11.14-alpine, 11-alpine, 11.14-alpine3.14, 11-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: b5b5a2f0b30010568f0ca807065cbc7bf0506f22
 Directory: 11/alpine
 
-Tags: 10.18-bullseye, 10-bullseye
+Tags: 10.19-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: a11e908fb50cacb6192d1db93dcf911bc1a724e6
 Directory: 10/bullseye
 
-Tags: 10.18, 10, 10.18-stretch, 10-stretch
+Tags: 10.19, 10, 10.19-stretch, 10-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: a11e908fb50cacb6192d1db93dcf911bc1a724e6
 Directory: 10/stretch
 
-Tags: 10.18-alpine, 10-alpine, 10.18-alpine3.14, 10-alpine3.14
+Tags: 10.19-alpine, 10-alpine, 10.19-alpine3.14, 10-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: a11e908fb50cacb6192d1db93dcf911bc1a724e6
 Directory: 10/alpine
 
-Tags: 9.6.23-bullseye, 9.6-bullseye, 9-bullseye
+Tags: 9.6.24-bullseye, 9.6-bullseye, 9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: f99ce49a164e89dd7681fa082fde1d2d07d82b03
 Directory: 9.6/bullseye
 
-Tags: 9.6.23, 9.6, 9, 9.6.23-stretch, 9.6-stretch, 9-stretch
+Tags: 9.6.24, 9.6, 9, 9.6.24-stretch, 9.6-stretch, 9-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: f99ce49a164e89dd7681fa082fde1d2d07d82b03
 Directory: 9.6/stretch
 
-Tags: 9.6.23-alpine, 9.6-alpine, 9-alpine, 9.6.23-alpine3.14, 9.6-alpine3.14, 9-alpine3.14
+Tags: 9.6.24-alpine, 9.6-alpine, 9-alpine, 9.6.24-alpine3.14, 9.6-alpine3.14, 9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edce9867844e2747021fd77bf3b0e3da560b23c7
+GitCommit: f99ce49a164e89dd7681fa082fde1d2d07d82b03
 Directory: 9.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/a11e908: Update 10 to 10.19, bullseye 10.19-1.pgdg110+1, stretch 10.19-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/f99ce49: Update 9.6 to 9.6.24, bullseye 9.6.24-1.pgdg110+1, stretch 9.6.24-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/d29fb5f: Update 14 to 14.1, bullseye 14.1-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/97da1af: Update 13 to 13.5, bullseye 13.5-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/f8a5afd: Update 12 to 12.9, bullseye 12.9-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/b5b5a2f: Update 11 to 11.14, bullseye 11.14-1.pgdg110+1, stretch 11.14-1.pgdg90+1