### PR TITLE
Update Clear Linux OS to 35440

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 23a2d1c1f7326bd71eeffe6b9499d07fe5387fcb
-GitFetch: refs/heads/base-35400
+GitCommit: 98d28812b5da1f186157f952ca9e60a17ce945f9
+GitFetch: refs/heads/base-35440


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35440

@bryteise @djklimes @bryteise