### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,137 +1,120 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: a96651faa387b5fd876e68a98cc081cb483d9b22
+GitCommit: 6ba2653bb91d3c67a1ba0a8fe7050da4093ce620
 Directory: dockerfiles-generated
 
-Tags: 1.0a3-python3.10-bullseye, python3.10-bullseye, 1.0a3-bullseye, bullseye
-SharedTags: 1.0a3-python3.10, python3.10, 1.0a3, latest
+Tags: 1.0a4-python3.10-bullseye, python3.10-bullseye, 1.0a4-bullseye, bullseye
+SharedTags: 1.0a4-python3.10, python3.10, 1.0a4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.10-bullseye
 
-Tags: 1.0a3-python3.10-buster, python3.10-buster, 1.0a3-buster, buster
+Tags: 1.0a4-python3.10-buster, python3.10-buster, 1.0a4-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.10-buster
 
-Tags: 1.0a3-python3.10-alpine3.15, python3.10-alpine3.15, 1.0a3-alpine3.15, alpine3.15, 1.0a3-python3.10-alpine, python3.10-alpine, 1.0a3-alpine, alpine
+Tags: 1.0a4-python3.10-alpine3.15, python3.10-alpine3.15, 1.0a4-alpine3.15, alpine3.15, 1.0a4-python3.10-alpine, python3.10-alpine, 1.0a4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-alpine3.15
 
-Tags: 1.0a3-python3.10-alpine3.14, python3.10-alpine3.14, 1.0a3-alpine3.14, alpine3.14
+Tags: 1.0a4-python3.10-alpine3.14, python3.10-alpine3.14, 1.0a4-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-alpine3.14
 
-Tags: 1.0a3-python3.9-bullseye, python3.9-bullseye
-SharedTags: 1.0a3-python3.9, python3.9
+Tags: 1.0a4-python3.9-bullseye, python3.9-bullseye
+SharedTags: 1.0a4-python3.9, python3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.9-bullseye
 
-Tags: 1.0a3-python3.9-buster, python3.9-buster
+Tags: 1.0a4-python3.9-buster, python3.9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.9-buster
 
-Tags: 1.0a3-python3.9-alpine3.15, python3.9-alpine3.15, 1.0a3-python3.9-alpine, python3.9-alpine
+Tags: 1.0a4-python3.9-alpine3.15, python3.9-alpine3.15, 1.0a4-python3.9-alpine, python3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.9-alpine3.15
 
-Tags: 1.0a3-python3.9-alpine3.14, python3.9-alpine3.14
+Tags: 1.0a4-python3.9-alpine3.14, python3.9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.9-alpine3.14
 
-Tags: 1.0a3-python3.9-windowsservercore-ltsc2022, python3.9-windowsservercore-ltsc2022
-SharedTags: 1.0a3-python3.9, python3.9
+Tags: 1.0a4-python3.9-windowsservercore-ltsc2022, python3.9-windowsservercore-ltsc2022
+SharedTags: 1.0a4-python3.9, python3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 File: Dockerfile.python3.9-windowsservercore-ltsc2022
 
-Tags: 1.0a3-python3.9-windowsservercore-1809, python3.9-windowsservercore-1809
-SharedTags: 1.0a3-python3.9, python3.9
+Tags: 1.0a4-python3.9-windowsservercore-1809, python3.9-windowsservercore-1809
+SharedTags: 1.0a4-python3.9, python3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.python3.9-windowsservercore-1809
 
-Tags: 1.0a3-python3.9-windowsservercore-ltsc2016, python3.9-windowsservercore-ltsc2016
-SharedTags: 1.0a3-python3.9, python3.9
+Tags: 1.0a4-python3.9-windowsservercore-ltsc2016, python3.9-windowsservercore-ltsc2016
+SharedTags: 1.0a4-python3.9, python3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2016
 File: Dockerfile.python3.9-windowsservercore-ltsc2016
 
-Tags: 1.0a3-python3.8-bullseye, python3.8-bullseye
-SharedTags: 1.0a3-python3.8, python3.8
+Tags: 1.0a4-python3.8-bullseye, python3.8-bullseye
+SharedTags: 1.0a4-python3.8, python3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.8-bullseye
 
-Tags: 1.0a3-python3.8-buster, python3.8-buster
+Tags: 1.0a4-python3.8-buster, python3.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.8-buster
 
-Tags: 1.0a3-python3.8-alpine3.15, python3.8-alpine3.15, 1.0a3-python3.8-alpine, python3.8-alpine
+Tags: 1.0a4-python3.8-alpine3.15, python3.8-alpine3.15, 1.0a4-python3.8-alpine, python3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.8-alpine3.15
 
-Tags: 1.0a3-python3.8-alpine3.14, python3.8-alpine3.14
+Tags: 1.0a4-python3.8-alpine3.14, python3.8-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.8-alpine3.14
 
-Tags: 1.0a3-python3.7-bullseye, python3.7-bullseye
-SharedTags: 1.0a3-python3.7, python3.7
+Tags: 1.0a4-python3.7-bullseye, python3.7-bullseye
+SharedTags: 1.0a4-python3.7, python3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.7-bullseye
 
-Tags: 1.0a3-python3.7-buster, python3.7-buster
+Tags: 1.0a4-python3.7-buster, python3.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.7-buster
 
-Tags: 1.0a3-python3.7-alpine3.15, python3.7-alpine3.15, 1.0a3-python3.7-alpine, python3.7-alpine
+Tags: 1.0a4-python3.7-alpine3.15, python3.7-alpine3.15, 1.0a4-python3.7-alpine, python3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.15
 
-Tags: 1.0a3-python3.7-alpine3.14, python3.7-alpine3.14
+Tags: 1.0a4-python3.7-alpine3.14, python3.7-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.14
 
-Tags: 1.0a3-python3.6-bullseye, python3.6-bullseye
-SharedTags: 1.0a3-python3.6, python3.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-File: Dockerfile.python3.6-bullseye
-
-Tags: 1.0a3-python3.6-buster, python3.6-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-File: Dockerfile.python3.6-buster
-
-Tags: 1.0a3-python3.6-alpine3.15, python3.6-alpine3.15, 1.0a3-python3.6-alpine, python3.6-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.6-alpine3.15
-
-Tags: 1.0a3-python3.6-alpine3.14, python3.6-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.6-alpine3.14
-
-Tags: 1.0a3-pypy3.8-bullseye, pypy3.8-bullseye, 1.0a3-pypy-bullseye, pypy-bullseye
-SharedTags: 1.0a3-pypy3.8, pypy3.8, 1.0a3-pypy, pypy
+Tags: 1.0a4-pypy3.8-bullseye, pypy3.8-bullseye, 1.0a4-pypy-bullseye, pypy-bullseye
+SharedTags: 1.0a4-pypy3.8, pypy3.8, 1.0a4-pypy, pypy
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.8-bullseye
 
-Tags: 1.0a3-pypy3.8-buster, pypy3.8-buster, 1.0a3-pypy-buster, pypy-buster
+Tags: 1.0a4-pypy3.8-buster, pypy3.8-buster, 1.0a4-pypy-buster, pypy-buster
 Architectures: amd64, arm64v8, i386, s390x
 File: Dockerfile.pypy3.8-buster
 
-Tags: 1.0a3-pypy3.8-windowsservercore-1809, pypy3.8-windowsservercore-1809, 1.0a3-pypy-windowsservercore-1809, pypy-windowsservercore-1809
-SharedTags: 1.0a3-pypy3.8, pypy3.8, 1.0a3-pypy, pypy
+Tags: 1.0a4-pypy3.8-windowsservercore-1809, pypy3.8-windowsservercore-1809, 1.0a4-pypy-windowsservercore-1809, pypy-windowsservercore-1809
+SharedTags: 1.0a4-pypy3.8, pypy3.8, 1.0a4-pypy, pypy
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.pypy3.8-windowsservercore-1809
 
-Tags: 1.0a3-pypy3.7-bullseye, pypy3.7-bullseye
-SharedTags: 1.0a3-pypy3.7, pypy3.7
+Tags: 1.0a4-pypy3.7-bullseye, pypy3.7-bullseye
+SharedTags: 1.0a4-pypy3.7, pypy3.7
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.7-bullseye
 
-Tags: 1.0a3-pypy3.7-buster, pypy3.7-buster
+Tags: 1.0a4-pypy3.7-buster, pypy3.7-buster
 Architectures: amd64, arm64v8, i386, s390x
 File: Dockerfile.pypy3.7-buster
 
-Tags: 1.0a3-pypy3.7-windowsservercore-1809, pypy3.7-windowsservercore-1809
-SharedTags: 1.0a3-pypy3.7, pypy3.7
+Tags: 1.0a4-pypy3.7-windowsservercore-1809, pypy3.7-windowsservercore-1809
+SharedTags: 1.0a4-pypy3.7, pypy3.7
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.pypy3.7-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/f719c3a: Merge pull request https://github.com/hylang/docker-hylang/pull/4 from tianon/1.0a4
- https://github.com/hylang/docker-hylang/commit/6ba2653: Update to 1.0a4

(See also https://github.com/docker-library/official-images/pull/11642)

Note for users that the image now also includes `hyrule` (since the majority of users will want some parts of that too).