### PR TITLE
[nats] Release v2.6.6

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,31 +4,31 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 236c6c16266bd9f64c9d990cd16bc9fabe445f50
+GitCommit: 4449db1e4301e7da4549befb980cccc41c2fa907
 
-Tags: 2.6.5-alpine3.14, 2.6-alpine3.14, 2-alpine3.14, alpine3.14, 2.6.5-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.6.6-alpine3.14, 2.6-alpine3.14, 2-alpine3.14, alpine3.14, 2.6.6-alpine, 2.6-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.6.5/alpine3.14
+Directory: 2.6.6/alpine3.14
 
-Tags: 2.6.5-scratch, 2.6-scratch, 2-scratch, scratch, 2.6.5-linux, 2.6-linux, 2-linux, linux
-SharedTags: 2.6.5, 2.6, 2, latest
+Tags: 2.6.6-scratch, 2.6-scratch, 2-scratch, scratch, 2.6.6-linux, 2.6-linux, 2-linux, linux
+SharedTags: 2.6.6, 2.6, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.6.5/scratch
+Directory: 2.6.6/scratch
 
-Tags: 2.6.5-windowsservercore-1809, 2.6-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.6.5-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.6.6-windowsservercore-1809, 2.6-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.6.6-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.6.5/windowsservercore-1809
+Directory: 2.6.6/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.6.5-nanoserver-1809, 2.6-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.6.5-nanoserver, 2.6-nanoserver, 2-nanoserver, nanoserver, 2.6.5, 2.6, 2, latest
+Tags: 2.6.6-nanoserver-1809, 2.6-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.6.6-nanoserver, 2.6-nanoserver, 2-nanoserver, nanoserver, 2.6.6, 2.6, 2, latest
 Architectures: windows-amd64
-Directory: 2.6.5/nanoserver-1809
+Directory: 2.6.6/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.6.5-windowsservercore-ltsc2016, 2.6-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.6.5-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.6.6-windowsservercore-ltsc2016, 2.6-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 2.6.6-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.6.5/windowsservercore-ltsc2016
+Directory: 2.6.6/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.6.6)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>