### PR TITLE
consul: 1.10.5, 1.9.12 and 1.8.18

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -6,20 +6,20 @@ GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: 5607edeffa1c759ce996b437374be9e6613bdc15
 Directory: 0.X
 
-Tags: 1.10.4, 1.10, latest
+Tags: 1.10.5, 1.10, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: c3b23cd7de836230efe031c850c039208de79e6f
+GitCommit: dd54964e243aa1d58ae59e61b59232a63e338f04
 Directory: 0.X
 
-Tags: 1.9.11, 1.9
+Tags: 1.9.12, 1.9
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 5c5d3420d092b2fdf7d2766b927dfcf78e83cfd5
+GitCommit: 133695b04d9565eddcc0245554bea5688171d342
 Directory: 0.X
 
-Tags: 1.8.17, 1.8
+Tags: 1.8.18, 1.8
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: be51d562f3bd6d440ee5c033b4e1b6f3c41c553c
+GitCommit: 759865d5cf5297813275625d3c5260cf7bdc007f
 Directory: 0.X


### PR DESCRIPTION
Updates `consul` image to latest releases from today.