### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,94 +4,94 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 19-ea-1-jdk-oraclelinux8, 19-ea-1-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-1-jdk-oracle, 19-ea-1-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-ea-1-jdk, 19-ea-1, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-2-jdk-oraclelinux8, 19-ea-2-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-2-jdk-oracle, 19-ea-2-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
+SharedTags: 19-ea-2-jdk, 19-ea-2, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: amd64, arm64v8
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/oraclelinux8
 
-Tags: 19-ea-1-jdk-oraclelinux7, 19-ea-1-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
+Tags: 19-ea-2-jdk-oraclelinux7, 19-ea-2-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/oraclelinux7
 
-Tags: 19-ea-1-jdk-bullseye, 19-ea-1-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
+Tags: 19-ea-2-jdk-bullseye, 19-ea-2-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/bullseye
 
-Tags: 19-ea-1-jdk-slim-bullseye, 19-ea-1-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-1-jdk-slim, 19-ea-1-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
+Tags: 19-ea-2-jdk-slim-bullseye, 19-ea-2-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-2-jdk-slim, 19-ea-2-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
 Architectures: amd64, arm64v8
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/slim-bullseye
 
-Tags: 19-ea-1-jdk-buster, 19-ea-1-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
+Tags: 19-ea-2-jdk-buster, 19-ea-2-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
 Architectures: amd64, arm64v8
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/buster
 
-Tags: 19-ea-1-jdk-slim-buster, 19-ea-1-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
+Tags: 19-ea-2-jdk-slim-buster, 19-ea-2-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/slim-buster
 
-Tags: 19-ea-1-jdk-windowsservercore-ltsc2022, 19-ea-1-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-ea-1-jdk-windowsservercore, 19-ea-1-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-1-jdk, 19-ea-1, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-2-jdk-windowsservercore-ltsc2022, 19-ea-2-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19-ea-2-jdk-windowsservercore, 19-ea-2-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-2-jdk, 19-ea-2, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19-ea-1-jdk-windowsservercore-1809, 19-ea-1-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-ea-1-jdk-windowsservercore, 19-ea-1-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-1-jdk, 19-ea-1, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-2-jdk-windowsservercore-1809, 19-ea-2-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19-ea-2-jdk-windowsservercore, 19-ea-2-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-2-jdk, 19-ea-2, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-1-jdk-windowsservercore-ltsc2016, 19-ea-1-windowsservercore-ltsc2016, 19-ea-jdk-windowsservercore-ltsc2016, 19-ea-windowsservercore-ltsc2016, 19-jdk-windowsservercore-ltsc2016, 19-windowsservercore-ltsc2016
-SharedTags: 19-ea-1-jdk-windowsservercore, 19-ea-1-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-1-jdk, 19-ea-1, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-2-jdk-windowsservercore-ltsc2016, 19-ea-2-windowsservercore-ltsc2016, 19-ea-jdk-windowsservercore-ltsc2016, 19-ea-windowsservercore-ltsc2016, 19-jdk-windowsservercore-ltsc2016, 19-windowsservercore-ltsc2016
+SharedTags: 19-ea-2-jdk-windowsservercore, 19-ea-2-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-2-jdk, 19-ea-2, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 19-ea-1-jdk-nanoserver-1809, 19-ea-1-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-ea-1-jdk-nanoserver, 19-ea-1-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19-ea-2-jdk-nanoserver-1809, 19-ea-2-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19-ea-2-jdk-nanoserver, 19-ea-2-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: 2836fabaca5c7e48ae71d3c8ec2e00bbcfb36f4e
+GitCommit: 5cda3280c94c72673acb8713e6a75bb3fe4adf0e
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18-ea-27-jdk-oraclelinux8, 18-ea-27-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-27-jdk-oracle, 18-ea-27-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-27-jdk, 18-ea-27, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-28-jdk-oraclelinux8, 18-ea-28-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-28-jdk-oracle, 18-ea-28-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-28-jdk, 18-ea-28, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-27-jdk-oraclelinux7, 18-ea-27-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-28-jdk-oraclelinux7, 18-ea-28-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-27-jdk-bullseye, 18-ea-27-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
+Tags: 18-ea-28-jdk-bullseye, 18-ea-28-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/bullseye
 
-Tags: 18-ea-27-jdk-slim-bullseye, 18-ea-27-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-27-jdk-slim, 18-ea-27-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-28-jdk-slim-bullseye, 18-ea-28-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-28-jdk-slim, 18-ea-28-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18-ea-27-jdk-buster, 18-ea-27-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-28-jdk-buster, 18-ea-28-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/buster
 
-Tags: 18-ea-27-jdk-slim-buster, 18-ea-27-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
+Tags: 18-ea-28-jdk-slim-buster, 18-ea-28-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/slim-buster
 
 Tags: 18-ea-11-jdk-alpine3.15, 18-ea-11-alpine3.15, 18-ea-jdk-alpine3.15, 18-ea-alpine3.15, 18-jdk-alpine3.15, 18-alpine3.15, 18-ea-11-jdk-alpine, 18-ea-11-alpine, 18-ea-jdk-alpine, 18-ea-alpine, 18-jdk-alpine, 18-alpine
@@ -104,31 +104,31 @@ Architectures: amd64
 GitCommit: 0cea342dc0644ce3c104a7b0907719e6c6357fcf
 Directory: 18/jdk/alpine3.14
 
-Tags: 18-ea-27-jdk-windowsservercore-ltsc2022, 18-ea-27-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
-SharedTags: 18-ea-27-jdk-windowsservercore, 18-ea-27-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-27-jdk, 18-ea-27, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-28-jdk-windowsservercore-ltsc2022, 18-ea-28-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
+SharedTags: 18-ea-28-jdk-windowsservercore, 18-ea-28-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-28-jdk, 18-ea-28, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18-ea-27-jdk-windowsservercore-1809, 18-ea-27-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-27-jdk-windowsservercore, 18-ea-27-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-27-jdk, 18-ea-27, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-28-jdk-windowsservercore-1809, 18-ea-28-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-28-jdk-windowsservercore, 18-ea-28-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-28-jdk, 18-ea-28, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-27-jdk-windowsservercore-ltsc2016, 18-ea-27-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-27-jdk-windowsservercore, 18-ea-27-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-27-jdk, 18-ea-27, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-28-jdk-windowsservercore-ltsc2016, 18-ea-28-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
+SharedTags: 18-ea-28-jdk-windowsservercore, 18-ea-28-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-28-jdk, 18-ea-28, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/windows/windowsservercore-ltsc2016
 Constraints: windowsservercore-ltsc2016
 
-Tags: 18-ea-27-jdk-nanoserver-1809, 18-ea-27-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-27-jdk-nanoserver, 18-ea-27-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-28-jdk-nanoserver-1809, 18-ea-28-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-28-jdk-nanoserver, 18-ea-28-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 734163cc7308e5bc215ebcd433bedbbd02711d9f
+GitCommit: 4e15fc5615f5c6f31a2fc5c4364d63bff1aa0031
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5cda328: Update 19 to 19-ea+2
- https://github.com/docker-library/openjdk/commit/4e15fc5: Update 18 to 18-ea+28
- https://github.com/docker-library/openjdk/commit/52263d8: Add missing "19" comment