### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.10, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 6eaaca3381617a6b3026d16a954a38fe7687a54c
+GitCommit: 5ec7771d821917f6839d682ab04101f4d87a8daf
 Directory: 3.9/ubuntu
 
 Tags: 3.9.10-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.10-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6eaaca3381617a6b3026d16a954a38fe7687a54c
+GitCommit: 5ec7771d821917f6839d682ab04101f4d87a8daf
 Directory: 3.9/alpine
 
 Tags: 3.9.10-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.26, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 3d132331d84eaa2754254b1f15e21d8d651de709
+GitCommit: c4b367a714a455b8cb98aefac7f4870c74bace40
 Directory: 3.8/ubuntu
 
 Tags: 3.8.26-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.26-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d132331d84eaa2754254b1f15e21d8d651de709
+GitCommit: c4b367a714a455b8cb98aefac7f4870c74bace40
 Directory: 3.8/alpine
 
 Tags: 3.8.26-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/5ec7771: Update 3.9 to otp 24.1.7
- https://github.com/docker-library/rabbitmq/commit/c4b367a: Update 3.8 to otp 24.1.7