### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 7.16.2
+Tags: 7.16.3
 Architectures: amd64, arm64v8
-GitCommit: 53dedd336f9a46a3287fe4137b188527e199b798
+GitCommit: 8ff9b35185c8b83467697a21338c0f998a5aad61
 Directory: 7
 
-Tags: 6.8.22
+Tags: 6.8.23
 Architectures: amd64
-GitCommit: d89d5afa00ffe783828b9f7b911e53e8ef6b0704
+GitCommit: 00b6bd7d3432a1c7ba195060bf6d13d9a2541c11
 Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 7.16.2
+Tags: 7.16.3
 Architectures: amd64, arm64v8
-GitCommit: 5ca74e65e55e6ad7722ec7889ca3b696a3274594
+GitCommit: 59a66a88b4d61b9930e3529fd3900b23e2b3309f
 Directory: 7
 
-Tags: 6.8.22
+Tags: 6.8.23
 Architectures: amd64
-GitCommit: d054cfa8b5dbb4ce60aa0ce04943a82fde49805c
+GitCommit: e344361c58744dd623753d9a45dc8502a279b942
 Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 7.16.2
+Tags: 7.16.3
 Architectures: amd64, arm64v8
-GitCommit: 9e4c70aeed0e9e75323aed29912190dfc5e6a227
+GitCommit: e657ceb22224f33534877035f573c7baa01ea80e
 Directory: 7
 
-Tags: 6.8.22
+Tags: 6.8.23
 Architectures: amd64
-GitCommit: f1217485facf54d9b79f08458d0bc19e90d8e929
+GitCommit: 4c31d4c6b43c303275256545b5ac5111afa0f2e1
 Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/8ff9b35: Update to 7.16.3
- https://github.com/docker-library/elasticsearch/commit/00b6bd7: Update to 6.8.23

logstash:
- https://github.com/docker-library/logstash/commit/e657ceb: Update to 7.16.3
- https://github.com/docker-library/logstash/commit/4c31d4c: Update to 6.8.23

kibana:
- https://github.com/docker-library/kibana/commit/59a66a8: Update to 7.16.3
- https://github.com/docker-library/kibana/commit/e344361: Update to 6.8.23