### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 6ba2653bb91d3c67a1ba0a8fe7050da4093ce620
+GitCommit: b70a6f9f8c7db8fe11c3dd2750a828319ca72be4
 Directory: dockerfiles-generated
 
 Tags: 1.0a4-python3.10-bullseye, python3.10-bullseye, 1.0a4-bullseye, bullseye
@@ -48,12 +48,6 @@ SharedTags: 1.0a4-python3.9, python3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.python3.9-windowsservercore-1809
-
-Tags: 1.0a4-python3.9-windowsservercore-ltsc2016, python3.9-windowsservercore-ltsc2016
-SharedTags: 1.0a4-python3.9, python3.9
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2016
-File: Dockerfile.python3.9-windowsservercore-ltsc2016
 
 Tags: 1.0a4-python3.8-bullseye, python3.8-bullseye
 SharedTags: 1.0a4-python3.8, python3.8


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/b70a6f9: Remove ltsc2016 variants (EOL)

Refs https://github.com/docker-library/official-images/pull/11661