### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0.1, 4.0, 4, latest
+Tags: 4.0.2, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: f58183960ff693e4ec0c28f9f85453d69f646243
+GitCommit: d9ed9b41dd291528f942c5c4a7a75df0c37a6e8c
 Directory: 4.0
 
-Tags: 3.11.11, 3.11, 3
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9e67d08a5990ba44b8464d7773f1bbbfaae834e4
+Tags: 3.11.12, 3.11, 3
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 70ecd6c8d9ef280b967db295e1ee3463b7a08ed2
 Directory: 3.11
 
-Tags: 3.0.25, 3.0
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9e67d08a5990ba44b8464d7773f1bbbfaae834e4
+Tags: 3.0.26, 3.0
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 4514513f79f99f5c57184b57a42171ef3e5f7984
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/d9ed9b4: Update 4.0 to 4.0.2
- https://github.com/docker-library/cassandra/commit/70ecd6c: Update 3.11 to 3.11.12
- https://github.com/docker-library/cassandra/commit/4514513: Update 3.0 to 3.0.26