### PR TITLE
Add haskell debian slim variants

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,15 +4,30 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.2.1-buster, 9.2-buster, 9-buster, buster, 9.2.1, 9.2, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 5f8acc1199035266b1cc74fcc47d8ea114268076
+GitCommit: 56d3f9996456bf633876fdb5d76bfb302b689f7c
 Directory: 9.2/buster
+
+Tags: 9.2.1-slim-buster, 9.2-slim-buster, 9-slim-buster, slim-buster, 9.2.1-slim, 9.2-slim, 9-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 56d3f9996456bf633876fdb5d76bfb302b689f7c
+Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
 Architectures: amd64, arm64v8
-GitCommit: 5f8acc1199035266b1cc74fcc47d8ea114268076
+GitCommit: 56d3f9996456bf633876fdb5d76bfb302b689f7c
 Directory: 9.0/buster
+
+Tags: 9.0.2-slim-buster, 9.0-slim-buster, 9.0.2-slim, 9.0-slim
+Architectures: amd64, arm64v8
+GitCommit: 56d3f9996456bf633876fdb5d76bfb302b689f7c
+Directory: 9.0/slim-buster
 
 Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
 Architectures: amd64, arm64v8
-GitCommit: 5f8acc1199035266b1cc74fcc47d8ea114268076
+GitCommit: 56d3f9996456bf633876fdb5d76bfb302b689f7c
 Directory: 8.10/buster
+
+Tags: 8.10.7-slim-buster, 8.10-slim-buster, 8-slim-buster, 8.10.7-slim, 8.10-slim, 8-slim
+Architectures: amd64, arm64v8
+GitCommit: 56d3f9996456bf633876fdb5d76bfb302b689f7c
+Directory: 8.10/slim-buster


### PR DESCRIPTION
The non-slim variants now also include profiling support.