### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.38.0, 4.38, 4, latest
+Tags: 4.38.1, 4.38, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d50d6bc7cb14949c9fc8d4384f06fd80ad6d3f75
+GitCommit: bfcd405d7e4b41dd17a11dd792fdbf01ec45d00c
 Directory: 4/debian
 
-Tags: 4.38.0-alpine, 4.38-alpine, 4-alpine, alpine
+Tags: 4.38.1-alpine, 4.38-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d50d6bc7cb14949c9fc8d4384f06fd80ad6d3f75
+GitCommit: bfcd405d7e4b41dd17a11dd792fdbf01ec45d00c
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/bfcd405: Update to 4.38.1, ghost-cli 1.18.1