### PR TITLE
[oraclelinux] Update 8/8-slim for amd64/arm64v8 for ELSA-2022-0366, ELSA-2022-0368, ELSA-2022-0370

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2fec92641c29d7a4cc704014d081fa42816ec82f
+amd64-GitCommit: d2cddc02be12d3574ddf2553d94d62ef2d906db1
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0b869f1e3a5cb823ace5ac25a0624e63d4d40f7a
+arm64v8-GitCommit: a081765cbdaf3306c7f1ccc45dd525cea67a96b5
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-3872, CVE-2021-3984, CVE-2021-4019, CVE-2021-4192, CVE-2021-4193, CVE-2021-3521 and CVE-2021-4122.

See the following for details:
https://linux.oracle.com/errata/ELSA-2022-0366.html
https://linux.oracle.com/errata/ELSA-2022-0368.html
https://linux.oracle.com/errata/ELSA-2022-0370.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>