### PR TITLE
[security] Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -49,154 +49,154 @@ GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
 Directory: 3.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.10.2-bullseye, 3.10-bullseye, 3-bullseye, bullseye
-SharedTags: 3.10.2, 3.10, 3, latest
+Tags: 3.10.3-bullseye, 3.10-bullseye, 3-bullseye, bullseye
+SharedTags: 3.10.3, 3.10, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/bullseye
 
-Tags: 3.10.2-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.2-slim, 3.10-slim, 3-slim, slim
+Tags: 3.10.3-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.3-slim, 3.10-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/slim-bullseye
 
-Tags: 3.10.2-buster, 3.10-buster, 3-buster, buster
+Tags: 3.10.3-buster, 3.10-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/buster
 
-Tags: 3.10.2-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.10.3-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/slim-buster
 
-Tags: 3.10.2-alpine3.15, 3.10-alpine3.15, 3-alpine3.15, alpine3.15, 3.10.2-alpine, 3.10-alpine, 3-alpine, alpine
+Tags: 3.10.3-alpine3.15, 3.10-alpine3.15, 3-alpine3.15, alpine3.15, 3.10.3-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/alpine3.15
 
-Tags: 3.10.2-alpine3.14, 3.10-alpine3.14, 3-alpine3.14, alpine3.14
+Tags: 3.10.3-alpine3.14, 3.10-alpine3.14, 3-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/alpine3.14
 
-Tags: 3.10.2-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 3.10.2-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.2, 3.10, 3, latest
+Tags: 3.10.3-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 3.10.3-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.3, 3.10, 3, latest
 Architectures: windows-amd64
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.10.2-windowsservercore-1809, 3.10-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.10.2-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.2, 3.10, 3, latest
+Tags: 3.10.3-windowsservercore-1809, 3.10-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.10.3-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.3, 3.10, 3, latest
 Architectures: windows-amd64
-GitCommit: 010197d6572b9915ba9e6e65e71c063fb8cc5b95
+GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.9.10-bullseye, 3.9-bullseye
-SharedTags: 3.9.10, 3.9
+Tags: 3.9.11-bullseye, 3.9-bullseye
+SharedTags: 3.9.11, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/bullseye
 
-Tags: 3.9.10-slim-bullseye, 3.9-slim-bullseye, 3.9.10-slim, 3.9-slim
+Tags: 3.9.11-slim-bullseye, 3.9-slim-bullseye, 3.9.11-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/slim-bullseye
 
-Tags: 3.9.10-buster, 3.9-buster
+Tags: 3.9.11-buster, 3.9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/buster
 
-Tags: 3.9.10-slim-buster, 3.9-slim-buster
+Tags: 3.9.11-slim-buster, 3.9-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/slim-buster
 
-Tags: 3.9.10-alpine3.15, 3.9-alpine3.15, 3.9.10-alpine, 3.9-alpine
+Tags: 3.9.11-alpine3.15, 3.9-alpine3.15, 3.9.11-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/alpine3.15
 
-Tags: 3.9.10-alpine3.14, 3.9-alpine3.14
+Tags: 3.9.11-alpine3.14, 3.9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/alpine3.14
 
-Tags: 3.9.10-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
-SharedTags: 3.9.10-windowsservercore, 3.9-windowsservercore, 3.9.10, 3.9
+Tags: 3.9.11-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
+SharedTags: 3.9.11-windowsservercore, 3.9-windowsservercore, 3.9.11, 3.9
 Architectures: windows-amd64
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.9.10-windowsservercore-1809, 3.9-windowsservercore-1809
-SharedTags: 3.9.10-windowsservercore, 3.9-windowsservercore, 3.9.10, 3.9
+Tags: 3.9.11-windowsservercore-1809, 3.9-windowsservercore-1809
+SharedTags: 3.9.11-windowsservercore, 3.9-windowsservercore, 3.9.11, 3.9
 Architectures: windows-amd64
-GitCommit: 0f753da42f7ca178a073836c4532dc1433d6cac0
+GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.8.12-bullseye, 3.8-bullseye
-SharedTags: 3.8.12, 3.8
+Tags: 3.8.13-bullseye, 3.8-bullseye
+SharedTags: 3.8.13, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d363af347b75743b81c8ee05e8da9167dbeeb0b9
+GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
 Directory: 3.8/bullseye
 
-Tags: 3.8.12-slim-bullseye, 3.8-slim-bullseye, 3.8.12-slim, 3.8-slim
+Tags: 3.8.13-slim-bullseye, 3.8-slim-bullseye, 3.8.13-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d363af347b75743b81c8ee05e8da9167dbeeb0b9
+GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
 Directory: 3.8/slim-bullseye
 
-Tags: 3.8.12-buster, 3.8-buster
+Tags: 3.8.13-buster, 3.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d363af347b75743b81c8ee05e8da9167dbeeb0b9
+GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
 Directory: 3.8/buster
 
-Tags: 3.8.12-slim-buster, 3.8-slim-buster
+Tags: 3.8.13-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d363af347b75743b81c8ee05e8da9167dbeeb0b9
+GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
 Directory: 3.8/slim-buster
 
-Tags: 3.8.12-alpine3.15, 3.8-alpine3.15, 3.8.12-alpine, 3.8-alpine
+Tags: 3.8.13-alpine3.15, 3.8-alpine3.15, 3.8.13-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d363af347b75743b81c8ee05e8da9167dbeeb0b9
+GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
 Directory: 3.8/alpine3.15
 
-Tags: 3.8.12-alpine3.14, 3.8-alpine3.14
+Tags: 3.8.13-alpine3.14, 3.8-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d363af347b75743b81c8ee05e8da9167dbeeb0b9
+GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
 Directory: 3.8/alpine3.14
 
-Tags: 3.7.12-bullseye, 3.7-bullseye
-SharedTags: 3.7.12, 3.7
+Tags: 3.7.13-bullseye, 3.7-bullseye
+SharedTags: 3.7.13, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bba5c132540121a0fff47bc806b4203f69b9b1a2
+GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
 Directory: 3.7/bullseye
 
-Tags: 3.7.12-slim-bullseye, 3.7-slim-bullseye, 3.7.12-slim, 3.7-slim
+Tags: 3.7.13-slim-bullseye, 3.7-slim-bullseye, 3.7.13-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bba5c132540121a0fff47bc806b4203f69b9b1a2
+GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
 Directory: 3.7/slim-bullseye
 
-Tags: 3.7.12-buster, 3.7-buster
+Tags: 3.7.13-buster, 3.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bba5c132540121a0fff47bc806b4203f69b9b1a2
+GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
 Directory: 3.7/buster
 
-Tags: 3.7.12-slim-buster, 3.7-slim-buster
+Tags: 3.7.13-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bba5c132540121a0fff47bc806b4203f69b9b1a2
+GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
 Directory: 3.7/slim-buster
 
-Tags: 3.7.12-alpine3.15, 3.7-alpine3.15, 3.7.12-alpine, 3.7-alpine
+Tags: 3.7.13-alpine3.15, 3.7-alpine3.15, 3.7.13-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bba5c132540121a0fff47bc806b4203f69b9b1a2
+GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
 Directory: 3.7/alpine3.15
 
-Tags: 3.7.12-alpine3.14, 3.7-alpine3.14
+Tags: 3.7.13-alpine3.14, 3.7-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bba5c132540121a0fff47bc806b4203f69b9b1a2
+GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
 Directory: 3.7/alpine3.14


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/cfebb82: Update 3.9 to 3.9.11, pip 22.0.4
- https://github.com/docker-library/python/commit/6b97190: Update 3.8 to 3.8.13, pip 22.0.4
- https://github.com/docker-library/python/commit/a9815ea: Update 3.7 to 3.7.13, pip 22.0.4
- https://github.com/docker-library/python/commit/2825144: Update 3.10 to 3.10.3, pip 22.0.4

https://pythoninsider.blogspot.com/2022/03/python-3103-3911-3813-and-3713-are-now.html