### PR TITLE
added support for MW 1.37 

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,16 +2,26 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@wikimedia.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: b19002eb9ee59f3e1856307b39b0d0303f16e962
+GitCommit: 8c813a7a252dce971d2e8a3c31bad67e6fd19850
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.36.2, 1.36, stable, latest
+Tags: 1.37.0, 1.37, stable, latest
+Directory: 1.37/apache
+
+Tags: 1.37.0-fpm, 1.37-fpm, stable-fpm
+Directory: 1.37/fpm
+
+Tags: 1.37.0-fpm-alpine, 1.37-fpm-alpine, stable-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Directory: 1.37/fpm-alpine
+
+Tags: 1.36.2, 1.36
 Directory: 1.36/apache
 
-Tags: 1.36.2-fpm, 1.36-fpm, stable-fpm
+Tags: 1.36.2-fpm, 1.36-fpm
 Directory: 1.36/fpm
 
-Tags: 1.36.2-fpm-alpine, 1.36-fpm-alpine, stable-fpm-alpine
+Tags: 1.36.2-fpm-alpine, 1.36-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.36/fpm-alpine
 


### PR DESCRIPTION
... via https://github.com/wikimedia/mediawiki-docker/pull/103 and https://github.com/wikimedia/mediawiki-docker/pull/104