### PR TITLE
Update Solr to 8.11.0

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -8,12 +8,12 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.11.0, 8.11, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
+GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
 Directory: 8.11
 
 Tags: 8.11.0-slim, 8.11-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
+GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
 Directory: 8.11/slim
 
 Tags: 8.10.1, 8.10

--- a/library/solr
+++ b/library/solr
@@ -6,12 +6,22 @@ Maintainers: The Apache Lucene/Solr Project <solr-user@lucene.apache.org> (@asfb
  Jan Høydahl (@janhoy)
 GitRepo: https://github.com/docker-solr/docker-solr.git
 
-Tags: 8.10.1, 8.10, 8, latest
+Tags: 8.11.0, 8.11, 8, latest
+Architectures: amd64, arm64v8
+GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
+Directory: 8.11
+
+Tags: 8.11.0-slim, 8.11-slim, 8-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
+Directory: 8.11/slim
+
+Tags: 8.10.1, 8.10
 Architectures: amd64, arm64v8
 GitCommit: 34e3cbbf3aa8aebb5aa5dafda01b176e83ed9fb1
 Directory: 8.10
 
-Tags: 8.10.1-slim, 8.10-slim, 8-slim, slim
+Tags: 8.10.1-slim, 8.10-slim
 Architectures: amd64, arm64v8
 GitCommit: 34e3cbbf3aa8aebb5aa5dafda01b176e83ed9fb1
 Directory: 8.10/slim


### PR DESCRIPTION
See the [official announcement](http://mail-archives.apache.org/mod_mbox/www-announce/202111.mbox/%3cCAPsWd+NngCV8Q28nene-4YDzrqs8oeo7-eO=oezZnbvyYEiQLg@mail.gmail.com%3e) which I'll paste here:

> Solr 8.11.0 Release Highlights
>  * Security
>    - MultiAuthPlugin (for authentication) and
> MultiAuthRuleBasedAuthorizationPlugin (for authorization) classes to
> support multiple authentication schemes, such as Bearer and Basic.
> This allows the Admin UI to use OIDC (JWTAuthPlugin) to authenticate
> users while still supporting Basic authentication for command-line
> tools and the Prometheus exporter.
> 
> A summary of important changes is published in the Solr Reference
> Guide at https://solr.apache.org/guide/8_11/solr-upgrade-notes.html.
> For the most exhaustive list, see the full release notes at
> https://solr.apache.org/docs/8_11_0/changes/Changes.html or by viewing
> the CHANGES.txt file accompanying the distribution.  Solr's release
> notes usually don't include Lucene layer changes.  Lucene's release
> notes are at https://lucene.apache.org/core/8_11_0/changes/Changes.html