### PR TITLE
Use newer clojure images w/ make installed in non-slim variants

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: d59ffe938c5eb9bbde84c959cbdf503ecdbac8a3
+GitCommit: 6240ee350907066c213d19d922dfbdd590de7afe
 
 Tags: latest
 Directory: target/openjdk-17-slim-bullseye/latest


### PR DESCRIPTION
We had a user request to install make in the non-slim lein and boot clojure image variants too (it was already in the tools-deps variants). This updates to the commit containing that change (merged in https://github.com/Quantisan/docker-clojure/pull/148).