### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev2, 2.6-dev, 2.6-dev2-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev3, 2.6-dev, 2.6-dev3-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a95bcbbd151d9802fc0eddc5c23ee0d8aa9f9803
+GitCommit: 6005935e8e33d6ad03c6c49efccb7dc937ebcf3f
 Directory: 2.6-rc
 
-Tags: 2.6-dev2-alpine, 2.6-dev-alpine, 2.6-dev2-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev3-alpine, 2.6-dev-alpine, 2.6-dev3-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a95bcbbd151d9802fc0eddc5c23ee0d8aa9f9803
+GitCommit: 6005935e8e33d6ad03c6c49efccb7dc937ebcf3f
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.4, 2.5, latest, 2.5.4-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.5, 2.5, latest, 2.5.5-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 52ca796af066139c00ec883ae3714621d50307f1
+GitCommit: f70bee43595199d470ce5c711807c32417e04463
 Directory: 2.5
 
-Tags: 2.5.4-alpine, 2.5-alpine, alpine, 2.5.4-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.5-alpine, 2.5-alpine, alpine, 2.5.5-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 52ca796af066139c00ec883ae3714621d50307f1
+GitCommit: f70bee43595199d470ce5c711807c32417e04463
 Directory: 2.5/alpine
 
-Tags: 2.4.14, 2.4, lts, 2.4.14-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.15, 2.4, lts, 2.4.15-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0379f8bfa39a5ef6ed7b78ca78a08f0a8e70f1e1
+GitCommit: f7756832603d518d07c2354a7c35d7a6c1c5a6da
 Directory: 2.4
 
-Tags: 2.4.14-alpine, 2.4-alpine, lts-alpine, 2.4.14-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.15-alpine, 2.4-alpine, lts-alpine, 2.4.15-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0379f8bfa39a5ef6ed7b78ca78a08f0a8e70f1e1
+GitCommit: f7756832603d518d07c2354a7c35d7a6c1c5a6da
 Directory: 2.4/alpine
 
-Tags: 2.3.18, 2.3, 2.3.18-bullseye, 2.3-bullseye
+Tags: 2.3.19, 2.3, 2.3.19-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77f27f70e022f877b7a454c6da942f04d3c33d48
+GitCommit: b429a6f005908205a0635e12a41d957ba87ad8fd
 Directory: 2.3
 
-Tags: 2.3.18-alpine, 2.3-alpine, 2.3.18-alpine3.15, 2.3-alpine3.15
+Tags: 2.3.19-alpine, 2.3-alpine, 2.3.19-alpine3.15, 2.3-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 77f27f70e022f877b7a454c6da942f04d3c33d48
+GitCommit: b429a6f005908205a0635e12a41d957ba87ad8fd
 Directory: 2.3/alpine
 
-Tags: 2.2.21, 2.2, 2.2.21-bullseye, 2.2-bullseye
+Tags: 2.2.22, 2.2, 2.2.22-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9f76527d258518eaad06857b155e250760405b75
+GitCommit: f72759101407613038d819bd1404a9b3bbb24baa
 Directory: 2.2
 
-Tags: 2.2.21-alpine, 2.2-alpine, 2.2.21-alpine3.15, 2.2-alpine3.15
+Tags: 2.2.22-alpine, 2.2-alpine, 2.2.22-alpine3.15, 2.2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f76527d258518eaad06857b155e250760405b75
+GitCommit: f72759101407613038d819bd1404a9b3bbb24baa
 Directory: 2.2/alpine
 
-Tags: 2.0.27, 2.0, 2.0.27-buster, 2.0-buster
+Tags: 2.0.28, 2.0, 2.0.28-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec1777bec18a022f898231b6a04524c0ae4d97b5
+GitCommit: a421e7e758d512cb77364d2a1a232f3bda28c066
 Directory: 2.0
 
-Tags: 2.0.27-alpine, 2.0-alpine, 2.0.27-alpine3.15, 2.0-alpine3.15
+Tags: 2.0.28-alpine, 2.0-alpine, 2.0.28-alpine3.15, 2.0-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ec1777bec18a022f898231b6a04524c0ae4d97b5
+GitCommit: a421e7e758d512cb77364d2a1a232f3bda28c066
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/f70bee4: Update 2.5 to 2.5.5
- https://github.com/docker-library/haproxy/commit/f775683: Update 2.4 to 2.4.15
- https://github.com/docker-library/haproxy/commit/b429a6f: Update 2.3 to 2.3.19
- https://github.com/docker-library/haproxy/commit/f727591: Update 2.2 to 2.2.22
- https://github.com/docker-library/haproxy/commit/a421e7e: Update 2.0 to 2.0.28
- https://github.com/docker-library/haproxy/commit/6005935: Update 2.6-rc to 2.6-dev3