### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.5/alpine
 
-Tags: 2.4.10, 2.4, lts, 2.4.10-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.11, 2.4, lts, 2.4.11-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6cba82d16640e7843483486e0de6ebb2543233cf
+GitCommit: 7a14969a302e3d954a0388647122cc41cd35bb96
 Directory: 2.4
 
-Tags: 2.4.10-alpine, 2.4-alpine, lts-alpine, 2.4.10-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.11-alpine, 2.4-alpine, lts-alpine, 2.4.11-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6cba82d16640e7843483486e0de6ebb2543233cf
+GitCommit: 7a14969a302e3d954a0388647122cc41cd35bb96
 Directory: 2.4/alpine
 
 Tags: 2.3.16, 2.3, 2.3.16-bullseye, 2.3-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7a14969: Update 2.4 to 2.4.11