### PR TITLE
archlinux: Release 20211212.0.41353

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20211205.0.40756
-GitCommit: 0a2aae237f3cd93c71f3c74d3c5d66b6f51415db
-GitFetch: refs/tags/v20211205.0.40756
+Tags: latest, base, base-20211212.0.41353
+GitCommit: 69c66671d300659de67e365683785296c9945e73
+GitFetch: refs/tags/v20211212.0.41353
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20211205.0.40756
-GitCommit: 0a2aae237f3cd93c71f3c74d3c5d66b6f51415db
-GitFetch: refs/tags/v20211205.0.40756
+Tags: base-devel, base-devel-20211212.0.41353
+GitCommit: 69c66671d300659de67e365683785296c9945e73
+GitFetch: refs/tags/v20211212.0.41353
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks