### PR TITLE
arangodb 3.8.5.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,5 +7,5 @@ GitCommit: df34e6d0c1bb3a70c3537669d482c329a1a14128
 Directory: alpine/3.7.17
 
 Tags: 3.8, 3.8.5, latest
-GitCommit: 0ea565ef7d2cae496544e4e5e7bf5fe2a6781d99
-Directory: alpine/3.8.5
+GitCommit: c0192510e0c381b8b611c0dd5b6d8413c6ff0693
+Directory: alpine/3.8.5.1


### PR DESCRIPTION
Updated ArangoDB 3.8 to 3.8.5.1 (3.8.5 with Hotfix 1).