### PR TITLE
Update Monica v3.6.1 image

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -1,18 +1,18 @@
-# This file is generated via https://github.com/monicahq/docker/blob/d6d6c223dea095c8c550f3b10de67382f4167132/generate-stackbrew-library.sh
+# This file is generated via https://github.com/monicahq/docker/blob/437356f9ed4fe4e22f12fc38451ae494f971175c/generate-stackbrew-library.sh
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 
 Tags: 3.6.1-apache, 3.6-apache, 3-apache, apache, 3.6.1, 3.6, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: d6d6c223dea095c8c550f3b10de67382f4167132
+GitCommit: 437356f9ed4fe4e22f12fc38451ae494f971175c
 
 Tags: 3.6.1-fpm-alpine, 3.6-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: d6d6c223dea095c8c550f3b10de67382f4167132
+GitCommit: 437356f9ed4fe4e22f12fc38451ae494f971175c
 
 Tags: 3.6.1-fpm, 3.6-fpm, 3-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: fpm
-GitCommit: d6d6c223dea095c8c550f3b10de67382f4167132
+GitCommit: 437356f9ed4fe4e22f12fc38451ae494f971175c


### PR DESCRIPTION
Update Monica to [v3.6.1](https://github.com/monicahq/monica/releases/tag/v3.6.1).

Includes feedback from @tianon see #11654