### PR TITLE
Release SonarQube 8.9.7

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -3,7 +3,22 @@ Maintainers: Christophe Levis <christophe.levis@sonarsource.com> (@christophelev
              Tobias Trabelsi <tobias.trabelsi@sonarsource.com> (@tobias-trabelsi-sonarsource),
              Lukasz Jarocki <lukasz.jarocki@sonarsource.com> (@lukasz-jarocki-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 4a9e01cbeeaf454233731c28585891b71baa1540
+GitCommit: 3f19b396006f2a8466854cae90329a55692fa073
+
+Tags: 8.9.7-community, 8.9-community, 8-community, lts, lts-community
+Directory: 8/community
+
+Tags: 8.9.7-developer, 8.9-developer, 8-developer, lts-developer
+Directory: 8/developer
+
+Tags: 8.9.7-enterprise, 8.9-enterprise, 8-enterprise, lts-enterprise
+Directory: 8/enterprise
+
+Tags: 8.9.7-datacenter-app, 8.9-datacenter-app, 8-datacenter-app, lts-datacenter-app
+Directory: 8/datacenter/app
+
+Tags: 8.9.7-datacenter-search, 8.9-datacenter-search, 8-datacenter-search, lts-datacenter-search
+Directory: 8/datacenter/search
 
 Tags: 9.3.0-community, 9.3-community, 9-community, community, latest
 Directory: 9/community


### PR DESCRIPTION
This also brings back the 8.9 LTS tags