### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -1,15 +1,29 @@
-# this file is generated via https://github.com/docker-library/mysql/blob/ee33a2144a0effe9459abf02f20a6202ae645e94/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mysql/blob/c77f72025a5523a86102fe45524ca6f9b66306c4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.28, 8.0, 8, latest
-GitCommit: aa600026fe54b1fa6b2a7ac80ffbb466618fcabf
+Tags: 8.0.28-oracle, 8.0-oracle, 8-oracle, oracle
+Architectures: amd64, arm64v8
+GitCommit: 4e7d3969ede713b2660ca04493125c6d714d343f
+Directory: 8.0
+File: Dockerfile.oracle
+
+Tags: 8.0.28, 8.0, 8, latest, 8.0.28-debian, 8.0-debian, 8-debian, debian
+Architectures: amd64
+GitCommit: 2d86ed268c0dcacb38d9a39daf7686a9d9d61400
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.37, 5.7, 5
-GitCommit: aa600026fe54b1fa6b2a7ac80ffbb466618fcabf
+Tags: 5.7.37-oracle, 5.7-oracle, 5-oracle
+Architectures: amd64
+GitCommit: 4e7d3969ede713b2660ca04493125c6d714d343f
+Directory: 5.7
+File: Dockerfile.oracle
+
+Tags: 5.7.37, 5.7, 5, 5.7.37-debian, 5.7-debian, 5-debian
+Architectures: amd64
+GitCommit: 2d86ed268c0dcacb38d9a39daf7686a9d9d61400
 Directory: 5.7
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/4d243fc: Merge pull request https://github.com/docker-library/mysql/pull/680 from infosiftr/oracle
- https://github.com/docker-library/mysql/commit/6a2fb1d: Merge pull request https://github.com/docker-library/mysql/pull/428 from infosiftr/ssl=0
- https://github.com/docker-library/mysql/commit/c77f720: Add Oracle Linux image variants
- https://github.com/docker-library/mysql/commit/2d86ed2: Drop explicit "mysql_ssl_rsa_setup" invocation
- https://github.com/docker-library/mysql/commit/b06a707: Merge pull request https://github.com/docker-library/mysql/pull/821 from infosiftr/signed-by
- https://github.com/docker-library/mysql/commit/4afbe06: Switch from apt-key/trusted.gpg(.d) to signed-by
- https://github.com/docker-library/mysql/commit/0bd6d4c: Fix .gitattributes