### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.22.3, 4.22, 4, latest
+Tags: 4.22.4, 4.22, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4e73479312a2462fd9b0c6dffcca94195805a8a8
+GitCommit: 782013199e52e188e1df489824bd9fb872baaae8
 Directory: 4/debian
 
-Tags: 4.22.3-alpine, 4.22-alpine, 4-alpine, alpine
+Tags: 4.22.4-alpine, 4.22-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4e73479312a2462fd9b0c6dffcca94195805a8a8
+GitCommit: 782013199e52e188e1df489824bd9fb872baaae8
 Directory: 4/alpine
 
 Tags: 3.42.7, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/7820131: Update to 4.22.4, ghost-cli 1.18.0