### PR TITLE
alpine: add 3.15 release candidate 4

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,6 +14,18 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
+Tags: 3.15.0-rc.4, 3.15
+Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
+GitFetch: refs/heads/v3.15
+GitCommit: 0e21beb3d6296ccd4cd914e249c3e9056dd832d9
+arm64v8-Directory: aarch64/
+arm32v6-Directory: armhf/
+arm32v7-Directory: armv7/
+ppc64le-Directory: ppc64le/
+s390x-Directory: s390x/
+i386-Directory: x86/
+amd64-Directory: x86_64/
+
 Tags: 3.14.3, 3.14, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.14


### PR DESCRIPTION
Add release candidate so users can start test the upcoming 3.15 release.