### PR TITLE
Trim list of active version tags for CrateDB

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -7,32 +7,3 @@ GitRepo: https://github.com/crate/docker-crate.git
 Tags: 4.6.6, 4.6, latest
 Architectures: amd64, arm64v8
 GitCommit: d057b840ff4dc986ac500996ebda13aebfb62267
-
-Tags: 4.5.5, 4.5
-Architectures: amd64, arm64v8
-GitCommit: 53f8d6336816b88f09d831c073cab749762c7be6
-
-Tags: 4.4.3, 4.4
-Architectures: amd64, arm64v8
-GitCommit: 2ccc43c2b34cd4182b7757298f97dd21f123b2d9
-
-Tags: 4.3.4, 4.3
-Architectures: amd64, arm64v8
-GitCommit: eae5f171ef089074d42d033af2988714a87190b6
-
-Tags: 4.2.7, 4.2
-Architectures: amd64, arm64v8
-GitCommit: 441cd8bb0115a268f30633839bc29d813dfaa0db
-
-Tags: 4.1.8, 4.1
-Architectures: amd64, arm64v8
-GitCommit: fbe46a3c699dfe79242e659626a39b09325d58ab
-
-Tags: 4.0.12, 4.0
-Architectures: amd64, arm64v8
-GitCommit: 7791cda08fbf054ab2ce7a988f8811074b8c3bf4
-
-Tags: 3.3.5, 3.3
-Architectures: amd64, arm64v8
-GitCommit: 896c3f63e8e3d4746019e379a7aefb5225b050e3
-GitFetch: refs/heads/3.3


### PR DESCRIPTION
Hi,

as advised at https://github.com/docker-library/official-images/pull/10618#discussion_r677701905, this patch trims the list of active releases on the Docker Hub official release channel.

Thank you for notifying us about this.

With kind regards,
Andreas.
