### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,14 +44,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 42ed5bfc52b78342e91456d84bb9248239bb1bcd
 Directory: 2.3/alpine
 
-Tags: 2.2.19, 2.2, 2.2.19-bullseye, 2.2-bullseye
+Tags: 2.2.20, 2.2, 2.2.20-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d8b5ff11d4587a5ab0aa24eb92e4303410782505
+GitCommit: 700a06f3ea366e468eea55fbabc3dc23ef1dd5a3
 Directory: 2.2
 
-Tags: 2.2.19-alpine, 2.2-alpine, 2.2.19-alpine3.15, 2.2-alpine3.15
+Tags: 2.2.20-alpine, 2.2-alpine, 2.2.20-alpine3.15, 2.2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d8b5ff11d4587a5ab0aa24eb92e4303410782505
+GitCommit: 700a06f3ea366e468eea55fbabc3dc23ef1dd5a3
 Directory: 2.2/alpine
 
 Tags: 2.0.26, 2.0, 2.0.26-buster, 2.0-buster
@@ -73,13 +73,3 @@ Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.15, 1.8-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
 Directory: 1.8/alpine
-
-Tags: 1.7.14, 1.7, 1.7.14-buster, 1.7-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
-Directory: 1.7
-
-Tags: 1.7.14-alpine, 1.7-alpine, 1.7.14-alpine3.12, 1.7-alpine3.12
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
-Directory: 1.7/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9ae8aba: Merge pull request https://github.com/docker-library/haproxy/pull/178 from TimWolla/1.7-eol
- https://github.com/docker-library/haproxy/commit/700a06f: Update 2.2 to 2.2.20
- https://github.com/docker-library/haproxy/commit/2c9901f: Remove HAProxy 1.7