### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -19,21 +19,6 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 5.9.2-php7.3-apache, 5.9-php7.3-apache, 5-php7.3-apache, php7.3-apache, 5.9.2-php7.3, 5.9-php7.3, 5-php7.3, php7.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
-Directory: latest/php7.3/apache
-
-Tags: 5.9.2-php7.3-fpm, 5.9-php7.3-fpm, 5-php7.3-fpm, php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
-Directory: latest/php7.3/fpm
-
-Tags: 5.9.2-php7.3-fpm-alpine, 5.9-php7.3-fpm-alpine, 5-php7.3-fpm-alpine, php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
-Directory: latest/php7.3/fpm-alpine
-
 Tags: 5.9.2-php8.0-apache, 5.9-php8.0-apache, 5-php8.0-apache, php8.0-apache, 5.9.2-php8.0, 5.9-php8.0, 5-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a59112cc8738962784daf2ed9383d5148281c66f
@@ -68,11 +53,6 @@ Tags: cli-2.6.0, cli-2.6, cli-2, cli, cli-2.6.0-php7.4, cli-2.6-php7.4, cli-2-ph
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php7.4/alpine
-
-Tags: cli-2.6.0-php7.3, cli-2.6-php7.3, cli-2-php7.3, cli-php7.3
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
-Directory: cli/php7.3/alpine
 
 Tags: cli-2.6.0-php8.0, cli-2.6-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/3211d76: Remove PHP 7.3 (EOL)