### PR TITLE
[oraclelinux] remove Oracle Linux 6 images

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -25,10 +25,3 @@ Tags: 7-slim
 Architectures: amd64, arm64v8
 Directory: 7-slim
 
-Tags: 6.10, 6
-Architectures: amd64
-Directory: 6
-
-Tags: 6-slim
-Architectures: amd64
-Directory: 6-slim


### PR DESCRIPTION
Oracle Linux 6 reached the end of premier support several months ago
and extended support is not available for the container images.

Signed-off-by: Avi Miller <avi.miller@oracle.com>