### PR TITLE
Odoo: update 13.0-15.0 to release 20211229

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 301937f44c563fadc492933f078676c2aa64bd56
+GitCommit: 51548ef50fd9a0b2347f5fbd533ff9a84af4e084
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hi,

here are the latest Odoo updates before the new year.

Thanks.