### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -11,7 +11,7 @@ Directory: 20.10
 
 Tags: 20.10.12-dind, 20.10-dind, 20-dind, dind, 20.10.12-dind-alpine3.15
 Architectures: amd64, arm64v8
-GitCommit: 8baa881aab85f8398d2edbbcc0da4bd1f556dd98
+GitCommit: 0efba9e3cd4537de89ba54de2ad8acc5e3b1759f
 Directory: 20.10/dind
 
 Tags: 20.10.12-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/aebfc85: Merge pull request https://github.com/docker-library/docker/pull/351 from infosiftr/modprobe-iptables
- https://github.com/docker-library/docker/commit/0efba9e: Invoke "modprobe ip_tables" if "iptables -L" fails
- https://github.com/docker-library/docker/commit/4472768: Remove reference to ltsc2016 variants (EOL)