### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 4.37.0, 4.37, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f34b95e04aef638107f5f3837f194e8819fe99c9
+GitCommit: 808c6c35fc82c6e1fc97c645bd580aa62ca5b959
 Directory: 4/debian
 
 Tags: 4.37.0-alpine, 4.37-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f34b95e04aef638107f5f3837f194e8819fe99c9
+GitCommit: 808c6c35fc82c6e1fc97c645bd580aa62ca5b959
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/396b4eb: Merge pull request https://github.com/docker-library/ghost/pull/292 from infosiftr/ipv6
- https://github.com/docker-library/ghost/commit/808c6c3: Switch from "0.0.0.0" to "::" to support IPv6 too