### PR TITLE
ROS | Update rolling to jammy base image

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -126,20 +126,15 @@ Directory: ros/galactic/ubuntu/focal/ros1-bridge
 # Release: rolling
 
 ########################################
-# Distro: ubuntu:focal
+# Distro: ubuntu:jammy
 
-Tags: rolling-ros-core, rolling-ros-core-focal
+Tags: rolling-ros-core, rolling-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 11c613986e35a1f36fd0fa18b49173e0c564cf1d
-Directory: ros/rolling/ubuntu/focal/ros-core
+GitCommit: 86029c8abad4b4e52d95a33af079bdb874fa0b0c
+Directory: ros/rolling/ubuntu/jammy/ros-core
 
-Tags: rolling-ros-base, rolling-ros-base-focal, rolling
+Tags: rolling-ros-base, rolling-ros-base-jammy, rolling
 Architectures: amd64, arm64v8
-GitCommit: a5644adacdca4a49faf10221620048175cdd7262
-Directory: ros/rolling/ubuntu/focal/ros-base
-
-Tags: rolling-ros1-bridge, rolling-ros1-bridge-focal
-Architectures: amd64, arm64v8
-GitCommit: e471aedbeaee1e0309bfe5dd1f2e8eea45f1adac
-Directory: ros/rolling/ubuntu/focal/ros1-bridge
+GitCommit: 86029c8abad4b4e52d95a33af079bdb874fa0b0c
+Directory: ros/rolling/ubuntu/jammy/ros-base
 


### PR DESCRIPTION
Also removes ros1-bridge tag, given no ROS1 distro targets Ubuntu jammy
https://github.com/osrf/docker_images/pull/601
https://discourse.ros.org/t/new-packages-for-ros-2-rolling-ridley/24431