### PR TITLE
Add Haskell GHC 9.0.2 version

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -6,8 +6,8 @@ Tags: 9.2.1-buster, 9.2-buster, 9-buster, buster, 9.2.1, 9.2, 9, latest
 GitCommit: 71b980bfedb718c656ab6152998da8f500202469
 Directory: 9.2/buster
 
-Tags: 9.0.1-buster, 9.0-buster, 9.0.1, 9.0
-GitCommit: f08ade43f48981b87505fbecca852194954fa61b
+Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
+GitCommit: 24ba1b08550873ddf20a4821091e51c0ee3468a1
 Directory: 9.0/buster
 
 Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8


### PR DESCRIPTION
https://www.haskell.org/ghc/blog/20211225-ghc-9.0.2-released.html

The PGP key changes depending on who does the release.

Thanks!