### PR TITLE
archlinux: Release 20220220.0.48372

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220213.0.47747
-GitCommit: 21e74ae38df26610b6ca02b38739f58e8ea976d2
-GitFetch: refs/tags/v20220213.0.47747
+Tags: latest, base, base-20220220.0.48372
+GitCommit: c23408b088fee3c46b3d0246564187ff2f4c55b1
+GitFetch: refs/tags/v20220220.0.48372
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220213.0.47747
-GitCommit: 21e74ae38df26610b6ca02b38739f58e8ea976d2
-GitFetch: refs/tags/v20220213.0.47747
+Tags: base-devel, base-devel-20220220.0.48372
+GitCommit: c23408b088fee3c46b3d0246564187ff2f4c55b1
+GitFetch: refs/tags/v20220220.0.48372
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks