### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.35.0, 4.35, 4, latest
+Tags: 4.36.0, 4.36, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c9c35d5106975f908abff980181a27618c0b747b
+GitCommit: 1b0cf719d18935da0f1fbcdd8b1f738967015ce8
 Directory: 4/debian
 
-Tags: 4.35.0-alpine, 4.35-alpine, 4-alpine, alpine
+Tags: 4.36.0-alpine, 4.36-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: c9c35d5106975f908abff980181a27618c0b747b
+GitCommit: 1b0cf719d18935da0f1fbcdd8b1f738967015ce8
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1b0cf71: Update to 4.36.0, ghost-cli 1.18.1