### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.16.1
+Tags: 7.16.2
 Architectures: amd64, arm64v8
-GitCommit: bbb16187cd4958056c20049b3aed36d912c7d3bd
+GitCommit: 53dedd336f9a46a3287fe4137b188527e199b798
 Directory: 7
 
-Tags: 6.8.21
+Tags: 6.8.22
 Architectures: amd64
-GitCommit: d342532c42d243fff57e87807557bff0e28a26b5
+GitCommit: d89d5afa00ffe783828b9f7b911e53e8ef6b0704
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.16.1
+Tags: 7.16.2
 Architectures: amd64, arm64v8
-GitCommit: d486bc8c105a77c7c20f875c9bdb1b7cb94ee70d
+GitCommit: 5ca74e65e55e6ad7722ec7889ca3b696a3274594
 Directory: 7
 
-Tags: 6.8.21
+Tags: 6.8.22
 Architectures: amd64
-GitCommit: ea60dea9cd2eae42bf1710d7f3ab790f01693029
+GitCommit: d054cfa8b5dbb4ce60aa0ce04943a82fde49805c
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.16.1
+Tags: 7.16.2
 Architectures: amd64, arm64v8
-GitCommit: eae0ee15dc396971d9c80716c3d3f8c7987a46c1
+GitCommit: 9e4c70aeed0e9e75323aed29912190dfc5e6a227
 Directory: 7
 
-Tags: 6.8.21
+Tags: 6.8.22
 Architectures: amd64
-GitCommit: 134f7640abdd578e9db6dbec1604974d0fadea12
+GitCommit: f1217485facf54d9b79f08458d0bc19e90d8e929
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/53dedd3: Update to 7.16.2
- https://github.com/docker-library/elasticsearch/commit/d89d5af: Update to 6.8.22

logstash:
- https://github.com/docker-library/logstash/commit/9e4c70a: Update to 7.16.2
- https://github.com/docker-library/logstash/commit/f121748: Update to 6.8.22

kibana:
- https://github.com/docker-library/kibana/commit/5ca74e6: Update to 7.16.2
- https://github.com/docker-library/kibana/commit/d054cfa: Update to 6.8.22