### PR TITLE
Odoo: update 13.0-15.0 to release 20211201

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: c51eacfe2a5f8f322ce04ed85bed4848f4194432
+GitCommit: e5654cfab340b6007957a89895d84ce2fe434827
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest update of Odoo supported versions.

Thanks