### PR TITLE
[RFC] Added Unit as an official Library image

### DIFF
--- a/library/unit
+++ b/library/unit
@@ -1,0 +1,60 @@
+# this file is generated via https://github.com/nginx/unit/blob/b9bc222021e77bbdfb12576b3e315b962cf6b399/pkg/docker/Makefile
+
+Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx)
+GitRepo: https://github.com/nginx/unit.git
+
+Tags: 1.29.1-go1.20, go1.20, go1, go
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.go1.20
+
+Tags: 1.29.1-jsc11, jsc11, jsc
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.jsc11
+
+Tags: 1.29.1-node18, node18, node
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.node18
+
+Tags: 1.29.1-perl5.36, perl5.36, perl5, perl
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.perl5.36
+
+Tags: 1.29.1-php8.2, php8.2, php8, php
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.php8.2
+
+Tags: 1.29.1-python3.11, python3.11, python3, python
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.python3.11
+
+Tags: 1.29.1-ruby3.2, ruby3.2, ruby3, ruby
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.ruby3.2
+
+Tags: 1.29.1-minimal, minimal
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+Directory: pkg/docker
+File: Dockerfile.minimal


### PR DESCRIPTION
Hello!

This PR is to start the process of adding [Unit](http://unit.nginx.org/) docker images under the umbrella of Docker Library.

Unit is a polyglot application server, and we're already using per-language Official Images to build our images upon. Basically for a given variant, we build Unit and the language module and ship it like that, enabling users to work in the already familiar environment for a language. That works really well for us as a vendor, so I would like to thank everyone involved in making Docker Library a success story as it is!

One of the issues we do have however shipping our own images is the overall finicky and cumbersome process of building multi-architecture images, which we see an increased demand for (especially for armv8a since Graviton2 and M1 introduction).  Enrolling Unit images under a Docker Library umbrella would be a great win for us in this case, similarly to what we (F5, Inc.) already enjoy with `nginx` images publishing.

At this point I would like to iron out technical issues we might encounter for this process, and when it's ready, work on Documentation part (which involves converting what we already have on http://unit.nginx.org/installation/#docker-images).

This PR currently points to my own fork of [unit repo](https://github.com/nginx/unit/).  The reason for that is I would like to have a formal review from Library maintainers for Dockerfiles/tags/library definition files/etc to happen before I actually push code to the main Unit repository (we're also using mercurial upstream, but that's another story - the github repository is automagically updated).  Once that is sorted out, I'll submit the patches for Unit internal review and will update this PR with a fresh set of library definitions. Hope that is OK, but let me know if you would like that plan to be amended or thrown out. :-)

To help fill out a review checklist:
 - I am an employee of F5, Inc. / NGINX Inc., and I have [commit rights](https://github.com/nginx/unit/commits?author=thresheek) to the repo. Our devteam leaders are OK with the enrollment to the Official Library.
 - Unit is published under [Apache 2.0](https://github.com/nginx/unit/blob/master/LICENSE) source code license.

cc @vbart @artemkonev

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - > I am an employee of F5, Inc. / NGINX Inc., and I have [commit rights](https://github.com/nginx/unit/commits?author=thresheek) to the repo. Our devteam leaders are OK with the enrollment to the Official Library.
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)?
    - Apache 2.0
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/2187
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)