### PR TITLE
[nats] Release v2.7.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,31 +4,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 4449db1e4301e7da4549befb980cccc41c2fa907
+GitCommit: 2f7b8366ee431aee2e99bd8a3a473d2e53172b97
 
-Tags: 2.6.6-alpine3.14, 2.6-alpine3.14, 2-alpine3.14, alpine3.14, 2.6.6-alpine, 2.6-alpine, 2-alpine, alpine
+Tags: 2.7.0-alpine3.15, 2.7-alpine3.15, 2-alpine3.15, alpine3.15, 2.7.0-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.6.6/alpine3.14
+Directory: 2.7.0/alpine3.15
 
-Tags: 2.6.6-scratch, 2.6-scratch, 2-scratch, scratch, 2.6.6-linux, 2.6-linux, 2-linux, linux
-SharedTags: 2.6.6, 2.6, 2, latest
+Tags: 2.7.0-scratch, 2.7-scratch, 2-scratch, scratch, 2.7.0-linux, 2.7-linux, 2-linux, linux
+SharedTags: 2.7.0, 2.7, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.6.6/scratch
+Directory: 2.7.0/scratch
 
-Tags: 2.6.6-windowsservercore-1809, 2.6-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.6.6-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.7.0-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.7.0-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.6.6/windowsservercore-1809
+Directory: 2.7.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.6.6-nanoserver-1809, 2.6-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.6.6-nanoserver, 2.6-nanoserver, 2-nanoserver, nanoserver, 2.6.6, 2.6, 2, latest
+Tags: 2.7.0-nanoserver-1809, 2.7-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.7.0-nanoserver, 2.7-nanoserver, 2-nanoserver, nanoserver, 2.7.0, 2.7, 2, latest
 Architectures: windows-amd64
-Directory: 2.6.6/nanoserver-1809
+Directory: 2.7.0/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 2.6.6-windowsservercore-ltsc2016, 2.6-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.6.6-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore
-Architectures: windows-amd64
-Directory: 2.6.6/windowsservercore-ltsc2016
-Constraints: windowsservercore-ltsc2016


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.7.0)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>