### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,62 +4,62 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.0.4-php7.4-apache, 4.0-php7.4-apache, 4-php7.4-apache, php7.4-apache
+Tags: 4.0.5-php7.4-apache, 4.0-php7.4-apache, 4-php7.4-apache, php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dd714aae69dd103e72ae519d4638b71da7c5e4f
+GitCommit: 786a6f32362959d4de9096ab5e93ff122c54e35a
 Directory: 4.0/php7.4/apache
 
-Tags: 4.0.4-php7.4-fpm-alpine, 4.0-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 4.0.5-php7.4-fpm-alpine, 4.0-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0dd714aae69dd103e72ae519d4638b71da7c5e4f
+GitCommit: 786a6f32362959d4de9096ab5e93ff122c54e35a
 Directory: 4.0/php7.4/fpm-alpine
 
-Tags: 4.0.4-php7.4-fpm, 4.0-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
+Tags: 4.0.5-php7.4-fpm, 4.0-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dd714aae69dd103e72ae519d4638b71da7c5e4f
+GitCommit: 786a6f32362959d4de9096ab5e93ff122c54e35a
 Directory: 4.0/php7.4/fpm
 
-Tags: 4.0.4, 4.0, 4, latest, 4.0.4-apache, 4.0-apache, 4-apache, apache, 4.0.4-php8.0, 4.0-php8.0, 4-php8.0, php8.0, 4.0.4-php8.0-apache, 4.0-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.0.5, 4.0, 4, latest, 4.0.5-apache, 4.0-apache, 4-apache, apache, 4.0.5-php8.0, 4.0-php8.0, 4-php8.0, php8.0, 4.0.5-php8.0-apache, 4.0-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dd714aae69dd103e72ae519d4638b71da7c5e4f
+GitCommit: 786a6f32362959d4de9096ab5e93ff122c54e35a
 Directory: 4.0/php8.0/apache
 
-Tags: 4.0.4-php8.0-fpm-alpine, 4.0-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.0.5-php8.0-fpm-alpine, 4.0-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0dd714aae69dd103e72ae519d4638b71da7c5e4f
+GitCommit: 786a6f32362959d4de9096ab5e93ff122c54e35a
 Directory: 4.0/php8.0/fpm-alpine
 
-Tags: 4.0.4-php8.0-fpm, 4.0-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.0.5-php8.0-fpm, 4.0-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dd714aae69dd103e72ae519d4638b71da7c5e4f
+GitCommit: 786a6f32362959d4de9096ab5e93ff122c54e35a
 Directory: 4.0/php8.0/fpm
 
-Tags: 3.10.3-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache
+Tags: 3.10.4-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5d8f256aa18f739c67df01783c8c44703b992455
+GitCommit: 3f0da93150f4b8d3623fdae365e70e41ecc3525e
 Directory: 3.10/php7.3/apache
 
-Tags: 3.10.3-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine
+Tags: 3.10.4-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d8f256aa18f739c67df01783c8c44703b992455
+GitCommit: 3f0da93150f4b8d3623fdae365e70e41ecc3525e
 Directory: 3.10/php7.3/fpm-alpine
 
-Tags: 3.10.3-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm
+Tags: 3.10.4-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5d8f256aa18f739c67df01783c8c44703b992455
+GitCommit: 3f0da93150f4b8d3623fdae365e70e41ecc3525e
 Directory: 3.10/php7.3/fpm
 
-Tags: 3.10.3, 3.10, 3, 3.10.3-apache, 3.10-apache, 3-apache, 3.10.3-php7.4, 3.10-php7.4, 3-php7.4, 3.10.3-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
+Tags: 3.10.4, 3.10, 3, 3.10.4-apache, 3.10-apache, 3-apache, 3.10.4-php7.4, 3.10-php7.4, 3-php7.4, 3.10.4-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5d8f256aa18f739c67df01783c8c44703b992455
+GitCommit: 3f0da93150f4b8d3623fdae365e70e41ecc3525e
 Directory: 3.10/php7.4/apache
 
-Tags: 3.10.3-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
+Tags: 3.10.4-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d8f256aa18f739c67df01783c8c44703b992455
+GitCommit: 3f0da93150f4b8d3623fdae365e70e41ecc3525e
 Directory: 3.10/php7.4/fpm-alpine
 
-Tags: 3.10.3-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
+Tags: 3.10.4-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5d8f256aa18f739c67df01783c8c44703b992455
+GitCommit: 3f0da93150f4b8d3623fdae365e70e41ecc3525e
 Directory: 3.10/php7.4/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@7c36233: Fix typo in README
- joomla-docker/docker-joomla@786a6f3: Update images of Joomla! 4.0.4 to 4.0.5
- joomla-docker/docker-joomla@cf64584: Update version of Joomla! 4.0.4 to 4.0.5
- joomla-docker/docker-joomla@3f0da93: Update images of Joomla! 3.10.3 to 3.10.4
- joomla-docker/docker-joomla@4bca8f2: Update version of Joomla! 3.10.3 to 3.10.4
- joomla-docker/docker-joomla@9eda1b6: Update README with maintenance and contribution information.