### PR TITLE
Add new "python-no-pyc" test

### DIFF
--- a/test/config.sh
+++ b/test/config.sh
@@ -196,6 +196,7 @@ imageTests+=(
 	[python]='
 		python-hy
 		python-imports
+		python-no-pyc
 		python-pip-requests-ssl
 		python-sqlite3
 		python-stack-size

--- a/test/tests/python-no-pyc/container.cmd
+++ b/test/tests/python-no-pyc/container.cmd
@@ -1,0 +1,1 @@
+rem N/A: Windows-based Python images may or may not contain ".pyc" and/or ".pyo" files because they are not a significant contributor to the overall image size

--- a/test/tests/python-no-pyc/container.sh
+++ b/test/tests/python-no-pyc/container.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eu
+
+find /usr/local /opt '(' -name '*.pyc' -o -name '*.pyo' ')' -print -exec false '{}' +

--- a/test/tests/python-no-pyc/run.sh
+++ b/test/tests/python-no-pyc/run.sh
@@ -1,0 +1,1 @@
+../run-sh-in-container.sh


### PR DESCRIPTION
This test validates that the Python images do not contain any pre-compiled `.pyc` or `.pyo` files in `/usr/local` (or `/opt`, for good measure).

Ideally this would also include all of `/usr` (not just `/usr/local`) but then it would also have to filter out results that are from Debian packages (`python`'s default variants are `FROM buildpack-deps` which includes a fair amount of Python packages).

See https://github.com/docker-library/python/issues/207

(The goal is to simplify how we avoid `.pyc` and `.pyo` files in the images but with a safety net to validate that we don't regress.)