### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.26, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: c4b367a714a455b8cb98aefac7f4870c74bace40
+GitCommit: bb03719026e58efe48da5199331cdb89ae6851c2
 Directory: 3.8/ubuntu
 
 Tags: 3.8.26-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.26-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b78ecfaf2e2223e9e874268c4903ec51a9ff515
+GitCommit: bb03719026e58efe48da5199331cdb89ae6851c2
 Directory: 3.8/alpine
 
 Tags: 3.8.26-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/bb03719: Update 3.8 to otp 24.1.7
- https://github.com/docker-library/rabbitmq/commit/8e2ca71: Update 3.8 to otp 24.1.6