### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/b1ae01f5030025e2ed17d8075841b5266c36f32f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/34ac46b1f8f808bcf20ef5adda8ff9852a4f4eb9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: b1ae01f5030025e2ed17d8075841b5266c36f32f
+GitCommit: 34ac46b1f8f808bcf20ef5adda8ff9852a4f4eb9
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 26c663c3b49330b339521dd52e69dbef3fcae640
+amd64-GitCommit: 3c3135c472313778fdafbb0745c0601e7b8e6e4e
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 78c6b4506218188c9149ba70749b67912861494f
+arm32v5-GitCommit: dff8b1e14ee4a7fd1a60e79fbc8a6ceb62d93b0b
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 49d22627f94917442aa82f8f0ada004503be0197
+arm32v6-GitCommit: 636b0cd4a936e5a8e849ab3af5def30615367086
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0121e2dc6ebb794f836721772a028258ea3ee4cd
+arm32v7-GitCommit: 480b3f26c066235ecc2fffa68a82b63d18b6f4f7
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 22bb23a2665eefb1520dc4c99d5ac9bdf87ae93b
+arm64v8-GitCommit: 8b6bd188690c41aa8623cf8dec7df97ec619beee
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 2a2b89ee14b9561db1d03f5cafec65b9a39cb4ba
+i386-GitCommit: 2e81ff82a3e2d86251b05eb5afe4c861397ebb8b
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: a827a41797661f714316ff8fb2cbcc742b191105
+mips64le-GitCommit: 7573f15dc6c65892d9d6afa537168fa67ec82680
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: d3573e455c64ed678f9f0e8bf98819b418c722a3
+ppc64le-GitCommit: cc71b41df0b8d433ee7edaa79cbbaa0c2f70bc81
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 4ee21de393d5ba79197b2eed7395ce8a1943e246
+riscv64-GitCommit: 8f4009c78530a3bc065eb9de29c669774d89a9f4
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: b40a1bd99995a59ad653862ef63a7b0df606c92c
+s390x-GitCommit: e7550de316aa230f3d05b52d9714cd4b72e37dac
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/34ac46b: Merge pull request https://github.com/docker-library/busybox/pull/128 from infosiftr/buildroot-2021.11.2
- https://github.com/docker-library/busybox/commit/ad8a60b: Update buildroot to 2021.11.2