### PR TITLE
Mark ltsc2016 as an unacceptable base now that it is EOL

### DIFF
--- a/naughty-from.sh
+++ b/naughty-from.sh
@@ -21,28 +21,19 @@ _is_naughty() {
 		# https://techcommunity.microsoft.com/t5/Containers/Removing-the-latest-Tag-An-Update-on-MCR/ba-p/393045
 		*=mcr.microsoft.com/windows/*:latest) return 0 ;;
 
-		# 20H2 is not *technically* EOL until 05/10/2022, but its use is discouraged here given the existence of ltsc2022
-		# 2004 is not *technically* EOL until 12/14/2021, but its use is discouraged here given the existence of ltsc2022
 
 		# https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
-		# "05/11/2021"
-		*=mcr.microsoft.com/windows/*:1909*) return 0 ;;
-
-		# https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
-		# "12/08/2020"
-		*=mcr.microsoft.com/windows/*:1903*) return 0 ;;
-
-		# https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
-		# "11/12/2019"
-		*=mcr.microsoft.com/windows/*:1803*) return 0 ;;
-
-		# https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
-		# "04/09/2019"
-		*=mcr.microsoft.com/windows/*:1709*) return 0 ;;
-
-		# https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle
-		# "10/09/2018"
-		*=mcr.microsoft.com/windows/nanoserver:sac2016) return 0 ;;
+		#*=mcr.microsoft.com/windows/*:ltsc2022) return 0 ;; # "10/13/2026"
+		#*=mcr.microsoft.com/windows/*:20H2*)    return 0 ;; # "05/10/2022" *technically*, but its use is discouraged here given the existence of ltsc2022
+		*=mcr.microsoft.com/windows/*:2004*)    return 0 ;; # "12/14/2021"
+		*=mcr.microsoft.com/windows/*:1909*)    return 0 ;; # "05/11/2021"
+		*=mcr.microsoft.com/windows/*:1903*)    return 0 ;; # "12/08/2020"
+		#*=mcr.microsoft.com/windows/*:1809*)    return 0 ;; # "01/09/2024"
+		*=mcr.microsoft.com/windows/*:1803*)    return 0 ;; # "11/12/2019"
+		*=mcr.microsoft.com/windows/*:1709*)    return 0 ;; # "04/09/2019"
+		*=mcr.microsoft.com/windows/*:ltsc2016) return 0 ;; # "01/11/2022"
+		*=mcr.microsoft.com/windows/*:sac2016)  return 0 ;; # "10/09/2018"
+		*=mcr.microsoft.com/windows/*:1607*)    return 0 ;; # "10/09/2018"
 
 		# a few explicitly permissible exceptions to Santa's naughty list
 		*=scratch \


### PR DESCRIPTION
See https://docs.microsoft.com/en-us/virtualization/windowscontainers/deploy-containers/base-image-lifecycle

This also reformats our list to match the order of the table we link to, and includes the non-EOL items commented out so it's easier to compare/update over time.