### PR TITLE
[hitch] 1.7.2

### DIFF
--- a/library/hitch
+++ b/library/hitch
@@ -1,8 +1,8 @@
-# this file was generated using https://github.com/varnish/docker-hitch/blob/1990ddf1f3052cabb010a5a052a4a6e87d82f6fa/populate.sh
+# this file was generated using https://github.com/varnish/docker-hitch/blob/054c998138c8f8ec6be03c7db711b8435de41e2b/populate.sh
 Maintainers: Thijs Feryn <thijs@varni.sh> (@thijsferyn),
              Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-hitch.git	
 
-Tags: 1, 1.7, 1.7.0, 1.7.0-1, latest
+Tags: 1, 1.7, 1.7.2, 1.7.2-1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1990ddf1f3052cabb010a5a052a4a6e87d82f6fa
+GitCommit: 054c998138c8f8ec6be03c7db711b8435de41e2b


### PR DESCRIPTION
new version, which notably fixes the build errors from the outdated test certificate