### PR TITLE
Add redmine suite aliases

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -1,10 +1,10 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/3a41d66499222d90f2f4207c7f6dafd38f4001c5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/6124914603592e7d8dc1a92db062b65073ef4320/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 4.2.3, 4.2, 4, latest
+Tags: 4.2.3, 4.2, 4, latest, 4.2.3-buster, 4.2-buster, 4-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 282e53760ea23d3415bb1e45d2a0d930f47575c3
 Directory: 4.2
@@ -13,11 +13,11 @@ Tags: 4.2.3-passenger, 4.2-passenger, 4-passenger, passenger
 GitCommit: 5444fd564ffba5c871a4d964b54c5559ee52e61e
 Directory: 4.2/passenger
 
-Tags: 4.2.3-alpine, 4.2-alpine, 4-alpine, alpine
+Tags: 4.2.3-alpine, 4.2-alpine, 4-alpine, alpine, 4.2.3-alpine3.13, 4.2-alpine3.13, 4-alpine3.13, alpine3.13
 GitCommit: 282e53760ea23d3415bb1e45d2a0d930f47575c3
 Directory: 4.2/alpine
 
-Tags: 4.1.5, 4.1
+Tags: 4.1.5, 4.1, 4.1.5-buster, 4.1-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c6ee97401c76351a5e228548717dfc4130f4179
 Directory: 4.1
@@ -26,11 +26,11 @@ Tags: 4.1.5-passenger, 4.1-passenger
 GitCommit: 5444fd564ffba5c871a4d964b54c5559ee52e61e
 Directory: 4.1/passenger
 
-Tags: 4.1.5-alpine, 4.1-alpine
+Tags: 4.1.5-alpine, 4.1-alpine, 4.1.5-alpine3.13, 4.1-alpine3.13
 GitCommit: 5c6ee97401c76351a5e228548717dfc4130f4179
 Directory: 4.1/alpine
 
-Tags: 4.0.9, 4.0
+Tags: 4.0.9, 4.0, 4.0.9-buster, 4.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
 Directory: 4.0
@@ -39,6 +39,6 @@ Tags: 4.0.9-passenger, 4.0-passenger
 GitCommit: 5444fd564ffba5c871a4d964b54c5559ee52e61e
 Directory: 4.0/passenger
 
-Tags: 4.0.9-alpine, 4.0-alpine
+Tags: 4.0.9-alpine, 4.0-alpine, 4.0.9-alpine3.13, 4.0-alpine3.13
 GitCommit: 02809f9dead7b26e490f84107c7a2170f11fd2b9
 Directory: 4.0/alpine


### PR DESCRIPTION
See https://github.com/docker-library/redmine/pull/250 -- this is going to unblock https://github.com/docker-library/redmine/pull/246 / https://github.com/docker-library/redmine/pull/249.

It will currently fail the "naughty" check (since the image we're currently `FROM` no longer exists), and that's why I've limited this to nothing but tag changes.