### PR TITLE
alpine: edge snapshot 20220316, bump v3.15.1 (CVE-2022-0778)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,10 @@
 Maintainers: Natanael Copa <ncopa@alpinelinux.org> (@ncopa)
 GitRepo: https://github.com/alpinelinux/docker-alpine.git
 
-Tags: 20210804, edge
+Tags: 20220316, edge
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/edge
-GitCommit: a29a148442aa2d6d13d3d87b224d058ec951ad46
+GitCommit: 1d264966e79d140f528deba4c8930da8d0b3478b
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.15.0, 3.15, 3, latest
+Tags: 3.15.1, 3.15, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.15
-GitCommit: 818c831891a18d2453ad6458011ea8cbff74d0e1
+GitCommit: 97d31961f0a778654d8ac5ff6111c1125ffaf633
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fixes https://github.com/alpinelinux/docker-alpine/issues/243