### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ELSA-2022-0621

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d0a836cc8077d9400b1c8b1d3f20968ae833446b
+amd64-GitCommit: d966bafc3fcc5aa861b434b30297e7644ff3e96d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d61ef5110090987a7a55b55e427d405bbb879203
+arm64v8-GitCommit: 01b9ed3ea9852734a28d29df26e87af800eeeb77
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2020-25709 and CVE-2020-25710.

See https://linux.oracle.com/errata/ELSA-2022-0621.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>