### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -45,13 +45,6 @@ GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
 Directory: 1.18-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.18beta1-windowsservercore-ltsc2016, 1.18-rc-windowsservercore-ltsc2016, rc-windowsservercore-ltsc2016
-SharedTags: 1.18beta1-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18beta1, 1.18-rc, rc
-Architectures: windows-amd64
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
-Directory: 1.18-rc/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 1.18beta1-nanoserver-ltsc2022, 1.18-rc-nanoserver-ltsc2022, rc-nanoserver-ltsc2022
 SharedTags: 1.18beta1-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
@@ -106,13 +99,6 @@ GitCommit: 6b93987c3ec7bb3082dd54a46e9b6b8de95b0eb1
 Directory: 1.17/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17.6-windowsservercore-ltsc2016, 1.17-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.17.6-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.6, 1.17, 1, latest
-Architectures: windows-amd64
-GitCommit: 6b93987c3ec7bb3082dd54a46e9b6b8de95b0eb1
-Directory: 1.17/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 1.17.6-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
 SharedTags: 1.17.6-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
@@ -166,13 +152,6 @@ Architectures: windows-amd64
 GitCommit: 099c7cdb0187a8f2e34e727ebe18fb8f0fa5a65e
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 1.16.13-windowsservercore-ltsc2016, 1.16-windowsservercore-ltsc2016
-SharedTags: 1.16.13-windowsservercore, 1.16-windowsservercore, 1.16.13, 1.16
-Architectures: windows-amd64
-GitCommit: 099c7cdb0187a8f2e34e727ebe18fb8f0fa5a65e
-Directory: 1.16/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 1.16.13-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
 SharedTags: 1.16.13-nanoserver, 1.16-nanoserver


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/a4e747e: Remove ltsc2016 variants (EOL)

Refs https://github.com/docker-library/official-images/pull/11661