### PR TITLE
archlinux: Release 20220320.0.50753

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220313.0.50300
-GitCommit: 8b4b4e25f0fcd46a492412bd3ddbe6736312d54a
-GitFetch: refs/tags/v20220313.0.50300
+Tags: latest, base, base-20220320.0.50753
+GitCommit: 13942875d8b6627ad09e4c7d51ae88c7b086a4b0
+GitFetch: refs/tags/v20220320.0.50753
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220313.0.50300
-GitCommit: 8b4b4e25f0fcd46a492412bd3ddbe6736312d54a
-GitFetch: refs/tags/v20220313.0.50300
+Tags: base-devel, base-devel-20220320.0.50753
+GitCommit: 13942875d8b6627ad09e4c7d51ae88c7b086a4b0
+GitFetch: refs/tags/v20220320.0.50753
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks