### PR TITLE
Odoo: update 13.0-15.0 to release 20211220

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: c9691f91bebeececc3d81d47edb45af2f35bae16
+GitCommit: 301937f44c563fadc492933f078676c2aa64bd56
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

Here are the latest updates of Odoo supported versions.

Thanks.