### PR TITLE
[Friendica] Fixing redis session handling and run_as

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -6,45 +6,45 @@ GitFetch: refs/heads/stable
 
 Tags: 2021.09-apache, 2021.09
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2021.09/apache
 
 Tags: 2021.09-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2021.09/fpm
 
 Tags: 2021.09-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2021.09/fpm-alpine
 
 Tags: 2022.02-apache, apache, stable-apache, 2022.02, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2022.02/apache
 
 Tags: 2022.02-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2022.02/fpm
 
 Tags: 2022.02-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2022.02/fpm-alpine
 
 Tags: 2022.05-dev-apache, dev-apache, 2022.05-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2022.05-dev/apache
 
 Tags: 2022.05-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2022.05-dev/fpm
 
 Tags: 2022.05-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
+GitCommit: c9965262bb3dfae91189bad8f9cfb6f4fe805800
 Directory: 2022.05-dev/fpm-alpine

--- a/library/friendica
+++ b/library/friendica
@@ -6,45 +6,45 @@ GitFetch: refs/heads/stable
 
 Tags: 2021.09-apache, 2021.09
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2021.09/apache
 
 Tags: 2021.09-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2021.09/fpm
 
 Tags: 2021.09-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2021.09/fpm-alpine
 
 Tags: 2022.02-apache, apache, stable-apache, 2022.02, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2022.02/apache
 
 Tags: 2022.02-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2022.02/fpm
 
 Tags: 2022.02-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2022.02/fpm-alpine
 
 Tags: 2022.05-dev-apache, dev-apache, 2022.05-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2022.05-dev/apache
 
 Tags: 2022.05-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2022.05-dev/fpm
 
 Tags: 2022.05-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6edd78174b1a6de7610146c092c7a316d435f527
+GitCommit: 39ef8ac58708f49f47ca9c800f1262cfcdd2e754
 Directory: 2022.05-dev/fpm-alpine


### PR DESCRIPTION
I accidentally introduced two major bugs :(

- Partly reverted the behavior for `run_as` and explicit `export` the two missing environment variables
- Using `expr "${REDIS_HOST}" : "/" 1>/dev/null;` to be `/bin/sh` compatible

btw I copied the Redis behavior from https://github.com/nextcloud/docker/blob/master/docker-entrypoint.sh#L60 , which is a `/bin/sh` script as well
--> shouldn't it get fixed there as well?