### PR TITLE
Update Clear Linux OS to 35540

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 62a8260273e92b506c38c45f0bfd0ae91369fc56
-GitFetch: refs/heads/base-35470
+GitCommit: 5a96246a0b27f6efd9bcf0b10d60c9891c31d04a
+GitFetch: refs/heads/base-35540


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35540

@bryteise @djklimes @bryteise