### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,74 +4,74 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 14.1, 14, latest, 14.1-bullseye, 14-bullseye, bullseye
+Tags: 14.2, 14, latest, 14.2-bullseye, 14-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 14/bullseye
 
-Tags: 14.1-alpine, 14-alpine, alpine, 14.1-alpine3.15, 14-alpine3.15, alpine3.15
+Tags: 14.2-alpine, 14-alpine, alpine, 14.2-alpine3.15, 14-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 933d00a846b272b8c24e35d139927eb744a9829b
 Directory: 14/alpine
 
-Tags: 13.5, 13, 13.5-bullseye, 13-bullseye
+Tags: 13.6, 13, 13.6-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 13/bullseye
 
-Tags: 13.5-alpine, 13-alpine, 13.5-alpine3.15, 13-alpine3.15
+Tags: 13.6-alpine, 13-alpine, 13.6-alpine3.15, 13-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: cbab7c1e5d05c923524818ab6585ff1bc341c2de
 Directory: 13/alpine
 
-Tags: 12.9, 12, 12.9-bullseye, 12-bullseye
+Tags: 12.10, 12, 12.10-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 12/bullseye
 
-Tags: 12.9-alpine, 12-alpine, 12.9-alpine3.15, 12-alpine3.15
+Tags: 12.10-alpine, 12-alpine, 12.10-alpine3.15, 12-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: a26f88de6c8e463512a0687031b807815ac329a5
 Directory: 12/alpine
 
-Tags: 11.14-bullseye, 11-bullseye
+Tags: 11.15-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 11/bullseye
 
-Tags: 11.14, 11, 11.14-stretch, 11-stretch
+Tags: 11.15, 11, 11.15-stretch, 11-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 11/stretch
 
-Tags: 11.14-alpine, 11-alpine, 11.14-alpine3.15, 11-alpine3.15
+Tags: 11.15-alpine, 11-alpine, 11.15-alpine3.15, 11-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: dae067313a9e0acc1c06e40247ded85d471eb9b1
 Directory: 11/alpine
 
-Tags: 10.19-bullseye, 10-bullseye
+Tags: 10.20-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 10/bullseye
 
-Tags: 10.19, 10, 10.19-stretch, 10-stretch
+Tags: 10.20, 10, 10.20-stretch, 10-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
 Directory: 10/stretch
 
-Tags: 10.19-alpine, 10-alpine, 10.19-alpine3.15, 10-alpine3.15
+Tags: 10.20-alpine, 10-alpine, 10.20-alpine3.15, 10-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: dac00caeed2c2e91ad50438a9718ecc40d423636
 Directory: 10/alpine
 
 Tags: 9.6.24-bullseye, 9.6-bullseye, 9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 0fa62a8a9ad6fddca3e81dea0fa22eb56b105c95
 Directory: 9.6/bullseye
 
 Tags: 9.6.24, 9.6, 9, 9.6.24-stretch, 9.6-stretch, 9-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
+GitCommit: 0fa62a8a9ad6fddca3e81dea0fa22eb56b105c95
 Directory: 9.6/stretch
 
 Tags: 9.6.24-alpine, 9.6-alpine, 9-alpine, 9.6.24-alpine3.15, 9.6-alpine3.15, 9-alpine3.15


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/7f810c0: Merge pull request https://github.com/docker-library/postgres/pull/921 from infosiftr/signed-by
- https://github.com/docker-library/postgres/commit/dac00ca: Update 10 to 10.20, bullseye 10.20-1.pgdg110+1, stretch 10.20-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/933d00a: Update 14 to 14.2, bullseye 14.2-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/cbab7c1: Update 13 to 13.6, bullseye 13.6-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/a26f88d: Update 12 to 12.10, bullseye 12.10-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/dae0673: Update 11 to 11.15, bullseye 11.15-1.pgdg110+1, stretch 11.15-1.pgdg90+1
- https://github.com/docker-library/postgres/commit/0fa62a8: Narrow postgres apt key package scope