### PR TITLE
Update bonita, add 2022.1-b1

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -19,3 +19,7 @@ Directory: docker
 Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13, latest
 GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
+
+Tags: 2022.1-b1
+GitCommit: d186e6d24a2dfd5b7020909b9e65aad14d1e59f9
+Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -24,6 +24,6 @@ GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
 
 Tags: 2022.1-b1
-GitFetch: refs/heads/release-7.14.0
-GitCommit: b72469b76d55e0cbd3d8de293d940b79b5fd147d
+GitFetch: refs/heads/docker/2022.1
+GitCommit: a75229e9e6c73d8187f672406d3155abb5e0b192
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -6,24 +6,20 @@ Maintainers: Baptiste Mesta <baptiste.mesta@bonitasoft.org> (@baptistemesta),
              Dumitru Corini <dumitru.corini@bonitasoft.org> (@DumitruCorini)
 Architectures: amd64, arm64v8, ppc64le
 GitRepo: https://github.com/bonitasoft/bonita-distrib.git
-
+Directory: docker
 
 Tags: 7.11.4, 7.11
 GitFetch: refs/heads/docker/7.11.4
 GitCommit: 7058084357dcd0fccf723ab2c7e21ec2b73f1f45
-Directory: docker
 
 Tags: 2021.1, 7.12.1, 7.12
 GitFetch: refs/heads/docker/2021.1
 GitCommit: bfdd527629063b73f053320e50e1f6bfcd135d0a
-Directory: docker
 
-Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13, latest
+Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13
 GitFetch: refs/heads/docker/2021.2
 GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
-Directory: docker
 
-Tags: 2022.1-b1
-GitFetch: refs/heads/docker/2022.1
-GitCommit: 6e39514bc4e558ac78930d87575c7502a89f1fec
-Directory: docker
+Tags: 2022.1-u0, 2022.1, 7.14.0, 7.14, latest
+GitFetch: refs/heads/master
+GitCommit: 694bf79347add872f8c6a4c0a7f5c3ef12c31dc8

--- a/library/bonita
+++ b/library/bonita
@@ -25,5 +25,5 @@ Directory: docker
 
 Tags: 2022.1-b1
 GitFetch: refs/heads/docker/2022.1
-GitCommit: a75229e9e6c73d8187f672406d3155abb5e0b192
+GitCommit: 6e39514bc4e558ac78930d87575c7502a89f1fec
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -25,5 +25,5 @@ Directory: docker
 
 Tags: 2022.1-b1
 GitFetch: refs/heads/release-7.14.0
-GitCommit: d0e1d76802033742313dab1da9fee133cc25db28
+GitCommit: c871e232eebce8fbc355934f3c1a5bc5601c2cc2
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -24,7 +24,6 @@ GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
 
 Tags: 2022.1-b1
-Architectures: amd64
 GitFetch: refs/heads/release-7.14.0
-GitCommit: 89271fc68c286a4f845d5a4d0c28bfa079a5af67
+GitCommit: d0e1d76802033742313dab1da9fee133cc25db28
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -19,7 +19,7 @@ GitCommit: bfdd527629063b73f053320e50e1f6bfcd135d0a
 Directory: docker
 
 Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13, latest
-GitFetch: refs/heads/docker/2022.1
+GitFetch: refs/heads/docker/2021.2
 GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
 

--- a/library/bonita
+++ b/library/bonita
@@ -9,7 +9,7 @@ GitRepo: https://github.com/bonitasoft/bonita-distrib.git
 
 
 Tags: 7.11.4, 7.11
-GitCommit: 231024c8290a9aa31a45b758a0765a684c21ed21
+GitCommit: 7058084357dcd0fccf723ab2c7e21ec2b73f1f45
 Directory: docker
 
 Tags: 2021.1, 7.12.1, 7.12

--- a/library/bonita
+++ b/library/bonita
@@ -21,5 +21,6 @@ GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
 
 Tags: 2022.1-b1
+Architectures: amd64
 GitCommit: 89271fc68c286a4f845d5a4d0c28bfa079a5af67
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -25,5 +25,5 @@ Directory: docker
 
 Tags: 2022.1-b1
 GitFetch: refs/heads/release-7.14.0
-GitCommit: c871e232eebce8fbc355934f3c1a5bc5601c2cc2
+GitCommit: b72469b76d55e0cbd3d8de293d940b79b5fd147d
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -21,5 +21,5 @@ GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
 
 Tags: 2022.1-b1
-GitCommit: d186e6d24a2dfd5b7020909b9e65aad14d1e59f9
+GitCommit: 89271fc68c286a4f845d5a4d0c28bfa079a5af67
 Directory: docker

--- a/library/bonita
+++ b/library/bonita
@@ -13,7 +13,7 @@ GitCommit: 7058084357dcd0fccf723ab2c7e21ec2b73f1f45
 Directory: docker
 
 Tags: 2021.1, 7.12.1, 7.12
-GitCommit: c9b816249504017bb3418252bf58ec9d4fc3e86e
+GitCommit: bfdd527629063b73f053320e50e1f6bfcd135d0a
 Directory: docker
 
 Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13, latest

--- a/library/bonita
+++ b/library/bonita
@@ -9,18 +9,22 @@ GitRepo: https://github.com/bonitasoft/bonita-distrib.git
 
 
 Tags: 7.11.4, 7.11
+GitFetch: refs/heads/docker/7.11.4
 GitCommit: 7058084357dcd0fccf723ab2c7e21ec2b73f1f45
 Directory: docker
 
 Tags: 2021.1, 7.12.1, 7.12
+GitFetch: refs/heads/docker/2021.1
 GitCommit: bfdd527629063b73f053320e50e1f6bfcd135d0a
 Directory: docker
 
 Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13, latest
+GitFetch: refs/heads/docker/2022.1
 GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
 Directory: docker
 
 Tags: 2022.1-b1
 Architectures: amd64
+GitFetch: refs/heads/release-7.14.0
 GitCommit: 89271fc68c286a4f845d5a4d0c28bfa079a5af67
 Directory: docker


### PR DESCRIPTION
This adds the beta version of bonita: 2022.1-b1

I did not remove any previous version because this one is still a beta.

There was a lot of changes in that new version. Please tell us if anything is wrong in these changes.

Also previous images still uses sks (mentioned there: https://github.com/docker-library/faq/pull/26 ) 
Do we need to update the already existing previous versions that uses it?

Thank you!