### PR TITLE
Registry v2.8.0 release

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -2,15 +2,12 @@ Maintainers: Milos Gajdos (@milosgajdos),
              Sebastiaan van Stijn (@thajeztah)
 GitRepo: https://github.com/docker/distribution-library-image.git
 
+Tags: 2.8.0, 2.8, 2, latest
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+GitFetch: refs/heads/master
+GitCommit: 5fd2614beccba35242694b13f8a37653c05ea852
+
 Tags: 2.8.0-beta.1
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 GitFetch: refs/heads/master
 GitCommit: c70c2acb365928f10bfc7706cc0f3f4d16f7427b
-
-Tags: 2.7.1, 2.7, 2, latest
-Architectures: amd64, arm64v8, arm32v6
-GitFetch: refs/heads/release/2.7
-GitCommit: ab00e8dae12d4515ed259015eab771ec92e92dd4
-amd64-Directory: amd64
-arm32v6-Directory: arm
-arm64v8-Directory: arm64

--- a/library/registry
+++ b/library/registry
@@ -6,8 +6,3 @@ Tags: 2.8.0, 2.8, 2, latest
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 GitFetch: refs/heads/master
 GitCommit: 5fd2614beccba35242694b13f8a37653c05ea852
-
-Tags: 2.8.0-beta.1
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-GitFetch: refs/heads/master
-GitCommit: c70c2acb365928f10bfc7706cc0f3f4d16f7427b


### PR DESCRIPTION
### Release notes
https://github.com/distribution/distribution/releases/tag/v2.8.0

### docker-library docs
https://github.com/docker-library/docs/pull/2113

Signed-off-by: Milos Gajdos <milosthegajdos@gmail.com>