### PR TITLE
Bump Traefik to v2.6.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,29 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.6.0-rc3-windowsservercore-1809, 2.6.0-rc3-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
+Tags: v2.6.0-windowsservercore-1809, 2.6.0-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 257abf1b31c2962fa25330465400c4b16a06d687
+GitCommit: 333cb722775df31365a41baf164b00a032083a57
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.0-rc3, 2.6.0-rc3, v2.6, 2.6, rocamadour
+Tags: v2.6.0, 2.6.0, v2.6, 2.6, rocamadour, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 257abf1b31c2962fa25330465400c4b16a06d687
-Directory: alpine
-
-Tags: v2.5.7-windowsservercore-1809, 2.5.7-windowsservercore-1809, v2.5-windowsservercore-1809, 2.5-windowsservercore-1809, brie-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a76bd42fe369759cd9c14abd3855dd24461c7ab8
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.5.7, 2.5.7, v2.5, 2.5, brie, latest
-Architectures: amd64, arm32v6, arm64v8
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a76bd42fe369759cd9c14abd3855dd24461c7ab8
+GitCommit: 333cb722775df31365a41baf164b00a032083a57
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.6.0](https://github.com/traefik/traefik/releases/tag/v2.6.0).

/cc @mpl @kevinpollet @ldez

Cheers
