### PR TITLE
Bump Traefik to v2.6.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.6.0-rc1-windowsservercore-1809, 2.6.0-rc1-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
+Tags: v2.6.0-rc2-windowsservercore-1809, 2.6.0-rc2-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 72e26bf14573fda137e2e4b9665e956a85a5776c
+GitCommit: 58dc5ec0c912ea2498d62791c00aa7613267f99a
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.0-rc1, 2.6.0-rc1, v2.6, 2.6, rocamadour
+Tags: v2.6.0-rc2, 2.6.0-rc2, v2.6, 2.6, rocamadour
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 72e26bf14573fda137e2e4b9665e956a85a5776c
+GitCommit: 58dc5ec0c912ea2498d62791c00aa7613267f99a
 Directory: alpine
 
 Tags: v2.5.6-windowsservercore-1809, 2.5.6-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.6.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.6.0-rc2).

/cc @ldez @rtribotte @ddtmachado

Cheers
