### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 7.0-rc1, 7.0-rc, 7.0-rc1-bullseye, 7.0-rc-bullseye
+Tags: 7.0-rc2, 7.0-rc, 7.0-rc2-bullseye, 7.0-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b90f94b39a5abe413737f797b92ee257ca8303b2
+GitCommit: 5da818a92261e46c0d1c1a075da5666d4b2a8a8b
 Directory: 7.0-rc
 
-Tags: 7.0-rc1-alpine, 7.0-rc-alpine, 7.0-rc1-alpine3.15, 7.0-rc-alpine3.15
+Tags: 7.0-rc2-alpine, 7.0-rc-alpine, 7.0-rc2-alpine3.15, 7.0-rc-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b90f94b39a5abe413737f797b92ee257ca8303b2
+GitCommit: 5da818a92261e46c0d1c1a075da5666d4b2a8a8b
 Directory: 7.0-rc/alpine
 
 Tags: 6.2.6, 6.2, 6, latest, 6.2.6-bullseye, 6.2-bullseye, 6-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/5da818a: Update to 7.0-rc2