### PR TITLE
Update to Flink 1.11.6 / 1.12.7 / 1.13.5 / 1.14.2

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -45,40 +45,40 @@ Directory: ./1.13/scala_2.11-java11-debian
 
 Tags: 1.12.7-scala_2.12-java8, 1.12-scala_2.12-java8, 1.12.7-scala_2.12, 1.12-scala_2.12, 1.12.7-java8, 1.12-java8, 1.12.7, 1.12
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.12/scala_2.12-java8-debian
 
 Tags: 1.12.7-scala_2.12-java11, 1.12-scala_2.12-java11, 1.12.7-java11, 1.12-java11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.12/scala_2.12-java11-debian
 
 Tags: 1.12.7-scala_2.11-java8, 1.12-scala_2.11-java8, 1.12.7-scala_2.11, 1.12-scala_2.11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.12/scala_2.11-java8-debian
 
 Tags: 1.12.7-scala_2.11-java11, 1.12-scala_2.11-java11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.12/scala_2.11-java11-debian
 
 Tags: 1.11.6-scala_2.12-java8, 1.11-scala_2.12-java8, 1.11.6-scala_2.12, 1.11-scala_2.12, 1.11.6-java8, 1.11-java8, 1.11.6, 1.11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.11/scala_2.12-java8-debian
 
 Tags: 1.11.6-scala_2.12-java11, 1.11-scala_2.12-java11, 1.11.6-java11, 1.11-java11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.11/scala_2.12-java11-debian
 
 Tags: 1.11.6-scala_2.11-java8, 1.11-scala_2.11-java8, 1.11.6-scala_2.11, 1.11-scala_2.11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.11/scala_2.11-java8-debian
 
 Tags: 1.11.6-scala_2.11-java11, 1.11-scala_2.11-java11
 Architectures: amd64
-GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+GitCommit: 79bcbe515597ed4639da10709742cdcbe331fbc3
 Directory: ./1.11/scala_2.11-java11-debian

--- a/library/flink
+++ b/library/flink
@@ -3,42 +3,82 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.14.0-scala_2.12-java8, 1.14-scala_2.12-java8, scala_2.12-java8, 1.14.0-scala_2.12, 1.14-scala_2.12, scala_2.12, 1.14.0-java8, 1.14-java8, java8, 1.14.0, 1.14, latest
+Tags: 1.14.2-scala_2.12-java8, 1.14-scala_2.12-java8, scala_2.12-java8, 1.14.2-scala_2.12, 1.14-scala_2.12, scala_2.12, 1.14.2-java8, 1.14-java8, java8, 1.14.2, 1.14, latest
 Architectures: amd64
-GitCommit: e2d7fda603c61359c625189debb22a30e8aeb84f
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.14/scala_2.12-java8-debian
 
-Tags: 1.14.0-scala_2.12-java11, 1.14-scala_2.12-java11, scala_2.12-java11, 1.14.0-java11, 1.14-java11, java11
+Tags: 1.14.2-scala_2.12-java11, 1.14-scala_2.12-java11, scala_2.12-java11, 1.14.2-java11, 1.14-java11, java11
 Architectures: amd64
-GitCommit: e2d7fda603c61359c625189debb22a30e8aeb84f
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.14/scala_2.12-java11-debian
 
-Tags: 1.14.0-scala_2.11-java8, 1.14-scala_2.11-java8, scala_2.11-java8, 1.14.0-scala_2.11, 1.14-scala_2.11, scala_2.11
+Tags: 1.14.2-scala_2.11-java8, 1.14-scala_2.11-java8, scala_2.11-java8, 1.14.2-scala_2.11, 1.14-scala_2.11, scala_2.11
 Architectures: amd64
-GitCommit: e2d7fda603c61359c625189debb22a30e8aeb84f
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.14/scala_2.11-java8-debian
 
-Tags: 1.14.0-scala_2.11-java11, 1.14-scala_2.11-java11, scala_2.11-java11
+Tags: 1.14.2-scala_2.11-java11, 1.14-scala_2.11-java11, scala_2.11-java11
 Architectures: amd64
-GitCommit: e2d7fda603c61359c625189debb22a30e8aeb84f
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.14/scala_2.11-java11-debian
 
-Tags: 1.13.3-scala_2.12-java8, 1.13-scala_2.12-java8, 1.13.3-scala_2.12, 1.13-scala_2.12, 1.13.3-java8, 1.13-java8, 1.13.3, 1.13
+Tags: 1.13.5-scala_2.12-java8, 1.13-scala_2.12-java8, 1.13.5-scala_2.12, 1.13-scala_2.12, 1.13.5-java8, 1.13-java8, 1.13.5, 1.13
 Architectures: amd64
-GitCommit: ed0c98767a67eb07e89ca15edb038f9ba37b94ff
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.13/scala_2.12-java8-debian
 
-Tags: 1.13.3-scala_2.12-java11, 1.13-scala_2.12-java11, 1.13.3-java11, 1.13-java11
+Tags: 1.13.5-scala_2.12-java11, 1.13-scala_2.12-java11, 1.13.5-java11, 1.13-java11
 Architectures: amd64
-GitCommit: ed0c98767a67eb07e89ca15edb038f9ba37b94ff
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.13/scala_2.12-java11-debian
 
-Tags: 1.13.3-scala_2.11-java8, 1.13-scala_2.11-java8, 1.13.3-scala_2.11, 1.13-scala_2.11
+Tags: 1.13.5-scala_2.11-java8, 1.13-scala_2.11-java8, 1.13.5-scala_2.11, 1.13-scala_2.11
 Architectures: amd64
-GitCommit: ed0c98767a67eb07e89ca15edb038f9ba37b94ff
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.13/scala_2.11-java8-debian
 
-Tags: 1.13.3-scala_2.11-java11, 1.13-scala_2.11-java11
+Tags: 1.13.5-scala_2.11-java11, 1.13-scala_2.11-java11
 Architectures: amd64
-GitCommit: ed0c98767a67eb07e89ca15edb038f9ba37b94ff
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
 Directory: ./1.13/scala_2.11-java11-debian
+
+Tags: 1.12.7-scala_2.12-java8, 1.12-scala_2.12-java8, 1.12.7-scala_2.12, 1.12-scala_2.12, 1.12.7-java8, 1.12-java8, 1.12.7, 1.12
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.12/scala_2.12-java8-debian
+
+Tags: 1.12.7-scala_2.12-java11, 1.12-scala_2.12-java11, 1.12.7-java11, 1.12-java11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.12/scala_2.12-java11-debian
+
+Tags: 1.12.7-scala_2.11-java8, 1.12-scala_2.11-java8, 1.12.7-scala_2.11, 1.12-scala_2.11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.12/scala_2.11-java8-debian
+
+Tags: 1.12.7-scala_2.11-java11, 1.12-scala_2.11-java11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.12/scala_2.11-java11-debian
+
+Tags: 1.11.6-scala_2.12-java8, 1.11-scala_2.12-java8, 1.11.6-scala_2.12, 1.11-scala_2.12, 1.11.6-java8, 1.11-java8, 1.11.6, 1.11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.11/scala_2.12-java8-debian
+
+Tags: 1.11.6-scala_2.12-java11, 1.11-scala_2.12-java11, 1.11.6-java11, 1.11-java11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.11/scala_2.12-java11-debian
+
+Tags: 1.11.6-scala_2.11-java8, 1.11-scala_2.11-java8, 1.11.6-scala_2.11, 1.11-scala_2.11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.11/scala_2.11-java8-debian
+
+Tags: 1.11.6-scala_2.11-java11, 1.11-scala_2.11-java11
+Architectures: amd64
+GitCommit: 0ebeb6ccefea52933ff60c8e5fa7d77adb4090dc
+Directory: ./1.11/scala_2.11-java11-debian


### PR DESCRIPTION
Upgrades Flink 1.11-1.14 to the latest versions, which address the log4j vulnerabilities [CVE-2021-44228](https://nvd.nist.gov/vuln/detail/CVE-2021-44228) and [CVE-2021-45046](https://nvd.nist.gov/vuln/detail/CVE-2021-45046).