### PR TITLE
Add Couchbase Server EE 6.5.2

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -20,3 +20,10 @@ Directory: community/couchbase-server/6.6.0
 Tags: 6.0.5, enterprise-6.0.5
 GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
 Directory: enterprise/couchbase-server/6.0.5
+
+# One-off addition of older release 6.5.2 which has been updated
+# to a newer base image
+
+Tags: 6.5.2, enterprise-6.5.2
+GitCommit: d24fe7e4e45de16395e6da37a97969e8ce198b45
+Directory: enterprise/couchbase-server/6.5.2


### PR DESCRIPTION
This release was previously overlooked as it came out after a newer version (6.6.1). For completeness, adding it in now.