### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,21 +12,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Richard Kelly (@rpkelly),
              Joseph Howell-Burke (@jhowell-burke)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 3a37136d64befa991ec7a677b43910700c45d59b
+GitCommit: e3e844624affdec30b221d64fca178edbd58fe78
 
-Tags: 2.0.20220218.1, 2, latest
+Tags: 2.0.20220316.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 6cc54a83e56928911881798df73bc40e08c512c6
+amd64-GitCommit: d55c04f219a765500b97b89955a6a628ce9e9857
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 90a28e6475ba19bdd7705ddc0c81eb9941db537b
+arm64v8-GitCommit: b79f0187938600484e468f34db86a3b37d0377c2
 
-Tags: 2.0.20220218.1-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20220316.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 81e17555f1a5cfb550bdadf846a2e9ca54ec2416
+amd64-GitCommit: eb34529fd15e21a1fc455dbcbc486ea26cafebbe
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 26dc7009256d810c7d6f8c8b118a6f5444b435f0
+arm64v8-GitCommit: db6711b34aa4a7424f55f551d55377668e78b3e6
 
 Tags: 2018.03.0.20220209.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
New AL2 images release 2.0.20220316.0

Thanks,
Sam