### PR TITLE
Bump Traefik to v2.5.5 and v1.7.34

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,21 +13,21 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 9bd4bc631d219eef3cf9603c34af1cd298eb8f88
 Directory: alpine
 
-Tags: v1.7.33-windowsservercore-1809, 1.7.33-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
+Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 87f6cff7d81f0a10c093b0c8f73a3547f1cc33df
+GitCommit: 4434758cf14bbd1ec9511b3f2a37b0a6ce846db6
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v1.7.33-alpine, 1.7.33-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
+Tags: v1.7.34-alpine, 1.7.34-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 87f6cff7d81f0a10c093b0c8f73a3547f1cc33df
+GitCommit: 4434758cf14bbd1ec9511b3f2a37b0a6ce846db6
 Directory: alpine
 
-Tags: v1.7.33, 1.7.33, v1.7, 1.7, maroilles
+Tags: v1.7.34, 1.7.34, v1.7, 1.7, maroilles
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 87f6cff7d81f0a10c093b0c8f73a3547f1cc33df
+GitCommit: 4434758cf14bbd1ec9511b3f2a37b0a6ce846db6
 Directory: scratch

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
-Tags: v2.5.4-windowsservercore-1809, 2.5.4-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
+Tags: v2.5.5-windowsservercore-1809, 2.5.5-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f9d18d1eebcaf805d02bd683f771bcaebb643c44
+GitCommit: 9bd4bc631d219eef3cf9603c34af1cd298eb8f88
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.4, 2.5.4, v2.5, 2.5, brie, latest
+Tags: v2.5.5, 2.5.5, v2.5, 2.5, brie, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f9d18d1eebcaf805d02bd683f771bcaebb643c44
+GitCommit: 9bd4bc631d219eef3cf9603c34af1cd298eb8f88
 Directory: alpine
 
 Tags: v1.7.33-windowsservercore-1809, 1.7.33-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.5.5](https://github.com/traefik/traefik/releases/tag/v2.5.5) and [v1.7.34](https://github.com/traefik/traefik/releases/tag/v1.7.34).

/cc @ddtmachado @tomMoulard @rtribotte

Cheers
