### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,15 +1,15 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: b70a6f9f8c7db8fe11c3dd2750a828319ca72be4
+GitCommit: 21ba5dd50a89b8afc63a1352f8a41a16cf2c6c8a
 Directory: dockerfiles-generated
 
 Tags: 1.0a4-python3.10-bullseye, python3.10-bullseye, 1.0a4-bullseye, bullseye
 SharedTags: 1.0a4-python3.10, python3.10, 1.0a4, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-bullseye
 
 Tags: 1.0a4-python3.10-buster, python3.10-buster, 1.0a4-buster, buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-buster
 
 Tags: 1.0a4-python3.10-alpine3.15, python3.10-alpine3.15, 1.0a4-alpine3.15, alpine3.15, 1.0a4-python3.10-alpine, python3.10-alpine, 1.0a4-alpine, alpine


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/21ba5dd: Remove mips64le from Python 3.10 variants