### PR TITLE
Ubuntu 21.04 Hirsute EOL

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -3,7 +3,7 @@
 
 Maintainers: Tianon Gravi <tianon@debian.org> (@tianon), Michael Hudson-Doyle <michael.hudson@ubuntu.com> (@mwhudson)
 GitRepo: https://github.com/tianon/docker-brew-ubuntu-core.git
-GitCommit: 453ffa89bc98474f954e7f8916deb7e565a83fd7
+GitCommit: a11c63cee4049ffbe8acb8ba43c2c58fceb60057
 # https://github.com/tianon/docker-brew-ubuntu-core/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 7a6c081cbf5fd53c66c954766280a5d0cf1a6a5a
@@ -35,11 +35,6 @@ Directory: bionic
 Tags: 20.04, focal-20220113, focal, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: focal
-
-# 20220113 (hirsute)
-Tags: 21.04, hirsute-20220113, hirsute
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-Directory: hirsute
 
 # 20220128 (impish)
 Tags: 21.10, impish-20220128, impish, rolling


### PR DESCRIPTION
As announced [1], Ubuntu Hirsute has reached the end of it's life.

[1]
https://lists.ubuntu.com/archives/ubuntu-security-announce/2022-January/006363.html