### PR TITLE
Update Clear Linux OS to 35970

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: d9a584ef3d0c9d291407706ad1a44aa649eb7dbe
-GitFetch: refs/heads/base-35940
+GitCommit: 18d48d99eec36aa5489f600dd58685ef478934db
+GitFetch: refs/heads/base-35970


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 35970

@bryteise @djklimes @bryteise