### PR TITLE
library/perl: Add Debian bullseye, drop Debian stretch

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,85 +1,101 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 311f05366d91427d289740dd15fb9401dc4347ef
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8e053ca86a2dcb8862f738c19af3dd6c849460cd
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 
-Tags: 5.34.0, 5.34, 5, latest, 5.34.0-buster, 5.34-buster, 5-buster, buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.34.0, 5.34, 5, latest, 5.34.0-bullseye, 5.34-bullseye, 5-bullseye, bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.034.000-main-bullseye
+
+Tags: 5.34.0-buster, 5.34-buster, 5-buster, buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.034.000-main-buster
 
-Tags: 5.34.0-slim, 5.34-slim, 5-slim, slim, 5.34.0-slim-buster, 5.34-slim-buster, 5-slim-buster, slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.34.0-slim, 5.34-slim, 5-slim, slim, 5.34.0-slim-bullseye, 5.34-slim-bullseye, 5-slim-bullseye, slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.034.000-slim-bullseye
+
+Tags: 5.34.0-slim-buster, 5.34-slim-buster, 5-slim-buster, slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.034.000-slim-buster
 
-Tags: 5.34.0-threaded, 5.34-threaded, 5-threaded, threaded, 5.34.0-threaded-buster, 5.34-threaded-buster, 5-threaded-buster, threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.34.0-threaded, 5.34-threaded, 5-threaded, threaded, 5.34.0-threaded-bullseye, 5.34-threaded-bullseye, 5-threaded-bullseye, threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.034.000-main,threaded-bullseye
+
+Tags: 5.34.0-threaded-buster, 5.34-threaded-buster, 5-threaded-buster, threaded-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.034.000-main,threaded-buster
 
-Tags: 5.34.0-slim-threaded, 5.34-slim-threaded, 5-slim-threaded, slim-threaded, 5.34.0-slim-threaded-buster, 5.34-slim-threaded-buster, 5-slim-threaded-buster, slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.34.0-slim-threaded, 5.34-slim-threaded, 5-slim-threaded, slim-threaded, 5.34.0-slim-threaded-bullseye, 5.34-slim-threaded-bullseye, 5-slim-threaded-bullseye, slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.034.000-slim,threaded-bullseye
+
+Tags: 5.34.0-slim-threaded-buster, 5.34-slim-threaded-buster, 5-slim-threaded-buster, slim-threaded-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.034.000-slim,threaded-buster
 
-Tags: 5.32.1, 5.32, 5.32.1-buster, 5.32-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.32.1, 5.32, 5.32.1-bullseye, 5.32-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.032.001-main-bullseye
+
+Tags: 5.32.1-buster, 5.32-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.032.001-main-buster
 
-Tags: 5.32.1-stretch, 5.32-stretch, 5-stretch, stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-main-stretch
+Tags: 5.32.1-slim, 5.32-slim, 5.32.1-slim-bullseye, 5.32-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.032.001-slim-bullseye
 
-Tags: 5.32.1-slim, 5.32-slim, 5.32.1-slim-buster, 5.32-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.32.1-slim-buster, 5.32-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.032.001-slim-buster
 
-Tags: 5.32.1-slim-stretch, 5.32-slim-stretch, 5-slim-stretch, slim-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-slim-stretch
+Tags: 5.32.1-threaded, 5.32-threaded, 5.32.1-threaded-bullseye, 5.32-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.032.001-main,threaded-bullseye
 
-Tags: 5.32.1-threaded, 5.32-threaded, 5.32.1-threaded-buster, 5.32-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.32.1-threaded-buster, 5.32-threaded-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.032.001-main,threaded-buster
 
-Tags: 5.32.1-threaded-stretch, 5.32-threaded-stretch, 5-threaded-stretch, threaded-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-main,threaded-stretch
+Tags: 5.32.1-slim-threaded, 5.32-slim-threaded, 5.32.1-slim-threaded-bullseye, 5.32-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.032.001-slim,threaded-bullseye
 
-Tags: 5.32.1-slim-threaded, 5.32-slim-threaded, 5.32.1-slim-threaded-buster, 5.32-slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.32.1-slim-threaded-buster, 5.32-slim-threaded-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.032.001-slim,threaded-buster
 
-Tags: 5.32.1-slim-threaded-stretch, 5.32-slim-threaded-stretch, 5-slim-threaded-stretch, slim-threaded-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-slim,threaded-stretch
+Tags: 5.30.3, 5.30, 5.30.3-bullseye, 5.30-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.030.003-main-bullseye
 
-Tags: 5.30.3, 5.30, 5.30.3-buster, 5.30-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.30.3-buster, 5.30-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.030.003-main-buster
 
-Tags: 5.30.3-stretch, 5.30-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.030.003-main-stretch
+Tags: 5.30.3-slim, 5.30-slim, 5.30.3-slim-bullseye, 5.30-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.030.003-slim-bullseye
 
-Tags: 5.30.3-slim, 5.30-slim, 5.30.3-slim-buster, 5.30-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.30.3-slim-buster, 5.30-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.030.003-slim-buster
 
-Tags: 5.30.3-slim-stretch, 5.30-slim-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.030.003-slim-stretch
+Tags: 5.30.3-threaded, 5.30-threaded, 5.30.3-threaded-bullseye, 5.30-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.030.003-main,threaded-bullseye
 
-Tags: 5.30.3-threaded, 5.30-threaded, 5.30.3-threaded-buster, 5.30-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.30.3-threaded-buster, 5.30-threaded-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.030.003-main,threaded-buster
 
-Tags: 5.30.3-threaded-stretch, 5.30-threaded-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.030.003-main,threaded-stretch
+Tags: 5.30.3-slim-threaded, 5.30-slim-threaded, 5.30.3-slim-threaded-bullseye, 5.30-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.030.003-slim,threaded-bullseye
 
-Tags: 5.30.3-slim-threaded, 5.30-slim-threaded, 5.30.3-slim-threaded-buster, 5.30-slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 5.30.3-slim-threaded-buster, 5.30-slim-threaded-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.030.003-slim,threaded-buster
-
-Tags: 5.30.3-slim-threaded-stretch, 5.30-slim-threaded-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.030.003-slim,threaded-stretch


### PR DESCRIPTION
This switches the base image for Perl to use Debian bullseye.  We also
drop updating the tags still using Debian stretch, and also add arm32v5
and mips64le for multiarch.

https://github.com/Perl/docker-perl/issues/88
https://github.com/Perl/docker-perl/pull/107