### PR TITLE
 telegraf: add capabilities to telegraf binary

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -2,7 +2,7 @@ Maintainers: David Reimschussel <dreimschussel@influxdata.com> (@reimda),
              Josh Powers <jpowers@influxdata.com> (@powersj),
              Mya Longmire <mlongmire@influxdata.com> (@MyaLongmire)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
-GitCommit: 725fae95efff8850004099d569d0e2360d95e854
+GitCommit: 015d702be2c9abad81d86603c377d4278bff2b77
 
 Tags: 1.18, 1.18.3
 Architectures: amd64, arm32v7, arm64v8

--- a/library/telegraf
+++ b/library/telegraf
@@ -2,7 +2,7 @@ Maintainers: David Reimschussel <dreimschussel@influxdata.com> (@reimda),
              Josh Powers <jpowers@influxdata.com> (@powersj),
              Mya Longmire <mlongmire@influxdata.com> (@MyaLongmire)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
-GitCommit: 015d702be2c9abad81d86603c377d4278bff2b77
+GitCommit: 06a1e02cac960db9be3f95ceb7e53cfd235d05a6
 
 Tags: 1.18, 1.18.3
 Architectures: amd64, arm32v7, arm64v8


### PR DESCRIPTION
This adds the CAP_NET_RAW and CAP_NET_BIND_SERVICE capabilities to the telegraf
binary to the entrypoint. This allows the ping command and the binary to
bind to privliged ports.