### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-9233 and ELSA-2022-9232

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7d179623a8bd6040e9421cad3b65272adf0531c6
+amd64-GitCommit: 42d007377b1d8e0adcd7cb3cf5595c07f7763984
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4606015d3992ad565d3e299b68a181e2513493cc
+arm64v8-GitCommit: a705ad7b05dfdad4f6c07c1a734e658be1d00a64
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-0778 and CVE-2022-23990.

See https://linux.oracle.com/errata/ELSA-2022-9233.html and https://linux.oracle.com/errata/ELSA-2022-9232.html for details.

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com