### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,8 +1,18 @@
-# this file is generated via https://github.com/docker-library/redis/blob/231905d0841f52ee4f3a5b8b42d62cd6d14a1a93/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redis/blob/5800387c04b3a07957e578258e0438187dd9e5d2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
+
+Tags: 7.0-rc1, 7.0-rc, 7.0-rc1-bullseye, 7.0-rc-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: b90f94b39a5abe413737f797b92ee257ca8303b2
+Directory: 7.0-rc
+
+Tags: 7.0-rc1-alpine, 7.0-rc-alpine, 7.0-rc1-alpine3.15, 7.0-rc-alpine3.15
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: b90f94b39a5abe413737f797b92ee257ca8303b2
+Directory: 7.0-rc/alpine
 
 Tags: 6.2.6, 6.2, 6, latest, 6.2.6-bullseye, 6.2-bullseye, 6-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/5800387: Ditch "7.0" alias for "7.0-rc"
- https://github.com/docker-library/redis/commit/fb8bdd7: Merge pull request https://github.com/docker-library/redis/pull/304 from infosiftr/7.0-rc
- https://github.com/docker-library/redis/commit/b90f94b: Add 7.0-rc1