### PR TITLE
mariadb fix /docker-entrypoint-initdb.d replication

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,35 +6,35 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.8.2-rc-focal, 10.8-rc-focal, 10.8.2-rc, 10.8-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.8
 
 Tags: 10.7.3-focal, 10.7-focal, 10-focal, focal, 10.7.3, 10.7, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.7
 
 Tags: 10.6.7-focal, 10.6-focal, 10.6.7, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.6
 
 Tags: 10.5.15-focal, 10.5-focal, 10.5.15, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.5
 
 Tags: 10.4.24-focal, 10.4-focal, 10.4.24, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.4
 
 Tags: 10.3.34-focal, 10.3-focal, 10.3.34, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.3
 
 Tags: 10.2.43-bionic, 10.2-bionic, 10.2.43, 10.2
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a36b14438a8400d7478da4f5f7974dba150d668d
+GitCommit: 5b93a88ae340de53d621125bef89e3571a325cfa
 Directory: 10.2


### PR DESCRIPTION
A regression that a container master doesn't contain
the binary logs of its initdb.d data and cannot replicate this.

Fix details: https://github.com/MariaDB/mariadb-docker/pull/421.