### PR TITLE
archlinux: Release 20220102.0.42924

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20211226.0.42348
-GitCommit: 1acb430bb00474d98245578d7c7d434720b06d59
-GitFetch: refs/tags/v20211226.0.42348
+Tags: latest, base, base-20220102.0.42924
+GitCommit: b1932d027edb55cdd038f2f30d9199e23ec6dca7
+GitFetch: refs/tags/v20220102.0.42924
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20211226.0.42348
-GitCommit: 1acb430bb00474d98245578d7c7d434720b06d59
-GitFetch: refs/tags/v20211226.0.42348
+Tags: base-devel, base-devel-20220102.0.42924
+GitCommit: b1932d027edb55cdd038f2f30d9199e23ec6dca7
+GitFetch: refs/tags/v20220102.0.42924
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks