### PR TITLE
consul: 1.11.1, 1.10.6, 1.9.13 and 1.8.19

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,19 +1,25 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.11.0, 1.11, latest
+Tags: 1.11.1, 1.11, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: b53fc6323b67fa3bf3ea63be31dfe6053162f610 
+GitCommit: 85f1536e9106178e638121e2fe574476551ea614
 Directory: 0.X
 
-Tags: 1.10.5, 1.10
+Tags: 1.10.6, 1.10
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: dd54964e243aa1d58ae59e61b59232a63e338f04
+GitCommit: c5493e998192edd327c3fa17cd9fc2bcac67c3f6
 Directory: 0.X
 
-Tags: 1.9.12, 1.9
+Tags: 1.9.13, 1.9
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 133695b04d9565eddcc0245554bea5688171d342
+GitCommit: c2a400ca113a1a7c92694a006d03a2845432bdf6
+Directory: 0.X
+
+Tags: 1.8.19, 1.8
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: a73d6ad2748282dee5ad645827f6d1543e357f71
 Directory: 0.X


### PR DESCRIPTION
This reflects releases today for [hashcorp/consul](https://github.com/hashicorp/consul). One notable aspect of this change is that despite 1.8 being EOL (as noted in the previous release's PR #11516), we are adding it back here to address [CVE-2021-44716](https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2021-44716).