### PR TITLE
Add Brandon Pfeifer to Kapacitor maintainers

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,7 +1,6 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              j. Emrys Landivar <landivar@gmail.com> (@docmerlin),
              Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife)
-
 GitRepo: git://github.com/influxdata/influxdata-docker
 GitCommit: 4a3d6bea3b5bff4fb782eda1b5a6db3e6306e75c
 
@@ -18,4 +17,3 @@ Directory: kapacitor/1.6
 
 Tags: 1.6-alpine, 1.6.3-alpine, alpine
 Directory: kapacitor/1.6/alpine
-

--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,5 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
-             j. Emrys Landivar <landivar@gmail.com> (@docmerlin)
+             j. Emrys Landivar <landivar@gmail.com> (@docmerlin),
+             Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife)
+
 GitRepo: git://github.com/influxdata/influxdata-docker
 GitCommit: 4a3d6bea3b5bff4fb782eda1b5a6db3e6306e75c
 


### PR DESCRIPTION
Brandon Pfeifer <[bpfeifer@influxdata.com](mailto:bpfeifer@influxdata.com)> (@bnpfeife) to list of kapacitor maintainers