### PR TITLE
[varnish] Release 6.0.10, 6.6.2, and 7.0.2

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,28 +1,28 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/bb83de3a522067896b9febfe9d9407eab92e0759/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/d1212e4b8fd35b58c19b01ed389f8841d0a4ea38/populate.sh
 Maintainers: Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 7.0.1, 7.0, latest
+Tags: fresh, 7.0.2, 7.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: bb83de3a522067896b9febfe9d9407eab92e0759
+GitCommit: 6423e32e0afd20fa876276e1525cb318920fbefa
 
-Tags: fresh-alpine, 7.0.1-alpine, 7.0-alpine, alpine
+Tags: fresh-alpine, 7.0.2-alpine, 7.0-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: bb83de3a522067896b9febfe9d9407eab92e0759
+GitCommit: 6423e32e0afd20fa876276e1525cb318920fbefa
 
-Tags: old, 6.6.1, 6.6
+Tags: old, 6.6.2, 6.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: d24057bde1acfa41f5abf1d0d4772eac0bcccf70
+GitCommit: 6423e32e0afd20fa876276e1525cb318920fbefa
 
-Tags: old-alpine, 6.6.1-alpine, 6.6-alpine
+Tags: old-alpine, 6.6.2-alpine, 6.6-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/alpine
-GitCommit: d24057bde1acfa41f5abf1d0d4772eac0bcccf70
+GitCommit: 6423e32e0afd20fa876276e1525cb318920fbefa
 
-Tags: stable, 6.0.8, 6.0
+Tags: stable, 6.0.10, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/debian
-GitCommit: d24057bde1acfa41f5abf1d0d4772eac0bcccf70
+GitCommit: d1212e4b8fd35b58c19b01ed389f8841d0a4ea38


### PR DESCRIPTION
Varnish versions 6.0.10, 6.6.2, and 7.0.2 were released on 2022-01-25 to address the VSV00008 HTTP/1 Request Smuggling Vulnerability (more information here: https://varnish-cache.org/security/VSV00008.html).

The related varnish/docker-varnish repository has been updated to use these new versions (varnish/docker-varnish#46), so this PR updates the `library/varnish` file accordingly.

Edit: Updated to incorporate the changes from varnish/docker-varnish#47, which I had overlooked in the previous PR.