### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,124 +5,124 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.17.4-bullseye, 1.17-bullseye, 1-bullseye, bullseye
-SharedTags: 1.17.4, 1.17, 1, latest
+Tags: 1.17.5-bullseye, 1.17-bullseye, 1-bullseye, bullseye
+SharedTags: 1.17.5, 1.17, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/bullseye
 
-Tags: 1.17.4-buster, 1.17-buster, 1-buster, buster
+Tags: 1.17.5-buster, 1.17-buster, 1-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/buster
 
-Tags: 1.17.4-stretch, 1.17-stretch, 1-stretch, stretch
+Tags: 1.17.5-stretch, 1.17-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/stretch
 
-Tags: 1.17.4-alpine3.15, 1.17-alpine3.15, 1-alpine3.15, alpine3.15, 1.17.4-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.17.5-alpine3.15, 1.17-alpine3.15, 1-alpine3.15, alpine3.15, 1.17.5-alpine, 1.17-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/alpine3.15
 
-Tags: 1.17.4-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14
+Tags: 1.17.5-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/alpine3.14
 
-Tags: 1.17.4-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.17.4-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.4, 1.17, 1, latest
+Tags: 1.17.5-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.17.5-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.5, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.17.4-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.17.4-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.4, 1.17, 1, latest
+Tags: 1.17.5-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.17.5-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.5, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17.4-windowsservercore-ltsc2016, 1.17-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.17.4-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.4, 1.17, 1, latest
+Tags: 1.17.5-windowsservercore-ltsc2016, 1.17-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
+SharedTags: 1.17.5-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.5, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.17.4-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.17.4-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.5-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.17.5-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.17.4-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.17.4-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.5-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.17.5-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 6e7f92fa56dff6445d4c9364eec741bd174617d9
+GitCommit: dbdde931579e4a3d446b17167c67f573658d6989
 Directory: 1.17/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.16.11-bullseye, 1.16-bullseye
-SharedTags: 1.16.11, 1.16
+Tags: 1.16.12-bullseye, 1.16-bullseye
+SharedTags: 1.16.12, 1.16
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/bullseye
 
-Tags: 1.16.11-buster, 1.16-buster
+Tags: 1.16.12-buster, 1.16-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/buster
 
-Tags: 1.16.11-stretch, 1.16-stretch
+Tags: 1.16.12-stretch, 1.16-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/stretch
 
-Tags: 1.16.11-alpine3.15, 1.16-alpine3.15, 1.16.11-alpine, 1.16-alpine
+Tags: 1.16.12-alpine3.15, 1.16-alpine3.15, 1.16.12-alpine, 1.16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/alpine3.15
 
-Tags: 1.16.11-alpine3.14, 1.16-alpine3.14
+Tags: 1.16.12-alpine3.14, 1.16-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/alpine3.14
 
-Tags: 1.16.11-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
-SharedTags: 1.16.11-windowsservercore, 1.16-windowsservercore, 1.16.11, 1.16
+Tags: 1.16.12-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
+SharedTags: 1.16.12-windowsservercore, 1.16-windowsservercore, 1.16.12, 1.16
 Architectures: windows-amd64
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.16.11-windowsservercore-1809, 1.16-windowsservercore-1809
-SharedTags: 1.16.11-windowsservercore, 1.16-windowsservercore, 1.16.11, 1.16
+Tags: 1.16.12-windowsservercore-1809, 1.16-windowsservercore-1809
+SharedTags: 1.16.12-windowsservercore, 1.16-windowsservercore, 1.16.12, 1.16
 Architectures: windows-amd64
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16.11-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016
-SharedTags: 1.16.11-windowsservercore, 1.16-windowsservercore, 1.16.11, 1.16
+Tags: 1.16.12-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016
+SharedTags: 1.16.12-windowsservercore, 1.16-windowsservercore, 1.16.12, 1.16
 Architectures: windows-amd64
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 1.16.11-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
-SharedTags: 1.16.11-nanoserver, 1.16-nanoserver
+Tags: 1.16.12-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
+SharedTags: 1.16.12-nanoserver, 1.16-nanoserver
 Architectures: windows-amd64
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.16.11-nanoserver-1809, 1.16-nanoserver-1809
-SharedTags: 1.16.11-nanoserver, 1.16-nanoserver
+Tags: 1.16.12-nanoserver-1809, 1.16-nanoserver-1809
+SharedTags: 1.16.12-nanoserver, 1.16-nanoserver
 Architectures: windows-amd64
-GitCommit: fdc086f3668e4a6520120121f65e0cb44da44946
+GitCommit: 17e6986fb3b995d71eab6c19880010644638ba47
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/dbdde93: Update 1.17 to 1.17.5
- https://github.com/docker-library/golang/commit/17e6986: Update 1.16 to 1.16.12