### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,57 +5,57 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.18beta1-bullseye, 1.18-rc-bullseye, rc-bullseye
-SharedTags: 1.18beta1, 1.18-rc, rc
+Tags: 1.18beta2-bullseye, 1.18-rc-bullseye, rc-bullseye
+SharedTags: 1.18beta2, 1.18-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/bullseye
 
-Tags: 1.18beta1-buster, 1.18-rc-buster, rc-buster
+Tags: 1.18beta2-buster, 1.18-rc-buster, rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/buster
 
-Tags: 1.18beta1-stretch, 1.18-rc-stretch, rc-stretch
+Tags: 1.18beta2-stretch, 1.18-rc-stretch, rc-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/stretch
 
-Tags: 1.18beta1-alpine3.15, 1.18-rc-alpine3.15, rc-alpine3.15, 1.18beta1-alpine, 1.18-rc-alpine, rc-alpine
+Tags: 1.18beta2-alpine3.15, 1.18-rc-alpine3.15, rc-alpine3.15, 1.18beta2-alpine, 1.18-rc-alpine, rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/alpine3.15
 
-Tags: 1.18beta1-alpine3.14, 1.18-rc-alpine3.14, rc-alpine3.14
+Tags: 1.18beta2-alpine3.14, 1.18-rc-alpine3.14, rc-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/alpine3.14
 
-Tags: 1.18beta1-windowsservercore-ltsc2022, 1.18-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 1.18beta1-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18beta1, 1.18-rc, rc
+Tags: 1.18beta2-windowsservercore-ltsc2022, 1.18-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 1.18beta2-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18beta2, 1.18-rc, rc
 Architectures: windows-amd64
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.18beta1-windowsservercore-1809, 1.18-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.18beta1-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18beta1, 1.18-rc, rc
+Tags: 1.18beta2-windowsservercore-1809, 1.18-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.18beta2-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18beta2, 1.18-rc, rc
 Architectures: windows-amd64
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.18beta1-nanoserver-ltsc2022, 1.18-rc-nanoserver-ltsc2022, rc-nanoserver-ltsc2022
-SharedTags: 1.18beta1-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
+Tags: 1.18beta2-nanoserver-ltsc2022, 1.18-rc-nanoserver-ltsc2022, rc-nanoserver-ltsc2022
+SharedTags: 1.18beta2-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.18beta1-nanoserver-1809, 1.18-rc-nanoserver-1809, rc-nanoserver-1809
-SharedTags: 1.18beta1-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
+Tags: 1.18beta2-nanoserver-1809, 1.18-rc-nanoserver-1809, rc-nanoserver-1809
+SharedTags: 1.18beta2-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
 Architectures: windows-amd64
-GitCommit: be0797ac1d92bdc78647ebf8b8edb380b2d9657e
+GitCommit: 20770e021d1931892a68710e290af8792d9754f9
 Directory: 1.18-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/20770e0: Update 1.18-rc to 1.18beta2