### PR TITLE
Almalinux Add PowerPC arch and upgrade to 8.5.4

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -4,23 +4,15 @@ GitRepo: https://github.com/AlmaLinux/docker-images.git
 Tags: latest, 8, 8.5, 8.5-20220306
 GitFetch: refs/heads/al-8.5.4-20220306
 GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al-8.5.4-20220306
-arm64v8-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+amd64-File: Dockerfile-x86_64-default
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al-8.5.4-20220306
-ppc64le-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
 ppc64le-File: Dockerfile-ppc64le-default
 Architectures: amd64, arm64v8, ppc64le
 
 Tags: minimal, 8-minimal, 8.5-minimal-20220306
 GitFetch: refs/heads/al-8.5.4-20220306
 GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al-8.5.4-20220306
-arm64v8-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+amd64-File: Dockerfile-x86_64-minimal
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al-8.5.4-20220306
-ppc64le-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le

--- a/library/almalinux
+++ b/library/almalinux
@@ -1,16 +1,26 @@
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
-Tags: latest, 8, 8.5, 8.5-20211112
-GitFetch: refs/heads/almalinux-8-x86_64-default
-GitCommit: 6e2df1f70f5c144198756f4be9a30e412e8bb065
-arm64v8-GitFetch: refs/heads/almalinux-8-aarch64-default
-arm64v8-GitCommit: 445a8085003f2b1d2de35218d49bf12944497575
-Architectures: amd64, arm64v8
+Tags: latest, 8, 8.5, 8.5-20220306
+GitFetch: refs/heads/al-8.5.4-20220306
+GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+File: Dockerfile-x86_64-default
+arm64v8-GitFetch: refs/heads/al-8.5.4-20220306
+arm64v8-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+arm64v8-File: Dockerfile-aarch64-default
+ppc64le-GitFetch: refs/heads/al-8.5.4-20220306
+ppc64le-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+ppc64le-File: Dockerfile-ppc64le-default
+Architectures: amd64, arm64v8, ppc64le
 
-Tags: minimal, 8-minimal, 8.5-minimal-20211112
-GitFetch: refs/heads/almalinux-8-x86_64-minimal
-GitCommit: a5eb1823772e0154c96351879864d0badaf3c918
-arm64v8-GitFetch: refs/heads/almalinux-8-aarch64-minimal
-arm64v8-GitCommit: 2d75f992852621c11016c10ea7d74b6d5d552310
-Architectures: amd64, arm64v8
+Tags: minimal, 8-minimal, 8.5-minimal-20220306
+GitFetch: refs/heads/al-8.5.4-20220306
+GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+File: Dockerfile-x86_64-minimal
+arm64v8-GitFetch: refs/heads/al-8.5.4-20220306
+arm64v8-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+arm64v8-File: Dockerfile-aarch64-minimal
+ppc64le-GitFetch: refs/heads/al-8.5.4-20220306
+ppc64le-GitCommit: 800ecbd636ec5ebbedc99e46391dbea6e71c2646
+ppc64le-File: Dockerfile-ppc64le-minimal
+Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
### Adding new arch support

- adding new `ppc64le` arch support in `AlmaLinux` docker images

### `latest` tag upgrading to new AlmaLinux 8.5.4 release

- almalinux-release upgraded from 8.5-2.el8 to 8.5-4.el8
- binutils upgraded from 2.30-108.el8 to 2.30-108.el8_5.1
- cryptsetup-libs upgraded from 2.3.3-4.el8 to cryptsetup-libs-2.3.3-4.el8_5.1
- cyrus-sasl-lib upgraded from 2.1.27-5.el8 to cyrus-sasl-lib-2.1.27-6.el8_5
- langpacks-en-1.0-12.el8 added
- libgcc upgraded from 8.5.0-3.el8.alma to 8.5.0-4.el8_5.alma
- libstdc++ upgraded from 8.5.0-3.el8.alma to 8.5.0-4.el8_5.alma
- openssl-libs upgraded from 1.1.1k-4.el8 to 1.1.1k-5.el8_5
- platform-python upgraded from 3.6.8-41.el8 to 3.6.8-41.el8.alma
- python3-libs upgraded from 3.6.8-41.el8 to 3.6.8-41.el8.alma
- python3-rpm upgraded from 4.14.3-19.el8 to 4.14.3-19.el8_5.2
- rpm upgraded from 4.14.3-19.el8 to 4.14.3-19.el8_5.2
- rpm-build-libs upgraded from 4.14.3-19.el8 to 4.14.3-19.el8_5.2
- rpm-libs upgraded from 4.14.3-19.el8 to 4.14.3-19.el8_5.2
- systemd upgraded from 239-51.el8 to 239-51.el8_5.3
- systemd-libs upgraded from 239-51.el8 to 239-51.el8_5.3
- systemd-pam upgraded from 239-51.el8 to 239-51.el8_5.3
- vim-minimal upgraded from 8.0.1763-16.el8 to 8.0.1763-16.el8_5.4

### `minimal` tag upgrading to new AlmaLinux 8.5.4 release

- almalinux-release upgraded from 8.5-2.el8 to 8.5-4.el8
- cyrus-sasl-lib upgraded from 2.1.27-5.el8 to 2.1.27-6.el8_5
- langpacks-en 1.0-12.el8 added
- libgcc upgraded from 8.5.0-3.el8.alma to 8.5.0-4.el8_5.alma
- libstdc++ upgraded from 8.5.0-3.el8.alma to 8.5.0-4.el8_5.alma
- openssl-libs upgraded from 1.1.1k-4.el8 to 1.1.1k-5.el8_5
- rpm upgraded from 4.14.3-19.el8 to 4.14.3-19.el8_5
- rpm-libs upgraded from 4.14.3-19.el8 to 4.14.3-19.el8_5
- systemd-libs upgraded from 239-51.el8 to 239-51.el8_5.3