### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,25 +1,35 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/cbd26d92eb01f7212f1fbee822b0042021b6b8a7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/50b6692229b0d82c35f925548c8cd24111319d18/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.5-dev15, 2.5-dev, 2.5-dev15-bullseye, 2.5-dev-bullseye
+Tags: 2.6-dev0, 2.6-dev, 2.6-dev0-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de6408459b0df546722793eb8dd8c6838bc479d0
-Directory: 2.5-rc
+GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+Directory: 2.6-rc
 
-Tags: 2.5-dev15-alpine, 2.5-dev-alpine, 2.5-dev15-alpine3.14, 2.5-dev-alpine3.14
+Tags: 2.6-dev0-alpine, 2.6-dev-alpine, 2.6-dev0-alpine3.14, 2.6-dev-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: de6408459b0df546722793eb8dd8c6838bc479d0
-Directory: 2.5-rc/alpine
+GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+Directory: 2.6-rc/alpine
 
-Tags: 2.4.8, 2.4, lts, latest, 2.4.8-bullseye, 2.4-bullseye, lts-bullseye, bullseye
+Tags: 2.5.0, 2.5, latest, 2.5.0-bullseye, 2.5-bullseye, bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+Directory: 2.5
+
+Tags: 2.5.0-alpine, 2.5-alpine, alpine, 2.5.0-alpine3.14, 2.5-alpine3.14, alpine3.14
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+Directory: 2.5/alpine
+
+Tags: 2.4.8, 2.4, lts, 2.4.8-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 1e80d29e88b34cf1a7230325d6d5ff66424b4262
 Directory: 2.4
 
-Tags: 2.4.8-alpine, 2.4-alpine, lts-alpine, alpine, 2.4.8-alpine3.14, 2.4-alpine3.14, lts-alpine3.14, alpine3.14
+Tags: 2.4.8-alpine, 2.4-alpine, lts-alpine, 2.4.8-alpine3.14, 2.4-alpine3.14, lts-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1e80d29e88b34cf1a7230325d6d5ff66424b4262
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6d97265: Merge pull request https://github.com/docker-library/haproxy/pull/174 from TimWolla/haproxy-2.6
- https://github.com/docker-library/haproxy/commit/50b6692: Add HAProxy 2.5 / 2.6-rc