### PR TITLE
Remove failing plone architectures

### DIFF
--- a/library/plone
+++ b/library/plone
@@ -5,16 +5,16 @@ Maintainers: Alin Voinea <alin.voinea@gmail.com> (@avoinea),
 GitRepo: https://github.com/plone/plone.docker.git
 
 Tags: 5.2.5-python39, 5.2-python39, 5-python39, python39, 5.2.5, 5.2, 5, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8, i386, s390x
 GitCommit: 10c996f6efa821a8dab8238b87e4ff720398353a
 Directory: 5.2/5.2.5/debian
 
 Tags: 5.2.5-python38, 5.2-python38, 5-python38, python38
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8, i386, s390x
 GitCommit: 10c996f6efa821a8dab8238b87e4ff720398353a
 Directory: 5.2/5.2.5/python38
 
 Tags: 5.2.5-python37, 5.2-python37, 5-python37, python37
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8, i386, s390x
 GitCommit: 10c996f6efa821a8dab8238b87e4ff720398353a
 Directory: 5.2/5.2.5/python37


### PR DESCRIPTION
None of these architectures has built successfully since ~March (except the Alpine builds which are now removed).

See also https://github.com/plone/plone.docker/issues/161.

All the failures end similar to this:

```console
...
Got collective.recipe.plonesite 1.12.0.
Unused options for buildout: 'deprecation-warnings' 'effective-user'.
Installing instance.
Getting distribution for 'Plone==5.2.5'.
Got Plone 5.2.5.
Getting distribution for 'RelStorage[mysql,oracle,postgresql]==3.4.0'.
WARNING: The easy_install command is deprecated and will be removed in a future version.
warning: no files found matching '*.test' under directory 'src'
warning: no files found matching '*.c' under directory 'src'
warning: no files found matching '*.ipp' under directory 'include'
warning: no previously-included files matching 'relstorage.*.rst' found under directory 'docs'
warning: no previously-included files matching '_build' found under directory 'docs'
gcc: error trying to exec 'cc1plus': execvp: No such file or directory
error: Setup script exited with error: command 'gcc' failed with exit status 1
An error occurred when trying to install /plone/buildout-cache/downloads/dist/RelStorage-3.4.0.tar.gz. Look above this message for any errors that were output by easy_install.
While:
  Installing instance.
  Getting distribution for 'RelStorage[mysql,oracle,postgresql]==3.4.0'.

An internal error occurred due to a bug in either zc.buildout or in a
recipe being used:
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/buildout.py", line 2174, in main
    getattr(buildout, command)(args)
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/buildout.py", line 817, in install
    installed_files = self[part]._call(recipe.install)
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/buildout.py", line 1603, in _call
    return f()
  File "/plone/buildout-cache/eggs/cp37m/plone.recipe.zope2instance-6.10.0-py3.7.egg/plone/recipe/zope2instance/recipe.py", line 155, in install
    installed.extend(self.install_scripts())
  File "/plone/buildout-cache/eggs/cp37m/plone.recipe.zope2instance-6.10.0-py3.7.egg/plone/recipe/zope2instance/recipe.py", line 949, in install_scripts
    requirements, ws = self.egg.working_set(["plone.recipe.zope2instance"])
  File "/plone/buildout-cache/eggs/cp37m/zc.recipe.egg-2.0.7-py3.7.egg/zc/recipe/egg/egg.py", line 87, in working_set
    allow_unknown_extras=bool_option(buildout_section, 'allow-unknown-extras')
  File "/plone/buildout-cache/eggs/cp37m/zc.recipe.egg-2.0.7-py3.7.egg/zc/recipe/egg/egg.py", line 168, in _working_set
    allow_unknown_extras=allow_unknown_extras)
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/easy_install.py", line 963, in install
    return installer.install(specs, working_set)
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/easy_install.py", line 688, in install
    for dist in self._get_dist(requirement, ws):
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/easy_install.py", line 580, in _get_dist
    dists = [_move_to_eggs_dir_and_compile(dist, self._dest)]
  File "/usr/local/lib/python3.7/site-packages/zc/buildout/easy_install.py", line 1751, in _move_to_eggs_dir_and_compile
    [tmp_loc] = glob.glob(os.path.join(tmp_dest, '*'))
ValueError: not enough values to unpack (expected 1, got 0)
```