### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,58 +5,58 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.18rc1-bullseye, 1.18-rc-bullseye, rc-bullseye
-SharedTags: 1.18rc1, 1.18-rc, rc
+Tags: 1.18.0-bullseye, 1.18-bullseye
+SharedTags: 1.18.0, 1.18
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/bullseye
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/bullseye
 
-Tags: 1.18rc1-buster, 1.18-rc-buster, rc-buster
+Tags: 1.18.0-buster, 1.18-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/buster
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/buster
 
-Tags: 1.18rc1-stretch, 1.18-rc-stretch, rc-stretch
+Tags: 1.18.0-stretch, 1.18-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/stretch
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/stretch
 
-Tags: 1.18rc1-alpine3.15, 1.18-rc-alpine3.15, rc-alpine3.15, 1.18rc1-alpine, 1.18-rc-alpine, rc-alpine
+Tags: 1.18.0-alpine3.15, 1.18-alpine3.15, 1.18.0-alpine, 1.18-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/alpine3.15
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/alpine3.15
 
-Tags: 1.18rc1-alpine3.14, 1.18-rc-alpine3.14, rc-alpine3.14
+Tags: 1.18.0-alpine3.14, 1.18-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/alpine3.14
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/alpine3.14
 
-Tags: 1.18rc1-windowsservercore-ltsc2022, 1.18-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 1.18rc1-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18rc1, 1.18-rc, rc
+Tags: 1.18.0-windowsservercore-ltsc2022, 1.18-windowsservercore-ltsc2022
+SharedTags: 1.18.0-windowsservercore, 1.18-windowsservercore, 1.18.0, 1.18
 Architectures: windows-amd64
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/windows/windowsservercore-ltsc2022
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.18rc1-windowsservercore-1809, 1.18-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.18rc1-windowsservercore, 1.18-rc-windowsservercore, rc-windowsservercore, 1.18rc1, 1.18-rc, rc
+Tags: 1.18.0-windowsservercore-1809, 1.18-windowsservercore-1809
+SharedTags: 1.18.0-windowsservercore, 1.18-windowsservercore, 1.18.0, 1.18
 Architectures: windows-amd64
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/windows/windowsservercore-1809
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.18rc1-nanoserver-ltsc2022, 1.18-rc-nanoserver-ltsc2022, rc-nanoserver-ltsc2022
-SharedTags: 1.18rc1-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
+Tags: 1.18.0-nanoserver-ltsc2022, 1.18-nanoserver-ltsc2022
+SharedTags: 1.18.0-nanoserver, 1.18-nanoserver
 Architectures: windows-amd64
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/windows/nanoserver-ltsc2022
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.18rc1-nanoserver-1809, 1.18-rc-nanoserver-1809, rc-nanoserver-1809
-SharedTags: 1.18rc1-nanoserver, 1.18-rc-nanoserver, rc-nanoserver
+Tags: 1.18.0-nanoserver-1809, 1.18-nanoserver-1809
+SharedTags: 1.18.0-nanoserver, 1.18-nanoserver
 Architectures: windows-amd64
-GitCommit: 7db3fb743f7d5d24d75493eacfc0595ce97979da
-Directory: 1.18-rc/windows/nanoserver-1809
+GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
+Directory: 1.18/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 1.17.8-bullseye, 1.17-bullseye, 1-bullseye, bullseye
@@ -111,58 +111,4 @@ SharedTags: 1.17.8-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 1.16.15-bullseye, 1.16-bullseye
-SharedTags: 1.16.15, 1.16
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/bullseye
-
-Tags: 1.16.15-buster, 1.16-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/buster
-
-Tags: 1.16.15-stretch, 1.16-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/stretch
-
-Tags: 1.16.15-alpine3.15, 1.16-alpine3.15, 1.16.15-alpine, 1.16-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/alpine3.15
-
-Tags: 1.16.15-alpine3.14, 1.16-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/alpine3.14
-
-Tags: 1.16.15-windowsservercore-ltsc2022, 1.16-windowsservercore-ltsc2022
-SharedTags: 1.16.15-windowsservercore, 1.16-windowsservercore, 1.16.15, 1.16
-Architectures: windows-amd64
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 1.16.15-windowsservercore-1809, 1.16-windowsservercore-1809
-SharedTags: 1.16.15-windowsservercore, 1.16-windowsservercore, 1.16.15, 1.16
-Architectures: windows-amd64
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 1.16.15-nanoserver-ltsc2022, 1.16-nanoserver-ltsc2022
-SharedTags: 1.16.15-nanoserver, 1.16-nanoserver
-Architectures: windows-amd64
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: 1.16.15-nanoserver-1809, 1.16-nanoserver-1809
-SharedTags: 1.16.15-nanoserver, 1.16-nanoserver
-Architectures: windows-amd64
-GitCommit: ceac6589f926d83c96ce7ccb1574b4b735feac3c
-Directory: 1.16/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/64de1d3: Merge pull request https://github.com/docker-library/golang/pull/411 from infosiftr/1.18
- https://github.com/docker-library/golang/commit/e4e2e5e: Update to 1.18 GA (drop 1.16)