### PR TITLE
Bump Traefik to v2.5.7 and v2.6.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 257abf1b31c2962fa25330465400c4b16a06d687
 Directory: alpine
 
-Tags: v2.5.6-windowsservercore-1809, 2.5.6-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
+Tags: v2.5.7-windowsservercore-1809, 2.5.7-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9f3d70f8ab22453f3bd38ccafe0571de28021c76
+GitCommit: a76bd42fe369759cd9c14abd3855dd24461c7ab8
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.5.6, 2.5.6, v2.5, 2.5, brie, latest
+Tags: v2.5.7, 2.5.7, v2.5, 2.5, brie, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9f3d70f8ab22453f3bd38ccafe0571de28021c76
+GitCommit: a76bd42fe369759cd9c14abd3855dd24461c7ab8
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.6.0-rc2-windowsservercore-1809, 2.6.0-rc2-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
+Tags: v2.6.0-rc3-windowsservercore-1809, 2.6.0-rc3-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 58dc5ec0c912ea2498d62791c00aa7613267f99a
+GitCommit: 257abf1b31c2962fa25330465400c4b16a06d687
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.0-rc2, 2.6.0-rc2, v2.6, 2.6, rocamadour
+Tags: v2.6.0-rc3, 2.6.0-rc3, v2.6, 2.6, rocamadour
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 58dc5ec0c912ea2498d62791c00aa7613267f99a
+GitCommit: 257abf1b31c2962fa25330465400c4b16a06d687
 Directory: alpine
 
 Tags: v2.5.6-windowsservercore-1809, 2.5.6-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.5.7](https://github.com/traefik/traefik/releases/tag/v2.5.7) and [v2.6.0-rc3](https://github.com/traefik/traefik/releases/tag/v2.6.0-rc3).

/cc @mpl @kevinpollet @ldez

Cheers
