### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-0892,ELSA-2022-0894,ELSA-2022-0899,ELSA-2022-0951

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 331914f83f6b5c3dd6f0d98cdda5a1593d685704
+amd64-GitCommit: d0e10e6ffa7d654df353662fec4447dffb0e3557
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e0bc1ba9a2b94b0946365fdfb3faceae470f4fe6
+arm64v8-GitCommit: e088962e8750905213fbf0ad870bd726ef7f07b1
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for:

CVE-2021-23177
CVE-2021-31566
CVE-2022-0261
CVE-2022-0318
CVE-2022-0359
CVE-2022-0361
CVE-2022-0392
CVE-2022-0413
CVE-2022-23308
CVE-2021-45960
CVE-2021-46143
CVE-2022-22822
CVE-2022-22823
CVE-2022-22824
CVE-2022-22825
CVE-2022-22826
CVE-2022-22827
CVE-2022-23852
CVE-2022-25235
CVE-2022-25236
CVE-2022-25315

See the following for details:
https://linux.oracle.com/errata/ELSA-2022-0892.html
https://linux.oracle.com/errata/ELSA-2022-0894.html
https://linux.oracle.com/errata/ELSA-2022-0899.html
https://linux.oracle.com/errata/ELSA-2022-0951.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>