### PR TITLE
archlinux: Release 20220313.0.50300

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220306.0.49442
-GitCommit: 2db5dcede3dd6194b942e4c037393f22a581d567
-GitFetch: refs/tags/v20220306.0.49442
+Tags: latest, base, base-20220313.0.50300
+GitCommit: 8b4b4e25f0fcd46a492412bd3ddbe6736312d54a
+GitFetch: refs/tags/v20220313.0.50300
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220306.0.49442
-GitCommit: 2db5dcede3dd6194b942e4c037393f22a581d567
-GitFetch: refs/tags/v20220306.0.49442
+Tags: base-devel, base-devel-20220313.0.50300
+GitCommit: 8b4b4e25f0fcd46a492412bd3ddbe6736312d54a
+GitFetch: refs/tags/v20220313.0.50300
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks