### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -49,93 +49,93 @@ GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
 Directory: 3.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.10.3-bullseye, 3.10-bullseye, 3-bullseye, bullseye
-SharedTags: 3.10.3, 3.10, 3, latest
+Tags: 3.10.4-bullseye, 3.10-bullseye, 3-bullseye, bullseye
+SharedTags: 3.10.4, 3.10, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/bullseye
 
-Tags: 3.10.3-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.3-slim, 3.10-slim, 3-slim, slim
+Tags: 3.10.4-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.4-slim, 3.10-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/slim-bullseye
 
-Tags: 3.10.3-buster, 3.10-buster, 3-buster, buster
+Tags: 3.10.4-buster, 3.10-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/buster
 
-Tags: 3.10.3-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.10.4-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/slim-buster
 
-Tags: 3.10.3-alpine3.15, 3.10-alpine3.15, 3-alpine3.15, alpine3.15, 3.10.3-alpine, 3.10-alpine, 3-alpine, alpine
+Tags: 3.10.4-alpine3.15, 3.10-alpine3.15, 3-alpine3.15, alpine3.15, 3.10.4-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/alpine3.15
 
-Tags: 3.10.3-alpine3.14, 3.10-alpine3.14, 3-alpine3.14, alpine3.14
+Tags: 3.10.4-alpine3.14, 3.10-alpine3.14, 3-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/alpine3.14
 
-Tags: 3.10.3-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 3.10.3-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.3, 3.10, 3, latest
+Tags: 3.10.4-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 3.10.4-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.4, 3.10, 3, latest
 Architectures: windows-amd64
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.10.3-windowsservercore-1809, 3.10-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.10.3-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.3, 3.10, 3, latest
+Tags: 3.10.4-windowsservercore-1809, 3.10-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.10.4-windowsservercore, 3.10-windowsservercore, 3-windowsservercore, windowsservercore, 3.10.4, 3.10, 3, latest
 Architectures: windows-amd64
-GitCommit: 2825144ae5bfbb841e69bec6a9b301a3b7e0e7ab
+GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.9.11-bullseye, 3.9-bullseye
-SharedTags: 3.9.11, 3.9
+Tags: 3.9.12-bullseye, 3.9-bullseye
+SharedTags: 3.9.12, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/bullseye
 
-Tags: 3.9.11-slim-bullseye, 3.9-slim-bullseye, 3.9.11-slim, 3.9-slim
+Tags: 3.9.12-slim-bullseye, 3.9-slim-bullseye, 3.9.12-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/slim-bullseye
 
-Tags: 3.9.11-buster, 3.9-buster
+Tags: 3.9.12-buster, 3.9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/buster
 
-Tags: 3.9.11-slim-buster, 3.9-slim-buster
+Tags: 3.9.12-slim-buster, 3.9-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/slim-buster
 
-Tags: 3.9.11-alpine3.15, 3.9-alpine3.15, 3.9.11-alpine, 3.9-alpine
+Tags: 3.9.12-alpine3.15, 3.9-alpine3.15, 3.9.12-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/alpine3.15
 
-Tags: 3.9.11-alpine3.14, 3.9-alpine3.14
+Tags: 3.9.12-alpine3.14, 3.9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/alpine3.14
 
-Tags: 3.9.11-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
-SharedTags: 3.9.11-windowsservercore, 3.9-windowsservercore, 3.9.11, 3.9
+Tags: 3.9.12-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
+SharedTags: 3.9.12-windowsservercore, 3.9-windowsservercore, 3.9.12, 3.9
 Architectures: windows-amd64
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.9.11-windowsservercore-1809, 3.9-windowsservercore-1809
-SharedTags: 3.9.11-windowsservercore, 3.9-windowsservercore, 3.9.11, 3.9
+Tags: 3.9.12-windowsservercore-1809, 3.9-windowsservercore-1809
+SharedTags: 3.9.12-windowsservercore, 3.9-windowsservercore, 3.9.12, 3.9
 Architectures: windows-amd64
-GitCommit: cfebb82586e85db75dfac39f7bf41a4728c52df9
+GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/acf9b90: Update 3.10 to 3.10.4
- https://github.com/docker-library/python/commit/e3f954f: Update 3.9 to 3.9.12

https://pythoninsider.blogspot.com/2022/03/python-3104-and-3912-are-now-available.html