### PR TITLE
[security] Update MediaWiki to 1.35.5 / 1.36.3 / 1.37.1

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,36 +2,36 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 1795938062adeb7251b6a7180e0e40b975b5827a
+GitCommit: daebab6abd474474deb62c5544127f86dd507172
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.37.0, 1.37, stable, latest
+Tags: 1.37.1, 1.37, stable, latest
 Directory: 1.37/apache
 
-Tags: 1.37.0-fpm, 1.37-fpm, stable-fpm
+Tags: 1.37.1-fpm, 1.37-fpm, stable-fpm
 Directory: 1.37/fpm
 
-Tags: 1.37.0-fpm-alpine, 1.37-fpm-alpine, stable-fpm-alpine
+Tags: 1.37.1-fpm-alpine, 1.37-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.37/fpm-alpine
 
-Tags: 1.36.2, 1.36, legacy
+Tags: 1.36.3, 1.36, legacy
 Directory: 1.36/apache
 
-Tags: 1.36.2-fpm, 1.36-fpm, legacy-fpm
+Tags: 1.36.3-fpm, 1.36-fpm, legacy-fpm
 Directory: 1.36/fpm
 
-Tags: 1.36.2-fpm-alpine, 1.36-fpm-alpine, legacy-fpm-alpine
+Tags: 1.36.3-fpm-alpine, 1.36-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.36/fpm-alpine
 
-Tags: 1.35.4, 1.35, lts, legacylts
+Tags: 1.35.5, 1.35, lts, legacylts
 Directory: 1.35/apache
 
-Tags: 1.35.4-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
+Tags: 1.35.5-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.4-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.35.5-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 


### PR DESCRIPTION
Fixes CVE-2021-44854, CVE-2021-44855, CVE-2021-44856,
CVE-2021-44857, CVE-2021-44858, CVE-2021-45038.

* https://www.mediawiki.org/wiki/2021-12_security_release/FAQ
* https://lists.wikimedia.org/hyperkitty/list/wikitech-l@lists.wikimedia.org/thread/QEN3EK4JXAVJMJ5GF3GYOAKNJPEKFQYA/