### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev14, 2.5-dev, 2.5-dev14-bullseye, 2.5-dev-bullseye
+Tags: 2.5-dev15, 2.5-dev, 2.5-dev15-bullseye, 2.5-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 27f0b5e2131d3a787c981ade76525ab5b6170f2e
+GitCommit: de6408459b0df546722793eb8dd8c6838bc479d0
 Directory: 2.5-rc
 
-Tags: 2.5-dev14-alpine, 2.5-dev-alpine, 2.5-dev14-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.5-dev15-alpine, 2.5-dev-alpine, 2.5-dev15-alpine3.14, 2.5-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 27f0b5e2131d3a787c981ade76525ab5b6170f2e
+GitCommit: de6408459b0df546722793eb8dd8c6838bc479d0
 Directory: 2.5-rc/alpine
 
 Tags: 2.4.8, 2.4, lts, latest, 2.4.8-bullseye, 2.4-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/de64084: Update 2.5-rc to 2.5-dev15