### PR TITLE
Remove mips64le from friendica

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -2,6 +2,7 @@
 
 Maintainers: Friendica <info@friendi.ca> (@friendica), Philipp Holzer <admin@philipp.info> (@nupplaphil)
 GitRepo: https://github.com/friendica/docker.git
+GitFetch: refs/heads/stable
 
 Tags: 2021.09-apache, apache, stable-apache, 2021.09, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/friendica
+++ b/library/friendica
@@ -4,12 +4,12 @@ Maintainers: Friendica <info@friendi.ca> (@friendica), Philipp Holzer <admin@phi
 GitRepo: https://github.com/friendica/docker.git
 
 Tags: 2021.09-apache, apache, stable-apache, 2021.09, latest, stable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 51dc7021f0f377a425de24ca32738b58f6867e0c
 Directory: 2021.09/apache
 
 Tags: 2021.09-fpm, fpm, stable-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 51dc7021f0f377a425de24ca32738b58f6867e0c
 Directory: 2021.09/fpm
 
@@ -19,12 +19,12 @@ GitCommit: 51dc7021f0f377a425de24ca32738b58f6867e0c
 Directory: 2021.09/fpm-alpine
 
 Tags: 2021.12-dev-apache, dev-apache, 2021.12-dev, dev
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8aa05541382295d09f2b4debf5c3d97e233f8599
 Directory: 2021.12-dev/apache
 
 Tags: 2021.12-dev-fpm, dev-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8aa05541382295d09f2b4debf5c3d97e233f8599
 Directory: 2021.12-dev/fpm
 


### PR DESCRIPTION
It's been failing to build for a while:

    + apt-get install -y --no-install-recommends rsync bzip2 msmtp tini gosu
    Reading package lists...
    Building dependency tree...
    Reading state information...
    E: Unable to locate package gosu