### PR TITLE
22.0.0.2 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,5 +1,5 @@
 Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
-             Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
+             Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitCommit: 097132542871f70feec7e0643e122fda9d7eb456
 Architectures: amd64, i386, ppc64le, s390x

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,8 +1,7 @@
 Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
-             Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 4a37111114bd450a2d7e60fa9e5a0c2f8a9ac57d
+GitCommit: 097132542871f70feec7e0643e122fda9d7eb456
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -14,6 +13,11 @@ Tags: beta-java11
 Directory: releases/latest/beta
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
+
+Tags: beta-java17
+Directory: releases/latest/beta
+Architectures: amd64, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk17
 
 Tags: kernel-slim, kernel-slim-java8-openj9
 Directory: releases/latest/kernel-slim

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
-GitCommit: 9c399b917088038bb11ac047bea95813803f7111
+GitCommit: 4a37111114bd450a2d7e60fa9e5a0c2f8a9ac57d
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -45,33 +45,33 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.1-kernel-slim-java8-openj9
-Directory: releases/22.0.0.1/kernel-slim
+Tags: 22.0.0.2-kernel-slim-java8-openj9
+Directory: releases/22.0.0.2/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 22.0.0.1-kernel-slim-java11-openj9
-Directory: releases/22.0.0.1/kernel-slim
+Tags: 22.0.0.2-kernel-slim-java11-openj9
+Directory: releases/22.0.0.2/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.1-kernel-slim-java17-openj9
-Directory: releases/22.0.0.1/kernel-slim
+Tags: 22.0.0.2-kernel-slim-java17-openj9
+Directory: releases/22.0.0.2/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.1-full-java8-openj9
-Directory: releases/22.0.0.1/full
+Tags: 22.0.0.2-full-java8-openj9
+Directory: releases/22.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 22.0.0.1-full-java11-openj9
-Directory: releases/22.0.0.1/full
+Tags: 22.0.0.2-full-java11-openj9
+Directory: releases/22.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.1-full-java17-openj9
-Directory: releases/22.0.0.1/full
+Tags: 22.0.0.2-full-java17-openj9
+Directory: releases/22.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,5 +1,5 @@
 Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
-             Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
+             Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitCommit: 021afc250a11f65a79b754dde0fdfccf0625991d
 Architectures: amd64, ppc64le, s390x

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,8 +1,7 @@
 Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
-             Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 4a37111114bd450a2d7e60fa9e5a0c2f8a9ac57d
+GitCommit: 021afc250a11f65a79b754dde0fdfccf0625991d
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke),
              Arthur De Magalhaes <arthurdm@ca.ibm.com> (@arthurdm)
 GitRepo: https://github.com/WASdev/ci.docker.git
-GitCommit: 557fd1d774f6a43247206a079aca1d9650406e45
+GitCommit: 4a37111114bd450a2d7e60fa9e5a0c2f8a9ac57d
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
@@ -33,31 +33,31 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.1-kernel-java8-ibmjava
-Directory: ga/22.0.0.1/kernel
+Tags: 22.0.0.2-kernel-java8-ibmjava
+Directory: ga/22.0.0.2/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 22.0.0.1-kernel-java11-openj9
-Directory: ga/22.0.0.1/kernel
+Tags: 22.0.0.2-kernel-java11-openj9
+Directory: ga/22.0.0.2/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.1-kernel-java17-openj9
-Directory: ga/22.0.0.1/kernel
+Tags: 22.0.0.2-kernel-java17-openj9
+Directory: ga/22.0.0.2/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.1-full-java8-ibmjava
-Directory: ga/22.0.0.1/full
+Tags: 22.0.0.2-full-java8-ibmjava
+Directory: ga/22.0.0.2/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 22.0.0.1-full-java11-openj9
-Directory: ga/22.0.0.1/full
+Tags: 22.0.0.2-full-java11-openj9
+Directory: ga/22.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.1-full-java17-openj9
-Directory: ga/22.0.0.1/full
+Tags: 22.0.0.2-full-java17-openj9
+Directory: ga/22.0.0.2/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 


### PR DESCRIPTION
Updates to open-liberty and websphere-liberty for the release of 22.0.0.2. Addition of the open-liberty beta image using java 17.