### PR TITLE
Upgrade LTS version of XWiki to 13.10.3

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -11,24 +11,24 @@ GitCommit: be3ac33aa49c811f489990b4115dbe92e0fa8040
 Tags: 14-postgres-tomcat, 14.0-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres
 Architectures: amd64, arm64v8
 Directory: 14/postgres-tomcat
-GitCommit: be3ac33aa49c811f489990b4115dbe92e0fa8040
+GitCommit: 81320f6e74ec8afc478bddbdd0d732856b38e488
 
 Tags: 14-mariadb-tomcat, 14.0-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb
 Architectures: amd64, arm64v8
 Directory: 14/mariadb-tomcat
 GitCommit: be3ac33aa49c811f489990b4115dbe92e0fa8040
 
-Tags: 13, 13.10, 13.10.2, 13-mysql-tomcat, 13.10-mysql-tomcat, 13.10.2-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+Tags: 13, 13.10, 13.10.3, 13-mysql-tomcat, 13.10-mysql-tomcat, 13.10.3-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64
 Directory: 13/mysql-tomcat
-GitCommit: be3ac33aa49c811f489990b4115dbe92e0fa8040
+GitCommit: 81320f6e74ec8afc478bddbdd0d732856b38e488
 
-Tags: 13-postgres-tomcat, 13.10-postgres-tomcat, 13.10.2-postgres-tomcat, lts-postgres-tomcat, lts-postgres
+Tags: 13-postgres-tomcat, 13.10-postgres-tomcat, 13.10.3-postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 13/postgres-tomcat
-GitCommit: be3ac33aa49c811f489990b4115dbe92e0fa8040
+GitCommit: 81320f6e74ec8afc478bddbdd0d732856b38e488
 
-Tags: 13-mariadb-tomcat, 13.10-mariadb-tomcat, 13.10.2-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
+Tags: 13-mariadb-tomcat, 13.10-mariadb-tomcat, 13.10.3-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
 Architectures: amd64, arm64v8
 Directory: 13/mariadb-tomcat
-GitCommit: be3ac33aa49c811f489990b4115dbe92e0fa8040
+GitCommit: 81320f6e74ec8afc478bddbdd0d732856b38e488


### PR DESCRIPTION
  * bump version of XWiki LTS to 13.10.3
  * Update sha1 for 14/postgres-tomcat since the base image of postgres has been updated