### PR TITLE
21.0.0.12 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: def02577a234a6f62ecc72364b006ac77989a8b8
+GitCommit: a918bf17c57e220747fe699509455f63c6d66dc6
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -72,25 +72,5 @@ File: Dockerfile.ubuntu.openjdk8
 
 Tags: 21.0.0.9-full-java11-openj9
 Directory: releases/21.0.0.9/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 21.0.0.6-kernel-slim-java8-openj9
-Directory: releases/21.0.0.6/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 21.0.0.6-kernel-slim-java11-openj9
-Directory: releases/21.0.0.6/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 21.0.0.6-full-java8-openj9
-Directory: releases/21.0.0.6/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 21.0.0.6-full-java11-openj9
-Directory: releases/21.0.0.6/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: bfa6a3c40defa7deace207359c8c5ff2ef847935
+GitCommit: def02577a234a6f62ecc72364b006ac77989a8b8
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -35,23 +35,23 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 21.0.0.11-kernel-slim-java8-openj9
-Directory: releases/21.0.0.11/kernel-slim
+Tags: 21.0.0.12-kernel-slim-java8-openj9
+Directory: releases/21.0.0.12/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 21.0.0.11-kernel-slim-java11-openj9
-Directory: releases/21.0.0.11/kernel-slim
+Tags: 21.0.0.12-kernel-slim-java11-openj9
+Directory: releases/21.0.0.12/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 21.0.0.11-full-java8-openj9
-Directory: releases/21.0.0.11/full
+Tags: 21.0.0.12-full-java8-openj9
+Directory: releases/21.0.0.12/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 21.0.0.11-full-java11-openj9
-Directory: releases/21.0.0.11/full
+Tags: 21.0.0.12-full-java11-openj9
+Directory: releases/21.0.0.12/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: fcfbbebb844944acf6e0b6064256324335732e03
+GitCommit: def02577a234a6f62ecc72364b006ac77989a8b8
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
@@ -23,21 +23,21 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 21.0.0.11-kernel-java8-ibmjava
-Directory: ga/21.0.0.11/kernel
+Tags: 21.0.0.12-kernel-java8-ibmjava
+Directory: ga/21.0.0.12/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.11-kernel-java11-openj9
-Directory: ga/21.0.0.11/kernel
+Tags: 21.0.0.12-kernel-java11-openj9
+Directory: ga/21.0.0.12/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 21.0.0.11-full-java8-ibmjava
-Directory: ga/21.0.0.11/full
+Tags: 21.0.0.12-full-java8-ibmjava
+Directory: ga/21.0.0.12/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 21.0.0.11-full-java11-openj9
-Directory: ga/21.0.0.11/full
+Tags: 21.0.0.12-full-java11-openj9
+Directory: ga/21.0.0.12/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: def02577a234a6f62ecc72364b006ac77989a8b8
+GitCommit: 2cac18f3d3dc4905bd408b1299ab2ee480fd5752
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
@@ -56,23 +56,5 @@ File: Dockerfile.ubuntu.ibmjava8
 
 Tags: 21.0.0.9-full-java11-openj9
 Directory: ga/21.0.0.9/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 21.0.0.6-kernel-java8-ibmjava
-Directory: ga/21.0.0.6/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 21.0.0.6-kernel-java11-openj9
-Directory: ga/21.0.0.6/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 21.0.0.6-full-java8-ibmjava
-Directory: ga/21.0.0.6/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 21.0.0.6-full-java11-openj9
-Directory: ga/21.0.0.6/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11


### PR DESCRIPTION
Updates for the release of websphere-liberty and open-liberty version 21.0.0.12 including:
- Addition of 21.0.0.12 images
- Removal of 21.0.0.6 images