### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.32.1, 4.32, 4, latest
+Tags: 4.32.2, 4.32, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a710352ab58e65982bc7e1abaa2ae06d5eb068bb
+GitCommit: 7a6df53edfc81ce8e63a69011994c70333601de1
 Directory: 4/debian
 
-Tags: 4.32.1-alpine, 4.32-alpine, 4-alpine, alpine
+Tags: 4.32.2-alpine, 4.32-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: a710352ab58e65982bc7e1abaa2ae06d5eb068bb
+GitCommit: 7a6df53edfc81ce8e63a69011994c70333601de1
 Directory: 4/alpine
 
 Tags: 3.42.8, 3.42, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/7a6df53: Update to 4.32.2, ghost-cli 1.18.1