### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 19-ea-11-jdk-oraclelinux8, 19-ea-11-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-11-jdk-oracle, 19-ea-11-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-ea-11-jdk, 19-ea-11, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-12-jdk-oraclelinux8, 19-ea-12-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-12-jdk-oracle, 19-ea-12-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
+SharedTags: 19-ea-12-jdk, 19-ea-12, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: amd64, arm64v8
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/oraclelinux8
 
-Tags: 19-ea-11-jdk-oraclelinux7, 19-ea-11-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
+Tags: 19-ea-12-jdk-oraclelinux7, 19-ea-12-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/oraclelinux7
 
-Tags: 19-ea-11-jdk-bullseye, 19-ea-11-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
+Tags: 19-ea-12-jdk-bullseye, 19-ea-12-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
 Architectures: amd64, arm64v8
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/bullseye
 
-Tags: 19-ea-11-jdk-slim-bullseye, 19-ea-11-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-11-jdk-slim, 19-ea-11-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
+Tags: 19-ea-12-jdk-slim-bullseye, 19-ea-12-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-12-jdk-slim, 19-ea-12-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
 Architectures: amd64, arm64v8
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/slim-bullseye
 
-Tags: 19-ea-11-jdk-buster, 19-ea-11-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
+Tags: 19-ea-12-jdk-buster, 19-ea-12-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
 Architectures: amd64, arm64v8
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/buster
 
-Tags: 19-ea-11-jdk-slim-buster, 19-ea-11-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
+Tags: 19-ea-12-jdk-slim-buster, 19-ea-12-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/slim-buster
 
 Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
@@ -45,24 +45,24 @@ Architectures: amd64
 GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
 Directory: 19/jdk/alpine3.14
 
-Tags: 19-ea-11-jdk-windowsservercore-ltsc2022, 19-ea-11-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-ea-11-jdk-windowsservercore, 19-ea-11-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-11-jdk, 19-ea-11, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-12-jdk-windowsservercore-ltsc2022, 19-ea-12-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19-ea-12-jdk-windowsservercore, 19-ea-12-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-12-jdk, 19-ea-12, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19-ea-11-jdk-windowsservercore-1809, 19-ea-11-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-ea-11-jdk-windowsservercore, 19-ea-11-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-11-jdk, 19-ea-11, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-12-jdk-windowsservercore-1809, 19-ea-12-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19-ea-12-jdk-windowsservercore, 19-ea-12-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-12-jdk, 19-ea-12, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-11-jdk-nanoserver-1809, 19-ea-11-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-ea-11-jdk-nanoserver, 19-ea-11-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19-ea-12-jdk-nanoserver-1809, 19-ea-12-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19-ea-12-jdk-nanoserver, 19-ea-12-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: af93b1bf823466b116ff89bc5c2b963a020859c7
+GitCommit: 4a5f9fe74f5a298a85fafbe73f515eadcf361de8
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/4a5f9fe: Update 19 to 19-ea+12