### PR TITLE
alpine: bump 3.15.2 (libretls CVE-2022-0778)

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.15.1, 3.15, 3, latest
+Tags: 3.15.2, 3.15, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.15
-GitCommit: 97d31961f0a778654d8ac5ff6111c1125ffaf633
+GitCommit: 3c5b5826ab4448874a22ed69069f18e897c3ac31
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Fix libretls CVE-2022-0778

https://github.com/alpinelinux/docker-alpine/issues/243#issuecomment-1072268823