### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
 Directory: 2.5/alpine
 
-Tags: 2.4.8, 2.4, lts, 2.4.8-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.9, 2.4, lts, 2.4.9-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1e80d29e88b34cf1a7230325d6d5ff66424b4262
+GitCommit: 57633793a0dbfeb81221ec4ac09707312397e683
 Directory: 2.4
 
-Tags: 2.4.8-alpine, 2.4-alpine, lts-alpine, 2.4.8-alpine3.14, 2.4-alpine3.14, lts-alpine3.14
+Tags: 2.4.9-alpine, 2.4-alpine, lts-alpine, 2.4.9-alpine3.14, 2.4-alpine3.14, lts-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e80d29e88b34cf1a7230325d6d5ff66424b4262
+GitCommit: 57633793a0dbfeb81221ec4ac09707312397e683
 Directory: 2.4/alpine
 
-Tags: 2.3.15, 2.3, 2.3.15-bullseye, 2.3-bullseye
+Tags: 2.3.16, 2.3, 2.3.16-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71dbe58808bd40dcd3da787888efaac6dba4ca23
+GitCommit: 07c64064f7cb0f9d82e369bb623fe3fdc11cd76f
 Directory: 2.3
 
-Tags: 2.3.15-alpine, 2.3-alpine, 2.3.15-alpine3.14, 2.3-alpine3.14
+Tags: 2.3.16-alpine, 2.3-alpine, 2.3.16-alpine3.14, 2.3-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71dbe58808bd40dcd3da787888efaac6dba4ca23
+GitCommit: 07c64064f7cb0f9d82e369bb623fe3fdc11cd76f
 Directory: 2.3/alpine
 
 Tags: 2.2.18, 2.2, 2.2.18-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5763379: Update 2.4 to 2.4.9
- https://github.com/docker-library/haproxy/commit/07c6406: Update 2.3 to 2.3.16