### PR TITLE
[ros] rolling ros1-bridge demo package version bump

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -140,6 +140,6 @@ Directory: ros/rolling/ubuntu/focal/ros-base
 
 Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: 048b3f6392998df61c330b789602bf83aae9c1be
+GitCommit: 99de493c86284df5c4c1a2a2692311a53a63a08b
 Directory: ros/rolling/ubuntu/focal/ros1-bridge
 


### PR DESCRIPTION
ros-rolling-demo-nodes-cpp: 0.17.0 -> 0.18.0
ros-rolling-demo-nodes-py: 0.17.0 -> 0.18.0