### PR TITLE
arangodb 3.9.0

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -6,6 +6,10 @@ Tags: 3.7, 3.7.17
 GitCommit: df34e6d0c1bb3a70c3537669d482c329a1a14128
 Directory: alpine/3.7.17
 
-Tags: 3.8, 3.8.5, latest
+Tags: 3.8, 3.8.5
 GitCommit: c0192510e0c381b8b611c0dd5b6d8413c6ff0693
 Directory: alpine/3.8.5.1
+
+Tags: 3.9, 3.9.0, latest
+GitCommit: de7e9211691614f105c7809cb13405ef5afa0be8
+Directory: alpine/3.9.0


### PR DESCRIPTION
Added ArangoDB 3.8 (3.9.0).