### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,80 +6,80 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 5.9.0-apache, 5.9-apache, 5-apache, apache, 5.9.0, 5.9, 5, latest, 5.9.0-php7.4-apache, 5.9-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.9.0-php7.4, 5.9-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php7.4/apache
 
 Tags: 5.9.0-fpm, 5.9-fpm, 5-fpm, fpm, 5.9.0-php7.4-fpm, 5.9-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php7.4/fpm
 
 Tags: 5.9.0-fpm-alpine, 5.9-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.9.0-php7.4-fpm-alpine, 5.9-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php7.4/fpm-alpine
 
 Tags: 5.9.0-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.0-php7.3, 5.9-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php7.3/apache
 
 Tags: 5.9.0-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php7.3/fpm
 
 Tags: 5.9.0-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php7.3/fpm-alpine
 
 Tags: 5.9.0-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.0-php8.0, 5.9-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php8.0/apache
 
 Tags: 5.9.0-php8.0-fpm, 5.9-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php8.0/fpm
 
 Tags: 5.9.0-php8.0-fpm-alpine, 5.9-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php8.0/fpm-alpine
 
 Tags: 5.9.0-php8.1-apache, 5.9-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.9.0-php8.1, 5.9-php8.1, 5-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php8.1/apache
 
 Tags: 5.9.0-php8.1-fpm, 5.9-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php8.1/fpm
 
 Tags: 5.9.0-php8.1-fpm-alpine, 5.9-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2127e69580708e512d925d6e273482032464be06
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: latest/php8.1/fpm-alpine
 
 Tags: cli-2.6.0, cli-2.6, cli-2, cli, cli-2.6.0-php7.4, cli-2.6-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php7.4/alpine
 
 Tags: cli-2.6.0-php7.3, cli-2.6-php7.3, cli-2-php7.3, cli-php7.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php7.3/alpine
 
 Tags: cli-2.6.0-php8.0, cli-2.6-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php8.0/alpine
 
 Tags: cli-2.6.0-php8.1, cli-2.6-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ac38921f1d8b7e043009b99e9c65c4fa108b78a
+GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php8.1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/1b78733: Merge pull request https://github.com/docker-library/wordpress/pull/688 from infosiftr/add-intl
- https://github.com/docker-library/wordpress/commit/376f01a: Enable the intl extension for "site health checker"