### PR TITLE
CouchDB patch release - v3.2.1

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -4,11 +4,11 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: c2dc5a84add2d673bce151e0aa8174d09d227d22
+GitCommit: 5e0a54ced383627836c4fcc3d6a4e65e72e7890c
 
-Tags: latest, 3.2.0, 3.2, 3
+Tags: latest, 3.2.1, 3.2, 3
 Architectures: amd64, arm64v8
-Directory: 3.2.0
+Directory: 3.2.1
 
 Tags: 3.1.2, 3.1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
New CouchDB version, release notes [here](https://docs.couchdb.org/en/stable/whatsnew/3.2.html#version-3-2-1).