### PR TITLE
Update Aerospike 5.7.0.10

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -2,12 +2,12 @@ Maintainers: Lucien Volmar <lucien@aerospike.com> (@volmarl),
              Michael Coberly <mcoberly@aerospike.com> (@mcoberly2),
              Phuc Vinh <pvinh@aerospike.com> (@pvinh-spike)
 
-Tags: ee-5.7.0.8
+Tags: ee-5.7.0.10
 Architectures: amd64
 GitRepo: https://github.com/aerospike/aerospike-server-enterprise.docker.git
-GitCommit: 2d11fe93cec1c1adc86968a26b1b8827f61dc81f
+GitCommit: fd3d4f9bceac8c221b39cad6072c42582bff2f78
 
-Tags: ce-5.7.0.8
+Tags: ce-5.7.0.10
 Architectures: amd64
 GitRepo: https://github.com/aerospike/aerospike-server.docker.git
-GitCommit: 9316b9e2dca468e2bbed08e12550f5d208447a14
+GitCommit: cd21e935015ec519e3761ab3e13c9038f34867d1


### PR DESCRIPTION
Thank you again for your excellent response.

Based on your feedback we have embedded sha256sum with renamed as-tini-static as init:
* tini binary sha256sum embedded in the docker file
* use as-tini binary for disambiguation

https://download.aerospike.com/download/server/notes.html