### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -59,110 +59,110 @@ GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
 Directory: 1.18-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.17.7-bullseye, 1.17-bullseye, 1-bullseye, bullseye
-SharedTags: 1.17.7, 1.17, 1, latest
+Tags: 1.17.8-bullseye, 1.17-bullseye, 1-bullseye, bullseye
+SharedTags: 1.17.8, 1.17, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/bullseye
 
-Tags: 1.17.7-buster, 1.17-buster, 1-buster, buster
+Tags: 1.17.8-buster, 1.17-buster, 1-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/buster
 
-Tags: 1.17.7-stretch, 1.17-stretch, 1-stretch, stretch
+Tags: 1.17.8-stretch, 1.17-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/stretch
 
-Tags: 1.17.7-alpine3.15, 1.17-alpine3.15, 1-alpine3.15, alpine3.15, 1.17.7-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.17.8-alpine3.15, 1.17-alpine3.15, 1-alpine3.15, alpine3.15, 1.17.8-alpine, 1.17-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/alpine3.15
 
-Tags: 1.17.7-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14
+Tags: 1.17.8-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/alpine3.14
 
-Tags: 1.17.7-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.17.7-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.7, 1.17, 1, latest
+Tags: 1.17.8-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.17.8-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.8, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: e773873197db6195f2273ba57802884d83a60d3b
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.17.7-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.17.7-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.7, 1.17, 1, latest
+Tags: 1.17.8-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.17.8-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.8, 1.17, 1, latest
 Architectures: windows-amd64
-GitCommit: e773873197db6195f2273ba57802884d83a60d3b
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17.7-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.17.7-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.8-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.17.8-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: e773873197db6195f2273ba57802884d83a60d3b
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.17.7-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.17.7-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.8-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.17.8-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: e773873197db6195f2273ba57802884d83a60d3b
+GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.16.14-bullseye, 1.16-bullseye
-SharedTags: 1.16.14, 1.16
+Tags: 1.16.15-bullseye, 1.16-bullseye
+SharedTags: 1.16.15, 1.16
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/bullseye
 
-Tags: 1.16.14-buster, 1.16-buster
+Tags: 1.16.15-buster, 1.16-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/buster
 
-Tags: 1.16.14-stretch, 1.16-stretch
+Tags: 1.16.15-stretch, 1.16-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/stretch
 
-Tags: 1.16.14-alpine3.15, 1.16-alpine3.15, 1.16.14-alpine, 1.16-alpine
+Tags: 1.16.15-alpine3.15, 1.16-alpine3.15, 1.16.15-alpine, 1.16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/alpine3.15
 
-Tags: 1.16.14-alpine3.14, 1.16-alpine3.14
+Tags: 1.16.15-alpine3.14, 1.16-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1e80a2c42de0bfe3dfbc60acf820b910037e711
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/alpine3.14
 
-Tags: 1.16.14-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
-SharedTags: 1.16.14-windowsservercore, 1.16-windowsservercore, 1.16.14, 1.16
+Tags: 1.16.15-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
+SharedTags: 1.16.15-windowsservercore, 1.16-windowsservercore, 1.16.15, 1.16
 Architectures: windows-amd64
-GitCommit: 1c76165a5f1fb3237cea9e5d0f534a9bb23c6967
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.16.14-windowsservercore-1809, 1.16-windowsservercore-1809
-SharedTags: 1.16.14-windowsservercore, 1.16-windowsservercore, 1.16.14, 1.16
+Tags: 1.16.15-windowsservercore-1809, 1.16-windowsservercore-1809
+SharedTags: 1.16.15-windowsservercore, 1.16-windowsservercore, 1.16.15, 1.16
 Architectures: windows-amd64
-GitCommit: 1c76165a5f1fb3237cea9e5d0f534a9bb23c6967
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.16.14-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
-SharedTags: 1.16.14-nanoserver, 1.16-nanoserver
+Tags: 1.16.15-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
+SharedTags: 1.16.15-nanoserver, 1.16-nanoserver
 Architectures: windows-amd64
-GitCommit: 1c76165a5f1fb3237cea9e5d0f534a9bb23c6967
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.16.14-nanoserver-1809, 1.16-nanoserver-1809
-SharedTags: 1.16.14-nanoserver, 1.16-nanoserver
+Tags: 1.16.15-nanoserver-1809, 1.16-nanoserver-1809
+SharedTags: 1.16.15-nanoserver, 1.16-nanoserver
 Architectures: windows-amd64
-GitCommit: 1c76165a5f1fb3237cea9e5d0f534a9bb23c6967
+GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
 Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/67757c0: Update 1.17 to 1.17.8
- https://github.com/docker-library/golang/commit/ceac658: Update 1.16 to 1.16.15