### PR TITLE
Bump Traefik to v2.5.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 72e26bf14573fda137e2e4b9665e956a85a5776c
 Directory: alpine
 
-Tags: v2.5.5-windowsservercore-1809, 2.5.5-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
+Tags: v2.5.6-windowsservercore-1809, 2.5.6-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9bd4bc631d219eef3cf9603c34af1cd298eb8f88
+GitCommit: 9f3d70f8ab22453f3bd38ccafe0571de28021c76
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.5, 2.5.5, v2.5, 2.5, brie, latest
+Tags: v2.5.6, 2.5.6, v2.5, 2.5, brie, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9bd4bc631d219eef3cf9603c34af1cd298eb8f88
+GitCommit: 9f3d70f8ab22453f3bd38ccafe0571de28021c76
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.5.6](https://github.com/traefik/traefik/releases/tag/v2.5.6).

/cc @ddtmachado @kevinpollet @ldez

Cheers