### PR TITLE
Update Ruby to 3.0.3, 2.7.5, 2.6.9

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -34,92 +34,92 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9d85d0a89d473e30aca7c2eee65695676ac41a31
 Directory: 3.1-rc/alpine3.13
 
-Tags: 3.0.2-bullseye, 3.0-bullseye, 3-bullseye, bullseye, 3.0.2, 3.0, 3, latest
+Tags: 3.0.3-bullseye, 3.0-bullseye, 3-bullseye, bullseye, 3.0.3, 3.0, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 3.0/bullseye
 
-Tags: 3.0.2-slim-bullseye, 3.0-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.0.2-slim, 3.0-slim, 3-slim, slim
+Tags: 3.0.3-slim-bullseye, 3.0-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.0.3-slim, 3.0-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 3.0/slim-bullseye
 
-Tags: 3.0.2-buster, 3.0-buster, 3-buster, buster
+Tags: 3.0.3-buster, 3.0-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 3.0/buster
 
-Tags: 3.0.2-slim-buster, 3.0-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.0.3-slim-buster, 3.0-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 3.0/slim-buster
 
-Tags: 3.0.2-alpine3.14, 3.0-alpine3.14, 3-alpine3.14, alpine3.14, 3.0.2-alpine, 3.0-alpine, 3-alpine, alpine
+Tags: 3.0.3-alpine3.14, 3.0-alpine3.14, 3-alpine3.14, alpine3.14, 3.0.3-alpine, 3.0-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bda17e37f416a6b866c1d5def53017b5a025f106
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 3.0/alpine3.14
 
-Tags: 3.0.2-alpine3.13, 3.0-alpine3.13, 3-alpine3.13, alpine3.13
+Tags: 3.0.3-alpine3.13, 3.0-alpine3.13, 3-alpine3.13, alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bda17e37f416a6b866c1d5def53017b5a025f106
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 3.0/alpine3.13
 
-Tags: 2.7.4-bullseye, 2.7-bullseye, 2-bullseye, 2.7.4, 2.7, 2
+Tags: 2.7.5-bullseye, 2.7-bullseye, 2-bullseye, 2.7.5, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.7/bullseye
 
-Tags: 2.7.4-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.4-slim, 2.7-slim, 2-slim
+Tags: 2.7.5-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.5-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.7/slim-bullseye
 
-Tags: 2.7.4-buster, 2.7-buster, 2-buster
+Tags: 2.7.5-buster, 2.7-buster, 2-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.7/buster
 
-Tags: 2.7.4-slim-buster, 2.7-slim-buster, 2-slim-buster
+Tags: 2.7.5-slim-buster, 2.7-slim-buster, 2-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.7/slim-buster
 
-Tags: 2.7.4-alpine3.14, 2.7-alpine3.14, 2-alpine3.14, 2.7.4-alpine, 2.7-alpine, 2-alpine
+Tags: 2.7.5-alpine3.14, 2.7-alpine3.14, 2-alpine3.14, 2.7.5-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bda17e37f416a6b866c1d5def53017b5a025f106
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.7/alpine3.14
 
-Tags: 2.7.4-alpine3.13, 2.7-alpine3.13, 2-alpine3.13
+Tags: 2.7.5-alpine3.13, 2.7-alpine3.13, 2-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bda17e37f416a6b866c1d5def53017b5a025f106
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.7/alpine3.13
 
-Tags: 2.6.8-bullseye, 2.6-bullseye, 2.6.8, 2.6
+Tags: 2.6.9-bullseye, 2.6-bullseye, 2.6.9, 2.6
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.6/bullseye
 
-Tags: 2.6.8-slim-bullseye, 2.6-slim-bullseye, 2.6.8-slim, 2.6-slim
+Tags: 2.6.9-slim-bullseye, 2.6-slim-bullseye, 2.6.9-slim, 2.6-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.6/slim-bullseye
 
-Tags: 2.6.8-buster, 2.6-buster
+Tags: 2.6.9-buster, 2.6-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 761ae37f67acc54d49f085dc4e5a2443a77700e6
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.6/buster
 
-Tags: 2.6.8-slim-buster, 2.6-slim-buster
+Tags: 2.6.9-slim-buster, 2.6-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 49168590766ac3eb0ad286154b2e01760b79f4b2
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.6/slim-buster
 
-Tags: 2.6.8-alpine3.14, 2.6-alpine3.14, 2.6.8-alpine, 2.6-alpine
+Tags: 2.6.9-alpine3.14, 2.6-alpine3.14, 2.6.9-alpine, 2.6-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bda17e37f416a6b866c1d5def53017b5a025f106
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.6/alpine3.14
 
-Tags: 2.6.8-alpine3.13, 2.6-alpine3.13
+Tags: 2.6.9-alpine3.13, 2.6-alpine3.13
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bda17e37f416a6b866c1d5def53017b5a025f106
+GitCommit: 9b3b69f1d3a80b2f19eedb3c6ef4f6763836031b
 Directory: 2.6/alpine3.13


### PR DESCRIPTION
Update in coordination with https://github.com/docker-library/ruby/pull/368