### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 700a06f3ea366e468eea55fbabc3dc23ef1dd5a3
 Directory: 2.2/alpine
 
-Tags: 2.0.26, 2.0, 2.0.26-buster, 2.0-buster
+Tags: 2.0.27, 2.0, 2.0.27-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4e8e42f7d8e647a8a8b9040e419a8c86bcd4ee51
+GitCommit: ec1777bec18a022f898231b6a04524c0ae4d97b5
 Directory: 2.0
 
-Tags: 2.0.26-alpine, 2.0-alpine, 2.0.26-alpine3.15, 2.0-alpine3.15
+Tags: 2.0.27-alpine, 2.0-alpine, 2.0.27-alpine3.15, 2.0-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e8e42f7d8e647a8a8b9040e419a8c86bcd4ee51
+GitCommit: ec1777bec18a022f898231b6a04524c0ae4d97b5
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ec1777b: Update 2.0 to 2.0.27