### PR TITLE
telegraf: add capabilities to telegraf binary

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -2,7 +2,7 @@ Maintainers: David Reimschussel <dreimschussel@influxdata.com> (@reimda),
              Josh Powers <jpowers@influxdata.com> (@powersj),
              Mya Longmire <mlongmire@influxdata.com> (@MyaLongmire)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
-GitCommit: 71683dc519403ecd6e586f984c073673b1cea35f
+GitCommit: 015d702be2c9abad81d86603c377d4278bff2b77
 
 Tags: 1.18, 1.18.3
 Architectures: amd64, arm32v7, arm64v8
@@ -18,9 +18,9 @@ Directory: telegraf/1.19
 Tags: 1.19-alpine, 1.19.3-alpine
 Directory: telegraf/1.19/alpine
 
-Tags: 1.20, 1.20.3, latest
+Tags: 1.20, 1.20.4, latest
 Architectures: amd64, arm32v7, arm64v8
 Directory: telegraf/1.20
 
-Tags: 1.20-alpine, 1.20.3-alpine, alpine
+Tags: 1.20-alpine, 1.20.4-alpine, alpine
 Directory: telegraf/1.20/alpine


### PR DESCRIPTION
This adds the CAP_NET_RAW and CAP_NET_BIND_SERVICE capabilities to the telegraf
binary to the entrypoint. This allows the ping command and the binary to
bind to privliged ports.