### PR TITLE
Remove i386 from composer

### DIFF
--- a/library/composer
+++ b/library/composer
@@ -4,13 +4,13 @@ Maintainers: Composer (@composer), Rob Bast (@alcohol)
 GitRepo: https://github.com/composer/docker.git
 
 Tags: 2.1.12, 2.1, 2, latest
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/main
 GitCommit: b6cee8bbf062f78dda9f6d784e4e7b64e030748c
 Directory: 2.1
 
 Tags: 1.10.23, 1.10, 1
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/main
 GitCommit: f026ed9f89c88c726cb6fc3b34f3e677bc232a2e
 Directory: 1.10


### PR DESCRIPTION
It's been failing to build for a while:

    + apk add --no-cache --virtual .composer-rundeps p7zip bash coreutils git make mercurial openssh-client patch subversion tini unzip zip
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/main/x86/APKINDEX.tar.gz
    fetch https://dl-cdn.alpinelinux.org/alpine/v3.14/community/x86/APKINDEX.tar.gz
    ERROR: unable to select packages:
      mercurial (no such package):
        required by: .composer-rundeps-20211119.213859[mercurial]

(If you'd like to implement a workaround for this, I'd suggest either removing `mercurial` entirely or removing it conditionally when `apk --print-arch` is `x86`)