### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev2, 2.6-dev, 2.6-dev2-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev3, 2.6-dev, 2.6-dev3-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a95bcbbd151d9802fc0eddc5c23ee0d8aa9f9803
+GitCommit: 6005935e8e33d6ad03c6c49efccb7dc937ebcf3f
 Directory: 2.6-rc
 
-Tags: 2.6-dev2-alpine, 2.6-dev-alpine, 2.6-dev2-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev3-alpine, 2.6-dev-alpine, 2.6-dev3-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a95bcbbd151d9802fc0eddc5c23ee0d8aa9f9803
+GitCommit: 6005935e8e33d6ad03c6c49efccb7dc937ebcf3f
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.4, 2.5, latest, 2.5.4-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6005935: Update 2.6-rc to 2.6-dev3