### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/b739aec8401a072f43ed5f5eec806e8cc1d1b106/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/222c5a1347165e8f6a691353ab3646dce73497ce/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -79,13 +79,6 @@ GitCommit: db32c7803dfc67e5a359514371e66d6405695e45
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.10.1-windowsservercore-ltsc2016, 3.10-windowsservercore-ltsc2016, 3-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 3.10.1-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.1, 3.10, 3, latest
-Architectures: windows-amd64
-GitCommit: db32c7803dfc67e5a359514371e66d6405695e45
-Directory: 3.10/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 3.9.9-bullseye, 3.9-bullseye
 SharedTags: 3.9.9, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -130,13 +123,6 @@ Architectures: windows-amd64
 GitCommit: 3d43bcf8ddd26ae85fd6a63a7e1d502b445c9cce
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 3.9.9-windowsservercore-ltsc2016, 3.9-windowsservercore-ltsc2016
-SharedTags: 3.9.9-windowsservercore, 3.9-windowsservercore, 3.9.9, 3.9
-Architectures: windows-amd64
-GitCommit: 3d43bcf8ddd26ae85fd6a63a7e1d502b445c9cce
-Directory: 3.9/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 3.8.12-bullseye, 3.8-bullseye
 SharedTags: 3.8.12, 3.8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/222c5a1: Remove ltsc2016 variants (EOL)

Refs https://github.com/docker-library/official-images/pull/11661