### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,62 +4,77 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.0.6-php7.4-apache, 4.0-php7.4-apache, 4-php7.4-apache, php7.4-apache
+Tags: 4.1.0-php7.4-apache, 4.1-php7.4-apache, 4-php7.4-apache, php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
-Directory: 4.0/php7.4/apache
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php7.4/apache
 
-Tags: 4.0.6-php7.4-fpm-alpine, 4.0-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 4.1.0-php7.4-fpm-alpine, 4.1-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
-Directory: 4.0/php7.4/fpm-alpine
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php7.4/fpm-alpine
 
-Tags: 4.0.6-php7.4-fpm, 4.0-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
+Tags: 4.1.0-php7.4-fpm, 4.1-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
-Directory: 4.0/php7.4/fpm
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php7.4/fpm
 
-Tags: 4.0.6, 4.0, 4, latest, 4.0.6-apache, 4.0-apache, 4-apache, apache, 4.0.6-php8.0, 4.0-php8.0, 4-php8.0, php8.0, 4.0.6-php8.0-apache, 4.0-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.1.0, 4.1, 4, latest, 4.1.0-apache, 4.1-apache, 4-apache, apache, 4.1.0-php8.0, 4.1-php8.0, 4-php8.0, php8.0, 4.1.0-php8.0-apache, 4.1-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
-Directory: 4.0/php8.0/apache
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php8.0/apache
 
-Tags: 4.0.6-php8.0-fpm-alpine, 4.0-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.1.0-php8.0-fpm-alpine, 4.1-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
-Directory: 4.0/php8.0/fpm-alpine
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php8.0/fpm-alpine
 
-Tags: 4.0.6-php8.0-fpm, 4.0-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.1.0-php8.0-fpm, 4.1-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
-Directory: 4.0/php8.0/fpm
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php8.0/fpm
 
-Tags: 3.10.5-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache
+Tags: 4.1.0-php8.1-apache, 4.1-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php8.1/apache
+
+Tags: 4.1.0-php8.1-fpm-alpine, 4.1-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php8.1/fpm-alpine
+
+Tags: 4.1.0-php8.1-fpm, 4.1-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+Directory: 4.1/php8.1/fpm
+
+Tags: 3.10.6-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
 Directory: 3.10/php7.3/apache
 
-Tags: 3.10.5-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine
+Tags: 3.10.6-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
+GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
 Directory: 3.10/php7.3/fpm-alpine
 
-Tags: 3.10.5-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm
+Tags: 3.10.6-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
+GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
 Directory: 3.10/php7.3/fpm
 
-Tags: 3.10.5, 3.10, 3, 3.10.5-apache, 3.10-apache, 3-apache, 3.10.5-php7.4, 3.10-php7.4, 3-php7.4, 3.10.5-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
+Tags: 3.10.6, 3.10, 3, 3.10.6-apache, 3.10-apache, 3-apache, 3.10.6-php7.4, 3.10-php7.4, 3-php7.4, 3.10.6-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
+GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
 Directory: 3.10/php7.4/apache
 
-Tags: 3.10.5-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
+Tags: 3.10.6-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
+GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
 Directory: 3.10/php7.4/fpm-alpine
 
-Tags: 3.10.5-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
+Tags: 3.10.6-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66e04002a2e115cbf6f05704c8d8a96f66f73ad4
+GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
 Directory: 3.10/php7.4/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@d758ff2: Merge pull request from joomla-docker/staging
- joomla-docker/docker-joomla@94faec5: Removes libmcrypt-dev from all images.
- joomla-docker/docker-joomla@15b8346: Removes mcrypt from all Joomla 4.1 images.
- joomla-docker/docker-joomla@f597ccb: Removes Mcrypt from Dockerfile.template when not Joomla 3.10.
- joomla-docker/docker-joomla@003213c: Adds PHP v8.1 to Joomla v4.1.0. Updated Redis to v5.3.6. Removed Mcrypt from Joomla v4.1 containers.
- joomla-docker/docker-joomla@0e251ad: Updated the Dockerfile.template to 4.1
- joomla-docker/docker-joomla@335a8cb: Update images of Joomla! 3.10.5 to 3.10.6
- joomla-docker/docker-joomla@4137d12: Update version of Joomla! 3.10.5 to 3.10.6
- joomla-docker/docker-joomla@2b10924: Update images of Joomla! 4.0.6 to 4.1.0
- joomla-docker/docker-joomla@c062960: Update version of Joomla! 4.0.6 to 4.1.0