### PR TITLE
Add haskell 9.2.1

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,7 +2,11 @@ Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB),
              Herbert Valerio Riedel <hvr@gnu.org> (@hvr)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.0.1-buster, 9.0-buster, 9-buster, buster, 9.0.1, 9.0, 9, latest
+Tags: 9.2.1-buster, 9.2-buster, 9-buster, buster, 9.2.1, 9.2, 9, latest
+GitCommit: 71b980bfedb718c656ab6152998da8f500202469
+Directory: 9.2/buster
+
+Tags: 9.0.1-buster, 9.0-buster, 9.0.1, 9.0
 GitCommit: f08ade43f48981b87505fbecca852194954fa61b
 Directory: 9.0/buster
 


### PR DESCRIPTION
Normally we only list the last 2 major versions, however 9.0.1 was a bit botched. The majority of users are still using 8.10 line, so I am leaving it in for now.