### PR TITLE
[security] Update phpMyAdmin to 5.1.2

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -3,17 +3,17 @@ Maintainers: Isaac Bennetch <bennetch@gmail.com> (@ibennetch),
              William Desportes <williamdes@wdes.fr> (@williamdes)
 GitRepo: https://github.com/phpmyadmin/docker.git
 
-Tags: 5.1.1-apache, 5.1-apache, 5-apache, apache, 5.1.1, 5.1, 5, latest
+Tags: 5.1.2-apache, 5.1-apache, 5-apache, apache, 5.1.2, 5.1, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 935605b8d0a4e8632c1b63fbba4967b22c1a5a15
+GitCommit: 4dd05de348925e3df5f1878b60f39333dee0546d
 Directory: apache
 
-Tags: 5.1.1-fpm, 5.1-fpm, 5-fpm, fpm
+Tags: 5.1.2-fpm, 5.1-fpm, 5-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 935605b8d0a4e8632c1b63fbba4967b22c1a5a15
+GitCommit: 4dd05de348925e3df5f1878b60f39333dee0546d
 Directory: fpm
 
-Tags: 5.1.1-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine
+Tags: 5.1.2-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 935605b8d0a4e8632c1b63fbba4967b22c1a5a15
+GitCommit: 4dd05de348925e3df5f1878b60f39333dee0546d
 Directory: fpm-alpine


### PR DESCRIPTION
This regular bugfix release from 5.1.1 to 5.1.2 also includes a few security fixes. We're also now using PHP 8.0 as our base.

Signed-off-by: Isaac Bennetch <bennetch@gmail.com>