### PR TITLE
[oraclelinux] Update 7/7-slim for amd64/arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2feb4d6f4c922dcd492a711c1f766c238b2918cd
+amd64-GitCommit: b2e7fcc1a12012fe22ae1ed2cb205ada06846c1a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 867bf7c50a65b43d4b290d2a3326f4b010cce489
+arm64v8-GitCommit: c88648112d976df3ffb4dc89e8eeb4fe7b360795
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8
@@ -24,4 +24,3 @@ Directory: 7
 Tags: 7-slim
 Architectures: amd64, arm64v8
 Directory: 7-slim
-


### PR DESCRIPTION
Addresses the following errata/CVEs:

* [ELSA-2021-4785](https://linux.oracle.com/errata/ELSA-2021-4785.html): [CVE-2021-20271](https://linux.oracle.com/cve/CVE-2021-20271.html)
* [ELSA-2021-4788](https://linux.oracle.com/errata/ELSA-2021-4788.html): [CVE-2021-37750](https://linux.oracle.com/cve/CVE-2021-37750.html>)
* [ELSA-2021-4782](https://linux.oracle.com/errata/ELSA-2021-4782.html): [CVE-2021-41617](https://linux.oracle.com/cve/CVE-2021-41617.html)

Signed-off-by: Avi Miller <avi.miller@oracle.com>