### PR TITLE
Remove i386 from websphere-liberty

### DIFF
--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -3,7 +3,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitCommit: fcfbbebb844944acf6e0b6064256324335732e03
-Architectures: amd64, i386, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
 Directory: ga/latest/kernel


### PR DESCRIPTION
It's been failing for a while during `populate_scc.sh` (unfortunately without any useful output at all):

```console
Step 19/24 : RUN if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache     && chown -R 1001:0 /opt/ibm/wlp/output     && chmod -R g+rwx /opt/ibm/wlp/output
 ---> Running in 922589b40cc4
Removing intermediate container 922589b40cc4
The command '/bin/sh -c if [ "$OPENJ9_SCC" = "true" ]; then populate_scc.sh; fi     && rm -rf /output/messaging /output/resources/security /logs/* $WLP_OUTPUT_DIR/.classCache     && chown -R 1001:0 /opt/ibm/wlp/output     && chmod -R g+rwx /opt/ibm/wlp/output' returned a non-zero code: 1
```