### PR TITLE
archlinux: Release 20220123.0.45312

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220116.0.44468
-GitCommit: e0d2e1b718a4b8f8cc8f2a06546cc25e2b053035
-GitFetch: refs/tags/v20220116.0.44468
+Tags: latest, base, base-20220123.0.45312
+GitCommit: b87dc520ad482a23c0f1973bf2104a4a3745b4b0
+GitFetch: refs/tags/v20220123.0.45312
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220116.0.44468
-GitCommit: e0d2e1b718a4b8f8cc8f2a06546cc25e2b053035
-GitFetch: refs/tags/v20220116.0.44468
+Tags: base-devel, base-devel-20220123.0.45312
+GitCommit: b87dc520ad482a23c0f1973bf2104a4a3745b4b0
+GitFetch: refs/tags/v20220123.0.45312
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks