### PR TITLE
Upgrade to Backdrop 1.21.3

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -1,16 +1,15 @@
 Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Geoff St. Pierre <serundeputy@gmail.com> (@serundeputy),
              Jen Lampton <jen+docker@jeneration.com> (@jenlampton),
-             Pol Dellaiera <pol.dellaiera@protonmail.com> (@drupol),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.17.3, 1.17, 1, 1.17.3-apache, 1.17-apache, 1-apache, apache, latest
+Tags: 1.21.3, 1.21, 1, 1.21.3-apache, 1.21-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: b760ba970a67f3dcdc975ed8b77f915895184577
+GitCommit: cb71efedce22392184d6d10aa67109e8f7e86725
 Directory: 1/apache
 
-Tags: 1.17.3-fpm, 1.17-fpm, 1-fpm, fpm
+Tags: 1.21.3-fpm, 1.21-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: b760ba970a67f3dcdc975ed8b77f915895184577
+GitCommit: cb71efedce22392184d6d10aa67109e8f7e86725
 Directory: 1/fpm


### PR DESCRIPTION
Update to 1.21.3

Here's the latest release info
https://github.com/backdrop/backdrop/releases/tag/1.21.3
https://github.com/backdrop-ops/backdrop-docker/commit/cb71efedce22392184d6d10aa67109e8f7e86725