### PR TITLE
Odoo: update 13.0-15.0 to release 20220317

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 912599984d8613373c649a827d82b05fc69bbe22
+GitCommit: 3b93ef1d1becfcd6e56e10ee82a15446e932390b
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest releases of Odoo supported versions.

Thanks