### PR TITLE
Telegraf v1.21.1

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -2,14 +2,7 @@ Maintainers: David Reimschussel <dreimschussel@influxdata.com> (@reimda),
              Josh Powers <jpowers@influxdata.com> (@powersj),
              Mya Longmire <mlongmire@influxdata.com> (@MyaLongmire)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
-GitCommit: 725fae95efff8850004099d569d0e2360d95e854
-
-Tags: 1.18, 1.18.3
-Architectures: amd64, arm32v7, arm64v8
-Directory: telegraf/1.18
-
-Tags: 1.18-alpine, 1.18.3-alpine
-Directory: telegraf/1.18/alpine
+GitCommit: a640cf9bb1fd9fc8d301bc1a441cdc0330bb31e1
 
 Tags: 1.19, 1.19.3
 Architectures: amd64, arm32v7, arm64v8
@@ -18,9 +11,16 @@ Directory: telegraf/1.19
 Tags: 1.19-alpine, 1.19.3-alpine
 Directory: telegraf/1.19/alpine
 
-Tags: 1.20, 1.20.4, latest
+Tags: 1.20, 1.20.4
 Architectures: amd64, arm32v7, arm64v8
 Directory: telegraf/1.20
 
-Tags: 1.20-alpine, 1.20.4-alpine, alpine
+Tags: 1.20-alpine, 1.20.4-alpine
 Directory: telegraf/1.20/alpine
+
+Tags: 1.21, 1.21.1, latest
+Architectures: amd64, arm32v7, arm64v8
+Directory: telegraf/1.21
+
+Tags: 1.21-alpine, 1.21.1-alpine, alpine
+Directory: telegraf/1.21/alpine


### PR DESCRIPTION
This release has the fix to use setcap only when running as root (https://github.com/influxdata/influxdata-docker/pull/558). Thanks @yosifkit for all your great reviews!