### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,17 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.27, 8.0, 8, latest
-GitCommit: 15fe7357b165ee8aaa3ce165386f910a53a75087
+Tags: 8.0.28, 8.0, 8, latest
+GitCommit: aa600026fe54b1fa6b2a7ac80ffbb466618fcabf
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.36, 5.7, 5
-GitCommit: bdf0905b75bc9f7d91cedd859476af8d7629e539
+Tags: 5.7.37, 5.7, 5
+GitCommit: aa600026fe54b1fa6b2a7ac80ffbb466618fcabf
 Directory: 5.7
-File: Dockerfile.debian
-
-Tags: 5.6.51, 5.6
-GitCommit: d60655b1b42f677c315d5fe2ca0e87126ca921f5
-Directory: 5.6
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/f4032a1: Merge pull request https://github.com/docker-library/mysql/pull/808 from ltangvald/master
- https://github.com/docker-library/mysql/commit/aa60002: Remove EOL 5.6
- https://github.com/docker-library/mysql/commit/25b68c6: Update server versions
- https://github.com/docker-library/mysql/commit/e0359cc: Apply template changes
- https://github.com/docker-library/mysql/commit/2fc7349: Update to new MySQL GPG Key
- https://github.com/docker-library/mysql/commit/37cf404: Merge pull request https://github.com/docker-library/mysql/pull/798 from ducksecops/master
- https://github.com/docker-library/mysql/commit/4207add: update GOSU to 1.14