### PR TITLE
Haskell stack does not support ARM64

### DIFF
--- a/test/tests/haskell-stack/container.sh
+++ b/test/tests/haskell-stack/container.sh
@@ -1,6 +1,13 @@
 #!/bin/bash
 set -e
 
+case "$(dpkg --print-architecture)" in
+	*"arm64"*)
+		echo >&2 'skipping; stack does not support ARM64 at this time'
+		exit 0
+		;;
+esac
+
 # stack mostly sends to stderr
 if ! stackResult="$(stack --resolver ghc-$(ghc --print-project-version) new myproject 2>&1 > /dev/null)"; then
 	case "$stackResult" in


### PR DESCRIPTION
Hi, I am [working on adding ARM64 support to the Haskell images](https://github.com/haskell/docker-haskell/pull/53). Unfortunately [Haskell stack does not support ARM64](https://github.com/commercialhaskell/stack/issues/2103). I have pinged the maintainers and there is interest in adding this support, but no actual movement.

I would prefer not to hold back the images because of stack lacking this support, so I would like to [exclude stack on ARM64](https://github.com/haskell/docker-haskell/pull/53/files#diff-39063df2796e6504921f2044b99976896af812fae32144d3050b9cbf0783394aR120-R137). As such I am making a change to the stack test so that it will gracefully skip on ARM64.

I will make this clear in the docs with a follow up PR once everything is ready to go.

Actually, I could wait until ARM64 support for Haskell images is ready for release and include that in this PR if you want. However, I wanted to get feedback to see if this solution would be acceptable.