### PR TITLE
Updated nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -5,12 +5,12 @@ GitRepo: https://github.com/nginxinc/docker-nginx.git
 
 Tags: 1.21.4, mainline, 1, 1.21, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2decc81a019b5df087c9162d3621b1c9beb3104f
+GitCommit: ef8e9912a2de9b51ce9d1f79a5c047eb48b05fc1
 Directory: mainline/debian
 
 Tags: 1.21.4-perl, mainline-perl, 1-perl, 1.21-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2decc81a019b5df087c9162d3621b1c9beb3104f
+GitCommit: ef8e9912a2de9b51ce9d1f79a5c047eb48b05fc1
 Directory: mainline/debian-perl
 
 Tags: 1.21.4-alpine, mainline-alpine, 1-alpine, 1.21-alpine, alpine
@@ -23,22 +23,22 @@ Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitCommit: 57f73af83954482c647ac32724a5408bcfc1e7fd
 Directory: mainline/alpine-perl
 
-Tags: 1.20.1, stable, 1.20
+Tags: 1.20.2, stable, 1.20
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
+GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
 Directory: stable/debian
 
-Tags: 1.20.1-perl, stable-perl, 1.20-perl
+Tags: 1.20.2-perl, stable-perl, 1.20-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
+GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
 Directory: stable/debian-perl
 
-Tags: 1.20.1-alpine, stable-alpine, 1.20-alpine
+Tags: 1.20.2-alpine, stable-alpine, 1.20-alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
+GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
 Directory: stable/alpine
 
-Tags: 1.20.1-alpine-perl, stable-alpine-perl, 1.20-alpine-perl
+Tags: 1.20.2-alpine-perl, stable-alpine-perl, 1.20-alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: f3fe494531f9b157d9c09ba509e412dace54cd4f
+GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
 Directory: stable/alpine-perl


### PR DESCRIPTION
- Updated stable nginx to 1.20.2, moving it to Debian 11 "Bullseye" and Alpine 3.14
- Fixed mainline nginx builds on i386 Debian 11 "Bullseye"