### PR TITLE
[oraclelinux] Update 8/8-slim for amd64/arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1cf3473e8bef72cd63c8fc185d0a681c32a3b565
+amd64-GitCommit: 6ffe51e89b4e06c6befd3902c636ca08f52a71e1
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b7386be5144b4c07e99f31e8b9c8aba720fde040
+arm64v8-GitCommit: 5077a0acf336c905756c4c3b67454f4ac66fdb5e
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-3712.

See https://linux.oracle.com/errata/ELSA-2021-5226.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>