### PR TITLE
Solr fix for Log4j CVE-2021-44228

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -8,12 +8,12 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.11.0, 8.11, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
+GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
 Directory: 8.11
 
 Tags: 8.11.0-slim, 8.11-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
+GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
 Directory: 8.11/slim
 
 Tags: 8.10.1, 8.10

--- a/library/solr
+++ b/library/solr
@@ -8,12 +8,12 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.11.0, 8.11, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
+GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
 Directory: 8.11
 
 Tags: 8.11.0-slim, 8.11-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 2e10b447bd468aecc2992916a796c327f9c80209
+GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
 Directory: 8.11/slim
 
 Tags: 8.10.1, 8.10

--- a/library/solr
+++ b/library/solr
@@ -8,150 +8,150 @@ GitRepo: https://github.com/docker-solr/docker-solr.git
 
 Tags: 8.11.0, 8.11, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.11
 
 Tags: 8.11.0-slim, 8.11-slim, 8-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 6596ada4279a9640e9e339d21469a3ff319fa0ce
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.11/slim
 
 Tags: 8.10.1, 8.10
 Architectures: amd64, arm64v8
-GitCommit: 34e3cbbf3aa8aebb5aa5dafda01b176e83ed9fb1
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.10
 
 Tags: 8.10.1-slim, 8.10-slim
 Architectures: amd64, arm64v8
-GitCommit: 34e3cbbf3aa8aebb5aa5dafda01b176e83ed9fb1
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.10/slim
 
 Tags: 8.9.0, 8.9
 Architectures: amd64, arm64v8
-GitCommit: b786d89646823e5250368cb25fa2f55fdc50ec7e
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.9
 
 Tags: 8.9.0-slim, 8.9-slim
 Architectures: amd64, arm64v8
-GitCommit: b786d89646823e5250368cb25fa2f55fdc50ec7e
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.9/slim
 
 Tags: 8.8.2, 8.8
 Architectures: amd64, arm64v8
-GitCommit: 2e73e7067302f889eb42ade28df4adaf3b527d95
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.8
 
 Tags: 8.8.2-slim, 8.8-slim
 Architectures: amd64, arm64v8
-GitCommit: 2e73e7067302f889eb42ade28df4adaf3b527d95
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.8/slim
 
 Tags: 8.7.0, 8.7
 Architectures: amd64, arm64v8
-GitCommit: 5ca83ea788711fb540d2073d95da115af53d1319
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.7
 
 Tags: 8.7.0-slim, 8.7-slim
 Architectures: amd64, arm64v8
-GitCommit: 5ca83ea788711fb540d2073d95da115af53d1319
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.7/slim
 
 Tags: 8.6.3, 8.6
 Architectures: amd64, arm64v8
-GitCommit: 0a9474015d0fe6dd9e29388a0f733f2ef1848523
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.6
 
 Tags: 8.6.3-slim, 8.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 0a9474015d0fe6dd9e29388a0f733f2ef1848523
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.6/slim
 
 Tags: 8.5.2, 8.5
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.5
 
 Tags: 8.5.2-slim, 8.5-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.5/slim
 
 Tags: 8.4.1, 8.4
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.4
 
 Tags: 8.4.1-slim, 8.4-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.4/slim
 
 Tags: 8.3.1, 8.3
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.3
 
 Tags: 8.3.1-slim, 8.3-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.3/slim
 
 Tags: 8.2.0, 8.2
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.2
 
 Tags: 8.2.0-slim, 8.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.2/slim
 
 Tags: 8.1.1, 8.1
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.1
 
 Tags: 8.1.1-slim, 8.1-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.1/slim
 
 Tags: 8.0.0, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.0
 
 Tags: 8.0.0-slim, 8.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 8.0/slim
 
 Tags: 7.7.3, 7.7, 7
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 7.7
 
 Tags: 7.7.3-slim, 7.7-slim, 7-slim
 Architectures: amd64, arm64v8
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 7.7/slim
 
 Tags: 6.6.6, 6.6, 6
 Architectures: amd64
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 6.6
 
 Tags: 6.6.6-slim, 6.6-slim, 6-slim
 Architectures: amd64
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 6.6/slim
 
 Tags: 5.5.5, 5.5, 5
 Architectures: amd64
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 5.5
 
 Tags: 5.5.5-slim, 5.5-slim, 5-slim
 Architectures: amd64
-GitCommit: 86159575c4b6da2010ae9ee003bf5a6de31157cb
+GitCommit: d9aceb632fcad5d5e7ab42b94dd25a008f5b9112
 Directory: 5.5/slim


### PR DESCRIPTION
This is a docker-only fix for Log4j CVE-2021-44228 by setting a system property.
https://solr.apache.org/security.html#apache-solr-affected-by-apache-log4j-cve-2021-44228

I verified the system property is set.  Technically the updates to 5.x & 6.x wasn't necessary as they are not vulnerable but the docker-solr project manages the scripts universally by a common template and I'd rather not address that at this time.