### PR TITLE
Swipl 8.5.2

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -4,8 +4,8 @@ GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
 GitCommit: cd4fbab463d93710ea0d48aad3dbc7ad1876549c
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 8.3.29
-Directory: 8.3.29/stretch
+Tags: latest, 8.5.2
+Directory: 8.5.2/bullseye
 
 Tags: stable, 8.4.1
 Directory: 8.4.1/bullseye

--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <J.Wielemaker@vu.nl> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: ca3e88bd44217c3effa881d30b19d7eb1ec1260a
+GitCommit: cd4fbab463d93710ea0d48aad3dbc7ad1876549c
 Architectures: amd64, arm32v7, arm64v8
 
 Tags: latest, 8.3.29
 Directory: 8.3.29/stretch
 
-Tags: stable, 8.4.0
-Directory: 8.4.0/stretch
+Tags: stable, 8.4.1
+Directory: 8.4.1/bullseye


### PR DESCRIPTION
Updated SWI-Prolog, both stable and devel to the latest releases.   Due to build errors as a result of outdated dependencies I've updated the base image from stretch-slim to bullseye-slim.   Please let me know if this causes problems and how to resolve these.