### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/a13dd8301eadc9d3c2e9de0d7eceea0b469c7f4d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/8a7173ef6719c1d1dfa4aa4d67fc80fdab76d11a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: a13dd8301eadc9d3c2e9de0d7eceea0b469c7f4d
+GitCommit: 8a7173ef6719c1d1dfa4aa4d67fc80fdab76d11a
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ff17fbb3d35448e1f427fb2562c017129317cec2
+amd64-GitCommit: 50b2c75ecc4c23c4ec47f3a4a0a2fd82002a1a33
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d5eee7e3354fc474108c03f2b01c3c0ee12db3cc
+arm32v5-GitCommit: c568833afa6e2193af864e7da678ea893d8ac1d4
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 3dcc1ab93b4fafca575d06030797a144f46c9c64
+arm32v6-GitCommit: d95dcdc7c7e39129978208214990406b350bed1a
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: d0baf48c020349ccaa06a9ba76ba41370c5de645
+arm32v7-GitCommit: c2d3171adf3363b075393eb3f5a5863e53295e1e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 198f8891140cc1f68ec70eaf8d68b4b987ae43c3
+arm64v8-GitCommit: d8f474ec09ec4cca2c6b786b456ca360db77ec76
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: cbee1f26dd9bfee4a32b83665c52c71eb45d9e98
+i386-GitCommit: 48f62e35cb87d1bf055ac9f382145706b1ab5cd6
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: e16f0f41e1bb95aacb5b0d4807869cb44a6b1988
+mips64le-GitCommit: 0722393a54d3babb454a4bfd4b9dfd534483376c
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 7191eaeb06360c65cf0eed52eca0d98eb98777b8
+ppc64le-GitCommit: 0a314abc52fb1cbf90fae96a8c670a64ec9c0ae7
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 09c7e4f0ef4ddb91b6d5fbd3dc1da57909da4799
+riscv64-GitCommit: b5385c775dd1b297eec7e800475f9fac0ab3696c
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: c487cff5909bae266eadb6762b2fc02fe7cb2a78
+s390x-GitCommit: 1b8b4a7c679956c9469c8d2832aba501ac47c3c4
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/8a7173e: Merge pull request https://github.com/docker-library/busybox/pull/124 from infosiftr/debian-unstable
- https://github.com/docker-library/busybox/commit/985d62d: Switch from "python" to "python3" and add "file" explicitly (for Debian Unstable / Debian Ports builds)
- https://github.com/docker-library/busybox/commit/a0f9bd1: Add Debian Unstable to the CI builds (to verify that Debian Ports arches like riscv64 are likely to continue working)
- https://github.com/docker-library/busybox/commit/378989b: Merge pull request https://github.com/docker-library/busybox/pull/123 from infosiftr/buildroot-2021.11
- https://github.com/docker-library/busybox/commit/e237f1d: Update Buildroot to 2021.11
- https://github.com/docker-library/busybox/commit/3e3ba2e: Use "sort -V" to deal with 1.33.2 (for now)