### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -3,125 +3,124 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
-GitFetch: refs/heads/ugh-3.10.2-3.9.10-3.11.0a4
 
 Tags: 3.11.0a4-bullseye, 3.11-rc-bullseye
 SharedTags: 3.11.0a4, 3.11-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 475515049d39e26da9a169da9b098e6c578e8f51
 Directory: 3.11-rc/bullseye
 
 Tags: 3.11.0a4-slim-bullseye, 3.11-rc-slim-bullseye, 3.11.0a4-slim, 3.11-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 475515049d39e26da9a169da9b098e6c578e8f51
 Directory: 3.11-rc/bullseye/slim
 
 Tags: 3.11.0a4-alpine3.15, 3.11-rc-alpine3.15, 3.11.0a4-alpine, 3.11-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 475515049d39e26da9a169da9b098e6c578e8f51
 Directory: 3.11-rc/alpine3.15
 
-Tags: 3.11.0a3-windowsservercore-ltsc2022, 3.11-rc-windowsservercore-ltsc2022
-SharedTags: 3.11.0a3-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a3, 3.11-rc
+Tags: 3.11.0a4-windowsservercore-ltsc2022, 3.11-rc-windowsservercore-ltsc2022
+SharedTags: 3.11.0a4-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a4, 3.11-rc
 Architectures: windows-amd64
-GitCommit: d162396abd34f321f01d56d17e0d2ed954678ba2
+GitCommit: 475515049d39e26da9a169da9b098e6c578e8f51
 Directory: 3.11-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.11.0a3-windowsservercore-1809, 3.11-rc-windowsservercore-1809
-SharedTags: 3.11.0a3-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a3, 3.11-rc
+Tags: 3.11.0a4-windowsservercore-1809, 3.11-rc-windowsservercore-1809
+SharedTags: 3.11.0a4-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a4, 3.11-rc
 Architectures: windows-amd64
-GitCommit: d162396abd34f321f01d56d17e0d2ed954678ba2
+GitCommit: 475515049d39e26da9a169da9b098e6c578e8f51
 Directory: 3.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.2-bullseye, 3.10-bullseye, 3-bullseye, bullseye
 SharedTags: 3.10.2, 3.10, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/bullseye
 
 Tags: 3.10.2-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.2-slim, 3.10-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/bullseye/slim
 
 Tags: 3.10.2-buster, 3.10-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/buster
 
 Tags: 3.10.2-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/buster/slim
 
 Tags: 3.10.2-alpine3.15, 3.10-alpine3.15, 3-alpine3.15, alpine3.15, 3.10.2-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/alpine3.15
 
 Tags: 3.10.2-alpine3.14, 3.10-alpine3.14, 3-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/alpine3.14
 
-Tags: 3.10.1-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 3.10.1-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.1, 3.10, 3, latest
+Tags: 3.10.2-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 3.10.2-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.2, 3.10, 3, latest
 Architectures: windows-amd64
-GitCommit: db32c7803dfc67e5a359514371e66d6405695e45
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.10.1-windowsservercore-1809, 3.10-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.10.1-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.1, 3.10, 3, latest
+Tags: 3.10.2-windowsservercore-1809, 3.10-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.10.2-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.2, 3.10, 3, latest
 Architectures: windows-amd64
-GitCommit: db32c7803dfc67e5a359514371e66d6405695e45
+GitCommit: d7fa897e3d1c57cf144b6253ffb08a11b7a7511c
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.9.10-bullseye, 3.9-bullseye
 SharedTags: 3.9.10, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/bullseye
 
 Tags: 3.9.10-slim-bullseye, 3.9-slim-bullseye, 3.9.10-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/bullseye/slim
 
 Tags: 3.9.10-buster, 3.9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/buster
 
 Tags: 3.9.10-slim-buster, 3.9-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/buster/slim
 
 Tags: 3.9.10-alpine3.15, 3.9-alpine3.15, 3.9.10-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/alpine3.15
 
 Tags: 3.9.10-alpine3.14, 3.9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d9e3cb33000bbaf8cf9a1db47054d5e5ef7cda0
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/alpine3.14
 
-Tags: 3.9.9-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
-SharedTags: 3.9.9-windowsservercore, 3.9-windowsservercore, 3.9.9, 3.9
+Tags: 3.9.10-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
+SharedTags: 3.9.10-windowsservercore, 3.9-windowsservercore, 3.9.10, 3.9
 Architectures: windows-amd64
-GitCommit: 3d43bcf8ddd26ae85fd6a63a7e1d502b445c9cce
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.9.9-windowsservercore-1809, 3.9-windowsservercore-1809
-SharedTags: 3.9.9-windowsservercore, 3.9-windowsservercore, 3.9.9, 3.9
+Tags: 3.9.10-windowsservercore-1809, 3.9-windowsservercore-1809
+SharedTags: 3.9.10-windowsservercore, 3.9-windowsservercore, 3.9.10, 3.9
 Architectures: windows-amd64
-GitCommit: 3d43bcf8ddd26ae85fd6a63a7e1d502b445c9cce
+GitCommit: 6a2c0f48f011aa279a0c9190725fc84a220460bc
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/d7fa897: Update to 3.10.2, setuptools 57.5.0, pip 21.2.4
- https://github.com/docker-library/python/commit/6a2c0f4: Update to 3.9.10, setuptools 57.5.0, pip 21.2.4
- https://github.com/docker-library/python/commit/4755150: Update to 3.11.0a4, setuptools 57.5.0, pip 21.2.4

(This is a follow-up to https://github.com/docker-library/official-images/pull/11684, see it for more details)