### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.9.0-apache, 5.9-apache, 5-apache, apache, 5.9.0, 5.9, 5, latest, 5.9.0-php7.4-apache, 5.9-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.9.0-php7.4, 5.9-php7.4, 5-php7.4, php7.4
+Tags: 5.9.1-apache, 5.9-apache, 5-apache, apache, 5.9.1, 5.9, 5, latest, 5.9.1-php7.4-apache, 5.9-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.9.1-php7.4, 5.9-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php7.4/apache
 
-Tags: 5.9.0-fpm, 5.9-fpm, 5-fpm, fpm, 5.9.0-php7.4-fpm, 5.9-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.9.1-fpm, 5.9-fpm, 5-fpm, fpm, 5.9.1-php7.4-fpm, 5.9-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php7.4/fpm
 
-Tags: 5.9.0-fpm-alpine, 5.9-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.9.0-php7.4-fpm-alpine, 5.9-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.9.1-fpm-alpine, 5.9-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.9.1-php7.4-fpm-alpine, 5.9-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.9.0-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.0-php7.3, 5.9-php7.3, 5-php7.3, php7.3
+Tags: 5.9.1-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.1-php7.3, 5.9-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php7.3/apache
 
-Tags: 5.9.0-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.9.1-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php7.3/fpm
 
-Tags: 5.9.0-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.9.1-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.9.0-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.0-php8.0, 5.9-php8.0, 5-php8.0, php8.0
+Tags: 5.9.1-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.1-php8.0, 5.9-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php8.0/apache
 
-Tags: 5.9.0-php8.0-fpm, 5.9-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.9.1-php8.0-fpm, 5.9-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php8.0/fpm
 
-Tags: 5.9.0-php8.0-fpm-alpine, 5.9-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.9.1-php8.0-fpm-alpine, 5.9-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 5.9.0-php8.1-apache, 5.9-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.9.0-php8.1, 5.9-php8.1, 5-php8.1, php8.1
+Tags: 5.9.1-php8.1-apache, 5.9-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.9.1-php8.1, 5.9-php8.1, 5-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php8.1/apache
 
-Tags: 5.9.0-php8.1-fpm, 5.9-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
+Tags: 5.9.1-php8.1-fpm, 5.9-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php8.1/fpm
 
-Tags: 5.9.0-php8.1-fpm-alpine, 5.9-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 5.9.1-php8.1-fpm-alpine, 5.9-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
 Directory: latest/php8.1/fpm-alpine
 
 Tags: cli-2.6.0, cli-2.6, cli-2, cli, cli-2.6.0-php7.4, cli-2.6-php7.4, cli-2-php7.4, cli-php7.4
@@ -83,63 +83,3 @@ Tags: cli-2.6.0-php8.1, cli-2.6-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php8.1/alpine
-
-Tags: beta-5.9.1-RC1-apache, beta-5.9.1-apache, beta-5.9-apache, beta-5-apache, beta-apache, beta-5.9.1-RC1, beta-5.9.1, beta-5.9, beta-5, beta, beta-5.9.1-RC1-php7.4-apache, beta-5.9.1-php7.4-apache, beta-5.9-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.9.1-RC1-php7.4, beta-5.9.1-php7.4, beta-5.9-php7.4, beta-5-php7.4, beta-php7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php7.4/apache
-
-Tags: beta-5.9.1-RC1-fpm, beta-5.9.1-fpm, beta-5.9-fpm, beta-5-fpm, beta-fpm, beta-5.9.1-RC1-php7.4-fpm, beta-5.9.1-php7.4-fpm, beta-5.9-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php7.4/fpm
-
-Tags: beta-5.9.1-RC1-fpm-alpine, beta-5.9.1-fpm-alpine, beta-5.9-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.9.1-RC1-php7.4-fpm-alpine, beta-5.9.1-php7.4-fpm-alpine, beta-5.9-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php7.4/fpm-alpine
-
-Tags: beta-5.9.1-RC1-php7.3-apache, beta-5.9.1-php7.3-apache, beta-5.9-php7.3-apache, beta-5-php7.3-apache, beta-php7.3-apache, beta-5.9.1-RC1-php7.3, beta-5.9.1-php7.3, beta-5.9-php7.3, beta-5-php7.3, beta-php7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php7.3/apache
-
-Tags: beta-5.9.1-RC1-php7.3-fpm, beta-5.9.1-php7.3-fpm, beta-5.9-php7.3-fpm, beta-5-php7.3-fpm, beta-php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php7.3/fpm
-
-Tags: beta-5.9.1-RC1-php7.3-fpm-alpine, beta-5.9.1-php7.3-fpm-alpine, beta-5.9-php7.3-fpm-alpine, beta-5-php7.3-fpm-alpine, beta-php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php7.3/fpm-alpine
-
-Tags: beta-5.9.1-RC1-php8.0-apache, beta-5.9.1-php8.0-apache, beta-5.9-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.9.1-RC1-php8.0, beta-5.9.1-php8.0, beta-5.9-php8.0, beta-5-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php8.0/apache
-
-Tags: beta-5.9.1-RC1-php8.0-fpm, beta-5.9.1-php8.0-fpm, beta-5.9-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php8.0/fpm
-
-Tags: beta-5.9.1-RC1-php8.0-fpm-alpine, beta-5.9.1-php8.0-fpm-alpine, beta-5.9-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php8.0/fpm-alpine
-
-Tags: beta-5.9.1-RC1-php8.1-apache, beta-5.9.1-php8.1-apache, beta-5.9-php8.1-apache, beta-5-php8.1-apache, beta-php8.1-apache, beta-5.9.1-RC1-php8.1, beta-5.9.1-php8.1, beta-5.9-php8.1, beta-5-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php8.1/apache
-
-Tags: beta-5.9.1-RC1-php8.1-fpm, beta-5.9.1-php8.1-fpm, beta-5.9-php8.1-fpm, beta-5-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php8.1/fpm
-
-Tags: beta-5.9.1-RC1-php8.1-fpm-alpine, beta-5.9.1-php8.1-fpm-alpine, beta-5.9-php8.1-fpm-alpine, beta-5-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbb08a03231a175e52f37d55824c53fb4d330b15
-Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/8874538: Update latest to 5.9.1
- https://github.com/docker-library/wordpress/commit/f6adab6: Update beta to 5.9.1