### PR TITLE
archlinux: Release 20220109.0.43549

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220102.0.42924
-GitCommit: b1932d027edb55cdd038f2f30d9199e23ec6dca7
-GitFetch: refs/tags/v20220102.0.42924
+Tags: latest, base, base-20220109.0.43549
+GitCommit: e4f441112df865c5292cb5de8497d322d54ad215
+GitFetch: refs/tags/v20220109.0.43549
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220102.0.42924
-GitCommit: b1932d027edb55cdd038f2f30d9199e23ec6dca7
-GitFetch: refs/tags/v20220102.0.42924
+Tags: base-devel, base-devel-20220109.0.43549
+GitCommit: e4f441112df865c5292cb5de8497d322d54ad215
+GitFetch: refs/tags/v20220109.0.43549
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks