### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 19-ea-7-jdk-oraclelinux8, 19-ea-7-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-7-jdk-oracle, 19-ea-7-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-ea-7-jdk, 19-ea-7, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-8-jdk-oraclelinux8, 19-ea-8-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-8-jdk-oracle, 19-ea-8-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
+SharedTags: 19-ea-8-jdk, 19-ea-8, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: amd64, arm64v8
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/oraclelinux8
 
-Tags: 19-ea-7-jdk-oraclelinux7, 19-ea-7-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
+Tags: 19-ea-8-jdk-oraclelinux7, 19-ea-8-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/oraclelinux7
 
-Tags: 19-ea-7-jdk-bullseye, 19-ea-7-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
+Tags: 19-ea-8-jdk-bullseye, 19-ea-8-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
 Architectures: amd64, arm64v8
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/bullseye
 
-Tags: 19-ea-7-jdk-slim-bullseye, 19-ea-7-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-7-jdk-slim, 19-ea-7-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
+Tags: 19-ea-8-jdk-slim-bullseye, 19-ea-8-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-8-jdk-slim, 19-ea-8-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
 Architectures: amd64, arm64v8
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/slim-bullseye
 
-Tags: 19-ea-7-jdk-buster, 19-ea-7-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
+Tags: 19-ea-8-jdk-buster, 19-ea-8-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
 Architectures: amd64, arm64v8
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/buster
 
-Tags: 19-ea-7-jdk-slim-buster, 19-ea-7-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
+Tags: 19-ea-8-jdk-slim-buster, 19-ea-8-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/slim-buster
 
 Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
@@ -45,56 +45,56 @@ Architectures: amd64
 GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
 Directory: 19/jdk/alpine3.14
 
-Tags: 19-ea-7-jdk-windowsservercore-ltsc2022, 19-ea-7-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-ea-7-jdk-windowsservercore, 19-ea-7-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-7-jdk, 19-ea-7, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-8-jdk-windowsservercore-ltsc2022, 19-ea-8-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19-ea-8-jdk-windowsservercore, 19-ea-8-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-8-jdk, 19-ea-8, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19-ea-7-jdk-windowsservercore-1809, 19-ea-7-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-ea-7-jdk-windowsservercore, 19-ea-7-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-7-jdk, 19-ea-7, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-8-jdk-windowsservercore-1809, 19-ea-8-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19-ea-8-jdk-windowsservercore, 19-ea-8-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-8-jdk, 19-ea-8, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-7-jdk-nanoserver-1809, 19-ea-7-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-ea-7-jdk-nanoserver, 19-ea-7-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19-ea-8-jdk-nanoserver-1809, 19-ea-8-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19-ea-8-jdk-nanoserver, 19-ea-8-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
+GitCommit: ffcc4b9190be32ed7c4c92f6aa8fe2463da291d6
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18-ea-33-jdk-oraclelinux8, 18-ea-33-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-33-jdk-oracle, 18-ea-33-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-33-jdk, 18-ea-33, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-34-jdk-oraclelinux8, 18-ea-34-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-34-jdk-oracle, 18-ea-34-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18-ea-34-jdk, 18-ea-34, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-33-jdk-oraclelinux7, 18-ea-33-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-ea-34-jdk-oraclelinux7, 18-ea-34-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-33-jdk-bullseye, 18-ea-33-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
+Tags: 18-ea-34-jdk-bullseye, 18-ea-34-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/bullseye
 
-Tags: 18-ea-33-jdk-slim-bullseye, 18-ea-33-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-33-jdk-slim, 18-ea-33-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-ea-34-jdk-slim-bullseye, 18-ea-34-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-34-jdk-slim, 18-ea-34-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18-ea-33-jdk-buster, 18-ea-33-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-ea-34-jdk-buster, 18-ea-34-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/buster
 
-Tags: 18-ea-33-jdk-slim-buster, 18-ea-33-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
+Tags: 18-ea-34-jdk-slim-buster, 18-ea-34-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/slim-buster
 
 Tags: 18-ea-11-jdk-alpine3.15, 18-ea-11-alpine3.15, 18-ea-jdk-alpine3.15, 18-ea-alpine3.15, 18-jdk-alpine3.15, 18-alpine3.15, 18-ea-11-jdk-alpine, 18-ea-11-alpine, 18-ea-jdk-alpine, 18-ea-alpine, 18-jdk-alpine, 18-alpine
@@ -107,24 +107,24 @@ Architectures: amd64
 GitCommit: 0cea342dc0644ce3c104a7b0907719e6c6357fcf
 Directory: 18/jdk/alpine3.14
 
-Tags: 18-ea-33-jdk-windowsservercore-ltsc2022, 18-ea-33-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
-SharedTags: 18-ea-33-jdk-windowsservercore, 18-ea-33-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-33-jdk, 18-ea-33, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-34-jdk-windowsservercore-ltsc2022, 18-ea-34-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
+SharedTags: 18-ea-34-jdk-windowsservercore, 18-ea-34-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-34-jdk, 18-ea-34, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18-ea-33-jdk-windowsservercore-1809, 18-ea-33-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-33-jdk-windowsservercore, 18-ea-33-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-33-jdk, 18-ea-33, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-ea-34-jdk-windowsservercore-1809, 18-ea-34-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-ea-34-jdk-windowsservercore, 18-ea-34-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-34-jdk, 18-ea-34, 18-ea-jdk, 18-ea, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-33-jdk-nanoserver-1809, 18-ea-33-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-33-jdk-nanoserver, 18-ea-33-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-ea-34-jdk-nanoserver-1809, 18-ea-34-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-ea-34-jdk-nanoserver, 18-ea-34-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 00c03a0fb571affa3796781b990e4d08c2a4122d
+GitCommit: 678b0d76f3fc95d0e1c48dfe93dc82afaa8c10e1
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/ffcc4b9: Update 19 to 19-ea+8
- https://github.com/docker-library/openjdk/commit/678b0d7: Update 18 to 18-ea+34