### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.9.13, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: d626d4d177ec5f25cc3b5344c985af0741e57c3c
+GitCommit: 8ab90ef58bb4e768dfac69e87fa079f9053c4816
 Directory: 3.9/ubuntu
 
 Tags: 3.9.13-management, 3.9-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.13-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d626d4d177ec5f25cc3b5344c985af0741e57c3c
+GitCommit: 8ab90ef58bb4e768dfac69e87fa079f9053c4816
 Directory: 3.9/alpine
 
 Tags: 3.9.13-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.27, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 20669d606671f010bdc1bb427d5b513ecef607c1
+GitCommit: 4b08a370c6d5c657da55d9e35c4a3eb487c96417
 Directory: 3.8/ubuntu
 
 Tags: 3.8.27-management, 3.8-management
@@ -36,7 +36,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.27-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20669d606671f010bdc1bb427d5b513ecef607c1
+GitCommit: 4b08a370c6d5c657da55d9e35c4a3eb487c96417
 Directory: 3.8/alpine
 
 Tags: 3.8.27-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8ab90ef: Update 3.9 to otp 24.2.1
- https://github.com/docker-library/rabbitmq/commit/4b08a37: Update 3.8 to otp 24.2.1