### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -139,6 +139,21 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: fae040f3db68991f178f0a9631a03ca9837f5647
 Directory: ubuntu/impish
 
+Tags: jammy-curl, 22.04-curl
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
+Directory: ubuntu/jammy/curl
+
+Tags: jammy-scm, 22.04-scm
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
+Directory: ubuntu/jammy/scm
+
+Tags: jammy, 22.04
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
+Directory: ubuntu/jammy
+
 Tags: xenial-curl, 16.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/f7fdd6b: Merge pull request https://github.com/docker-library/buildpack-deps/pull/125 from vicamo/for-upstream/add-ubuntu-jammy
- https://github.com/docker-library/buildpack-deps/commit/e2fc735: Add Ubuntu Jammy 22.04