### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -84,62 +84,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 43bf6f0b18d8f06fa804b753d90ade61ea49c35f
 Directory: cli/php8.1/alpine
 
-Tags: beta-5.9-RC3-apache, beta-5.9-apache, beta-5-apache, beta-apache, beta-5.9-RC3, beta-5.9, beta-5, beta, beta-5.9-RC3-php7.4-apache, beta-5.9-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.9-RC3-php7.4, beta-5.9-php7.4, beta-5-php7.4, beta-php7.4
+Tags: beta-5.9-RC4-apache, beta-5.9-apache, beta-5-apache, beta-apache, beta-5.9-RC4, beta-5.9, beta-5, beta, beta-5.9-RC4-php7.4-apache, beta-5.9-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.9-RC4-php7.4, beta-5.9-php7.4, beta-5-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php7.4/apache
 
-Tags: beta-5.9-RC3-fpm, beta-5.9-fpm, beta-5-fpm, beta-fpm, beta-5.9-RC3-php7.4-fpm, beta-5.9-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-5.9-RC4-fpm, beta-5.9-fpm, beta-5-fpm, beta-fpm, beta-5.9-RC4-php7.4-fpm, beta-5.9-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php7.4/fpm
 
-Tags: beta-5.9-RC3-fpm-alpine, beta-5.9-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.9-RC3-php7.4-fpm-alpine, beta-5.9-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-5.9-RC4-fpm-alpine, beta-5.9-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.9-RC4-php7.4-fpm-alpine, beta-5.9-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-5.9-RC3-php7.3-apache, beta-5.9-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.9-RC3-php7.3, beta-5.9-php7.3, beta-5-php7.3, beta-php7.3
+Tags: beta-5.9-RC4-php7.3-apache, beta-5.9-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.9-RC4-php7.3, beta-5.9-php7.3, beta-5-php7.3, beta-php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php7.3/apache
 
-Tags: beta-5.9-RC3-php7.3-fpm, beta-5.9-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
+Tags: beta-5.9-RC4-php7.3-fpm, beta-5.9-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php7.3/fpm
 
-Tags: beta-5.9-RC3-php7.3-fpm-alpine, beta-5.9-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
+Tags: beta-5.9-RC4-php7.3-fpm-alpine, beta-5.9-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php7.3/fpm-alpine
 
-Tags: beta-5.9-RC3-php8.0-apache, beta-5.9-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.9-RC3-php8.0, beta-5.9-php8.0, beta-5-php8.0, beta-php8.0
+Tags: beta-5.9-RC4-php8.0-apache, beta-5.9-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.9-RC4-php8.0, beta-5.9-php8.0, beta-5-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php8.0/apache
 
-Tags: beta-5.9-RC3-php8.0-fpm, beta-5.9-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-5.9-RC4-php8.0-fpm, beta-5.9-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php8.0/fpm
 
-Tags: beta-5.9-RC3-php8.0-fpm-alpine, beta-5.9-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-5.9-RC4-php8.0-fpm-alpine, beta-5.9-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-5.9-RC3-php8.1-apache, beta-5.9-php8.1-apache, beta-5-php8.1-apache, beta-php8.1-apache, beta-5.9-RC3-php8.1, beta-5.9-php8.1, beta-5-php8.1, beta-php8.1
+Tags: beta-5.9-RC4-php8.1-apache, beta-5.9-php8.1-apache, beta-5-php8.1-apache, beta-php8.1-apache, beta-5.9-RC4-php8.1, beta-5.9-php8.1, beta-5-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php8.1/apache
 
-Tags: beta-5.9-RC3-php8.1-fpm, beta-5.9-php8.1-fpm, beta-5-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-5.9-RC4-php8.1-fpm, beta-5.9-php8.1-fpm, beta-5-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php8.1/fpm
 
-Tags: beta-5.9-RC3-php8.1-fpm-alpine, beta-5.9-php8.1-fpm-alpine, beta-5-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-5.9-RC4-php8.1-fpm-alpine, beta-5.9-php8.1-fpm-alpine, beta-5-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1c9f6d5baa8c356d9b44e2690b9df5aa7b30b1f6
+GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
 Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/8d25abc: Update beta to 5.9-RC4