### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/9aba676320fbc6792713e5dd2327c2fdb002b2a2/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/b1ae01f5030025e2ed17d8075841b5266c36f32f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 9aba676320fbc6792713e5dd2327c2fdb002b2a2
+GitCommit: b1ae01f5030025e2ed17d8075841b5266c36f32f
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ecf0f5ecd9697ac16b9662679511bd5e011d34b4
+amd64-GitCommit: 26c663c3b49330b339521dd52e69dbef3fcae640
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: e457a83cda046859a24bf4fef4c56651546abf9b
+arm32v5-GitCommit: 78c6b4506218188c9149ba70749b67912861494f
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 8442b3916b5bcf4f69f5642491e846e3eed295c1
+arm32v6-GitCommit: 49d22627f94917442aa82f8f0ada004503be0197
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 8629c10d8c6339f9b4c070d02f2ae1b721fa33e6
+arm32v7-GitCommit: 0121e2dc6ebb794f836721772a028258ea3ee4cd
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2139a2b02e363ba1d744608ea3f7ee21b22ab07f
+arm64v8-GitCommit: 22bb23a2665eefb1520dc4c99d5ac9bdf87ae93b
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 7696008409ae807825d8d2a822cfb14c78c63df3
+i386-GitCommit: 2a2b89ee14b9561db1d03f5cafec65b9a39cb4ba
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 06532535431afd25906308b5dbe795af884138a8
+mips64le-GitCommit: a827a41797661f714316ff8fb2cbcc742b191105
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: cf9f58c29efecce9a5fbcdf4049940a2498295e2
+ppc64le-GitCommit: d3573e455c64ed678f9f0e8bf98819b418c722a3
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: a2b6817f79cc78c88d47e1456164af12d7043863
+riscv64-GitCommit: 4ee21de393d5ba79197b2eed7395ce8a1943e246
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 22c76a469c2dbb3985253a7b1a11fad94f83a8ab
+s390x-GitCommit: b40a1bd99995a59ad653862ef63a7b0df606c92c
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/b1ae01f: Merge pull request https://github.com/docker-library/busybox/pull/126 from infosiftr/buildroot-2021.11.1
- https://github.com/docker-library/busybox/commit/3a74ae1: Update buildroot to 2021.11.1