### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ELSA-2022-9224 and ELSA-2022-9227

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d0e10e6ffa7d654df353662fec4447dffb0e3557
+amd64-GitCommit: 7d179623a8bd6040e9421cad3b65272adf0531c6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e088962e8750905213fbf0ad870bd726ef7f07b1
+arm64v8-GitCommit: 4606015d3992ad565d3e299b68a181e2513493cc
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-0778, CVE-2021-46143 and CVE-2022-23990.

For details, see:
https://linux.oracle.com/errata/ELSA-2022-9224.html
https://linux.oracle.com/errata/ELSA-2022-9227.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>