### PR TITLE
Update Rocky Linux Images - March 2022

### DIFF
--- a/library/rockylinux
+++ b/library/rockylinux
@@ -1,7 +1,16 @@
-Maintainers: The Rocky Linux Foundation <infrastructure@rockylinux.org> (@rocky_linux)
+Maintainers: The Rocky Linux Foundation <infrastructure@rockylinux.org> (@rocky-linux),
+             Neil Hanlon <neil@resf.org> (@neilhanlon)
 GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
-Tags: latest, 8, 8.5
+Tags: latest, 8, 8.5.20220308
+GitFetch: refs/heads/Rocky-8.5.20220308-x86_64
+GitCommit: 82660c9c8d02077321bf6b12bd6aa512dbfce4fc 
+arm64v8-GitFetch: refs/heads/Rocky-8.5.20220308-aarch64
+arm64v8-GitCommit: a73d2de52b19977008c07227b7527c719b7db623
+Architectures: amd64, arm64v8
+
+
+Tags: 8.5
 GitFetch: refs/heads/Rocky-8.5-x86_64
 GitCommit: eee13752a34b9195c97d0bce92c05a838484eee8
 arm64v8-GitFetch: refs/heads/Rocky-8.5-aarch64


### PR DESCRIPTION
Hi all,

The plan with the images is to keep the minor version tag (e.g. 8.5) pinned to the initial release, and use latest as
well as the major version (8) tag to follow the most recent image.

I believe the change I've done should accomplish that, but would appreciate a second set of eyes, too.

Thank you!

Best,
Neil
