### PR TITLE
Update Clear Linux OS to 35680

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: d65e5e9bd32e41b5562f867688782065da88cae7
-GitFetch: refs/heads/base-35550
+GitCommit: d13d2ab00b3894076a4c9e67dc3a600eb4c4c6b7
+GitFetch: refs/heads/base-35680


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35680

@bryteise @djklimes @bryteise