### PR TITLE
Odoo: update 13.0-15.0 to release 20211119

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 9c3d1ccd190e24c8346c0feb00c78afb6e9e5118
+GitCommit: c51eacfe2a5f8f322ce04ed85bed4848f4194432
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

as usual, here are the latest updates of Odoo supported versions.


Thanks a lot.