### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.31.0, 4.31, 4, latest
+Tags: 4.32.0, 4.32, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: be43363f4bef777e70428f67c854c0ea5d56173f
+GitCommit: f9e21738c57f92c845497d9ea27f6f7c10b1cf9c
 Directory: 4/debian
 
-Tags: 4.31.0-alpine, 4.31-alpine, 4-alpine, alpine
+Tags: 4.32.0-alpine, 4.32-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: be43363f4bef777e70428f67c854c0ea5d56173f
+GitCommit: f9e21738c57f92c845497d9ea27f6f7c10b1cf9c
 Directory: 4/alpine
 
 Tags: 3.42.8, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/f9e2173: Update to 4.32.0, ghost-cli 1.18.1