### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d8b5ff11d4587a5ab0aa24eb92e4303410782505
 Directory: 2.2/alpine
 
-Tags: 2.0.25, 2.0, 2.0.25-buster, 2.0-buster
+Tags: 2.0.26, 2.0, 2.0.26-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: 4e8e42f7d8e647a8a8b9040e419a8c86bcd4ee51
 Directory: 2.0
 
-Tags: 2.0.25-alpine, 2.0-alpine, 2.0.25-alpine3.15, 2.0-alpine3.15
+Tags: 2.0.26-alpine, 2.0-alpine, 2.0.26-alpine3.15, 2.0-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
+GitCommit: 4e8e42f7d8e647a8a8b9040e419a8c86bcd4ee51
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4e8e42f: Update 2.0 to 2.0.26