### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -49,13 +49,6 @@ GitCommit: 2c8a4d772e2dfac0126c6c56557a27e442ade414
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-4-jdk-windowsservercore-ltsc2016, 19-ea-4-windowsservercore-ltsc2016, 19-ea-jdk-windowsservercore-ltsc2016, 19-ea-windowsservercore-ltsc2016, 19-jdk-windowsservercore-ltsc2016, 19-windowsservercore-ltsc2016
-SharedTags: 19-ea-4-jdk-windowsservercore, 19-ea-4-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-4-jdk, 19-ea-4, 19-ea-jdk, 19-ea, 19-jdk, 19
-Architectures: windows-amd64
-GitCommit: 2c8a4d772e2dfac0126c6c56557a27e442ade414
-Directory: 19/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 19-ea-4-jdk-nanoserver-1809, 19-ea-4-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
 SharedTags: 19-ea-4-jdk-nanoserver, 19-ea-4-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
@@ -118,13 +111,6 @@ GitCommit: 213b5f051de6fbbb8804640be610f6a8a3b5f252
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-30-jdk-windowsservercore-ltsc2016, 18-ea-30-windowsservercore-ltsc2016, 18-ea-jdk-windowsservercore-ltsc2016, 18-ea-windowsservercore-ltsc2016, 18-jdk-windowsservercore-ltsc2016, 18-windowsservercore-ltsc2016
-SharedTags: 18-ea-30-jdk-windowsservercore, 18-ea-30-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-30-jdk, 18-ea-30, 18-ea-jdk, 18-ea, 18-jdk, 18
-Architectures: windows-amd64
-GitCommit: 213b5f051de6fbbb8804640be610f6a8a3b5f252
-Directory: 18/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 18-ea-30-jdk-nanoserver-1809, 18-ea-30-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
 SharedTags: 18-ea-30-jdk-nanoserver, 18-ea-30-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
@@ -176,13 +162,6 @@ Architectures: windows-amd64
 GitCommit: 41610205127c2a4f0af64f68b859726993503a89
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 17.0.1-jdk-windowsservercore-ltsc2016, 17.0.1-windowsservercore-ltsc2016, 17.0-jdk-windowsservercore-ltsc2016, 17.0-windowsservercore-ltsc2016, 17-jdk-windowsservercore-ltsc2016, 17-windowsservercore-ltsc2016, jdk-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 17.0.1-jdk-windowsservercore, 17.0.1-windowsservercore, 17.0-jdk-windowsservercore, 17.0-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, jdk-windowsservercore, windowsservercore, 17.0.1-jdk, 17.0.1, 17.0-jdk, 17.0, 17-jdk, 17, jdk, latest
-Architectures: windows-amd64
-GitCommit: 41610205127c2a4f0af64f68b859726993503a89
-Directory: 17/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 17.0.1-jdk-nanoserver-1809, 17.0.1-nanoserver-1809, 17.0-jdk-nanoserver-1809, 17.0-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
 SharedTags: 17.0.1-jdk-nanoserver, 17.0.1-nanoserver, 17.0-jdk-nanoserver, 17.0-nanoserver, 17-jdk-nanoserver, 17-nanoserver, jdk-nanoserver, nanoserver
@@ -236,13 +215,6 @@ GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.13-jdk-windowsservercore-ltsc2016, 11.0.13-windowsservercore-ltsc2016, 11.0-jdk-windowsservercore-ltsc2016, 11.0-windowsservercore-ltsc2016, 11-jdk-windowsservercore-ltsc2016, 11-windowsservercore-ltsc2016
-SharedTags: 11.0.13-jdk-windowsservercore, 11.0.13-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.13-jdk, 11.0.13, 11.0-jdk, 11.0, 11-jdk, 11
-Architectures: windows-amd64
-GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
-Directory: 11/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 11.0.13-jdk-nanoserver-1809, 11.0.13-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.13-jdk-nanoserver, 11.0.13-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
@@ -284,13 +256,6 @@ Architectures: windows-amd64
 GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 11.0.13-jre-windowsservercore-ltsc2016, 11.0-jre-windowsservercore-ltsc2016, 11-jre-windowsservercore-ltsc2016
-SharedTags: 11.0.13-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.13-jre, 11.0-jre, 11-jre
-Architectures: windows-amd64
-GitCommit: 61bfbb30ae5a0395f08d41107b86bcce90d70ba6
-Directory: 11/jre/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 11.0.13-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.13-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
@@ -344,13 +309,6 @@ GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u312-jdk-windowsservercore-ltsc2016, 8u312-windowsservercore-ltsc2016, 8-jdk-windowsservercore-ltsc2016, 8-windowsservercore-ltsc2016
-SharedTags: 8u312-jdk-windowsservercore, 8u312-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u312-jdk, 8u312, 8-jdk, 8
-Architectures: windows-amd64
-GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
-Directory: 8/jdk/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 8u312-jdk-nanoserver-1809, 8u312-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u312-jdk-nanoserver, 8u312-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
@@ -392,13 +350,6 @@ Architectures: windows-amd64
 GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 8u312-jre-windowsservercore-ltsc2016, 8-jre-windowsservercore-ltsc2016
-SharedTags: 8u312-jre-windowsservercore, 8-jre-windowsservercore, 8u312-jre, 8-jre
-Architectures: windows-amd64
-GitCommit: 3ce4449d7f01afa6001a711e17cdd379b76848f8
-Directory: 8/jre/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 8u312-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u312-jre-nanoserver, 8-jre-nanoserver


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/abebf93: Remove ltsc2016 variants (EOL)

Refs https://github.com/docker-library/official-images/pull/11661