### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -8,30 +8,31 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Sean Kelly (@cbgbt),
              Tanu Rampal (@trampal),
              Kyle Gosselin-Harris (@kgharris),
-             Preston Carpenter (@timidger)
+             Preston Carpenter (@timidger),
+             Richard Kelly (@rpkelly)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: d7cc3212c8c5e3690db6094fb47a8af47d747774
+GitCommit: c9ec4113f694e139e5b2fc2eaf02da0aaa3c7f6c
 
-Tags: 2.0.20211005.0, 2, latest
+Tags: 2.0.20211201.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 52f51a121d3d8c2c8c4560f8c6cc70dcd4ee9064
+amd64-GitCommit: 7c08ab3e1afa28cd5a9819e1b05d141f28ed5557
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 8f97b83f399c6505b164ff65cf4b19e6c42e6682
+arm64v8-GitCommit: eb49f67c3f8896806bf96382b43a6c50fc669bd3
 
-Tags: 2.0.20211005.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20211201.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 88795b1b01976327b8be552342f1106f47c3c155
+amd64-GitCommit: 6e79f8593cda0b3822595c5513895213ab7adb36
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 74076f50bc5a992c8ffe4b0e6ab4ff26578aba9b
+arm64v8-GitCommit: b10675df29cb7987bc231d813b2ab88ea5fbe103
 
-Tags: 2018.03.0.20211015.1, 2018.03, 1
+Tags: 2018.03.0.20211201.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 6439ad492e98f0a1b225199e8170506a1c3ac889
+amd64-GitCommit: 1142e9739519cd6a2992a029ae25b6db686183f8
 
-Tags: 2018.03.0.20211015.1-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20211201.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: bd1b726ab8cc9dedc7732608e8247525dd977c4d
+amd64-GitCommit: 6da53c8eb5e75467c2121aa46dda93e2b0849fed


### PR DESCRIPTION
Updates for Amazon Linux 1 and 2.

These updates include mitigations for CVE-2021-43527

Thanks!