### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.14.2
+Tags: 7.16.1
 Architectures: amd64, arm64v8
-GitCommit: ade24e9202c209408df15dc88959020313b67773
-Directory: 7.14
+GitCommit: bbb16187cd4958056c20049b3aed36d912c7d3bd
+Directory: 7
 
-Tags: 6.8.20
+Tags: 6.8.21
 Architectures: amd64
-GitCommit: 7c27790b5084246183270861bc4d450dd80301d2
+GitCommit: d342532c42d243fff57e87807557bff0e28a26b5
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.14.2
+Tags: 7.16.1
 Architectures: amd64, arm64v8
-GitCommit: 93b1fa087fd940757b530511d868fdc7931149de
-Directory: 7.14
+GitCommit: d486bc8c105a77c7c20f875c9bdb1b7cb94ee70d
+Directory: 7
 
-Tags: 6.8.20
+Tags: 6.8.21
 Architectures: amd64
-GitCommit: 61d8511e32cd477ab0ba3af1e4256b9f1c8358b7
+GitCommit: ea60dea9cd2eae42bf1710d7f3ab790f01693029
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.14.2
+Tags: 7.16.1
 Architectures: amd64, arm64v8
-GitCommit: c77765eaeb758ec15bc9525a44eff05eecc884aa
-Directory: 7.14
+GitCommit: eae0ee15dc396971d9c80716c3d3f8c7987a46c1
+Directory: 7
 
-Tags: 6.8.20
+Tags: 6.8.21
 Architectures: amd64
-GitCommit: 5bcca98c9dc32e7f2311c2e90d557ee669ae1db8
+GitCommit: 134f7640abdd578e9db6dbec1604974d0fadea12
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/f87d9cc: Merge pull request https://github.com/docker-library/elasticsearch/pull/201 from infosiftr/7.16
- https://github.com/docker-library/elasticsearch/commit/bbb1618: Update to 7.16.1
- https://github.com/docker-library/elasticsearch/commit/d342532: Update to 6.8.21

logstash:
- https://github.com/docker-library/logstash/commit/3457e01: Merge pull request https://github.com/docker-library/logstash/pull/103 from infosiftr/7.16
- https://github.com/docker-library/logstash/commit/eae0ee1: Update to 7.16.1
- https://github.com/docker-library/logstash/commit/134f764: Update to 6.8.21

kibana:
- https://github.com/docker-library/kibana/commit/00270dd: Merge pull request https://github.com/docker-library/kibana/pull/95 from infosiftr/7.16
- https://github.com/docker-library/kibana/commit/d486bc8: Update to 7.16.1
- https://github.com/docker-library/kibana/commit/ea60dea: Update to 6.8.21

This should include the `log4j` fixes.