### PR TITLE
Add "under an OSI-approved license" explicitly to the checklist

### DIFF
--- a/NEW-IMAGE-CHECKLIST.md
+++ b/NEW-IMAGE-CHECKLIST.md
@@ -3,6 +3,7 @@
 **NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)
 
 -	[ ] associated with or contacted upstream?
+-	[ ] available under [an OSI-approved license](https://opensource.org/licenses)?
 -	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
 -	[ ] is it reasonably popular, or does it solve a particular use case well?
 -	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)


### PR DESCRIPTION
The goal/intent here is to more strictly enforce the first bullet point in https://github.com/docker-library/official-images#what-are-official-images:

> - Focus on [Free](https://www.debian.org/social_contract#guidelines) and [Open-Source](https://opensource.org/) Software