### PR TITLE
Drop end of life CentOS versions

### DIFF
--- a/library/centos
+++ b/library/centos
@@ -2,15 +2,6 @@ Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
 GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
 Directory: docker
 
-Tags: latest, centos8, 8, centos8.4.2105, 8.4.2105
-GitFetch: refs/heads/CentOS-8-x86_64
-GitCommit: 607af70702bacc6f46fab2ded055ab23d9113831
-arm64v8-GitFetch: refs/heads/CentOS-8-aarch64
-arm64v8-GitCommit: e79ccf67325a31bf0bb79a8a0e82d3d8a4de2da8
-ppc64le-GitFetch: refs/heads/CentOS-8-ppc64le
-ppc64le-GitCommit: 76f876b31bb82108a1acf2cee1032c1d2ebc3bd9
-Architectures: amd64, arm64v8, ppc64le
-
 Tags: centos7, 7, centos7.9.2009, 7.9.2009
 GitFetch: refs/heads/CentOS-7-x86_64
 GitCommit: b2d195220e1c5b181427c3172829c23ab9cd27eb
@@ -23,14 +14,3 @@ ppc64le-GitCommit: a8e4f3da8300d18da4c0e5256d64763965e66810
 i386-GitFetch: refs/heads/CentOS-7-i386
 i386-GitCommit: 206003c215684a869a686cf9ea5f9697e577c546
 Architectures: amd64, arm64v8, arm32v7, ppc64le, i386
-
-Tags: centos6, 6
-GitFetch: refs/heads/CentOS-6
-GitCommit: 23b05f6a35520ebf338e4df918e4952830da068b
-i386-GitFetch: refs/heads/CentOS-6i386
-i386-GitCommit: 53cd22704a89c6ed59d43e2e70e63316026af4f7
-Architectures: amd64, i386
-
-Tags: centos6.10, 6.10
-GitFetch: refs/heads/CentOS-6.10
-GitCommit: da050e2fc6c28d8d72d8bf78c49537247b5ddf76


### PR DESCRIPTION
CC `centos` image maintainer: @bstinsonmhk Are there going to be `stream8` or `stream9` images added?

Removing it here will remove it from the "Supported" section on the Hub readme, but the tag will still be available to users who want it.  (See https://github.com/docker-library/official-images#library-definition-files for more detail on this.)

This drops CentOS 6 and 8 images since they are both End of life. From the [CentOS](https://en.wikipedia.org/wiki/CentOS#End-of-support_schedule) page on Wikipedia:
- `centos:6` 2020-11-30
- `centos:8` 2021-12-31

This is a follow up to https://github.com/docker-library/official-images/pull/11771#issuecomment-1030293755 and https://github.com/docker-library/official-images/issues/11679.