### PR TITLE
Update Jetty images to fix bug with docker-entrypoint.sh

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -7,117 +7,117 @@ GitRepo: https://github.com/eclipse/jetty.docker.git
 Tags: 11.0.7-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jre11-slim
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 11.0.7-jre11, 11.0-jre11, 11-jre11
 Architectures: amd64, arm64v8
 Directory: 11.0-jre11
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 11.0.7-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk17-slim
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 11.0.7, 11.0, 11, 11.0.7-jdk17, 11.0-jdk17, 11-jdk17
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk17
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 11.0.7-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk11-slim
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 11.0.7-jdk11, 11.0-jdk11, 11-jdk11
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk11
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 10.0.7-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jre11-slim
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 10.0.7-jre11, 10.0-jre11, 10-jre11
 Architectures: amd64, arm64v8
 Directory: 10.0-jre11
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 10.0.7-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk17-slim
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 10.0.7, 10.0, 10, 10.0.7-jdk17, 10.0-jdk17, 10-jdk17
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk17
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 10.0.7-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk11-slim
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 10.0.7-jdk11, 10.0-jdk11, 10-jdk11
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk11
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre8-slim
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64, arm64v8
 Directory: 9.4-jre8
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk17-slim
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44, 9.4, 9, 9.4.44-jdk17, 9.4-jdk17, 9-jdk17, latest, jdk17
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk17
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk11-slim
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk11
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk8-slim
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.4.44-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk8
-GitCommit: 033705867b6bed1241ade2c5698be1e91e7d3870
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.3.30-jre8, 9.3-jre8, 9.3
 Architectures: amd64, arm64v8
 Directory: 9.3-jre8
-GitCommit: 9a582aaecb5795802b98a520b72469ff8b77637a
+GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
 
 Tags: 9.2.30-jre8, 9.2-jre8, 9.2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update Jetty images to fix issues with `docker-entrypoint.sh` and `generate-jetty.start.sh`, which do not use the command line arguments correctly.

See issue https://github.com/eclipse/jetty.docker/issues/74