### PR TITLE
Add arm64v8 support to Haskell

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -3,13 +3,16 @@ Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB),
 GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.2.1-buster, 9.2-buster, 9-buster, buster, 9.2.1, 9.2, 9, latest
-GitCommit: 71b980bfedb718c656ab6152998da8f500202469
+Architectures: amd64, arm64v8
+GitCommit: 5f8acc1199035266b1cc74fcc47d8ea114268076
 Directory: 9.2/buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
-GitCommit: 24ba1b08550873ddf20a4821091e51c0ee3468a1
+Architectures: amd64, arm64v8
+GitCommit: 5f8acc1199035266b1cc74fcc47d8ea114268076
 Directory: 9.0/buster
 
 Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
-GitCommit: f08ade43f48981b87505fbecca852194954fa61b
+Architectures: amd64, arm64v8
+GitCommit: 5f8acc1199035266b1cc74fcc47d8ea114268076
 Directory: 8.10/buster


### PR DESCRIPTION
And some related docs changes - https://github.com/docker-library/docs/pull/2101

arm64v8 does not include haskell stack as [it does not support it](https://github.com/commercialhaskell/stack/issues/2103). Many Haskell users do not use stack, so I did not want to hold this up waiting on it.

I did a fair restructure of the dockerfiles to support multiple processor architectures, mostly modelled after the golang images. Feedback appreciated.