### PR TITLE
arangodb 3.8.5

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -6,6 +6,6 @@ Tags: 3.7, 3.7.16
 GitCommit: 71fc4a9f6a3fa2f5f02b517e25a6c5c94a6170e9
 Directory: alpine/3.7.16
 
-Tags: 3.8, 3.8.4, latest
-GitCommit: 052a2fa3f1555cb45a028e7f50dddef07e456f94
-Directory: alpine/3.8.4
+Tags: 3.8, 3.8.5, latest
+GitCommit: 0ea565ef7d2cae496544e4e5e7bf5fe2a6781d99
+Directory: alpine/3.8.5


### PR DESCRIPTION
Updated ArangoDB 3.8 to 3.8.5.