### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.9, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: d38e983d2cf8246046b6dac396d9483c72231223
+GitCommit: 3dfa5300285cfd418309e11748defe66737e4b68
 Directory: 3.9/ubuntu
 
 Tags: 3.9.9-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.9-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d38e983d2cf8246046b6dac396d9483c72231223
+GitCommit: 3dfa5300285cfd418309e11748defe66737e4b68
 Directory: 3.9/alpine
 
 Tags: 3.9.9-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -24,22 +24,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/alpine/management
 
-Tags: 3.8.25, 3.8
+Tags: 3.8.26, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 78df7f9ed67fbd7fd6d50969d49a1ad72c45dd05
+GitCommit: 3d132331d84eaa2754254b1f15e21d8d651de709
 Directory: 3.8/ubuntu
 
-Tags: 3.8.25-management, 3.8-management
+Tags: 3.8.26-management, 3.8-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 0d1c84a50aa69305b2fa3e98632a206d3d2a3f9f
 Directory: 3.8/ubuntu/management
 
-Tags: 3.8.25-alpine, 3.8-alpine
+Tags: 3.8.26-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78df7f9ed67fbd7fd6d50969d49a1ad72c45dd05
+GitCommit: 3d132331d84eaa2754254b1f15e21d8d651de709
 Directory: 3.8/alpine
 
-Tags: 3.8.25-management-alpine, 3.8-management-alpine
+Tags: 3.8.26-management-alpine, 3.8-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0d1c84a50aa69305b2fa3e98632a206d3d2a3f9f
 Directory: 3.8/alpine/management


### PR DESCRIPTION
Changes:

- docker-library/rabbitmq@3d13233: Update 3.8 to 3.8.26
- https://github.com/docker-library/rabbitmq/commit/3dfa530: Update 3.9 to otp 24.1.6
- https://github.com/docker-library/rabbitmq/commit/734d18e: Update 3.8 to otp 24.1.6