### PR TITLE
archlinux: Release 20220130.0.46058

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220123.0.45312
-GitCommit: b87dc520ad482a23c0f1973bf2104a4a3745b4b0
-GitFetch: refs/tags/v20220123.0.45312
+Tags: latest, base, base-20220130.0.46058
+GitCommit: 2a506eddc83cd0487ce42799b08fc4e584824d9d
+GitFetch: refs/tags/v20220130.0.46058
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220123.0.45312
-GitCommit: b87dc520ad482a23c0f1973bf2104a4a3745b4b0
-GitFetch: refs/tags/v20220123.0.45312
+Tags: base-devel, base-devel-20220130.0.46058
+GitCommit: 2a506eddc83cd0487ce42799b08fc4e584824d9d
+GitFetch: refs/tags/v20220130.0.46058
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks