### PR TITLE
Bump to latest Mono 6.12.0.122 release

### DIFF
--- a/library/mono
+++ b/library/mono
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/mono/docker/blob/master/generate-stackbrew-library.sh
+# this file is generated via https://github.com/mono/docker/blob/main/generate-stackbrew-library.sh
 
 Maintainers: Jo Shields <jo.shields@xamarin.com> (@directhex),
              Alexander Köplinger <alkpli@microsoft.com> (@akoeplinger)
@@ -6,20 +6,24 @@ GitRepo: https://github.com/mono/docker.git
 
 Tags: 6.12.0.122, latest, 6.12.0, 6.12, 6
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitFetch: refs/heads/main
 GitCommit: 6ed8ac2ad31d7a9b0683af602859d5827573200a
 Directory: 6.12.0.122
 
 Tags: 6.12.0.122-slim, slim, 6.12.0-slim, 6.12-slim, 6-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitFetch: refs/heads/main
 GitCommit: 6ed8ac2ad31d7a9b0683af602859d5827573200a
 Directory: 6.12.0.122/slim
 
 Tags: 6.10.0.104, 6.10.0, 6.10
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitFetch: refs/heads/main
 GitCommit: 75724c92ab23f733363a9447addf0d0c09b90944
 Directory: 6.10.0.104
 
 Tags: 6.10.0.104-slim, 6.10.0-slim, 6.10-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
+GitFetch: refs/heads/main
 GitCommit: 75724c92ab23f733363a9447addf0d0c09b90944
 Directory: 6.10.0.104/slim

--- a/library/mono
+++ b/library/mono
@@ -7,23 +7,23 @@ GitRepo: https://github.com/mono/docker.git
 Tags: 6.12.0.122, latest, 6.12.0, 6.12, 6
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitFetch: refs/heads/main
-GitCommit: 6ed8ac2ad31d7a9b0683af602859d5827573200a
+GitCommit: 0403aaf506b8f6859332a5035f660a7a228d3a97
 Directory: 6.12.0.122
 
 Tags: 6.12.0.122-slim, slim, 6.12.0-slim, 6.12-slim, 6-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitFetch: refs/heads/main
-GitCommit: 6ed8ac2ad31d7a9b0683af602859d5827573200a
+GitCommit: 0403aaf506b8f6859332a5035f660a7a228d3a97
 Directory: 6.12.0.122/slim
 
 Tags: 6.10.0.104, 6.10.0, 6.10
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitFetch: refs/heads/main
-GitCommit: 75724c92ab23f733363a9447addf0d0c09b90944
+GitCommit: 0403aaf506b8f6859332a5035f660a7a228d3a97
 Directory: 6.10.0.104
 
 Tags: 6.10.0.104-slim, 6.10.0-slim, 6.10-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
 GitFetch: refs/heads/main
-GitCommit: 75724c92ab23f733363a9447addf0d0c09b90944
+GitCommit: 0403aaf506b8f6859332a5035f660a7a228d3a97
 Directory: 6.10.0.104/slim

--- a/library/mono
+++ b/library/mono
@@ -4,22 +4,22 @@ Maintainers: Jo Shields <jo.shields@xamarin.com> (@directhex),
              Alexander Köplinger <alkpli@microsoft.com> (@akoeplinger)
 GitRepo: https://github.com/mono/docker.git
 
-Tags: 6.12.0.107, latest, 6.12.0, 6.12, 6
+Tags: 6.12.0.122, latest, 6.12.0, 6.12, 6
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: 490ebd19e006c00165baca7fbef00c9e98a96d34
-Directory: 6.12.0.107
+GitCommit: 6ed8ac2ad31d7a9b0683af602859d5827573200a
+Directory: 6.12.0.122
 
-Tags: 6.12.0.107-slim, slim, 6.12.0-slim, 6.12-slim, 6-slim
+Tags: 6.12.0.122-slim, slim, 6.12.0-slim, 6.12-slim, 6-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: 490ebd19e006c00165baca7fbef00c9e98a96d34
-Directory: 6.12.0.107/slim
+GitCommit: 6ed8ac2ad31d7a9b0683af602859d5827573200a
+Directory: 6.12.0.122/slim
 
 Tags: 6.10.0.104, 6.10.0, 6.10
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: a449b2a57e1cfadd098c2bcad13f89c4eab83e54
+GitCommit: 75724c92ab23f733363a9447addf0d0c09b90944
 Directory: 6.10.0.104
 
 Tags: 6.10.0.104-slim, 6.10.0-slim, 6.10-slim
 Architectures: amd64, i386, arm32v7, arm32v5, arm64v8, ppc64le
-GitCommit: a449b2a57e1cfadd098c2bcad13f89c4eab83e54
+GitCommit: 75724c92ab23f733363a9447addf0d0c09b90944
 Directory: 6.10.0.104/slim


### PR DESCRIPTION
Includes fix for https://github.com/mono/docker/issues/89

/cc @tianon 