### PR TITLE
Update Jetty versions to 9.4.45, 10.0.8 and 11.0.8

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,115 +4,115 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.7-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
+Tags: 11.0.8-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jre11-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 11.0.7-jre11, 11.0-jre11, 11-jre11
+Tags: 11.0.8-jre11, 11.0-jre11, 11-jre11
 Architectures: amd64, arm64v8
 Directory: 11.0-jre11
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 11.0.7-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
+Tags: 11.0.8-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk17-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 11.0.7, 11.0, 11, 11.0.7-jdk17, 11.0-jdk17, 11-jdk17
+Tags: 11.0.8, 11.0, 11, 11.0.8-jdk17, 11.0-jdk17, 11-jdk17
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk17
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 11.0.7-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
+Tags: 11.0.8-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk11-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 11.0.7-jdk11, 11.0-jdk11, 11-jdk11
+Tags: 11.0.8-jdk11, 11.0-jdk11, 11-jdk11
 Architectures: amd64, arm64v8
 Directory: 11.0-jdk11
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 10.0.7-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
+Tags: 10.0.8-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jre11-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 10.0.7-jre11, 10.0-jre11, 10-jre11
+Tags: 10.0.8-jre11, 10.0-jre11, 10-jre11
 Architectures: amd64, arm64v8
 Directory: 10.0-jre11
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 10.0.7-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
+Tags: 10.0.8-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk17-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 10.0.7, 10.0, 10, 10.0.7-jdk17, 10.0-jdk17, 10-jdk17
+Tags: 10.0.8, 10.0, 10, 10.0.8-jdk17, 10.0-jdk17, 10-jdk17
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk17
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 10.0.7-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
+Tags: 10.0.8-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk11-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 10.0.7-jdk11, 10.0-jdk11, 10-jdk11
+Tags: 10.0.8-jdk11, 10.0-jdk11, 10-jdk11
 Architectures: amd64, arm64v8
 Directory: 10.0-jdk11
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 9.4.45-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jre11, 9.4-jre11, 9-jre11
+Tags: 9.4.45-jre11, 9.4-jre11, 9-jre11
 Architectures: amd64, arm64v8
 Directory: 9.4-jre11
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 9.4.45-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jre8-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jre8, 9.4-jre8, 9-jre8
+Tags: 9.4.45-jre8, 9.4-jre8, 9-jre8
 Architectures: amd64, arm64v8
 Directory: 9.4-jre8
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim
+Tags: 9.4.45-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk17-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44, 9.4, 9, 9.4.44-jdk17, 9.4-jdk17, 9-jdk17, latest, jdk17
+Tags: 9.4.45, 9.4, 9, 9.4.45-jdk17, 9.4-jdk17, 9-jdk17, latest, jdk17
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk17
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 9.4.45-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk11-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 9.4.45-jdk11, 9.4-jdk11, 9-jdk11
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk11
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 9.4.45-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk8-slim
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
-Tags: 9.4.44-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 9.4.45-jdk8, 9.4-jdk8, 9-jdk8
 Architectures: amd64, arm64v8
 Directory: 9.4-jdk8
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+GitCommit: 2c5947b751af36b156002440beff2a86721844e0
 
 Tags: 9.3.30-jre8, 9.3-jre8, 9.3
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update Jetty versions to use
- 9.4.45.v20220203
- 10.0.8
- 11.0.8