### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2021-4587

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e003864d40f57cae645a22501e047b38f14ed262
+amd64-GitCommit: 2feb4d6f4c922dcd492a711c1f766c238b2918cd
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d694f76c9eb4b3c5c9c311f68845f225671058ce
+arm64v8-GitCommit: 867bf7c50a65b43d4b290d2a3326f4b010cce489
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-42574.

See https://linux.oracle.com/errata/ELSA-2021-4587.html for details.

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com