### PR TITLE
Update Clear Linux OS to 35860

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 6991f7f2dbba5d3d9fec9636fb44b2ac6708db4d
-GitFetch: refs/heads/base-35800
+GitCommit: 873f3821a4263dfe1c67d166cc41791ed2447565
+GitFetch: refs/heads/base-35860


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35860

@bryteise @djklimes @bryteise