### PR TITLE
Bump Traefik to v2.6.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.6.0-windowsservercore-1809, 2.6.0-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
+Tags: v2.6.1-windowsservercore-1809, 2.6.1-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 333cb722775df31365a41baf164b00a032083a57
+GitCommit: 19b29d4858c12d74647d59214e0a9417646343ca
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.0, 2.6.0, v2.6, 2.6, rocamadour, latest
+Tags: v2.6.1, 2.6.1, v2.6, 2.6, rocamadour, latest
 Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 333cb722775df31365a41baf164b00a032083a57
+GitCommit: 19b29d4858c12d74647d59214e0a9417646343ca
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.6.1](https://github.com/traefik/traefik/releases/tag/v2.6.1).

/cc @ldez @rtribotte @ddtmachado

Cheers
