### PR TITLE
[oraclelinux] Update 7/7-slim for amd64/arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6ffe51e89b4e06c6befd3902c636ca08f52a71e1
+amd64-GitCommit: 2fec92641c29d7a4cc704014d081fa42816ec82f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5077a0acf336c905756c4c3b67454f4ac66fdb5e
+arm64v8-GitCommit: 0b869f1e3a5cb823ace5ac25a0624e63d4d40f7a
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-3712.

See https://linux.oracle.com/errata/ELSA-2022-0064.html for details.

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com