### PR TITLE
alpine: bump 3.12.10, 3.13.8 and 3.14.4 (CVE-2022-0778)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -26,10 +26,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.14.3, 3.14
+Tags: 3.14.4, 3.14
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.14
-GitCommit: b88b69a4da55c759a174176b9e8d1da8697fd709
+GitCommit: ea777266460528766523d6007db57bd7fbdeb7dd
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -38,10 +38,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.13.7, 3.13
+Tags: 3.13.8, 3.13
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.13
-GitCommit: cdde2af5d054e84cb06f23bc99a1cf0827b25eff
+GitCommit: 7c00c38bea2a0ce95348d972577a2502dd45932d
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -50,10 +50,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.9, 3.12
+Tags: 3.12.10, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: 2793da4774fae12a67809b5956f6d70b02f99d79
+GitCommit: e62cf19c18f22e53f7c012cb442a36eac7d49085
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
fixes https://github.com/alpinelinux/docker-alpine/issues/243