### PR TITLE
kapacitor 1.6.3 and remove Cody from maintainers

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,8 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
-             Cody Shepherd <cody@influxdata.com> (@codyshepherd),
              j. Emrys Landivar <landivar@gmail.com> (@docmerlin)
 GitRepo: git://github.com/influxdata/influxdata-docker
-GitCommit: 9badda3a1d58922f45dd57fc676d4be76dd9cb2f
+GitCommit: 4a3d6bea3b5bff4fb782eda1b5a6db3e6306e75c
 
 Tags: 1.5, 1.5.9
 Architectures: amd64, arm32v7, arm64v8
@@ -11,10 +10,10 @@ Directory: kapacitor/1.5
 Tags: 1.5-alpine, 1.5.9-alpine
 Directory: kapacitor/1.5/alpine
 
-Tags: 1.6, 1.6.2, latest
+Tags: 1.6, 1.6.3, latest
 Architectures: amd64, arm64v8
 Directory: kapacitor/1.6
 
-Tags: 1.6-alpine, 1.6.2-alpine, alpine
+Tags: 1.6-alpine, 1.6.3-alpine, alpine
 Directory: kapacitor/1.6/alpine
 


### PR DESCRIPTION
This is to release kapacitor 1.6.3 and remove Cody from the maintainers list.