### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,34 +14,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.0, 2.5, latest, 2.5.0-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.1, 2.5, latest, 2.5.1-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+GitCommit: 28fe886ec663a7f916af11a01a026e1c7245df27
 Directory: 2.5
 
-Tags: 2.5.0-alpine, 2.5-alpine, alpine, 2.5.0-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.1-alpine, 2.5-alpine, alpine, 2.5.1-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
+GitCommit: 28fe886ec663a7f916af11a01a026e1c7245df27
 Directory: 2.5/alpine
 
-Tags: 2.4.11, 2.4, lts, 2.4.11-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.12, 2.4, lts, 2.4.12-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7a14969a302e3d954a0388647122cc41cd35bb96
+GitCommit: 30d8fd537e46f3c921f19e95effb1cc2ae43347b
 Directory: 2.4
 
-Tags: 2.4.11-alpine, 2.4-alpine, lts-alpine, 2.4.11-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.12-alpine, 2.4-alpine, lts-alpine, 2.4.12-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a14969a302e3d954a0388647122cc41cd35bb96
+GitCommit: 30d8fd537e46f3c921f19e95effb1cc2ae43347b
 Directory: 2.4/alpine
 
-Tags: 2.3.16, 2.3, 2.3.16-bullseye, 2.3-bullseye
+Tags: 2.3.17, 2.3, 2.3.17-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 07c64064f7cb0f9d82e369bb623fe3fdc11cd76f
+GitCommit: 42ed5bfc52b78342e91456d84bb9248239bb1bcd
 Directory: 2.3
 
-Tags: 2.3.16-alpine, 2.3-alpine, 2.3.16-alpine3.15, 2.3-alpine3.15
+Tags: 2.3.17-alpine, 2.3-alpine, 2.3.17-alpine3.15, 2.3-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
+GitCommit: 42ed5bfc52b78342e91456d84bb9248239bb1bcd
 Directory: 2.3/alpine
 
 Tags: 2.2.19, 2.2, 2.2.19-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/28fe886: Update 2.5 to 2.5.1
- https://github.com/docker-library/haproxy/commit/42ed5bf: Update 2.3 to 2.3.17
- https://github.com/docker-library/haproxy/commit/30d8fd5: Update 2.4 to 2.4.12