### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.10.0-beta.4, 3.10-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: b26686c36eca564298c0e311ec2a8a8a064e1269
+GitCommit: 162017bb977c4e5826b34bf903c61bedb52c246d
 Directory: 3.10-rc/ubuntu
 
 Tags: 3.10.0-beta.4-management, 3.10-rc-management
@@ -16,7 +16,7 @@ Directory: 3.10-rc/ubuntu/management
 
 Tags: 3.10.0-beta.4-alpine, 3.10-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b26686c36eca564298c0e311ec2a8a8a064e1269
+GitCommit: 162017bb977c4e5826b34bf903c61bedb52c246d
 Directory: 3.10-rc/alpine
 
 Tags: 3.10.0-beta.4-management-alpine, 3.10-rc-management-alpine
@@ -26,7 +26,7 @@ Directory: 3.10-rc/alpine/management
 
 Tags: 3.9.13, 3.9, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 5d709452e2a2dd6e7423aaf82ba8f11380f4eed6
+GitCommit: 99fffd58a22a408ba6b10f65a04010ef9e61e483
 Directory: 3.9/ubuntu
 
 Tags: 3.9.13-management, 3.9-management, 3-management, management
@@ -36,7 +36,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.13-alpine, 3.9-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d709452e2a2dd6e7423aaf82ba8f11380f4eed6
+GitCommit: 99fffd58a22a408ba6b10f65a04010ef9e61e483
 Directory: 3.9/alpine
 
 Tags: 3.9.13-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
@@ -46,7 +46,7 @@ Directory: 3.9/alpine/management
 
 Tags: 3.8.27, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 0f8a7caf218c4f55f170a948b00db89b25c984c0
+GitCommit: 074a2108c984a0f668321275f339a316418f7ca7
 Directory: 3.8/ubuntu
 
 Tags: 3.8.27-management, 3.8-management
@@ -56,7 +56,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.27-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f8a7caf218c4f55f170a948b00db89b25c984c0
+GitCommit: 074a2108c984a0f668321275f339a316418f7ca7
 Directory: 3.8/alpine
 
 Tags: 3.8.27-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/99fffd5: Update 3.9 to otp 24.3.2
- https://github.com/docker-library/rabbitmq/commit/074a210: Update 3.8 to otp 24.3.2
- https://github.com/docker-library/rabbitmq/commit/162017b: Update 3.10-rc to otp 24.3.2