### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev0, 2.6-dev, 2.6-dev0-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev1, 2.6-dev, 2.6-dev1-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 50b6692229b0d82c35f925548c8cd24111319d18
+GitCommit: 7dc5e5a7ecc00a0cb13cb950e345f1b1850be825
 Directory: 2.6-rc
 
-Tags: 2.6-dev0-alpine, 2.6-dev-alpine, 2.6-dev0-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev1-alpine, 2.6-dev-alpine, 2.6-dev1-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 633f24fd7cddfe751c62c9490925721e087cd172
+GitCommit: 7dc5e5a7ecc00a0cb13cb950e345f1b1850be825
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.1, 2.5, latest, 2.5.1-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7dc5e5a: Update 2.6-rc to 2.6-dev1