### PR TITLE
alpine:  security fixes in busybox

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.14.2, 3.14, 3, latest
+Tags: 3.14.3, 3.14, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.14
-GitCommit: 6046c206b93945695d9c3efedcafe629a327fd85
+GitCommit: b88b69a4da55c759a174176b9e8d1da8697fd709
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -26,10 +26,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.13.6, 3.13
+Tags: 3.13.7, 3.13
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.13
-GitCommit: 97bdddbacbe7f7fa6165ed2bdfa86d7d0ab43420
+GitCommit: cdde2af5d054e84cb06f23bc99a1cf0827b25eff
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -38,10 +38,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.8, 3.12
+Tags: 3.12.9, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: d9f83182075b7e627dfbea4f86f7f8134c48a5a5
+GitCommit: 2793da4774fae12a67809b5956f6d70b02f99d79
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -50,10 +50,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.11.12, 3.11
+Tags: 3.11.13, 3.11
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.11
-GitCommit: 48093276e3960aeccc4db369c11ea0460b90f349
+GitCommit: fd62af72be6e4a107fee6ac762dcf656503df075
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Fixes various CVE's in busybox:

- CVE-2021-42374
- CVE-2021-42375
- CVE-2021-42378
- CVE-2021-42379
- CVE-2021-42380
- CVE-2021-42381
- CVE-2021-42382
- CVE-2021-42383
- CVE-2021-42384
- CVE-2021-42385
- CVE-2021-42386

https://jfrog.com/blog/unboxing-busybox-14-new-vulnerabilities-uncovered-by-claroty-and-jfrog/

Note that CVE-2021-42373, CVE-2021-42376 and CVE-2021-42377 does not
affect alpine.