### PR TITLE
Odoo: update 13.0-15.0 to release 20220217

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 3a872aba1513b586999db54cb403d02a14aede32
+GitCommit: a88f54774e82c3c9a96474f5ae8ddc1153a690e5
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

You will find here the latest updates of Odoo supported versions.

Thanks.