### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,22 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.34.0, 4.34, 4, latest
+Tags: 4.34.3, 4.34, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6f53687517e7f389fa5538e5696d8964e20649be
+GitCommit: dc8aa7ecf6fdd7495b214c71a469cc668a8d521a
 Directory: 4/debian
 
-Tags: 4.34.0-alpine, 4.34-alpine, 4-alpine, alpine
+Tags: 4.34.3-alpine, 4.34-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 6f53687517e7f389fa5538e5696d8964e20649be
+GitCommit: dc8aa7ecf6fdd7495b214c71a469cc668a8d521a
 Directory: 4/alpine
-
-Tags: 3.42.9, 3.42, 3
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 78e84a64cdac72daa98a864575a05e2d15b01cb4
-Directory: 3/debian
-
-Tags: 3.42.9-alpine, 3.42-alpine, 3-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 78e84a64cdac72daa98a864575a05e2d15b01cb4
-Directory: 3/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/dc8aa7e: Update to 4.34.3, ghost-cli 1.18.1
- https://github.com/docker-library/ghost/commit/1ddbdc2: Merge pull request https://github.com/docker-library/ghost/pull/286 from acburdine/remove/v3
- https://github.com/docker-library/ghost/commit/fc3c931: Update to 4.34.2, ghost-cli 1.18.1
- https://github.com/docker-library/ghost/commit/b238f12: Remove v3 Dockerfiles
- https://github.com/docker-library/ghost/commit/9f75a9c: Update to 4.34.1, ghost-cli 1.18.1