### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -109,21 +109,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal
 
-Tags: hirsute-curl, 21.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/hirsute/curl
-
-Tags: hirsute-scm, 21.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/hirsute/scm
-
-Tags: hirsute, 21.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/hirsute
-
 Tags: impish-curl, 21.10-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: fae040f3db68991f178f0a9631a03ca9837f5647


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/a017681: Remove hirsute (EOL)