### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -39,13 +39,6 @@ GitCommit: 37e7c4dbca1f313e7c297f51c600615ceafb8a43
 Directory: 1.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.7.1-windowsservercore-ltsc2016, 1.7-windowsservercore-ltsc2016, 1-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 1.7.1, 1.7, 1, latest, 1.7.1-windowsservercore, 1.7-windowsservercore, 1-windowsservercore, windowsservercore
-Architectures: windows-amd64
-GitCommit: 37e7c4dbca1f313e7c297f51c600615ceafb8a43
-Directory: 1.7/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 1.6.5-bullseye, 1.6-bullseye
 SharedTags: 1.6.5, 1.6
 Architectures: amd64, arm32v7, arm64v8, i386
@@ -80,10 +73,3 @@ Architectures: windows-amd64
 GitCommit: 52273f729e87e22389794a4eae4dbd3a38a6cd79
 Directory: 1.6/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 1.6.5-windowsservercore-ltsc2016, 1.6-windowsservercore-ltsc2016
-SharedTags: 1.6.5, 1.6, 1.6.5-windowsservercore, 1.6-windowsservercore
-Architectures: windows-amd64
-GitCommit: 52273f729e87e22389794a4eae4dbd3a38a6cd79
-Directory: 1.6/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/fe40764: Remove ltsc2016 variants (EOL)

Refs https://github.com/docker-library/official-images/pull/11661