### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -24,13 +24,6 @@ GitCommit: a4d7c8bc23c54b2ce1430597df041f2402717ebc
 Directory: 5.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 5.0.5-windowsservercore-ltsc2016, 5.0-windowsservercore-ltsc2016, 5-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 5.0.5-windowsservercore, 5.0-windowsservercore, 5-windowsservercore, windowsservercore, 5.0.5, 5.0, 5, latest
-Architectures: windows-amd64
-GitCommit: a4d7c8bc23c54b2ce1430597df041f2402717ebc
-Directory: 5.0/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 5.0.5-nanoserver-ltsc2022, 5.0-nanoserver-ltsc2022, 5-nanoserver-ltsc2022, nanoserver-ltsc2022
 SharedTags: 5.0.5-nanoserver, 5.0-nanoserver, 5-nanoserver, nanoserver
 Architectures: windows-amd64
@@ -64,13 +57,6 @@ Architectures: windows-amd64
 GitCommit: 817cf283464fd9de9680cafe4f433a63845fd192
 Directory: 4.4-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 4.4.12-rc1-windowsservercore-ltsc2016, 4.4-rc-windowsservercore-ltsc2016
-SharedTags: 4.4.12-rc1-windowsservercore, 4.4-rc-windowsservercore, 4.4.12-rc1, 4.4-rc
-Architectures: windows-amd64
-GitCommit: 817cf283464fd9de9680cafe4f433a63845fd192
-Directory: 4.4-rc/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 4.4.12-rc1-nanoserver-ltsc2022, 4.4-rc-nanoserver-ltsc2022
 SharedTags: 4.4.12-rc1-nanoserver, 4.4-rc-nanoserver
@@ -106,13 +92,6 @@ GitCommit: 5bfcd26d18f93671091590c1ff86dbffec6d79b5
 Directory: 4.4/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.4.11-windowsservercore-ltsc2016, 4.4-windowsservercore-ltsc2016, 4-windowsservercore-ltsc2016
-SharedTags: 4.4.11-windowsservercore, 4.4-windowsservercore, 4-windowsservercore, 4.4.11, 4.4, 4
-Architectures: windows-amd64
-GitCommit: 5bfcd26d18f93671091590c1ff86dbffec6d79b5
-Directory: 4.4/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 4.4.11-nanoserver-ltsc2022, 4.4-nanoserver-ltsc2022, 4-nanoserver-ltsc2022
 SharedTags: 4.4.11-nanoserver, 4.4-nanoserver, 4-nanoserver
 Architectures: windows-amd64
@@ -146,13 +125,6 @@ Architectures: windows-amd64
 GitCommit: 5a9d31003ba249f6e0dc5a3536a904f408d538a4
 Directory: 4.2/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 4.2.18-windowsservercore-ltsc2016, 4.2-windowsservercore-ltsc2016
-SharedTags: 4.2.18-windowsservercore, 4.2-windowsservercore, 4.2.18, 4.2
-Architectures: windows-amd64
-GitCommit: 5a9d31003ba249f6e0dc5a3536a904f408d538a4
-Directory: 4.2/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 4.2.18-nanoserver-ltsc2022, 4.2-nanoserver-ltsc2022
 SharedTags: 4.2.18-nanoserver, 4.2-nanoserver
@@ -188,13 +160,6 @@ GitCommit: 98bd9009e6283de1e3e77f2774717c0b507af9b5
 Directory: 4.0-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.0.28-rc0-windowsservercore-ltsc2016, 4.0-rc-windowsservercore-ltsc2016
-SharedTags: 4.0.28-rc0-windowsservercore, 4.0-rc-windowsservercore, 4.0.28-rc0, 4.0-rc
-Architectures: windows-amd64
-GitCommit: 98bd9009e6283de1e3e77f2774717c0b507af9b5
-Directory: 4.0-rc/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
-
 Tags: 4.0.28-rc0-nanoserver-ltsc2022, 4.0-rc-nanoserver-ltsc2022
 SharedTags: 4.0.28-rc0-nanoserver, 4.0-rc-nanoserver
 Architectures: windows-amd64
@@ -228,13 +193,6 @@ Architectures: windows-amd64
 GitCommit: a84ae7f3427e4c5940682f80a2c064b66fbaae16
 Directory: 4.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
-
-Tags: 4.0.27-windowsservercore-ltsc2016, 4.0-windowsservercore-ltsc2016
-SharedTags: 4.0.27-windowsservercore, 4.0-windowsservercore, 4.0.27, 4.0
-Architectures: windows-amd64
-GitCommit: a84ae7f3427e4c5940682f80a2c064b66fbaae16
-Directory: 4.0/windows/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016
 
 Tags: 4.0.27-nanoserver-ltsc2022, 4.0-nanoserver-ltsc2022
 SharedTags: 4.0.27-nanoserver, 4.0-nanoserver


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/2b2c403: Remove ltsc2016 variants (EOL)

Refs https://github.com/docker-library/official-images/pull/11661