### PR TITLE
Odoo: update 13.0-15.0 to release 20220307

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: f0cd6329a437a38351bce403edc01ebbf08e8aee
+GitCommit: 912599984d8613373c649a827d82b05fc69bbe22
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo supported versions.

Thanks.