### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,109 +5,109 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.18.0-bullseye, 1.18-bullseye
-SharedTags: 1.18.0, 1.18
+Tags: 1.18.0-bullseye, 1.18-bullseye, 1-bullseye, bullseye
+SharedTags: 1.18.0, 1.18, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/bullseye
 
-Tags: 1.18.0-buster, 1.18-buster
+Tags: 1.18.0-buster, 1.18-buster, 1-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/buster
 
-Tags: 1.18.0-stretch, 1.18-stretch
+Tags: 1.18.0-stretch, 1.18-stretch, 1-stretch, stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/stretch
 
-Tags: 1.18.0-alpine3.15, 1.18-alpine3.15, 1.18.0-alpine, 1.18-alpine
+Tags: 1.18.0-alpine3.15, 1.18-alpine3.15, 1-alpine3.15, alpine3.15, 1.18.0-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/alpine3.15
 
-Tags: 1.18.0-alpine3.14, 1.18-alpine3.14
+Tags: 1.18.0-alpine3.14, 1.18-alpine3.14, 1-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/alpine3.14
 
-Tags: 1.18.0-windowsservercore-ltsc2022, 1.18-windowsservercore-ltsc2022
-SharedTags: 1.18.0-windowsservercore, 1.18-windowsservercore, 1.18.0, 1.18
+Tags: 1.18.0-windowsservercore-ltsc2022, 1.18-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.18.0-windowsservercore, 1.18-windowsservercore, 1-windowsservercore, windowsservercore, 1.18.0, 1.18, 1, latest
 Architectures: windows-amd64
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.18.0-windowsservercore-1809, 1.18-windowsservercore-1809
-SharedTags: 1.18.0-windowsservercore, 1.18-windowsservercore, 1.18.0, 1.18
+Tags: 1.18.0-windowsservercore-1809, 1.18-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.18.0-windowsservercore, 1.18-windowsservercore, 1-windowsservercore, windowsservercore, 1.18.0, 1.18, 1, latest
 Architectures: windows-amd64
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.18.0-nanoserver-ltsc2022, 1.18-nanoserver-ltsc2022
-SharedTags: 1.18.0-nanoserver, 1.18-nanoserver
+Tags: 1.18.0-nanoserver-ltsc2022, 1.18-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.18.0-nanoserver, 1.18-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.18.0-nanoserver-1809, 1.18-nanoserver-1809
-SharedTags: 1.18.0-nanoserver, 1.18-nanoserver
+Tags: 1.18.0-nanoserver-1809, 1.18-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.18.0-nanoserver, 1.18-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: e4e2e5e3b96141bf31de0f011c676406e8ef0f66
 Directory: 1.18/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.17.8-bullseye, 1.17-bullseye, 1-bullseye, bullseye
-SharedTags: 1.17.8, 1.17, 1, latest
+Tags: 1.17.8-bullseye, 1.17-bullseye
+SharedTags: 1.17.8, 1.17
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/bullseye
 
-Tags: 1.17.8-buster, 1.17-buster, 1-buster, buster
+Tags: 1.17.8-buster, 1.17-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/buster
 
-Tags: 1.17.8-stretch, 1.17-stretch, 1-stretch, stretch
+Tags: 1.17.8-stretch, 1.17-stretch
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/stretch
 
-Tags: 1.17.8-alpine3.15, 1.17-alpine3.15, 1-alpine3.15, alpine3.15, 1.17.8-alpine, 1.17-alpine, 1-alpine, alpine
+Tags: 1.17.8-alpine3.15, 1.17-alpine3.15, 1.17.8-alpine, 1.17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/alpine3.15
 
-Tags: 1.17.8-alpine3.14, 1.17-alpine3.14, 1-alpine3.14, alpine3.14
+Tags: 1.17.8-alpine3.14, 1.17-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/alpine3.14
 
-Tags: 1.17.8-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.17.8-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.8, 1.17, 1, latest
+Tags: 1.17.8-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022
+SharedTags: 1.17.8-windowsservercore, 1.17-windowsservercore, 1.17.8, 1.17
 Architectures: windows-amd64
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.17.8-windowsservercore-1809, 1.17-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.17.8-windowsservercore, 1.17-windowsservercore, 1-windowsservercore, windowsservercore, 1.17.8, 1.17, 1, latest
+Tags: 1.17.8-windowsservercore-1809, 1.17-windowsservercore-1809
+SharedTags: 1.17.8-windowsservercore, 1.17-windowsservercore, 1.17.8, 1.17
 Architectures: windows-amd64
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17.8-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.17.8-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.8-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022
+SharedTags: 1.17.8-nanoserver, 1.17-nanoserver
 Architectures: windows-amd64
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.17.8-nanoserver-1809, 1.17-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.17.8-nanoserver, 1.17-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.17.8-nanoserver-1809, 1.17-nanoserver-1809
+SharedTags: 1.17.8-nanoserver, 1.17-nanoserver
 Architectures: windows-amd64
 GitCommit: 67757c0feeb9867a54801ca378dcfc55b9db7e70
 Directory: 1.17/windows/nanoserver-1809


### PR DESCRIPTION
changes:

- change 1.18 to latest


wait for https://github.com/docker-library/golang/pull/414