### PR TITLE
caddy: v2.5.0-beta.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/c2a97d2c1ac79f2d20db8464d717eaa5a19c030c/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/438f3c69eb193dc0d61bcae9ab9855a7db65a0ff/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.4.6-alpine, 2-alpine, alpine
@@ -14,7 +14,7 @@ Tags: 2.4.6-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.4.6-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/builder
-GitCommit: c2a97d2c1ac79f2d20db8464d717eaa5a19c030c
+GitCommit: 86712399e65cb78b0840ab558307cf56c4285c42
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.4.6-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
@@ -25,27 +25,57 @@ GitCommit: c2a97d2c1ac79f2d20db8464d717eaa5a19c030c
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.4.6-windowsservercore-ltsc2016, 2-windowsservercore-ltsc2016, windowsservercore-ltsc2016
-SharedTags: 2.4.6-windowsservercore, 2-windowsservercore, windowsservercore, 2.4.6, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.4/windows/ltsc2016
-GitCommit: c2a97d2c1ac79f2d20db8464d717eaa5a19c030c
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2016
-
 Tags: 2.4.6-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
 SharedTags: 2.4.6-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.4/windows-builder/1809
-GitCommit: c2a97d2c1ac79f2d20db8464d717eaa5a19c030c
+GitCommit: 86712399e65cb78b0840ab558307cf56c4285c42
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.4.6-builder-windowsservercore-ltsc2016, 2-builder-windowsservercore-ltsc2016, builder-windowsservercore-ltsc2016
-SharedTags: 2.4.6-builder, 2-builder, builder
+Tags: 2.5.0-beta.1-alpine
+SharedTags: 2.5.0-beta.1
 GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.4/windows-builder/ltsc2016
-GitCommit: c2a97d2c1ac79f2d20db8464d717eaa5a19c030c
+Directory: 2.5/alpine
+GitCommit: 53fb6cb851ecb5ed954cc2a9f3d2320e17a3cd0e
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.5.0-beta.1-builder-alpine
+SharedTags: 2.5.0-beta.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.5/builder
+GitCommit: 86712399e65cb78b0840ab558307cf56c4285c42
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.5.0-beta.1-windowsservercore-1809
+SharedTags: 2.5.0-beta.1-windowsservercore, 2.5.0-beta.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.5/windows/1809
+GitCommit: 86712399e65cb78b0840ab558307cf56c4285c42
 Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2016
+Constraints: windowsservercore-1809
+
+Tags: 2.5.0-beta.1-windowsservercore-ltsc2022
+SharedTags: 2.5.0-beta.1-windowsservercore, 2.5.0-beta.1
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.5/windows/ltsc2022
+GitCommit: fa4b449388180ba50b78ede82462cd5c5b356bb0
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.5.0-beta.1-builder-windowsservercore-1809
+SharedTags: 2.5.0-beta.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.5/windows-builder/1809
+GitCommit: 86712399e65cb78b0840ab558307cf56c4285c42
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.5.0-beta.1-builder-windowsservercore-ltsc2022
+SharedTags: 2.5.0-beta.1-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.5/windows-builder/ltsc2022
+GitCommit: fa4b449388180ba50b78ede82462cd5c5b356bb0
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.5.0-beta.1

Note that this also bumps the base Alpine and Windows LTSC versions for Caddy 2.5+.

Signed-off-by: Dave Henderson <dhenderson@gmail.com>