### PR TITLE
Update Clear Linux OS to 35920

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 873f3821a4263dfe1c67d166cc41791ed2447565
-GitFetch: refs/heads/base-35860
+GitCommit: 1bbb594d72419e6271167d9ba0ebfcd6ae80bcea
+GitFetch: refs/heads/base-35920


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35920

@bryteise @djklimes @bryteise