### PR TITLE
Bump Traefik to v2.6.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,4 +1,4 @@
-Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
+Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
 Tags: v2.6.0-rc1-windowsservercore-1809, 2.6.0-rc1-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
 Architectures: windows-amd64

--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,18 @@
 Maintainers: Emile Vauge <emile@vauge.com> (@emilevauge), Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet)
 
+Tags: v2.6.0-rc1-windowsservercore-1809, 2.6.0-rc1-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 72e26bf14573fda137e2e4b9665e956a85a5776c
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.6.0-rc1, 2.6.0-rc1, v2.6, 2.6, rocamadour
+Architectures: amd64, arm32v6, arm64v8
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 72e26bf14573fda137e2e4b9665e956a85a5776c
+Directory: alpine
+
 Tags: v2.5.5-windowsservercore-1809, 2.5.5-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.6.0-rc1](https://github.com/traefik/traefik/releases/tag/v2.6.0-rc1).

/cc @ldez @rtribotte @ddtmachado

Cheers
