### PR TITLE
Update Amazon Linux images - Adds 2022.0.20220202.0

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,7 +11,7 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Preston Carpenter (@timidger),
              Richard Kelly (@rpkelly)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: bec380d80a169eef38b712e6a8fb3b0d7841bbeb
+GitCommit: fbcea5f101f947a5a732148863929e908230f3aa
 
 Tags: 2.0.20220121.0, 2, latest
 Architectures: amd64, arm64v8
@@ -36,3 +36,17 @@ Tags: 2018.03.0.20220119.1-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 55c91a9c5662a01d4117d3171104f66566b4c39e
+
+Tags: 2022.0.20220202.0, 2022
+Architectures: amd64, arm64v8
+amd64-GitFetch: refs/heads/al2022
+amd64-GitCommit: 55c055505a7ea0a83e47e66d293ba3631329ea05
+arm64v8-GitFetch: refs/heads/al2022-arm64
+arm64v8-GitCommit: 39ebc491f771c17a9a9d49cb605977d351449cc7
+
+Tags: 2022.0.20220202.0-with-sources, 2022-with-sources
+Architectures: amd64, arm64v8
+amd64-GitFetch: refs/heads/al2022-with-sources
+amd64-GitCommit: 644870f2e04d8eb9c7e4e0ca3d7e99a111c98105
+arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
+arm64v8-GitCommit: 372ba653bf7ddb8f33751a0e13000969a53afc70


### PR DESCRIPTION
Hello,

This change adds the new Amazon Linux 2022 container images.
There are currently in tech-preview phase.

The releasever is 2022.0.20220202.0.

Note that `latest` still points to Amazon Linux 2.