### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.8.2-apache, 5.8-apache, 5-apache, apache, 5.8.2, 5.8, 5, latest, 5.8.2-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.2-php7.4, 5.8-php7.4, 5-php7.4, php7.4
+Tags: 5.8.3-apache, 5.8-apache, 5-apache, apache, 5.8.3, 5.8, 5, latest, 5.8.3-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.3-php7.4, 5.8-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php7.4/apache
 
-Tags: 5.8.2-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.2-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.8.3-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.3-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php7.4/fpm
 
-Tags: 5.8.2-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.2-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.8.3-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.3-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.8.2-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.2-php7.3, 5.8-php7.3, 5-php7.3, php7.3
+Tags: 5.8.3-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.3-php7.3, 5.8-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php7.3/apache
 
-Tags: 5.8.2-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.8.3-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php7.3/fpm
 
-Tags: 5.8.2-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.8.3-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.8.2-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.2-php8.0, 5.8-php8.0, 5-php8.0, php8.0
+Tags: 5.8.3-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.3-php8.0, 5.8-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php8.0/apache
 
-Tags: 5.8.2-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.8.3-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php8.0/fpm
 
-Tags: 5.8.2-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.8.3-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 5.8.2-php8.1-apache, 5.8-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.8.2-php8.1, 5.8-php8.1, 5-php8.1, php8.1
+Tags: 5.8.3-php8.1-apache, 5.8-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.8.3-php8.1, 5.8-php8.1, 5-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php8.1/apache
 
-Tags: 5.8.2-php8.1-fpm, 5.8-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
+Tags: 5.8.3-php8.1-fpm, 5.8-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php8.1/fpm
 
-Tags: 5.8.2-php8.1-fpm-alpine, 5.8-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 5.8.3-php8.1-fpm-alpine, 5.8-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fbc4dd7593dd0cf7a239348cb7ebcdcbf505286f
+GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
 Directory: latest/php8.1/fpm-alpine
 
 Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/bd3350f: Update latest to 5.8.3