### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -1,60 +1,60 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/b9406c480220b6f9577cdf2427abe7ec4bf139ff/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/f2b3767e20791f944cbcd1e00028a6458a73a576/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 3.8-7.3.7-bullseye, 3.8-7.3-bullseye, 3.8-7-bullseye, 3.8-bullseye
-SharedTags: 3.8-7.3.7, 3.8-7.3, 3.8-7, 3.8
+Tags: 3.8-7.3.7-bullseye, 3.8-7.3-bullseye, 3.8-7-bullseye, 3.8-bullseye, 3-7.3.7-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
+SharedTags: 3.8-7.3.7, 3.8-7.3, 3.8-7, 3.8, 3-7.3.7, 3-7.3, 3-7, 3, latest
 Architectures: amd64, arm64v8, i386
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.8/bullseye
 
-Tags: 3.8-7.3.7-slim, 3.8-7.3-slim, 3.8-7-slim, 3.8-slim, 3.8-7.3.7-slim-bullseye, 3.8-7.3-slim-bullseye, 3.8-7-slim-bullseye, 3.8-slim-bullseye
+Tags: 3.8-7.3.7-slim, 3.8-7.3-slim, 3.8-7-slim, 3.8-slim, 3-7.3.7-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.8-7.3.7-slim-bullseye, 3.8-7.3-slim-bullseye, 3.8-7-slim-bullseye, 3.8-slim-bullseye, 3-7.3.7-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8, i386
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.8/slim-bullseye
 
-Tags: 3.8-7.3.7-buster, 3.8-7.3-buster, 3.8-7-buster, 3.8-buster
+Tags: 3.8-7.3.7-buster, 3.8-7.3-buster, 3.8-7-buster, 3.8-buster, 3-7.3.7-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
 Architectures: amd64, arm64v8, i386, s390x
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.8/buster
 
-Tags: 3.8-7.3.7-slim-buster, 3.8-7.3-slim-buster, 3.8-7-slim-buster, 3.8-slim-buster
+Tags: 3.8-7.3.7-slim-buster, 3.8-7.3-slim-buster, 3.8-7-slim-buster, 3.8-slim-buster, 3-7.3.7-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm64v8, i386, s390x
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.8/slim-buster
 
-Tags: 3.8-7.3.7-windowsservercore-1809, 3.8-7.3-windowsservercore-1809, 3.8-7-windowsservercore-1809, 3.8-windowsservercore-1809
-SharedTags: 3.8-7.3.7, 3.8-7.3, 3.8-7, 3.8, 3.8-7.3.7-windowsservercore, 3.8-7.3-windowsservercore, 3.8-7-windowsservercore, 3.8-windowsservercore
+Tags: 3.8-7.3.7-windowsservercore-1809, 3.8-7.3-windowsservercore-1809, 3.8-7-windowsservercore-1809, 3.8-windowsservercore-1809, 3-7.3.7-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.8-7.3.7, 3.8-7.3, 3.8-7, 3.8, 3-7.3.7, 3-7.3, 3-7, 3, latest, 3.8-7.3.7-windowsservercore, 3.8-7.3-windowsservercore, 3.8-7-windowsservercore, 3.8-windowsservercore, 3-7.3.7-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.8/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.7-7.3.7-bullseye, 3.7-7.3-bullseye, 3.7-7-bullseye, 3.7-bullseye, 3-7.3.7-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
-SharedTags: 3.7-7.3.7, 3.7-7.3, 3.7-7, 3.7, 3-7.3.7, 3-7.3, 3-7, 3, latest
+Tags: 3.7-7.3.7-bullseye, 3.7-7.3-bullseye, 3.7-7-bullseye, 3.7-bullseye
+SharedTags: 3.7-7.3.7, 3.7-7.3, 3.7-7, 3.7
 Architectures: amd64, arm64v8, i386
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.7/bullseye
 
-Tags: 3.7-7.3.7-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3-7.3.7-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.7-7.3.7-slim-bullseye, 3.7-7.3-slim-bullseye, 3.7-7-slim-bullseye, 3.7-slim-bullseye, 3-7.3.7-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.7-7.3.7-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3.7-7.3.7-slim-bullseye, 3.7-7.3-slim-bullseye, 3.7-7-slim-bullseye, 3.7-slim-bullseye
 Architectures: amd64, arm64v8, i386
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.7/slim-bullseye
 
-Tags: 3.7-7.3.7-buster, 3.7-7.3-buster, 3.7-7-buster, 3.7-buster, 3-7.3.7-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
+Tags: 3.7-7.3.7-buster, 3.7-7.3-buster, 3.7-7-buster, 3.7-buster
 Architectures: amd64, arm64v8, i386, s390x
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.7/buster
 
-Tags: 3.7-7.3.7-slim-buster, 3.7-7.3-slim-buster, 3.7-7-slim-buster, 3.7-slim-buster, 3-7.3.7-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.7-7.3.7-slim-buster, 3.7-7.3-slim-buster, 3.7-7-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm64v8, i386, s390x
 GitCommit: c691d58e3c28b17bfccadd5040a5ff3b57ef19b0
 Directory: 3.7/slim-buster
 
-Tags: 3.7-7.3.7-windowsservercore-1809, 3.7-7.3-windowsservercore-1809, 3.7-7-windowsservercore-1809, 3.7-windowsservercore-1809, 3-7.3.7-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.7-7.3.7, 3.7-7.3, 3.7-7, 3.7, 3-7.3.7, 3-7.3, 3-7, 3, latest, 3.7-7.3.7-windowsservercore, 3.7-7.3-windowsservercore, 3.7-7-windowsservercore, 3.7-windowsservercore, 3-7.3.7-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.7-7.3.7-windowsservercore-1809, 3.7-7.3-windowsservercore-1809, 3.7-7-windowsservercore-1809, 3.7-windowsservercore-1809
+SharedTags: 3.7-7.3.7, 3.7-7.3, 3.7-7, 3.7, 3.7-7.3.7-windowsservercore, 3.7-7.3-windowsservercore, 3.7-7-windowsservercore, 3.7-windowsservercore
 Architectures: windows-amd64
 GitCommit: 866a266ef231ca7c9efd2accc1fba1c55ad79b85
 Directory: 3.7/windows/windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/6b9be45: Merge pull request https://github.com/docker-library/pypy/pull/66 from bartbroere/patch-1
- https://github.com/docker-library/pypy/commit/f2b3767: Move the tags for '3' and 'latest'
- https://github.com/docker-library/pypy/commit/73f1577: Remove reference to ltsc2016 variants (EOL)