### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,7 +11,7 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Preston Carpenter (@timidger),
              Richard Kelly (@rpkelly)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: c9ec4113f694e139e5b2fc2eaf02da0aaa3c7f6c
+GitCommit: 74eec9ec400d191dbe3398ca0cbba0ac9f892929
 
 Tags: 2.0.20211201.0, 2, latest
 Architectures: amd64, arm64v8
@@ -36,3 +36,17 @@ Tags: 2018.03.0.20211201.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 6da53c8eb5e75467c2121aa46dda93e2b0849fed
+
+Tags: 2022.0.20211222.0, 2022
+Architectures: amd64, arm64v8
+amd64-GitFetch: refs/heads/al2022
+amd64-GitCommit: ac6b4afdddf59311a9d6f092f3426bd6b34c5f5f
+arm64v8-GitFetch: refs/heads/al2022-arm64
+arm64v8-GitCommit: fd0b2404e5908689f929b19b79057ea4262fbf79
+
+Tags: 2022.0.20211222.0-with-sources, 2022-with-sources
+Architectures: amd64, arm64v8
+amd64-GitFetch: refs/heads/al2022-with-sources
+amd64-GitCommit: c1b881cae00450fab6410e58d358526fbb20a506
+arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
+arm64v8-GitCommit: 09069e7943236ce9889d83f0bb582eaeec829b2c


### PR DESCRIPTION
Hi,

This change adds the first docker container images for Amazon Linux 2022 (Tech Preview).

Regards,
Sumit