### PR TITLE
Add a missing clojure image tag

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -127,7 +127,7 @@ Directory: target/openjdk-17-slim-bullseye/boot
 Tags: openjdk-17-boot-bullseye, openjdk-17-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
 Directory: target/openjdk-17-bullseye/boot
 
-Tags: openjdk-17, openjdk-17-slim-bullseye, tools-deps, tools-deps-1.10.3.1040, openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.1040, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.1040-slim-bullseye
+Tags: openjdk-17, openjdk-17-slim-bullseye, tools-deps, tools-deps-1.10.3.1040, tools-deps-1.10.3.1040-slim-bullseye, openjdk-17-tools-deps, openjdk-17-tools-deps-1.10.3.1040, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.10.3.1040-slim-bullseye
 Directory: target/openjdk-17-slim-bullseye/tools-deps
 
 Tags: openjdk-17-bullseye, openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.10.3.1040-bullseye, tools-deps-bullseye, tools-deps-1.10.3.1040-bullseye


### PR DESCRIPTION
I noticed this tag was missing in the clojure manifest.

I'm going to automate how we produce this manifest file soon... 😅 