### PR TITLE
Update Clear Linux OS to 35940

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 1bbb594d72419e6271167d9ba0ebfcd6ae80bcea
-GitFetch: refs/heads/base-35920
+GitCommit: d9a584ef3d0c9d291407706ad1a44aa649eb7dbe
+GitFetch: refs/heads/base-35940


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35940

@bryteise @djklimes @bryteise