### PR TITLE
Mariadb fixes

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,40 +1,40 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/2937a9bd36ac208e8322c8564f069b10261749f8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/cb0bb9ac8d442f4d227fc2ffeaf8d7eb3abbb7ec/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 10.8.2-focal, 10.8-focal, 10.8.2, 10.8
+Tags: 10.8.2-rc-focal, 10.8-rc-focal, 10.8.2-rc, 10.8-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.8
 
 Tags: 10.7.3-focal, 10.7-focal, 10-focal, focal, 10.7.3, 10.7, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.7
 
 Tags: 10.6.7-focal, 10.6-focal, 10.6.7, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.6
 
 Tags: 10.5.15-focal, 10.5-focal, 10.5.15, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.5
 
 Tags: 10.4.24-focal, 10.4-focal, 10.4.24, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.4
 
 Tags: 10.3.34-focal, 10.3-focal, 10.3.34, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.3
 
 Tags: 10.2.43-bionic, 10.2-bionic, 10.2.43, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cd10ba6c780e49e732ca0eacb76affaac6e87d74
+GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
 Directory: 10.2


### PR DESCRIPTION
Major:
* MDEV-27980 file-key-management plugin disabled in mysql_install_db breaks container initialization

The file-key-management plugin was broken in the mysql_install_db on all
versions. This prevents initializing innodb system tablespace encrypted.

This also prevents /docker-entrypoint-initdb.d/ from creating encrypted
tables.

* MariaDB upgrade started a temporary server without skip-slave-start

This causes potentially harmful interactions with the server while it
is undergoing and upgrade of its system tables.

* Use more semver in the tag for unstable images.

As mentioned here https://github.com/MariaDB/mariadb-docker/issues/415
and in the comments on https://github.com/MariaDB/mariadb-docker/commit/38c1c0d4fd87abf33f824639eab9a1eeec128b8c
a clear indication of unstable versions is desiriable.

The existence of a tag without a rc could make it harder for automation
to see the equivalence of underlying hashes to a non-rc tag like 10.8.

Important:

* Healthcheck - prevent duplicate test running

Running the healthcheck with a test, following by options, would
execute the test again for each option. While harmless it is
unnecessary.

Minor:

A few other healthcheck script cleanups.