### PR TITLE
[oraclelinux] Updating 7, 7-slim, 8 and 8-slim for ELBA-2022-1032

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 42d007377b1d8e0adcd7cb3cf5595c07f7763984
+amd64-GitCommit: 9edbd4c6161d2e4cb38f4ca220fa0307e616bf39
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a705ad7b05dfdad4f6c07c1a734e658be1d00a64
+arm64v8-GitCommit: d540d67e1c1602be0b9afc4b44f21c36bd140481
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for rebase to tzdata-2022a.

See https://linux.oracle.com/errata/ELBA-2022-1032.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>