### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,142 +4,82 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.8.3-apache, 5.8-apache, 5-apache, apache, 5.8.3, 5.8, 5, latest, 5.8.3-php7.4-apache, 5.8-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.8.3-php7.4, 5.8-php7.4, 5-php7.4, php7.4
+Tags: 5.9.0-apache, 5.9-apache, 5-apache, apache, 5.9.0, 5.9, 5, latest, 5.9.0-php7.4-apache, 5.9-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.9.0-php7.4, 5.9-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php7.4/apache
 
-Tags: 5.8.3-fpm, 5.8-fpm, 5-fpm, fpm, 5.8.3-php7.4-fpm, 5.8-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.9.0-fpm, 5.9-fpm, 5-fpm, fpm, 5.9.0-php7.4-fpm, 5.9-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php7.4/fpm
 
-Tags: 5.8.3-fpm-alpine, 5.8-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.8.3-php7.4-fpm-alpine, 5.8-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.9.0-fpm-alpine, 5.9-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.9.0-php7.4-fpm-alpine, 5.9-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.8.3-php7.3-apache, 5.8-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.8.3-php7.3, 5.8-php7.3, 5-php7.3, php7.3
+Tags: 5.9.0-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.0-php7.3, 5.9-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php7.3/apache
 
-Tags: 5.8.3-php7.3-fpm, 5.8-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.9.0-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php7.3/fpm
 
-Tags: 5.8.3-php7.3-fpm-alpine, 5.8-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.9.0-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.8.3-php8.0-apache, 5.8-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.8.3-php8.0, 5.8-php8.0, 5-php8.0, php8.0
+Tags: 5.9.0-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.0-php8.0, 5.9-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php8.0/apache
 
-Tags: 5.8.3-php8.0-fpm, 5.8-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.9.0-php8.0-fpm, 5.9-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php8.0/fpm
 
-Tags: 5.8.3-php8.0-fpm-alpine, 5.8-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.9.0-php8.0-fpm-alpine, 5.9-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 5.8.3-php8.1-apache, 5.8-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.8.3-php8.1, 5.8-php8.1, 5-php8.1, php8.1
+Tags: 5.9.0-php8.1-apache, 5.9-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.9.0-php8.1, 5.9-php8.1, 5-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php8.1/apache
 
-Tags: 5.8.3-php8.1-fpm, 5.8-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
+Tags: 5.9.0-php8.1-fpm, 5.9-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php8.1/fpm
 
-Tags: 5.8.3-php8.1-fpm-alpine, 5.8-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 5.9.0-php8.1-fpm-alpine, 5.9-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bd3350fc17d7a8f76dfb68271de65ebc4edb073c
+GitCommit: 2127e69580708e512d925d6e273482032464be06
 Directory: latest/php8.1/fpm-alpine
 
-Tags: cli-2.5.0, cli-2.5, cli-2, cli, cli-2.5.0-php7.4, cli-2.5-php7.4, cli-2-php7.4, cli-php7.4
+Tags: cli-2.6.0, cli-2.6, cli-2, cli, cli-2.6.0-php7.4, cli-2.6-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43bf6f0b18d8f06fa804b753d90ade61ea49c35f
+GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
 Directory: cli/php7.4/alpine
 
-Tags: cli-2.5.0-php7.3, cli-2.5-php7.3, cli-2-php7.3, cli-php7.3
+Tags: cli-2.6.0-php7.3, cli-2.6-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43bf6f0b18d8f06fa804b753d90ade61ea49c35f
+GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
 Directory: cli/php7.3/alpine
 
-Tags: cli-2.5.0-php8.0, cli-2.5-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.6.0-php8.0, cli-2.6-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43bf6f0b18d8f06fa804b753d90ade61ea49c35f
+GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
 Directory: cli/php8.0/alpine
 
-Tags: cli-2.5.0-php8.1, cli-2.5-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.6.0-php8.1, cli-2.6-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43bf6f0b18d8f06fa804b753d90ade61ea49c35f
+GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
 Directory: cli/php8.1/alpine
-
-Tags: beta-5.9-RC4-apache, beta-5.9-apache, beta-5-apache, beta-apache, beta-5.9-RC4, beta-5.9, beta-5, beta, beta-5.9-RC4-php7.4-apache, beta-5.9-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.9-RC4-php7.4, beta-5.9-php7.4, beta-5-php7.4, beta-php7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php7.4/apache
-
-Tags: beta-5.9-RC4-fpm, beta-5.9-fpm, beta-5-fpm, beta-fpm, beta-5.9-RC4-php7.4-fpm, beta-5.9-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php7.4/fpm
-
-Tags: beta-5.9-RC4-fpm-alpine, beta-5.9-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.9-RC4-php7.4-fpm-alpine, beta-5.9-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php7.4/fpm-alpine
-
-Tags: beta-5.9-RC4-php7.3-apache, beta-5.9-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.9-RC4-php7.3, beta-5.9-php7.3, beta-5-php7.3, beta-php7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php7.3/apache
-
-Tags: beta-5.9-RC4-php7.3-fpm, beta-5.9-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php7.3/fpm
-
-Tags: beta-5.9-RC4-php7.3-fpm-alpine, beta-5.9-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php7.3/fpm-alpine
-
-Tags: beta-5.9-RC4-php8.0-apache, beta-5.9-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.9-RC4-php8.0, beta-5.9-php8.0, beta-5-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php8.0/apache
-
-Tags: beta-5.9-RC4-php8.0-fpm, beta-5.9-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php8.0/fpm
-
-Tags: beta-5.9-RC4-php8.0-fpm-alpine, beta-5.9-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php8.0/fpm-alpine
-
-Tags: beta-5.9-RC4-php8.1-apache, beta-5.9-php8.1-apache, beta-5-php8.1-apache, beta-php8.1-apache, beta-5.9-RC4-php8.1, beta-5.9-php8.1, beta-5-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php8.1/apache
-
-Tags: beta-5.9-RC4-php8.1-fpm, beta-5.9-php8.1-fpm, beta-5-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php8.1/fpm
-
-Tags: beta-5.9-RC4-php8.1-fpm-alpine, beta-5.9-php8.1-fpm-alpine, beta-5-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8d25abc90d260e36c9bf403e15d678c02855a0ec
-Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/6ac3892: Update cli to 2.6.0
- https://github.com/docker-library/wordpress/commit/2127e69: Update latest to 5.9.0
- https://github.com/docker-library/wordpress/commit/3527ae6: Update beta to 5.9.0