### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.11, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 986be01d29ad1f7ee922e45e423dd1b128526cf3
+GitCommit: 844403953ac5d3d1a2e6029e85b779df9a105d58
 Directory: 3.9/ubuntu
 
 Tags: 3.9.11-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.11-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 986be01d29ad1f7ee922e45e423dd1b128526cf3
+GitCommit: 844403953ac5d3d1a2e6029e85b779df9a105d58
 Directory: 3.9/alpine
 
 Tags: 3.9.11-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.26, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: bdbbaaf071d50b9f0372c011c30795b6e4fd5374
+GitCommit: eb49905dccfa2b6ac6fb97e1aeb220c30984ce6b
 Directory: 3.8/ubuntu
 
 Tags: 3.8.26-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.26-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bdbbaaf071d50b9f0372c011c30795b6e4fd5374
+GitCommit: eb49905dccfa2b6ac6fb97e1aeb220c30984ce6b
 Directory: 3.8/alpine
 
 Tags: 3.8.26-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8444039: Update 3.9 to otp 24.2
- https://github.com/docker-library/rabbitmq/commit/eb49905: Update 3.8 to otp 24.2