### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/6898578de00125ce6e9efd306c92b6ffd29aaa4e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/36abfddd6f7235770d00f8546b199936b0ca77aa/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,75 +6,60 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 14.2, 14, latest, 14.2-bullseye, 14-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 14/bullseye
 
 Tags: 14.2-alpine, 14-alpine, alpine, 14.2-alpine3.15, 14-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 933d00a846b272b8c24e35d139927eb744a9829b
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 14/alpine
 
 Tags: 13.6, 13, 13.6-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 13/bullseye
 
 Tags: 13.6-alpine, 13-alpine, 13.6-alpine3.15, 13-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbab7c1e5d05c923524818ab6585ff1bc341c2de
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 13/alpine
 
 Tags: 12.10, 12, 12.10-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 12/bullseye
 
 Tags: 12.10-alpine, 12-alpine, 12.10-alpine3.15, 12-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a26f88de6c8e463512a0687031b807815ac329a5
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 12/alpine
 
 Tags: 11.15-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 11/bullseye
 
 Tags: 11.15, 11, 11.15-stretch, 11-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 11/stretch
 
 Tags: 11.15-alpine, 11-alpine, 11.15-alpine3.15, 11-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dae067313a9e0acc1c06e40247ded85d471eb9b1
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 11/alpine
 
 Tags: 10.20-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 10/bullseye
 
 Tags: 10.20, 10, 10.20-stretch, 10-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 7f810c00e184b2a2ebd070040e33348aba517531
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 10/stretch
 
 Tags: 10.20-alpine, 10-alpine, 10.20-alpine3.15, 10-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dac00caeed2c2e91ad50438a9718ecc40d423636
+GitCommit: 36abfddd6f7235770d00f8546b199936b0ca77aa
 Directory: 10/alpine
-
-Tags: 9.6.24-bullseye, 9.6-bullseye, 9-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0fa62a8a9ad6fddca3e81dea0fa22eb56b105c95
-Directory: 9.6/bullseye
-
-Tags: 9.6.24, 9.6, 9, 9.6.24-stretch, 9.6-stretch, 9-stretch
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 0fa62a8a9ad6fddca3e81dea0fa22eb56b105c95
-Directory: 9.6/stretch
-
-Tags: 9.6.24-alpine, 9.6-alpine, 9-alpine, 9.6.24-alpine3.15, 9.6-alpine3.15, 9-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a83005b407ee6d810413500d8a041c957fb10cf0
-Directory: 9.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/a1ea032: Merge pull request https://github.com/docker-library/postgres/pull/932 from infosiftr/eol-9.6
- https://github.com/docker-library/postgres/commit/36abfdd: Remove 9.6 (EOL)
- https://github.com/docker-library/postgres/commit/bc22a9f: Merge pull request https://github.com/docker-library/postgres/pull/931 from infosiftr/fix-deb-build
- https://github.com/docker-library/postgres/commit/72e336d: Also add "clang-6.0" explicitly on stretch builds of 11+
- https://github.com/docker-library/postgres/commit/6ef8010: Fix deb-build with newer packages that Build-Depends: postgresql-common