### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/34ac46b1f8f808bcf20ef5adda8ff9852a4f4eb9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/123138a63e6b63b46162a1e1920775374ef055a8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 34ac46b1f8f808bcf20ef5adda8ff9852a4f4eb9
+GitCommit: 123138a63e6b63b46162a1e1920775374ef055a8
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3c3135c472313778fdafbb0745c0601e7b8e6e4e
+amd64-GitCommit: d85fda50cddcc15cdafc78d61f9d9fc39638453c
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: dff8b1e14ee4a7fd1a60e79fbc8a6ceb62d93b0b
+arm32v5-GitCommit: a707af58576e309aa1a214e1d367952eb26078a5
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 636b0cd4a936e5a8e849ab3af5def30615367086
+arm32v6-GitCommit: c8993db1eadf472c6c2865c770213a5d1811a344
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 480b3f26c066235ecc2fffa68a82b63d18b6f4f7
+arm32v7-GitCommit: 154694c406e4a36b1de24587c1a18f64b844e141
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8b6bd188690c41aa8623cf8dec7df97ec619beee
+arm64v8-GitCommit: f295bf141c44527a937a52e872cc83e5b37e9225
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 2e81ff82a3e2d86251b05eb5afe4c861397ebb8b
+i386-GitCommit: 3f852a174c6ef05097c116c042201cae67abcb1e
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 7573f15dc6c65892d9d6afa537168fa67ec82680
+mips64le-GitCommit: ecde8a784018049c682d14209e70e6dfb96b5fb8
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: cc71b41df0b8d433ee7edaa79cbbaa0c2f70bc81
+ppc64le-GitCommit: cf661c0bc94ed507c9ff54b49d3ee289fcff8dec
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 8f4009c78530a3bc065eb9de29c669774d89a9f4
+riscv64-GitCommit: d3749146704e4e070e1d60bfa6a9ceabc2a821c6
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e7550de316aa230f3d05b52d9714cd4b72e37dac
+s390x-GitCommit: b827c918a4ac01219bc0fb119fedae03dcfcad73
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/123138a: Merge pull request https://github.com/docker-library/busybox/pull/129 from infosiftr/buildroot-2022.02
- https://github.com/docker-library/busybox/commit/d4681fe: Update buildroot to 2022.02