### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,24 +34,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 0379f8bfa39a5ef6ed7b78ca78a08f0a8e70f1e1
 Directory: 2.4/alpine
 
-Tags: 2.3.17, 2.3, 2.3.17-bullseye, 2.3-bullseye
+Tags: 2.3.18, 2.3, 2.3.18-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 42ed5bfc52b78342e91456d84bb9248239bb1bcd
+GitCommit: 77f27f70e022f877b7a454c6da942f04d3c33d48
 Directory: 2.3
 
-Tags: 2.3.17-alpine, 2.3-alpine, 2.3.17-alpine3.15, 2.3-alpine3.15
+Tags: 2.3.18-alpine, 2.3-alpine, 2.3.18-alpine3.15, 2.3-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 42ed5bfc52b78342e91456d84bb9248239bb1bcd
+GitCommit: 77f27f70e022f877b7a454c6da942f04d3c33d48
 Directory: 2.3/alpine
 
-Tags: 2.2.20, 2.2, 2.2.20-bullseye, 2.2-bullseye
+Tags: 2.2.21, 2.2, 2.2.21-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 700a06f3ea366e468eea55fbabc3dc23ef1dd5a3
+GitCommit: 9f76527d258518eaad06857b155e250760405b75
 Directory: 2.2
 
-Tags: 2.2.20-alpine, 2.2-alpine, 2.2.20-alpine3.15, 2.2-alpine3.15
+Tags: 2.2.21-alpine, 2.2-alpine, 2.2.21-alpine3.15, 2.2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 700a06f3ea366e468eea55fbabc3dc23ef1dd5a3
+GitCommit: 9f76527d258518eaad06857b155e250760405b75
 Directory: 2.2/alpine
 
 Tags: 2.0.27, 2.0, 2.0.27-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/77f27f7: Update 2.3 to 2.3.18
- https://github.com/docker-library/haproxy/commit/9f76527: Update 2.2 to 2.2.21