### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7dc5e5a7ecc00a0cb13cb950e345f1b1850be825
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.2, 2.5, latest, 2.5.2-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.3, 2.5, latest, 2.5.3-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2565d3f8cf7c8204f8945330410c94ff778d68ba
+GitCommit: 713899bff657b86878e448cf6505064639f34e32
 Directory: 2.5
 
-Tags: 2.5.2-alpine, 2.5-alpine, alpine, 2.5.2-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.3-alpine, 2.5-alpine, alpine, 2.5.3-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2565d3f8cf7c8204f8945330410c94ff778d68ba
+GitCommit: 713899bff657b86878e448cf6505064639f34e32
 Directory: 2.5/alpine
 
 Tags: 2.4.13, 2.4, lts, 2.4.13-bullseye, 2.4-bullseye, lts-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/713899b: Update 2.5 to 2.5.3