### PR TITLE
arangodb 3.7.16

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,9 +2,9 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.7, 3.7.15
-GitCommit: d46dfa818833436aa89907a045c803de84c7868a
-Directory: alpine/3.7.15
+Tags: 3.7, 3.7.16
+GitCommit: 71fc4a9f6a3fa2f5f02b517e25a6c5c94a6170e9
+Directory: alpine/3.7.16
 
 Tags: 3.8, 3.8.3, latest
 GitCommit: 1dc6491a317221b03622183f7e0a462c718f3e0e


### PR DESCRIPTION
Updated ArangoDB 3.7 to 3.7.16 and addressed https://github.com/docker-library/official-images/pull/11379#issuecomment-978168774.