### PR TITLE
[oraclelinux] Updating 7, 7-slim, 8 and 8-slim for ELSA-2022-0658 and ELSA-2022-0666

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d966bafc3fcc5aa861b434b30297e7644ff3e96d
+amd64-GitCommit: 331914f83f6b5c3dd6f0d98cdda5a1593d685704
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 01b9ed3ea9852734a28d29df26e87af800eeeb77
+arm64v8-GitCommit: e0bc1ba9a2b94b0946365fdfb3faceae470f4fe6
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-24407.

See http://linux.oracle.com/errata/ELSA-2022-0558.html and http://linux.oracle.com/errata/ELSA-2022-0666.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>