### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 19-ea-9-jdk-oraclelinux8, 19-ea-9-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-9-jdk-oracle, 19-ea-9-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-ea-9-jdk, 19-ea-9, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-10-jdk-oraclelinux8, 19-ea-10-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-10-jdk-oracle, 19-ea-10-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
+SharedTags: 19-ea-10-jdk, 19-ea-10, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: amd64, arm64v8
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/oraclelinux8
 
-Tags: 19-ea-9-jdk-oraclelinux7, 19-ea-9-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
+Tags: 19-ea-10-jdk-oraclelinux7, 19-ea-10-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/oraclelinux7
 
-Tags: 19-ea-9-jdk-bullseye, 19-ea-9-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
+Tags: 19-ea-10-jdk-bullseye, 19-ea-10-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
 Architectures: amd64, arm64v8
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/bullseye
 
-Tags: 19-ea-9-jdk-slim-bullseye, 19-ea-9-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-9-jdk-slim, 19-ea-9-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
+Tags: 19-ea-10-jdk-slim-bullseye, 19-ea-10-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-10-jdk-slim, 19-ea-10-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
 Architectures: amd64, arm64v8
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/slim-bullseye
 
-Tags: 19-ea-9-jdk-buster, 19-ea-9-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
+Tags: 19-ea-10-jdk-buster, 19-ea-10-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
 Architectures: amd64, arm64v8
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/buster
 
-Tags: 19-ea-9-jdk-slim-buster, 19-ea-9-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
+Tags: 19-ea-10-jdk-slim-buster, 19-ea-10-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/slim-buster
 
 Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
@@ -45,86 +45,76 @@ Architectures: amd64
 GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
 Directory: 19/jdk/alpine3.14
 
-Tags: 19-ea-9-jdk-windowsservercore-ltsc2022, 19-ea-9-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-ea-9-jdk-windowsservercore, 19-ea-9-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-9-jdk, 19-ea-9, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-10-jdk-windowsservercore-ltsc2022, 19-ea-10-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19-ea-10-jdk-windowsservercore, 19-ea-10-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-10-jdk, 19-ea-10, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19-ea-9-jdk-windowsservercore-1809, 19-ea-9-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-ea-9-jdk-windowsservercore, 19-ea-9-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-9-jdk, 19-ea-9, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-10-jdk-windowsservercore-1809, 19-ea-10-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19-ea-10-jdk-windowsservercore, 19-ea-10-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-10-jdk, 19-ea-10, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-9-jdk-nanoserver-1809, 19-ea-9-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-ea-9-jdk-nanoserver, 19-ea-9-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19-ea-10-jdk-nanoserver-1809, 19-ea-10-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19-ea-10-jdk-nanoserver, 19-ea-10-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: cd402bd5499e16b8f95389d3a5dd3be2f6269fc8
+GitCommit: 819d70fc35f9b0d601c6327a54c916e4f85f1a25
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18-ea-35-jdk-oraclelinux8, 18-ea-35-oraclelinux8, 18-ea-jdk-oraclelinux8, 18-ea-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18-ea-35-jdk-oracle, 18-ea-35-oracle, 18-ea-jdk-oracle, 18-ea-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18-ea-35-jdk, 18-ea-35, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-jdk-oraclelinux8, 18-oraclelinux8, 18-jdk-oracle, 18-oracle
+SharedTags: 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-ea-35-jdk-oraclelinux7, 18-ea-35-oraclelinux7, 18-ea-jdk-oraclelinux7, 18-ea-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-ea-35-jdk-bullseye, 18-ea-35-bullseye, 18-ea-jdk-bullseye, 18-ea-bullseye, 18-jdk-bullseye, 18-bullseye
+Tags: 18-jdk-bullseye, 18-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/bullseye
 
-Tags: 18-ea-35-jdk-slim-bullseye, 18-ea-35-slim-bullseye, 18-ea-jdk-slim-bullseye, 18-ea-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18-ea-35-jdk-slim, 18-ea-35-slim, 18-ea-jdk-slim, 18-ea-slim, 18-jdk-slim, 18-slim
+Tags: 18-jdk-slim-bullseye, 18-slim-bullseye, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18-ea-35-jdk-buster, 18-ea-35-buster, 18-ea-jdk-buster, 18-ea-buster, 18-jdk-buster, 18-buster
+Tags: 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/buster
 
-Tags: 18-ea-35-jdk-slim-buster, 18-ea-35-slim-buster, 18-ea-jdk-slim-buster, 18-ea-slim-buster, 18-jdk-slim-buster, 18-slim-buster
+Tags: 18-jdk-slim-buster, 18-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/slim-buster
 
-Tags: 18-ea-11-jdk-alpine3.15, 18-ea-11-alpine3.15, 18-ea-jdk-alpine3.15, 18-ea-alpine3.15, 18-jdk-alpine3.15, 18-alpine3.15, 18-ea-11-jdk-alpine, 18-ea-11-alpine, 18-ea-jdk-alpine, 18-ea-alpine, 18-jdk-alpine, 18-alpine
-Architectures: amd64
-GitCommit: 699e92630599a5aa9a93dfb7f93de80762045756
-Directory: 18/jdk/alpine3.15
-
-Tags: 18-ea-11-jdk-alpine3.14, 18-ea-11-alpine3.14, 18-ea-jdk-alpine3.14, 18-ea-alpine3.14, 18-jdk-alpine3.14, 18-alpine3.14
-Architectures: amd64
-GitCommit: 0cea342dc0644ce3c104a7b0907719e6c6357fcf
-Directory: 18/jdk/alpine3.14
-
-Tags: 18-ea-35-jdk-windowsservercore-ltsc2022, 18-ea-35-windowsservercore-ltsc2022, 18-ea-jdk-windowsservercore-ltsc2022, 18-ea-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
-SharedTags: 18-ea-35-jdk-windowsservercore, 18-ea-35-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-35-jdk, 18-ea-35, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
+SharedTags: 18-jdk-windowsservercore, 18-windowsservercore, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18-ea-35-jdk-windowsservercore-1809, 18-ea-35-windowsservercore-1809, 18-ea-jdk-windowsservercore-1809, 18-ea-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-ea-35-jdk-windowsservercore, 18-ea-35-windowsservercore, 18-ea-jdk-windowsservercore, 18-ea-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18-ea-35-jdk, 18-ea-35, 18-ea-jdk, 18-ea, 18-jdk, 18
+Tags: 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18-jdk-windowsservercore, 18-windowsservercore, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-ea-35-jdk-nanoserver-1809, 18-ea-35-nanoserver-1809, 18-ea-jdk-nanoserver-1809, 18-ea-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-ea-35-jdk-nanoserver, 18-ea-35-nanoserver, 18-ea-jdk-nanoserver, 18-ea-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: 2ce1dd58e0e3cb8aebeb90918b50403fa4fecac9
+GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/819d70f: Update 19 to 19-ea+10
- https://github.com/docker-library/openjdk/commit/ce82579: Update 18 to 18