### PR TITLE
[nats] Release v2.7.4

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,25 +4,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Jaime Piña <jaime@synadia.com> (@variadico)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 3797584aad79665c94dcf259fa3e7fcc5770bf81
+GitCommit: 9095670eefc7c5af2ba6400a42ff88097b018c70
 
-Tags: 2.7.3-alpine3.15, 2.7-alpine3.15, 2-alpine3.15, alpine3.15, 2.7.3-alpine, 2.7-alpine, 2-alpine, alpine
+Tags: 2.7.4-alpine3.15, 2.7-alpine3.15, 2-alpine3.15, alpine3.15, 2.7.4-alpine, 2.7-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.7.3/alpine3.15
+Directory: 2.7.4/alpine3.15
 
-Tags: 2.7.3-scratch, 2.7-scratch, 2-scratch, scratch, 2.7.3-linux, 2.7-linux, 2-linux, linux
-SharedTags: 2.7.3, 2.7, 2, latest
+Tags: 2.7.4-scratch, 2.7-scratch, 2-scratch, scratch, 2.7.4-linux, 2.7-linux, 2-linux, linux
+SharedTags: 2.7.4, 2.7, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.7.3/scratch
+Directory: 2.7.4/scratch
 
-Tags: 2.7.3-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.7.3-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.7.4-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.7.4-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.7.3/windowsservercore-1809
+Directory: 2.7.4/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.7.3-nanoserver-1809, 2.7-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.7.3-nanoserver, 2.7-nanoserver, 2-nanoserver, nanoserver, 2.7.3, 2.7, 2, latest
+Tags: 2.7.4-nanoserver-1809, 2.7-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.7.4-nanoserver, 2.7-nanoserver, 2-nanoserver, nanoserver, 2.7.4, 2.7, 2, latest
 Architectures: windows-amd64
-Directory: 2.7.3/nanoserver-1809
+Directory: 2.7.4/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.7.4)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>