### PR TITLE
consul: 1.11.2, 1.10.7 and 1.9.14; 1.8 EOL

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,25 +1,19 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.11.1, 1.11, latest
+Tags: 1.11.2, 1.11, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 85f1536e9106178e638121e2fe574476551ea614
+GitCommit: 971c4f12ec32b469d01e2373345c7f8d2390e772
 Directory: 0.X
 
-Tags: 1.10.6, 1.10
+Tags: 1.10.7, 1.10
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: c5493e998192edd327c3fa17cd9fc2bcac67c3f6
+GitCommit: 1db3a7d6c1e386ae83b95053a357ae36d18c2060
 Directory: 0.X
 
-Tags: 1.9.13, 1.9
+Tags: 1.9.14, 1.9
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: c2a400ca113a1a7c92694a006d03a2845432bdf6
-Directory: 0.X
-
-Tags: 1.8.19, 1.8
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: a73d6ad2748282dee5ad645827f6d1543e357f71
+GitCommit: 014bf7897325e9e8331a9c3ed9dad4d25135219c
 Directory: 0.X


### PR DESCRIPTION
Updates the Consul image to latest for 1.11, 1.10 and 1.9 series. The 1.8 refs are removed as 1.8.19 was the last release in the series and 1.8 is now EOL.