### PR TITLE
update r-base to 4.1.3 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.1.2, latest
+Tags: 4.1.3, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: df1414259dceb0282f163f29f4dccfa184d38d86
-Directory: r-base/4.1.2
+GitCommit: 2fb991537d60c20bc11a93a76587d6e25bb3a054
+Directory: r-base/4.1.3
 


### PR DESCRIPTION
Standard update of r-base to the new upstream release 4.1.3 made earlier today using the updated Debian binaries

Sole container change is to also install auxiliary package `docopt` as a pre-built binary, otherwise unchanged.