### PR TITLE
[oraclelinux] Update 8 and 8-slim for ELSA-2022-0366

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d2cddc02be12d3574ddf2553d94d62ef2d906db1
+amd64-GitCommit: d0a836cc8077d9400b1c8b1d3f20968ae833446b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a081765cbdaf3306c7f1ccc45dd525cea67a96b5
+arm64v8-GitCommit: d61ef5110090987a7a55b55e427d405bbb879203
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-3872, CVE-2021-3984, CVE-2021-4019, CVE-2021-4192 and CVE-2021-4193

See https://linux.oracle.com/errata/ELSA-2022-0366.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>