### PR TITLE
Skip pgp-happy-eyeballs on build tests

### DIFF
--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -46,6 +46,8 @@ jobs:
       - id: generate-jobs
         name: Generate Jobs
         run: |
+          # https://github.com/tianon/pgp-happy-eyeballs/issues/4
+          export BASHBREW_GENERATE_SKIP_PGP_PROXY=1
           git clone --depth 1 https://github.com/docker-library/bashbrew.git -b master ~/bashbrew
           strategy="$(.github/workflows/generate.sh ~/bashbrew)"
           jq . <<<"$strategy" # sanity check / debugging aid


### PR DESCRIPTION
This is the workaround for stale servers that we are seeing in https://github.com/docker-library/official-images/pull/11917#issuecomment-1049236174 and https://github.com/docker-library/official-images/pull/11727#issuecomment-1020420044.

Using this line in [generate.sh](https://github.com/docker-library/bashbrew/blob/22e529f066b4bee5c6141f53c1059877b386bdbe/scripts/github-actions/generate.sh#L170) to skip pgp-happy-eyeballs setup.

I don't think we should remove `pgp-happy-eyeballs` from the build servers since we haven't hit the stale keyservers there. This can be re-enabled once https://github.com/tianon/pgp-happy-eyeballs/issues/4 has a proper solution.