### PR TITLE
Odoo: update 13.0-15.0 to release 20220110

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 51548ef50fd9a0b2347f5fbd533ff9a84af4e084
+GitCommit: 9c6f67fcc51a29b496f3a44231aaf3c1b7773b60
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks a lot and Happy New Year.