### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 5.9.1-apache, 5.9-apache, 5-apache, apache, 5.9.1, 5.9, 5, latest, 5.9.1-php7.4-apache, 5.9-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.9.1-php7.4, 5.9-php7.4, 5-php7.4, php7.4
+Tags: 5.9.2-apache, 5.9-apache, 5-apache, apache, 5.9.2, 5.9, 5, latest, 5.9.2-php7.4-apache, 5.9-php7.4-apache, 5-php7.4-apache, php7.4-apache, 5.9.2-php7.4, 5.9-php7.4, 5-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.4/apache
 
-Tags: 5.9.1-fpm, 5.9-fpm, 5-fpm, fpm, 5.9.1-php7.4-fpm, 5.9-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
+Tags: 5.9.2-fpm, 5.9-fpm, 5-fpm, fpm, 5.9.2-php7.4-fpm, 5.9-php7.4-fpm, 5-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.4/fpm
 
-Tags: 5.9.1-fpm-alpine, 5.9-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.9.1-php7.4-fpm-alpine, 5.9-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 5.9.2-fpm-alpine, 5.9-fpm-alpine, 5-fpm-alpine, fpm-alpine, 5.9.2-php7.4-fpm-alpine, 5.9-php7.4-fpm-alpine, 5-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.9.1-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.1-php7.3, 5.9-php7.3, 5-php7.3, php7.3
+Tags: 5.9.2-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.2-php7.3, 5.9-php7.3, 5-php7.3, php7.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.3/apache
 
-Tags: 5.9.1-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
+Tags: 5.9.2-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.3/fpm
 
-Tags: 5.9.1-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
+Tags: 5.9.2-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.3/fpm-alpine
 
-Tags: 5.9.1-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.1-php8.0, 5.9-php8.0, 5-php8.0, php8.0
+Tags: 5.9.2-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.2-php8.0, 5.9-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php8.0/apache
 
-Tags: 5.9.1-php8.0-fpm, 5.9-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
+Tags: 5.9.2-php8.0-fpm, 5.9-php8.0-fpm, 5-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php8.0/fpm
 
-Tags: 5.9.1-php8.0-fpm-alpine, 5.9-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 5.9.2-php8.0-fpm-alpine, 5.9-php8.0-fpm-alpine, 5-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 5.9.1-php8.1-apache, 5.9-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.9.1-php8.1, 5.9-php8.1, 5-php8.1, php8.1
+Tags: 5.9.2-php8.1-apache, 5.9-php8.1-apache, 5-php8.1-apache, php8.1-apache, 5.9.2-php8.1, 5.9-php8.1, 5-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php8.1/apache
 
-Tags: 5.9.1-php8.1-fpm, 5.9-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
+Tags: 5.9.2-php8.1-fpm, 5.9-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php8.1/fpm
 
-Tags: 5.9.1-php8.1-fpm-alpine, 5.9-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 5.9.2-php8.1-fpm-alpine, 5.9-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8874538f8ac8e2adc0beac9ab5e637a823addf3b
+GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php8.1/fpm-alpine
 
 Tags: cli-2.6.0, cli-2.6, cli-2, cli, cli-2.6.0-php7.4, cli-2.6-php7.4, cli-2-php7.4, cli-php7.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/a59112c: Update latest to 5.9.2
- https://github.com/docker-library/wordpress/commit/cd5873a: Update beta to 5.9.2