### PR TITLE
Add devel tags to AL 2022 images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -37,14 +37,14 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 55c91a9c5662a01d4117d3171104f66566b4c39e
 
-Tags: 2022.0.20220202.0, 2022
+Tags: 2022.0.20220202.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
 amd64-GitCommit: 55c055505a7ea0a83e47e66d293ba3631329ea05
 arm64v8-GitFetch: refs/heads/al2022-arm64
 arm64v8-GitCommit: 39ebc491f771c17a9a9d49cb605977d351449cc7
 
-Tags: 2022.0.20220202.0-with-sources, 2022-with-sources
+Tags: 2022.0.20220202.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
 amd64-GitCommit: 644870f2e04d8eb9c7e4e0ca3d7e99a111c98105


### PR DESCRIPTION
Adds devel tags to Amazon Linux 2022 container images.
We need this as currently AL 2022 is in Tech Preview phase.