### PR TITLE
Update Clear Linux OS to 35380

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 325b7147df5d3b691f405981dc285dcf9a0bf571
-GitFetch: refs/heads/base-35320
+GitCommit: 970301d73c73b6f0fddf90f7f18878e09ee30406
+GitFetch: refs/heads/base-35380


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35380

@bryteise @mdhorn @phmccarty