### PR TITLE
MariaDB - fix aarch64 (10.2/bionic), healtcheck.sh

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,35 +6,35 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.8.2-rc-focal, 10.8-rc-focal, 10.8.2-rc, 10.8-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.8
 
 Tags: 10.7.3-focal, 10.7-focal, 10-focal, focal, 10.7.3, 10.7, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.7
 
 Tags: 10.6.7-focal, 10.6-focal, 10.6.7, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.6
 
 Tags: 10.5.15-focal, 10.5-focal, 10.5.15, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.5
 
 Tags: 10.4.24-focal, 10.4-focal, 10.4.24, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.4
 
 Tags: 10.3.34-focal, 10.3-focal, 10.3.34, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.3
 
 Tags: 10.2.43-bionic, 10.2-bionic, 10.2.43, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bd9968e3387fa60e0a149cae2c1bb43a53ea1f3e
+GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
 Directory: 10.2


### PR DESCRIPTION
We erroniously released a 10.2 aarch64 bionic package that
wasn't installable due to broken dependences. This is now fixed.

The healthcheck.sh script had spelling mistakes in its autogeneration
for the 10.6 tags that resulted in:
* The default datadir being /var/lib/mariadb instead of /var/lib/mysql
* the --su-mysql parameter got broken.