### PR TITLE
archlinux: Release 20220306.0.49442

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220227.0.49015
-GitCommit: f8e8111a24fc8f5598df32d591bf5ca179e133d4
-GitFetch: refs/tags/v20220227.0.49015
+Tags: latest, base, base-20220306.0.49442
+GitCommit: 2db5dcede3dd6194b942e4c037393f22a581d567
+GitFetch: refs/tags/v20220306.0.49442
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220227.0.49015
-GitCommit: f8e8111a24fc8f5598df32d591bf5ca179e133d4
-GitFetch: refs/tags/v20220227.0.49015
+Tags: base-devel, base-devel-20220306.0.49442
+GitCommit: 2db5dcede3dd6194b942e4c037393f22a581d567
+GitFetch: refs/tags/v20220306.0.49442
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks