### PR TITLE
archlinux: Release 20211121.0.39613

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20211114.0.39041
-GitCommit: 0f6392772d966dd7bb66f9d0fc626e01a3824c5c
-GitFetch: refs/tags/v20211114.0.39041
+Tags: latest, base, base-20211121.0.39613
+GitCommit: da7715c5a9d0b3409189187e6fe4339cb11bde0b
+GitFetch: refs/tags/v20211121.0.39613
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20211114.0.39041
-GitCommit: 0f6392772d966dd7bb66f9d0fc626e01a3824c5c
-GitFetch: refs/tags/v20211114.0.39041
+Tags: base-devel, base-devel-20211121.0.39613
+GitCommit: da7715c5a9d0b3409189187e6fe4339cb11bde0b
+GitFetch: refs/tags/v20211121.0.39613
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks