### PR TITLE
archlinux: Release 20220206.0.46909

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220130.0.46058
-GitCommit: 2a506eddc83cd0487ce42799b08fc4e584824d9d
-GitFetch: refs/tags/v20220130.0.46058
+Tags: latest, base, base-20220206.0.46909
+GitCommit: f51511d59a0e702e12ffd0f0f732fee37e4c18eb
+GitFetch: refs/tags/v20220206.0.46909
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220130.0.46058
-GitCommit: 2a506eddc83cd0487ce42799b08fc4e584824d9d
-GitFetch: refs/tags/v20220130.0.46058
+Tags: base-devel, base-devel-20220206.0.46909
+GitCommit: f51511d59a0e702e12ffd0f0f732fee37e4c18eb
+GitFetch: refs/tags/v20220206.0.46909
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks