### PR TITLE
Update Monica to v3.6.0

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -1,18 +1,18 @@
-# This file is generated via https://github.com/monicahq/docker/blob/03744c868b21cdd00d66e329b105f8b3d22c1173/generate-stackbrew-library.sh
+# This file is generated via https://github.com/monicahq/docker/blob/f9840328c1c811d21a59a5757ac3b8a2f67d623d/generate-stackbrew-library.sh
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 
-Tags: 3.5.0-apache, 3.5-apache, 3-apache, apache, 3.5.0, 3.5, 3, latest
+Tags: 3.6.0-apache, 3.6-apache, 3-apache, apache, 3.6.0, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: 03744c868b21cdd00d66e329b105f8b3d22c1173
+GitCommit: f9840328c1c811d21a59a5757ac3b8a2f67d623d
 
-Tags: 3.5.0-fpm-alpine, 3.5-fpm-alpine, 3-fpm-alpine, fpm-alpine
+Tags: 3.6.0-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: 03744c868b21cdd00d66e329b105f8b3d22c1173
+GitCommit: f9840328c1c811d21a59a5757ac3b8a2f67d623d
 
-Tags: 3.5.0-fpm, 3.5-fpm, 3-fpm, fpm
+Tags: 3.6.0-fpm, 3.6-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: fpm
-GitCommit: 03744c868b21cdd00d66e329b105f8b3d22c1173
+GitCommit: f9840328c1c811d21a59a5757ac3b8a2f67d623d


### PR DESCRIPTION
Update Monica to [v3.6.0](https://github.com/monicahq/monica/releases/tag/v3.6.0).