### PR TITLE
Update backdrop

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -6,10 +6,10 @@ GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
 Tags: 1.21.3, 1.21, 1, 1.21.3-apache, 1.21-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 0e2786d8e2965e8cb0a50cc0c5a003469948a201
+GitCommit: c1cfa96e4cfaae56dd4f3ca862231b83a95df0d1
 Directory: 1/apache
 
 Tags: 1.21.3-fpm, 1.21-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 0e2786d8e2965e8cb0a50cc0c5a003469948a201
+GitCommit: c1cfa96e4cfaae56dd4f3ca862231b83a95df0d1
 Directory: 1/fpm

--- a/library/backdrop
+++ b/library/backdrop
@@ -1,16 +1,15 @@
 Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Geoff St. Pierre <serundeputy@gmail.com> (@serundeputy),
              Jen Lampton <jen+docker@jeneration.com> (@jenlampton),
-             Pol Dellaiera <pol.dellaiera@protonmail.com> (@drupol),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
 Tags: 1.21.3, 1.21, 1, 1.21.3-apache, 1.21-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 5ff119dc2849a709d9621a9950eeb6aaca075197
+GitCommit: 0e2786d8e2965e8cb0a50cc0c5a003469948a201
 Directory: 1/apache
 
 Tags: 1.21.3-fpm, 1.21-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 5ff119dc2849a709d9621a9950eeb6aaca075197
+GitCommit: 0e2786d8e2965e8cb0a50cc0c5a003469948a201
 Directory: 1/fpm

--- a/library/backdrop
+++ b/library/backdrop
@@ -6,10 +6,10 @@ GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
 Tags: 1.21.3, 1.21, 1, 1.21.3-apache, 1.21-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: da1b682d69e2da86a87300cfd3380610a7abbd65
+GitCommit: 458205ef1ece9f624aacfd105fcea82d21277812
 Directory: 1/apache
 
 Tags: 1.21.3-fpm, 1.21-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: da1b682d69e2da86a87300cfd3380610a7abbd65
+GitCommit: 458205ef1ece9f624aacfd105fcea82d21277812
 Directory: 1/fpm

--- a/library/backdrop
+++ b/library/backdrop
@@ -5,12 +5,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.17.3, 1.17, 1, 1.17.3-apache, 1.17-apache, 1-apache, apache, latest
+Tags: 1.21.3, 1.21, 1, 1.21.3-apache, 1.21-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: b760ba970a67f3dcdc975ed8b77f915895184577
+GitCommit: 5ff119dc2849a709d9621a9950eeb6aaca075197
 Directory: 1/apache
 
-Tags: 1.17.3-fpm, 1.17-fpm, 1-fpm, fpm
+Tags: 1.21.3-fpm, 1.21-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: b760ba970a67f3dcdc975ed8b77f915895184577
+GitCommit: 5ff119dc2849a709d9621a9950eeb6aaca075197
 Directory: 1/fpm

--- a/library/backdrop
+++ b/library/backdrop
@@ -6,10 +6,10 @@ GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
 Tags: 1.21.3, 1.21, 1, 1.21.3-apache, 1.21-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: c1cfa96e4cfaae56dd4f3ca862231b83a95df0d1
+GitCommit: da1b682d69e2da86a87300cfd3380610a7abbd65
 Directory: 1/apache
 
 Tags: 1.21.3-fpm, 1.21-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: c1cfa96e4cfaae56dd4f3ca862231b83a95df0d1
+GitCommit: da1b682d69e2da86a87300cfd3380610a7abbd65
 Directory: 1/fpm


### PR DESCRIPTION
Update to 1.21.3

Here's the latest release info
https://github.com/backdrop/backdrop/releases/tag/1.21.3
https://github.com/backdrop-ops/backdrop-docker/commit/5ff119dc2849a709d9621a9950eeb6aaca075197