### PR TITLE
Update clojure image

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 562f43944e1f957f7456a6466ec6082aebb76922
+GitCommit: 813917fbfab83a6ae37f09c9d5a7bf4acb704896
 
 Tags: latest
 Directory: target/openjdk-17-slim-bullseye/latest

--- a/library/clojure
+++ b/library/clojure
@@ -7,10 +7,10 @@ GitCommit: 562f43944e1f957f7456a6466ec6082aebb76922
 Tags: latest
 Directory: target/openjdk-17-slim-bullseye/latest
 
-Tags: openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.8-buster
+Tags: openjdk-8-lein-buster, openjdk-8-lein-2.9.8-buster
 Directory: target/openjdk-8-buster/lein
 
-Tags: openjdk-8-slim-buster, openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.8-slim-buster
+Tags: openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.8-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
 Tags: openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
@@ -19,16 +19,16 @@ Directory: target/openjdk-8-buster/boot
 Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
 Directory: target/openjdk-8-slim-buster/boot
 
-Tags: openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.1020-buster
+Tags: openjdk-8-buster, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.1020-slim-buster
+Tags: openjdk-8-slim-buster, openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.1020-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.8-buster
+Tags: openjdk-11-lein-buster, openjdk-11-lein-2.9.8-buster
 Directory: target/openjdk-11-buster/lein
 
-Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.8-slim-buster
+Tags: openjdk-11-lein-slim-buster, openjdk-11-lein-2.9.8-slim-buster
 Directory: target/openjdk-11-slim-buster/lein
 
 Tags: openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster
@@ -37,16 +37,16 @@ Directory: target/openjdk-11-buster/boot
 Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.1020-buster
+Tags: openjdk-11-buster, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.1020-slim-buster
+Tags: openjdk-11-slim-buster, openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.1020-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.8-slim-buster, slim-buster, lein-slim-buster, lein-2.9.8-slim-buster
+Tags: openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.8-slim-buster, lein-slim-buster, lein-2.9.8-slim-buster
 Directory: target/openjdk-17-slim-buster/lein
 
-Tags: openjdk-17-buster, openjdk-17-lein-buster, openjdk-17-lein-2.9.8-buster, lein-buster, lein-2.9.8-buster
+Tags: openjdk-17-lein-buster, openjdk-17-lein-2.9.8-buster, lein-buster, lein-2.9.8-buster
 Directory: target/openjdk-17-buster/lein
 
 Tags: openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
@@ -55,16 +55,16 @@ Directory: target/openjdk-17-slim-buster/boot
 Tags: openjdk-17-boot-buster, openjdk-17-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
 Directory: target/openjdk-17-buster/boot
 
-Tags: openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.1020-slim-buster, tools-deps-1.10.3.1020-slim-buster, tools-deps-slim-buster
+Tags: openjdk-17-slim-buster, openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.1020-slim-buster, tools-deps-1.10.3.1020-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-17-slim-buster/tools-deps
 
-Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.1020-buster, tools-deps-buster, tools-deps-1.10.3.1020-buster
+Tags: openjdk-17-buster, openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.1020-buster, tools-deps-buster, tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-17-buster/tools-deps
 
-Tags: openjdk-18-slim-buster, openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.8-slim-buster
+Tags: openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.8-slim-buster
 Directory: target/openjdk-18-slim-buster/lein
 
-Tags: openjdk-18-buster, openjdk-18-lein-buster, openjdk-18-lein-2.9.8-buster
+Tags: openjdk-18-lein-buster, openjdk-18-lein-2.9.8-buster
 Directory: target/openjdk-18-buster/lein
 
 Tags: openjdk-18-boot-slim-buster, openjdk-18-boot-2.8.3-slim-buster
@@ -73,16 +73,16 @@ Directory: target/openjdk-18-slim-buster/boot
 Tags: openjdk-18-boot-buster, openjdk-18-boot-2.8.3-buster
 Directory: target/openjdk-18-buster/boot
 
-Tags: openjdk-18-tools-deps-slim-buster, openjdk-18-tools-deps-1.10.3.1020-slim-buster
+Tags: openjdk-18-slim-buster, openjdk-18-tools-deps-slim-buster, openjdk-18-tools-deps-1.10.3.1020-slim-buster
 Directory: target/openjdk-18-slim-buster/tools-deps
 
-Tags: openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.10.3.1020-buster
+Tags: openjdk-18-buster, openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-18-buster/tools-deps
 
-Tags: openjdk-8-bullseye, openjdk-8-lein-bullseye, openjdk-8-lein-2.9.8-bullseye
+Tags: openjdk-8-lein-bullseye, openjdk-8-lein-2.9.8-bullseye
 Directory: target/openjdk-8-bullseye/lein
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.8, openjdk-8-slim-bullseye, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.8-slim-bullseye
+Tags: openjdk-8-lein, openjdk-8-lein-2.9.8, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.8-slim-bullseye
 Directory: target/openjdk-8-slim-bullseye/lein
 
 Tags: openjdk-8-boot-bullseye, openjdk-8-boot-2.8.3-bullseye
@@ -91,16 +91,16 @@ Directory: target/openjdk-8-bullseye/boot
 Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-slim-bullseye, openjdk-8-boot-2.8.3-slim-bullseye
 Directory: target/openjdk-8-slim-bullseye/boot
 
-Tags: openjdk-8-tools-deps-bullseye, openjdk-8-tools-deps-1.10.3.1020-bullseye
+Tags: openjdk-8-bullseye, openjdk-8-tools-deps-bullseye, openjdk-8-tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-8-bullseye/tools-deps
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.1020, openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.10.3.1020-slim-bullseye
+Tags: openjdk-8, openjdk-8-slim-bullseye, openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.1020, openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-8-slim-bullseye/tools-deps
 
-Tags: openjdk-11-bullseye, openjdk-11-lein-bullseye, openjdk-11-lein-2.9.8-bullseye
+Tags: openjdk-11-lein-bullseye, openjdk-11-lein-2.9.8-bullseye
 Directory: target/openjdk-11-bullseye/lein
 
-Tags: openjdk-11-lein, openjdk-11-lein-2.9.8, openjdk-11-lein-slim-bullseye, openjdk-11-slim-bullseye, openjdk-11-lein-2.9.8-slim-bullseye
+Tags: openjdk-11-lein, openjdk-11-lein-2.9.8, openjdk-11-lein-slim-bullseye, openjdk-11-lein-2.9.8-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/lein
 
 Tags: openjdk-11-boot-bullseye, openjdk-11-boot-2.8.3-bullseye
@@ -109,16 +109,16 @@ Directory: target/openjdk-11-bullseye/boot
 Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, openjdk-11-boot-slim-bullseye, openjdk-11-boot-2.8.3-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/boot
 
-Tags: openjdk-11-tools-deps-bullseye, openjdk-11-tools-deps-1.10.3.1020-bullseye
+Tags: openjdk-11-bullseye, openjdk-11-tools-deps-bullseye, openjdk-11-tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-11-bullseye/tools-deps
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.1020, openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.10.3.1020-slim-bullseye
+Tags: openjdk-11, openjdk-11-slim-bullseye, openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.1020, openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/tools-deps
 
-Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.8, openjdk-17-slim-bullseye, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.8-slim-bullseye, slim-bullseye, lein-slim-bullseye, lein-2.9.8-slim-bullseye, lein, lein-2.9.8
+Tags: openjdk-17-lein, openjdk-17-lein-2.9.8, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.8-slim-bullseye, lein-slim-bullseye, lein-2.9.8-slim-bullseye, lein, lein-2.9.8
 Directory: target/openjdk-17-slim-bullseye/lein
 
-Tags: openjdk-17-bullseye, openjdk-17-lein-bullseye, openjdk-17-lein-2.9.8-bullseye, lein-bullseye, lein-2.9.8-bullseye, bullseye
+Tags: openjdk-17-lein-bullseye, openjdk-17-lein-2.9.8-bullseye, lein-bullseye, lein-2.9.8-bullseye
 Directory: target/openjdk-17-bullseye/lein
 
 Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-bullseye, openjdk-17-boot-2.8.3-slim-bullseye, boot, boot-2.8.3, boot-slim-bullseye, boot-2.8.3-slim-bullseye
@@ -127,16 +127,16 @@ Directory: target/openjdk-17-slim-bullseye/boot
 Tags: openjdk-17-boot-bullseye, openjdk-17-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
 Directory: target/openjdk-17-bullseye/boot
 
-Tags: tools-deps, tools-deps-1.10.3.1020, openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.1020, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.1020-slim-bullseye
+Tags: openjdk-17, openjdk-17-slim-bullseye, tools-deps, tools-deps-1.10.3.1020, openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.1020, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-17-slim-bullseye/tools-deps
 
-Tags: openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.1020-bullseye, tools-deps-bullseye, tools-deps-1.10.3.1020-bullseye
+Tags: openjdk-17-bullseye, openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.1020-bullseye, tools-deps-bullseye, tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-17-bullseye/tools-deps
 
-Tags: openjdk-18, openjdk-18-lein, openjdk-18-lein-2.9.8, openjdk-18-slim-bullseye, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.8-slim-bullseye
+Tags: openjdk-18-lein, openjdk-18-lein-2.9.8, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.8-slim-bullseye
 Directory: target/openjdk-18-slim-bullseye/lein
 
-Tags: openjdk-18-bullseye, openjdk-18-lein-bullseye, openjdk-18-lein-2.9.8-bullseye
+Tags: openjdk-18-lein-bullseye, openjdk-18-lein-2.9.8-bullseye
 Directory: target/openjdk-18-bullseye/lein
 
 Tags: openjdk-18-boot, openjdk-18-boot-2.8.3, openjdk-18-boot-slim-bullseye, openjdk-18-boot-2.8.3-slim-bullseye
@@ -145,13 +145,13 @@ Directory: target/openjdk-18-slim-bullseye/boot
 Tags: openjdk-18-boot-bullseye, openjdk-18-boot-2.8.3-bullseye
 Directory: target/openjdk-18-bullseye/boot
 
-Tags: openjdk-18-tools-deps, openjdk-18-tools-deps-1.10.3.1020, openjdk-18-tools-deps-slim-bullseye, openjdk-18-tools-deps-1.10.3.1020-slim-bullseye
+Tags: openjdk-18, openjdk-18-slim-bullseye, openjdk-18-tools-deps, openjdk-18-tools-deps-1.10.3.1020, openjdk-18-tools-deps-slim-bullseye, openjdk-18-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-18-slim-bullseye/tools-deps
 
-Tags: openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.10.3.1020-bullseye
+Tags: openjdk-18-bullseye, openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-18-bullseye/tools-deps
 
-Tags: openjdk-18-alpine, openjdk-18-lein-alpine, openjdk-18-lein-2.9.8-alpine
+Tags: openjdk-18-lein-alpine, openjdk-18-lein-2.9.8-alpine
 Architectures: amd64
 Directory: target/openjdk-18-alpine/lein
 
@@ -159,6 +159,6 @@ Tags: openjdk-18-boot-alpine, openjdk-18-boot-2.8.3-alpine
 Architectures: amd64
 Directory: target/openjdk-18-alpine/boot
 
-Tags: openjdk-18-tools-deps-alpine, openjdk-18-tools-deps-1.10.3.1020-alpine
+Tags: openjdk-18-alpine, openjdk-18-tools-deps-alpine, openjdk-18-tools-deps-1.10.3.1020-alpine
 Architectures: amd64
 Directory: target/openjdk-18-alpine/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -2,10 +2,10 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 09f93abaab24abff0988c80cab1d35e17156d7b4
+GitCommit: 562f43944e1f957f7456a6466ec6082aebb76922
 
 Tags: latest
-Directory: target/openjdk-11-slim-bullseye/latest
+Directory: target/openjdk-17-slim-bullseye/latest
 
 Tags: openjdk-8-buster, openjdk-8-lein-buster, openjdk-8-lein-2.9.8-buster
 Directory: target/openjdk-8-buster/lein
@@ -25,40 +25,40 @@ Directory: target/openjdk-8-buster/tools-deps
 Tags: openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.10.3.1020-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.8-buster, lein-buster, lein-2.9.8-buster
+Tags: openjdk-11-buster, openjdk-11-lein-buster, openjdk-11-lein-2.9.8-buster
 Directory: target/openjdk-11-buster/lein
 
-Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.8-slim-buster, slim-buster, lein-slim-buster, lein-2.9.8-slim-buster
+Tags: openjdk-11-lein-slim-buster, openjdk-11-slim-buster, openjdk-11-lein-2.9.8-slim-buster
 Directory: target/openjdk-11-slim-buster/lein
 
-Tags: openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
+Tags: openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster
 Directory: target/openjdk-11-buster/boot
 
-Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
+Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster
 Directory: target/openjdk-11-slim-buster/boot
 
-Tags: openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.1020-buster, tools-deps-buster, tools-deps-1.10.3.1020-buster
+Tags: openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-11-buster/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.1020-slim-buster, tools-deps-1.10.3.1020-slim-buster, tools-deps-slim-buster
+Tags: openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.10.3.1020-slim-buster
 Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.8-slim-buster
+Tags: openjdk-17-slim-buster, openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.8-slim-buster, slim-buster, lein-slim-buster, lein-2.9.8-slim-buster
 Directory: target/openjdk-17-slim-buster/lein
 
-Tags: openjdk-17-buster, openjdk-17-lein-buster, openjdk-17-lein-2.9.8-buster
+Tags: openjdk-17-buster, openjdk-17-lein-buster, openjdk-17-lein-2.9.8-buster, lein-buster, lein-2.9.8-buster
 Directory: target/openjdk-17-buster/lein
 
-Tags: openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster
+Tags: openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
 Directory: target/openjdk-17-slim-buster/boot
 
-Tags: openjdk-17-boot-buster, openjdk-17-boot-2.8.3-buster
+Tags: openjdk-17-boot-buster, openjdk-17-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
 Directory: target/openjdk-17-buster/boot
 
-Tags: openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.1020-slim-buster
+Tags: openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.10.3.1020-slim-buster, tools-deps-1.10.3.1020-slim-buster, tools-deps-slim-buster
 Directory: target/openjdk-17-slim-buster/tools-deps
 
-Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.1020-buster
+Tags: openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.10.3.1020-buster, tools-deps-buster, tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-17-buster/tools-deps
 
 Tags: openjdk-18-slim-buster, openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.8-slim-buster
@@ -79,64 +79,58 @@ Directory: target/openjdk-18-slim-buster/tools-deps
 Tags: openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.10.3.1020-buster
 Directory: target/openjdk-18-buster/tools-deps
 
-Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.8, openjdk-8-bullseye, openjdk-8-lein-bullseye, openjdk-8-lein-2.9.8-bullseye
-Architectures: amd64
+Tags: openjdk-8-bullseye, openjdk-8-lein-bullseye, openjdk-8-lein-2.9.8-bullseye
 Directory: target/openjdk-8-bullseye/lein
 
-Tags: openjdk-8-slim-bullseye, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.8-slim-bullseye
-Architectures: amd64
+Tags: openjdk-8, openjdk-8-lein, openjdk-8-lein-2.9.8, openjdk-8-slim-bullseye, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.8-slim-bullseye
 Directory: target/openjdk-8-slim-bullseye/lein
 
-Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-bullseye, openjdk-8-boot-2.8.3-bullseye
-Architectures: amd64
+Tags: openjdk-8-boot-bullseye, openjdk-8-boot-2.8.3-bullseye
 Directory: target/openjdk-8-bullseye/boot
 
-Tags: openjdk-8-boot-slim-bullseye, openjdk-8-boot-2.8.3-slim-bullseye
-Architectures: amd64
+Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-slim-bullseye, openjdk-8-boot-2.8.3-slim-bullseye
 Directory: target/openjdk-8-slim-bullseye/boot
 
-Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.1020, openjdk-8-tools-deps-bullseye, openjdk-8-tools-deps-1.10.3.1020-bullseye
-Architectures: amd64
+Tags: openjdk-8-tools-deps-bullseye, openjdk-8-tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-8-bullseye/tools-deps
 
-Tags: openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.10.3.1020-slim-bullseye
-Architectures: amd64
+Tags: openjdk-8-tools-deps, openjdk-8-tools-deps-1.10.3.1020, openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-8-slim-bullseye/tools-deps
 
-Tags: openjdk-11, openjdk-11-lein, openjdk-11-lein-2.9.8, lein, lein-2.9.8, openjdk-11-bullseye, openjdk-11-lein-bullseye, openjdk-11-lein-2.9.8-bullseye, lein-bullseye, lein-2.9.8-bullseye
+Tags: openjdk-11-bullseye, openjdk-11-lein-bullseye, openjdk-11-lein-2.9.8-bullseye
 Directory: target/openjdk-11-bullseye/lein
 
-Tags: openjdk-11-lein-slim-bullseye, openjdk-11-slim-bullseye, openjdk-11-lein-2.9.8-slim-bullseye, slim-bullseye, lein-slim-bullseye, lein-2.9.8-slim-bullseye
+Tags: openjdk-11-lein, openjdk-11-lein-2.9.8, openjdk-11-lein-slim-bullseye, openjdk-11-slim-bullseye, openjdk-11-lein-2.9.8-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/lein
 
-Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, boot, boot-2.8.3, openjdk-11-boot-bullseye, openjdk-11-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
+Tags: openjdk-11-boot-bullseye, openjdk-11-boot-2.8.3-bullseye
 Directory: target/openjdk-11-bullseye/boot
 
-Tags: openjdk-11-boot-slim-bullseye, openjdk-11-boot-2.8.3-slim-bullseye, boot-slim-bullseye, boot-2.8.3-slim-bullseye
+Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, openjdk-11-boot-slim-bullseye, openjdk-11-boot-2.8.3-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/boot
 
-Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.1020, tools-deps, tools-deps-1.10.3.1020, openjdk-11-tools-deps-bullseye, openjdk-11-tools-deps-1.10.3.1020-bullseye, tools-deps-bullseye, tools-deps-1.10.3.1020-bullseye
+Tags: openjdk-11-tools-deps-bullseye, openjdk-11-tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-11-bullseye/tools-deps
 
-Tags: openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.10.3.1020-slim-bullseye, tools-deps-1.10.3.1020-slim-bullseye, tools-deps-slim-bullseye
+Tags: openjdk-11-tools-deps, openjdk-11-tools-deps-1.10.3.1020, openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/tools-deps
 
-Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.8, openjdk-17-slim-bullseye, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.8-slim-bullseye
+Tags: openjdk-17, openjdk-17-lein, openjdk-17-lein-2.9.8, openjdk-17-slim-bullseye, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.8-slim-bullseye, slim-bullseye, lein-slim-bullseye, lein-2.9.8-slim-bullseye, lein, lein-2.9.8
 Directory: target/openjdk-17-slim-bullseye/lein
 
-Tags: openjdk-17-bullseye, openjdk-17-lein-bullseye, openjdk-17-lein-2.9.8-bullseye
+Tags: openjdk-17-bullseye, openjdk-17-lein-bullseye, openjdk-17-lein-2.9.8-bullseye, lein-bullseye, lein-2.9.8-bullseye, bullseye
 Directory: target/openjdk-17-bullseye/lein
 
-Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-bullseye, openjdk-17-boot-2.8.3-slim-bullseye
+Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-bullseye, openjdk-17-boot-2.8.3-slim-bullseye, boot, boot-2.8.3, boot-slim-bullseye, boot-2.8.3-slim-bullseye
 Directory: target/openjdk-17-slim-bullseye/boot
 
-Tags: openjdk-17-boot-bullseye, openjdk-17-boot-2.8.3-bullseye
+Tags: openjdk-17-boot-bullseye, openjdk-17-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
 Directory: target/openjdk-17-bullseye/boot
 
-Tags: openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.1020, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.1020-slim-bullseye
+Tags: tools-deps, tools-deps-1.10.3.1020, openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.1020, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.1020-slim-bullseye
 Directory: target/openjdk-17-slim-bullseye/tools-deps
 
-Tags: openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.1020-bullseye
+Tags: openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.1020-bullseye, tools-deps-bullseye, tools-deps-1.10.3.1020-bullseye
 Directory: target/openjdk-17-bullseye/tools-deps
 
 Tags: openjdk-18, openjdk-18-lein, openjdk-18-lein-2.9.8, openjdk-18-slim-bullseye, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.8-slim-bullseye


### PR DESCRIPTION
This changes a few things:

- Makes openjdk-17 the new default base image since it's the new LTS Java release
- Cleans up the consistency of the tags so that they all conform to what we've long been claiming about them (e.g. slim-bullseye as the default distro everywhere)
- Uses the various build tools as ENTRYPOINTs (but still allows for `docker run -ti image bash`) in openjdk-17+ images (still uses CMDs in older ones)
- Uses clj as the ENTRYPOINT in clojure:latest instead of lein
- Uses clj as the ENTRYPOINT instead of lein in all images that don't specify a built tool