### PR TITLE
Update alpine base image to alpine3.14

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -10,11 +10,11 @@ Tags: 8, 8u312, 8u312-al2, 8-al2-full, 8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.12, 8u312-alpine3.12, 8-alpine3.12-full, 8-alpine3.12-jdk, 8-alpine, 8u312-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.12, 8u312-alpine3.12, 8-alpine3.12-full, 8-alpine3.12-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine/3.12
 
-Tags: 8-alpine3.12-jre, 8u312-alpine3.12-jre, 8-alpine-jre, 8u312-alpine-jre
+Tags: 8-alpine3.12-jre, 8u312-alpine3.12-jre
 Architectures: amd64
 Directory: 8/jre/alpine/3.12
 
@@ -26,11 +26,11 @@ Tags: 8-alpine3.13-jre, 8u312-alpine3.13-jre
 Architectures: amd64
 Directory: 8/jre/alpine/3.13
 
-Tags: 8-alpine3.14, 8u312-alpine3.14, 8-alpine3.14-full, 8-alpine3.14-jdk
+Tags: 8-alpine3.14, 8u312-alpine3.14, 8-alpine3.14-full, 8-alpine3.14-jdk, 8-alpine, 8u312-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine/3.14
 
-Tags: 8-alpine3.14-jre, 8u312-alpine3.14-jre
+Tags: 8-alpine3.14-jre, 8u312-alpine3.14-jre, 8-alpine-jre, 8u312-alpine-jre
 Architectures: amd64
 Directory: 8/jre/alpine/3.14
 
@@ -38,7 +38,7 @@ Tags: 11, 11.0.13, 11.0.13-al2, 11-al2-full, 11-al2-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.12, 11.0.13-alpine3.12, 11-alpine3.12-full, 11-alpine3.12-jdk, 11-alpine, 11.0.13-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine3.12, 11.0.13-alpine3.12, 11-alpine3.12-full, 11-alpine3.12-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine/3.12
 
@@ -46,7 +46,7 @@ Tags: 11-alpine3.13, 11.0.13-alpine3.13, 11-alpine3.13-full, 11-alpine3.13-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine/3.13
 
-Tags: 11-alpine3.14, 11.0.13-alpine3.14, 11-alpine3.14-full, 11-alpine3.14-jdk
+Tags: 11-alpine3.14, 11.0.13-alpine3.14, 11-alpine3.14-full, 11-alpine3.14-jdk, 11-alpine, 11.0.13-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine/3.14
 


### PR DESCRIPTION
Update default Alpine base image from 3.12 to 3.14 for Corretto-8 and Corretto-11.