### PR TITLE
mariadb: feb2022 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,35 +1,40 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/c75ff03efb6527d6c6ce06839867a06b6fa9387d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/2937a9bd36ac208e8322c8564f069b10261749f8/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 10.7.1-focal, 10.7-focal, 10.7.1, 10.7
+Tags: 10.8.2-focal, 10.8-focal, 10.8.2, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d4efdb8951f606fe2837e9cc4db37225a5b7a621
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+Directory: 10.8
+
+Tags: 10.7.3-focal, 10.7-focal, 10-focal, focal, 10.7.3, 10.7, 10, latest
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
 Directory: 10.7
 
-Tags: 10.6.5-focal, 10.6-focal, 10-focal, focal, 10.6.5, 10.6, 10, latest
+Tags: 10.6.7-focal, 10.6-focal, 10.6.7, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d711333929498046f354e14430cbe65e4767fc63
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
 Directory: 10.6
 
-Tags: 10.5.13-focal, 10.5-focal, 10.5.13, 10.5
+Tags: 10.5.15-focal, 10.5-focal, 10.5.15, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8414e4ff9ebff49f28148a860d85131e11c049c6
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
 Directory: 10.5
 
-Tags: 10.4.22-focal, 10.4-focal, 10.4.22, 10.4
+Tags: 10.4.24-focal, 10.4-focal, 10.4.24, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 435a47c85a80be384524051f23cc3e8f132c31ff
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
 Directory: 10.4
 
-Tags: 10.3.32-focal, 10.3-focal, 10.3.32, 10.3
+Tags: 10.3.34-focal, 10.3-focal, 10.3.34, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a98e19f16db72ff1f6148cd797a0cb53dacacef3
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
 Directory: 10.3
 
-Tags: 10.2.41-bionic, 10.2-bionic, 10.2.41, 10.2
+Tags: 10.2.43-bionic, 10.2-bionic, 10.2.43, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9c804d5875d9faa880133b7720fdf7ccf35d6393
+GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
 Directory: 10.2


### PR DESCRIPTION
10.2.43, 10.3.34, 10.4.24, 10.5.15, 10.6.7, 10.7.3, 10.8.2.

Yes, a version is missing, we discovered a fault part way though
releasing.

10.7 is now GA and 10.8 is new.

Notable changes include a mariadb-upgrade and a healthcheck script (but no HEALTHCHECK directive via policy). I made the rational that its better to provide something right that people can use than leave it to them invent their own.

A set of document updates coming soon