### PR TITLE
Patch GeoNetwork with log4j 2.17.1

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -6,7 +6,7 @@ GitRepo: https://github.com/geonetwork/docker-geonetwork
 
 Tags: 3.10.10, 3.10
 Architectures: amd64, arm64v8
-GitCommit: 31d40ad44face58778f31879bb0d0c5578f7cc6d
+GitCommit: 739141f53daa1d82442475e739cfe0776951d2c3
 Directory: 3.10.10
 
 Tags: 3.10.10-postgres, 3.10-postgres
@@ -16,7 +16,7 @@ Directory: 3.10.10/postgres
 
 Tags: 3.12.2, 3.12, 3
 Architectures: amd64, arm64v8
-GitCommit: 1ccafbd1dfe186d5ce277bb8e8bfdf40473d971a
+GitCommit: 739141f53daa1d82442475e739cfe0776951d2c3
 Directory: 3.12.2
 
 Tags: 3.12.2-postgres, 3.12-postgres, 3-postgres
@@ -26,5 +26,5 @@ Directory: 3.12.2/postgres
 
 Tags: 4.0.5, 4.0, 4, latest
 Architectures: amd64, arm64v8
-GitCommit: 8e557004a50f04a2ac62a21009ce0ec745ed9b8d
+GitCommit: 739141f53daa1d82442475e739cfe0776951d2c3
 Directory: 4.0.5

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -6,7 +6,7 @@ GitRepo: https://github.com/geonetwork/docker-geonetwork
 
 Tags: 3.10.10, 3.10
 Architectures: amd64, arm64v8
-GitCommit: 739141f53daa1d82442475e739cfe0776951d2c3
+GitCommit: d9553f1c9bcf0cbdcee168acf0172f4bbed774dc
 Directory: 3.10.10
 
 Tags: 3.10.10-postgres, 3.10-postgres
@@ -16,7 +16,7 @@ Directory: 3.10.10/postgres
 
 Tags: 3.12.2, 3.12, 3
 Architectures: amd64, arm64v8
-GitCommit: 739141f53daa1d82442475e739cfe0776951d2c3
+GitCommit: d9553f1c9bcf0cbdcee168acf0172f4bbed774dc
 Directory: 3.12.2
 
 Tags: 3.12.2-postgres, 3.12-postgres, 3-postgres
@@ -26,5 +26,5 @@ Directory: 3.12.2/postgres
 
 Tags: 4.0.5, 4.0, 4, latest
 Architectures: amd64, arm64v8
-GitCommit: 739141f53daa1d82442475e739cfe0776951d2c3
+GitCommit: d9553f1c9bcf0cbdcee168acf0172f4bbed774dc
 Directory: 4.0.5

--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,8 +1,9 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/1ccafbd1dfe186d5ce277bb8e8bfdf40473d971a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/b81becdcc4fc0219c97b96e1170340efb1a5db04/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
 GitRepo: https://github.com/geonetwork/docker-geonetwork
+GitFetch: refs/heads/main
 
 Tags: 3.10.10, 3.10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Patch maitained series of GeoNetwork with log4j 2.17.1 until new GN versions
are released (GN 3.10.11, 3.12.3 and 4.0.6).﻿
