### PR TITLE
bugfix in Neo4j 4.4.4,  4.2.15 and 3.5.31

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -11,12 +11,12 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 Tags: 4.4.4, 4.4.4-community, 4.4, 4.4-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 0b2c95bcf4e2d9c26366890922dfd85d315cb96a
+GitCommit: 876cf20dc47018e528d01720668b7d6027c6cf04
 Directory: 4.4.4/community
 
 Tags: 4.4.4-enterprise, 4.4-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 0b2c95bcf4e2d9c26366890922dfd85d315cb96a
+GitCommit: 876cf20dc47018e528d01720668b7d6027c6cf04
 Directory: 4.4.4/enterprise
 
 Tags: 4.4.3, 4.4.3-community
@@ -149,11 +149,11 @@ Directory: 4.3.0/enterprise
 
 
 Tags: 4.2.15, 4.2.15-community, 4.2, 4.2-community
-GitCommit: 0b2c95bcf4e2d9c26366890922dfd85d315cb96a
+GitCommit: 876cf20dc47018e528d01720668b7d6027c6cf04
 Directory: 4.2.15/community
 
 Tags: 4.2.15-enterprise, 4.2-enterprise
-GitCommit: 0b2c95bcf4e2d9c26366890922dfd85d315cb96a
+GitCommit: 876cf20dc47018e528d01720668b7d6027c6cf04
 Directory: 4.2.15/enterprise
 
 Tags: 4.2.14, 4.2.14-community
@@ -277,11 +277,11 @@ GitCommit: 0fee8c3d7314e7729f45781f03e3fe165fa371aa
 Directory: 4.2.0/enterprise
 
 Tags: 3.5.31, 3.5.31-community, 3.5, 3.5-community
-GitCommit: cadb8ad1ca773aa958f9d63fe69fdbd3e99e3613
+GitCommit: 876cf20dc47018e528d01720668b7d6027c6cf04
 Directory: 3.5.31/community
 
 Tags: 3.5.31-enterprise, 3.5-enterprise
-GitCommit: cadb8ad1ca773aa958f9d63fe69fdbd3e99e3613
+GitCommit: 876cf20dc47018e528d01720668b7d6027c6cf04
 Directory: 3.5.31/enterprise
 
 Tags: 3.5.30, 3.5.30-community


### PR DESCRIPTION
Moving the entrypoint script caused some downstream failures, so I've added a simlink from the original script location to the new one.
The change needed to be applied to the last 3 Neo4j releases.