### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
 Directory: 2.6-rc
 
-Tags: 2.6-dev0-alpine, 2.6-dev-alpine, 2.6-dev0-alpine3.14, 2.6-dev-alpine3.14
+Tags: 2.6-dev0-alpine, 2.6-dev-alpine, 2.6-dev0-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.0, 2.5, latest, 2.5.0-bullseye, 2.5-bullseye, bullseye
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
 Directory: 2.5
 
-Tags: 2.5.0-alpine, 2.5-alpine, alpine, 2.5.0-alpine3.14, 2.5-alpine3.14, alpine3.14
+Tags: 2.5.0-alpine, 2.5-alpine, alpine, 2.5.0-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.5/alpine
 
 Tags: 2.4.9, 2.4, lts, 2.4.9-bullseye, 2.4-bullseye, lts-bullseye
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 57633793a0dbfeb81221ec4ac09707312397e683
 Directory: 2.4
 
-Tags: 2.4.9-alpine, 2.4-alpine, lts-alpine, 2.4.9-alpine3.14, 2.4-alpine3.14, lts-alpine3.14
+Tags: 2.4.9-alpine, 2.4-alpine, lts-alpine, 2.4.9-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57633793a0dbfeb81221ec4ac09707312397e683
+GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.4/alpine
 
 Tags: 2.3.16, 2.3, 2.3.16-bullseye, 2.3-bullseye
@@ -39,19 +39,19 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 07c64064f7cb0f9d82e369bb623fe3fdc11cd76f
 Directory: 2.3
 
-Tags: 2.3.16-alpine, 2.3-alpine, 2.3.16-alpine3.14, 2.3-alpine3.14
+Tags: 2.3.16-alpine, 2.3-alpine, 2.3.16-alpine3.15, 2.3-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 07c64064f7cb0f9d82e369bb623fe3fdc11cd76f
+GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.3/alpine
 
-Tags: 2.2.18, 2.2, 2.2.18-bullseye, 2.2-bullseye
+Tags: 2.2.19, 2.2, 2.2.19-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82898014efd86e3f712bf937d40232fc23cae475
+GitCommit: d8b5ff11d4587a5ab0aa24eb92e4303410782505
 Directory: 2.2
 
-Tags: 2.2.18-alpine, 2.2-alpine, 2.2.18-alpine3.14, 2.2-alpine3.14
+Tags: 2.2.19-alpine, 2.2-alpine, 2.2.19-alpine3.15, 2.2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 82898014efd86e3f712bf937d40232fc23cae475
+GitCommit: d8b5ff11d4587a5ab0aa24eb92e4303410782505
 Directory: 2.2/alpine
 
 Tags: 2.0.25, 2.0, 2.0.25-buster, 2.0-buster
@@ -59,9 +59,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 2.0
 
-Tags: 2.0.25-alpine, 2.0-alpine, 2.0.25-alpine3.14, 2.0-alpine3.14
+Tags: 2.0.25-alpine, 2.0-alpine, 2.0.25-alpine3.15, 2.0-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster
@@ -69,9 +69,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
 Directory: 1.8
 
-Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.14, 1.8-alpine3.14
+Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.15, 1.8-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 1.8/alpine
 
 Tags: 1.7.14, 1.7, 1.7.14-buster, 1.7-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/d8b5ff1: Update 2.2 to 2.2.19
- https://github.com/docker-library/haproxy/commit/d68797f: Merge pull request https://github.com/docker-library/haproxy/pull/176 from J0WI/alpine-3.15
- https://github.com/docker-library/haproxy/commit/633f24f: Alpine 3.15