### PR TITLE
Fedora Update 2022 03 18

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,20 +1,10 @@
 Maintainers: Clement Verna <cverna@fedoraproject.org> (@cverna), Vipul Siddharth <siddharthvipul1@fedoraproject.org> (@siddharthvipul)
 GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 
-Tags: 33
-Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
-GitFetch: refs/heads/33
-GitCommit: cec7e68b76f504a1310ba12ce6e4a8d6fe2b4660
-amd64-Directory: x86_64/
-arm64v8-Directory: aarch64/
-ppc64le-Directory: ppc64le/
-s390x-Directory: s390x/
-arm32v7-Directory: armhfp/
-
 Tags: 34
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/34
-GitCommit: ea30da82d99fdf3795fd14d0411670a0fdf81697
+GitCommit: 8adf82f023696a50cf9016a3611e3fe75c7e2cfc
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
@@ -24,19 +14,28 @@ ppc64le-Directory: ppc64le/
 Tags: 35, latest
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/35
-GitCommit: 40da686a159cbd72584bb16208e4c1384a042d83
+GitCommit: 906ac31cb72302d7986f729de8dc0b6451214a76		
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 ppc64le-Directory: ppc64le/
 
-Tags: rawhide,36
+Tags: 36
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/36
-GitCommit: ba2680a57fb2ea22d2d2d5be729ccf4678a8504e
+GitCommit: 7190c545d2f9f0f7e54d6d972fc84621a83c1ad4
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
+ppc64le-Directory: ppc64le/
+
+Tags: 37, rawhide				
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitFetch: refs/heads/37
+GitCommit: e69c90e039cbcd8c252f5b04323565948417e2aa
+amd64-Directory: x86_64/
+arm64v8-Directory: aarch64/
+s390x-Directory: s390x/
 ppc64le-Directory: ppc64le/


### PR DESCRIPTION
Fedora 36 is no longer rawhide
Add Fedora 37 and move the rawhide tag
Currently arm32 is not available on F37

Signed-off-by: Clement Verna <cverna@tutanota.com>