### PR TITLE
[varnish] fix tags

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,13 +1,13 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/4d8d263067cf5749ecb4088983f4f6168df9101f/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/1e10cfc061b0efdfa71b6311174ce12566846928/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 7.0.1, 7.1, latest
+Tags: fresh, 7.0.1, 7.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
 GitCommit: 4d8d263067cf5749ecb4088983f4f6168df9101f
 
-Tags: fresh-alpine, 7.0.1-alpine, 7.1-alpine, alpine
+Tags: fresh-alpine, 7.0.1-alpine, 7.0-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
 GitCommit: 4d8d263067cf5749ecb4088983f4f6168df9101f


### PR DESCRIPTION
the latest `7.0.1` release got wrongly tagged with `7.1`