### PR TITLE
Gracefully ignore Haskell stack edge case

### DIFF
--- a/test/tests/haskell-stack/container.sh
+++ b/test/tests/haskell-stack/container.sh
@@ -2,6 +2,19 @@
 set -e
 
 # stack mostly sends to stderr
-stack --resolver ghc-$(ghc --print-project-version) new myproject 2> /dev/null
+if ! stackResult="$(stack --resolver ghc-$(ghc --print-project-version) new myproject 2>&1 > /dev/null)"; then
+	case "$stackResult" in
+		*"Unable to load global hints for"*)
+			echo >&2 'skipping; stack does not yet support this Haskell version'
+			exit 0
+			;;
+		*)
+			echo >&2 'error: stack failed:'
+			echo >&2 "$stackResult"
+			exit 1
+			;;
+	esac
+fi
+
 cd myproject
 stack run 2> /dev/null


### PR DESCRIPTION
Haskell stack [can be slow to add new Haskell compiler versions](https://github.com/commercialhaskell/stackage-content/issues/95). The stack container test will fail until this is done, which blocks docker Haskell updating as well. Stack is just one way to use Haskell so for people not using stack, it is a pity to block here.

Rather, lets ignore that particular failure, but still verify with stack if the compiler version is supported. Once stack adds a new missing version the same docker Haskell container will immediately start working (so no need to rebuild the docker image or anything).

You can see this failure here https://github.com/haskell/docker-haskell/pull/51 . I tested by using my fork of official images with this update and it now passes.