### PR TITLE
Odoo: update 13.0-15.0 to release 20211213

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: e5654cfab340b6007957a89895d84ce2fe434827
+GitCommit: c9691f91bebeececc3d81d47edb45af2f35bae16
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thank you.