### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,7 +11,7 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Preston Carpenter (@timidger),
              Richard Kelly (@rpkelly)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 74eec9ec400d191dbe3398ca0cbba0ac9f892929
+GitCommit: b33d6d0636a1934f7e4507020199dcd8ed09809b
 
 Tags: 2.0.20211223.0, 2, latest
 Architectures: amd64, arm64v8
@@ -27,12 +27,12 @@ amd64-GitCommit: ed107105c535e30322377f98d8d300a5985ecd34
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 593cba2802c30302b7f5baec0b65a21bb9fb2020
 
-Tags: 2018.03.0.20211201.0, 2018.03, 1
+Tags: 2018.03.0.20220119.1, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 1142e9739519cd6a2992a029ae25b6db686183f8
+amd64-GitCommit: e92d0421ee96b1f6feaf907509370e74bf44c0ea
 
-Tags: 2018.03.0.20211201.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20220119.1-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 6da53c8eb5e75467c2121aa46dda93e2b0849fed
+amd64-GitCommit: 55c91a9c5662a01d4117d3171104f66566b4c39e


### PR DESCRIPTION
Please pick up these new images for our 2018.03 release - thanks!