### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/28272a8acf8f601fa571e0aed21cea96ff78001f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/a13dd8301eadc9d3c2e9de0d7eceea0b469c7f4d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 28272a8acf8f601fa571e0aed21cea96ff78001f
+GitCommit: a13dd8301eadc9d3c2e9de0d7eceea0b469c7f4d
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 09265c0682d58a784a336319d295704342264860
+amd64-GitCommit: ff17fbb3d35448e1f427fb2562c017129317cec2
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 8362b21b7a5ac842ae8739995a267750fdd9322b
+arm32v5-GitCommit: d5eee7e3354fc474108c03f2b01c3c0ee12db3cc
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 4afc64493e70ef50b80c4a1cb2209df081358622
+arm32v6-GitCommit: 3dcc1ab93b4fafca575d06030797a144f46c9c64
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 52accac26e30fccbcb16f211adcd12f4a1a74479
+arm32v7-GitCommit: d0baf48c020349ccaa06a9ba76ba41370c5de645
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5d04e31b8d2217fc884f76c702010e9315241ab5
+arm64v8-GitCommit: 198f8891140cc1f68ec70eaf8d68b4b987ae43c3
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 762982b75e2d05d543e8c877fa2038ecb42c6181
+i386-GitCommit: cbee1f26dd9bfee4a32b83665c52c71eb45d9e98
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: e3f73765170cfe654f127b4ff3ea36f212b660a6
+mips64le-GitCommit: e16f0f41e1bb95aacb5b0d4807869cb44a6b1988
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 38c944db2c45f70a2a26039e83f9f52274b1a708
+ppc64le-GitCommit: 7191eaeb06360c65cf0eed52eca0d98eb98777b8
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: e08c8f59b1748d4334e352ebb5793cd8dc0bc613
+riscv64-GitCommit: 09c7e4f0ef4ddb91b6d5fbd3dc1da57909da4799
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ddf0d81b6a67b7218887f665512d0f3b2256b830
+s390x-GitCommit: c487cff5909bae266eadb6762b2fc02fe7cb2a78
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/a13dd83: Update to 1.34.1, buildroot 2021.08.2, Alpine 3.15 (https://github.com/docker-library/busybox/pull/122)