### PR TITLE
Rewrite instances of "pythonX.X", "pyX.X", etc in tarball listings

### DIFF
--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -236,6 +236,8 @@ copy-tar() {
 								tar -tf "$dstG" \
 									| grep -vE "$uninterestingTarballGrep" \
 									| sed -e 's!^[.]/!!' \
+										-r \
+										-e 's!([/.-]|^)((lib)?(c?python|py)-?)[0-9]+([.][0-9]+)?([/.-]|$)!\1\2XXX\6!g' \
 									| sort \
 									> "$dstG  'tar -t'"
 							fi


### PR DESCRIPTION
This leads to significantly smaller diffs in instances like major distro releases where the Python version moves from something like 3.9 to 3.10 (and a large portion of the diff is then just directory renames as a result).

See https://github.com/docker-library/official-images/pull/12077 for a very successful case of this. :smile: