### PR TITLE
consul: 1.11.0

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,12 +1,12 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.11.0-beta3, 1.11.0-beta
+Tags: 1.11.0, 1.11, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 5607edeffa1c759ce996b437374be9e6613bdc15
+GitCommit: b53fc6323b67fa3bf3ea63be31dfe6053162f610 
 Directory: 0.X
 
-Tags: 1.10.5, 1.10, latest
+Tags: 1.10.5, 1.10
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: dd54964e243aa1d58ae59e61b59232a63e338f04
@@ -16,10 +16,4 @@ Tags: 1.9.12, 1.9
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: 133695b04d9565eddcc0245554bea5688171d342
-Directory: 0.X
-
-Tags: 1.8.18, 1.8
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 759865d5cf5297813275625d3c5260cf7bdc007f
 Directory: 0.X


### PR DESCRIPTION
Moves latest to point to `1.11` release series and removes references to `1.8` which are now EOL with the release of `1.11`. 