### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev1, 2.6-dev, 2.6-dev1-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev2, 2.6-dev, 2.6-dev2-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7dc5e5a7ecc00a0cb13cb950e345f1b1850be825
+GitCommit: a95bcbbd151d9802fc0eddc5c23ee0d8aa9f9803
 Directory: 2.6-rc
 
-Tags: 2.6-dev1-alpine, 2.6-dev-alpine, 2.6-dev1-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev2-alpine, 2.6-dev-alpine, 2.6-dev2-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7dc5e5a7ecc00a0cb13cb950e345f1b1850be825
+GitCommit: a95bcbbd151d9802fc0eddc5c23ee0d8aa9f9803
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.3, 2.5, latest, 2.5.3-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.4, 2.5, latest, 2.5.4-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 713899bff657b86878e448cf6505064639f34e32
+GitCommit: 52ca796af066139c00ec883ae3714621d50307f1
 Directory: 2.5
 
-Tags: 2.5.3-alpine, 2.5-alpine, alpine, 2.5.3-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.4-alpine, 2.5-alpine, alpine, 2.5.4-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 713899bff657b86878e448cf6505064639f34e32
+GitCommit: 52ca796af066139c00ec883ae3714621d50307f1
 Directory: 2.5/alpine
 
-Tags: 2.4.13, 2.4, lts, 2.4.13-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.14, 2.4, lts, 2.4.14-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dec4c2e2e18ec83517531ac58c95dc9d21492fcb
+GitCommit: 0379f8bfa39a5ef6ed7b78ca78a08f0a8e70f1e1
 Directory: 2.4
 
-Tags: 2.4.13-alpine, 2.4-alpine, lts-alpine, 2.4.13-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.14-alpine, 2.4-alpine, lts-alpine, 2.4.14-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dec4c2e2e18ec83517531ac58c95dc9d21492fcb
+GitCommit: 0379f8bfa39a5ef6ed7b78ca78a08f0a8e70f1e1
 Directory: 2.4/alpine
 
 Tags: 2.3.17, 2.3, 2.3.17-bullseye, 2.3-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a95bcbb: Update 2.6-rc to 2.6-dev2
- https://github.com/docker-library/haproxy/commit/52ca796: Update 2.5 to 2.5.4
- https://github.com/docker-library/haproxy/commit/0379f8b: Update 2.4 to 2.4.14