### PR TITLE
Release Couchbase Server EE 6.6.4 and 7.0.3 with log4j remediation

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -1,17 +1,17 @@
 Maintainers: Couchbase Docker Team <docker@couchbase.com> (@cb-robot)
 GitRepo: https://github.com/couchbase/docker
 
-Tags: latest, enterprise, 7.0.2, enterprise-7.0.2
-GitCommit: aec4494ab5280caf567997d72714f57572a6315b
-Directory: enterprise/couchbase-server/7.0.2
+Tags: latest, enterprise, 7.0.3, enterprise-7.0.3
+GitCommit: ce17444d6e082a8a08ba636c513e3460b98d3d2c
+Directory: enterprise/couchbase-server/7.0.3
 
 Tags: community, community-7.0.2
 GitCommit: aec4494ab5280caf567997d72714f57572a6315b
 Directory: community/couchbase-server/7.0.2
 
-Tags: 6.6.3, enterprise-6.6.3
-GitCommit: 3ff26f9a680d1449756b51e753324980087c0548
-Directory: enterprise/couchbase-server/6.6.3
+Tags: 6.6.4, enterprise-6.6.4
+GitCommit: e27aaf8d37861a570ad62a96ea04c84026a59282
+Directory: enterprise/couchbase-server/6.6.4
 
 Tags: community-6.6.0
 GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa


### PR DESCRIPTION
Proposing this now to get it in the queue and reviewed. If possible, please wait for a comment from me before actually submitting the change - we should be posting a blog today about the log4j remediation.
