### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7dc5e5a7ecc00a0cb13cb950e345f1b1850be825
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.1, 2.5, latest, 2.5.1-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.2, 2.5, latest, 2.5.2-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 28fe886ec663a7f916af11a01a026e1c7245df27
+GitCommit: 2565d3f8cf7c8204f8945330410c94ff778d68ba
 Directory: 2.5
 
-Tags: 2.5.1-alpine, 2.5-alpine, alpine, 2.5.1-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.2-alpine, 2.5-alpine, alpine, 2.5.2-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 28fe886ec663a7f916af11a01a026e1c7245df27
+GitCommit: 2565d3f8cf7c8204f8945330410c94ff778d68ba
 Directory: 2.5/alpine
 
-Tags: 2.4.12, 2.4, lts, 2.4.12-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.13, 2.4, lts, 2.4.13-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 30d8fd537e46f3c921f19e95effb1cc2ae43347b
+GitCommit: dec4c2e2e18ec83517531ac58c95dc9d21492fcb
 Directory: 2.4
 
-Tags: 2.4.12-alpine, 2.4-alpine, lts-alpine, 2.4.12-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.13-alpine, 2.4-alpine, lts-alpine, 2.4.13-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 30d8fd537e46f3c921f19e95effb1cc2ae43347b
+GitCommit: dec4c2e2e18ec83517531ac58c95dc9d21492fcb
 Directory: 2.4/alpine
 
 Tags: 2.3.17, 2.3, 2.3.17-bullseye, 2.3-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2565d3f: Update 2.5 to 2.5.2
- https://github.com/docker-library/haproxy/commit/dec4c2e: Update 2.4 to 2.4.13