### PR TITLE
Add new base images for Jetty

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,122 +4,327 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 11.0.8-jre11-slim, 11.0-jre11-slim, 11-jre11-slim
+Tags: 9.4.45-jre8-slim, 9.4-jre8-slim, 9-jre8-slim, 9.4.45-jre8-slim-openjdk, 9.4-jre8-slim-openjdk, 9-jre8-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 11.0-jre11-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jre8-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 11.0.8-jre11, 11.0-jre11, 11-jre11
+Tags: 9.4.45-jre8, 9.4-jre8, 9-jre8, 9.4.45-jre8-openjdk, 9.4-jre8-openjdk, 9-jre8-openjdk
 Architectures: amd64, arm64v8
-Directory: 11.0-jre11
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jre8
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 11.0.8-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim
+Tags: 9.4.45-jre11-slim, 9.4-jre11-slim, 9-jre11-slim, 9.4.45-jre11-slim-openjdk, 9.4-jre11-slim-openjdk, 9-jre11-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 11.0-jdk17-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jre11-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 11.0.8, 11.0, 11, 11.0.8-jdk17, 11.0-jdk17, 11-jdk17
+Tags: 9.4.45-jre11, 9.4-jre11, 9-jre11, 9.4.45-jre11-openjdk, 9.4-jre11-openjdk, 9-jre11-openjdk
 Architectures: amd64, arm64v8
-Directory: 11.0-jdk17
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jre11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 11.0.8-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim
+Tags: 9.4.45-jdk-8-slim, 9.4-jdk-8-slim, 9-jdk-8-slim, 9.4.45-jdk-8-slim-openjdk, 9.4-jdk-8-slim-openjdk, 9-jdk-8-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 11.0-jdk11-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jdk-8-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 11.0.8-jdk11, 11.0-jdk11, 11-jdk11
+Tags: 9.4.45-jdk8, 9.4-jdk8, 9-jdk8, 9.4.45-jdk8-openjdk, 9.4-jdk8-openjdk, 9-jdk8-openjdk
 Architectures: amd64, arm64v8
-Directory: 11.0-jdk11
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jdk8
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 10.0.8-jre11-slim, 10.0-jre11-slim, 10-jre11-slim
+Tags: 9.4.45-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim, 9.4.45-jdk17-slim-openjdk, 9.4-jdk17-slim-openjdk, 9-jdk17-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 10.0-jre11-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jdk17-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 10.0.8-jre11, 10.0-jre11, 10-jre11
+Tags: 9.4.45, 9.4, 9, 9.4.45-jdk17, 9.4-jdk17, 9-jdk17, 9.4.45-openjdk, 9.4-openjdk, 9-openjdk, 9.4.45-jdk17-openjdk, 9.4-jdk17-openjdk, 9-jdk17-openjdk, latest, jdk17
 Architectures: amd64, arm64v8
-Directory: 10.0-jre11
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 10.0.8-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim
+Tags: 9.4.45-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim, 9.4.45-jdk11-slim-openjdk, 9.4-jdk11-slim-openjdk, 9-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 10.0-jdk17-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jdk11-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 10.0.8, 10.0, 10, 10.0.8-jdk17, 10.0-jdk17, 10-jdk17
+Tags: 9.4.45-jdk11, 9.4-jdk11, 9-jdk11, 9.4.45-jdk11-openjdk, 9.4-jdk11-openjdk, 9-jdk11-openjdk
 Architectures: amd64, arm64v8
-Directory: 10.0-jdk17
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.4/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 10.0.8-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim
+Tags: 9.3.30-jre8, 9.3-jre8, 9.3.30-jre8-openjdk, 9.3-jre8-openjdk, 9.3
 Architectures: amd64, arm64v8
-Directory: 10.0-jdk11-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.3/jre8
+GitCommit: bd5eabf5fcd22aa849773576b0ccc5457121bf75
 
-Tags: 10.0.8-jdk11, 10.0-jdk11, 10-jdk11
+Tags: 9.2.30-jre8, 9.2-jre8, 9.2.30-jre8-openjdk, 9.2-jre8-openjdk, 9.2
 Architectures: amd64, arm64v8
-Directory: 10.0-jdk11
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/9.2/jre8
+GitCommit: bd5eabf5fcd22aa849773576b0ccc5457121bf75
 
-Tags: 9.4.45-jre11-slim, 9.4-jre11-slim, 9-jre11-slim
+Tags: 11.0.8-jre11-slim, 11.0-jre11-slim, 11-jre11-slim, 11.0.8-jre11-slim-openjdk, 11.0-jre11-slim-openjdk, 11-jre11-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jre11-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/11.0/jre11-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jre11, 9.4-jre11, 9-jre11
+Tags: 11.0.8-jre11, 11.0-jre11, 11-jre11, 11.0.8-jre11-openjdk, 11.0-jre11-openjdk, 11-jre11-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jre11
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/11.0/jre11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jre8-slim, 9.4-jre8-slim, 9-jre8-slim
+Tags: 11.0.8-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim, 11.0.8-jdk17-slim-openjdk, 11.0-jdk17-slim-openjdk, 11-jdk17-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jre8-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/11.0/jdk17-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jre8, 9.4-jre8, 9-jre8
+Tags: 11.0.8, 11.0, 11, 11.0.8-jdk17, 11.0-jdk17, 11-jdk17, 11.0.8-openjdk, 11.0-openjdk, 11-openjdk, 11.0.8-jdk17-openjdk, 11.0-jdk17-openjdk, 11-jdk17-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jre8
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/11.0/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim
+Tags: 11.0.8-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim, 11.0.8-jdk11-slim-openjdk, 11.0-jdk11-slim-openjdk, 11-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jdk17-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/11.0/jdk11-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45, 9.4, 9, 9.4.45-jdk17, 9.4-jdk17, 9-jdk17, latest, jdk17
+Tags: 11.0.8-jdk11, 11.0-jdk11, 11-jdk11, 11.0.8-jdk11-openjdk, 11.0-jdk11-openjdk, 11-jdk11-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jdk17
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/11.0/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim
+Tags: 10.0.8-jre11-slim, 10.0-jre11-slim, 10-jre11-slim, 10.0.8-jre11-slim-openjdk, 10.0-jre11-slim-openjdk, 10-jre11-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jdk11-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/10.0/jre11-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jdk11, 9.4-jdk11, 9-jdk11
+Tags: 10.0.8-jre11, 10.0-jre11, 10-jre11, 10.0.8-jre11-openjdk, 10.0-jre11-openjdk, 10-jre11-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jdk11
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/10.0/jre11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jdk8-slim, 9.4-jdk8-slim, 9-jdk8-slim
+Tags: 10.0.8-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim, 10.0.8-jdk17-slim-openjdk, 10.0-jdk17-slim-openjdk, 10-jdk17-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jdk8-slim
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/10.0/jdk17-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.4.45-jdk8, 9.4-jdk8, 9-jdk8
+Tags: 10.0.8, 10.0, 10, 10.0.8-jdk17, 10.0-jdk17, 10-jdk17, 10.0.8-openjdk, 10.0-openjdk, 10-openjdk, 10.0.8-jdk17-openjdk, 10.0-jdk17-openjdk, 10-jdk17-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.4-jdk8
-GitCommit: 2c5947b751af36b156002440beff2a86721844e0
+Directory: openjdk/10.0/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.3.30-jre8, 9.3-jre8, 9.3
+Tags: 10.0.8-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim, 10.0.8-jdk11-slim-openjdk, 10.0-jdk11-slim-openjdk, 10-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.3-jre8
-GitCommit: 4b79189d08d3ae2695ce275e304ffd03ccb4360b
+Directory: openjdk/10.0/jdk11-slim
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
-Tags: 9.2.30-jre8, 9.2-jre8, 9.2
+Tags: 10.0.8-jdk11, 10.0-jdk11, 10-jdk11, 10.0.8-jdk11-openjdk, 10.0-jdk11-openjdk, 10-jdk11-openjdk
 Architectures: amd64, arm64v8
-Directory: 9.2-jre8
-GitCommit: fb52367c984dda5b886738a30c54a686ac3e17bb
+Directory: openjdk/10.0/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jdk8
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jdk17-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.45-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jdk11-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0/jdk17-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.8-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0/jdk11-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0/jdk17-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.8-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0/jdk11-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk8-azul-zulu-openjdk-alpine, 9.4-jdk8-azul-zulu-openjdk-alpine, 9-jdk8-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/9.4/jdk8
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 9.4.45-azul-zulu-openjdk-alpine, 9.4-azul-zulu-openjdk-alpine, 9-azul-zulu-openjdk-alpine, 9.4.45-jdk17-azul-zulu-openjdk-alpine, 9.4-jdk17-azul-zulu-openjdk-alpine, 9-jdk17-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/9.4/jdk17
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 9.4.45-jdk11-azul-zulu-openjdk-alpine, 9.4-jdk11-azul-zulu-openjdk-alpine, 9-jdk11-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/9.4/jdk11
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 11.0.8-azul-zulu-openjdk-alpine, 11.0-azul-zulu-openjdk-alpine, 11-azul-zulu-openjdk-alpine, 11.0.8-jdk17-azul-zulu-openjdk-alpine, 11.0-jdk17-azul-zulu-openjdk-alpine, 11-jdk17-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/11.0/jdk17
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 11.0.8-jdk11-azul-zulu-openjdk-alpine, 11.0-jdk11-azul-zulu-openjdk-alpine, 11-jdk11-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/11.0/jdk11
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 10.0.8-azul-zulu-openjdk-alpine, 10.0-azul-zulu-openjdk-alpine, 10-azul-zulu-openjdk-alpine, 10.0.8-jdk17-azul-zulu-openjdk-alpine, 10.0-jdk17-azul-zulu-openjdk-alpine, 10-jdk17-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/10.0/jdk17
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 10.0.8-jdk11-azul-zulu-openjdk-alpine, 10.0-jdk11-azul-zulu-openjdk-alpine, 10-jdk11-azul-zulu-openjdk-alpine
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk-alpine/10.0/jdk11
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 9.4.45-jdk8-azul-zulu-openjdk, 9.4-jdk8-azul-zulu-openjdk, 9-jdk8-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/9.4/jdk8
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 9.4.45-azul-zulu-openjdk, 9.4-azul-zulu-openjdk, 9-azul-zulu-openjdk, 9.4.45-jdk17-azul-zulu-openjdk, 9.4-jdk17-azul-zulu-openjdk, 9-jdk17-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/9.4/jdk17
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 9.4.45-jdk11-azul-zulu-openjdk, 9.4-jdk11-azul-zulu-openjdk, 9-jdk11-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/9.4/jdk11
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 11.0.8-azul-zulu-openjdk, 11.0-azul-zulu-openjdk, 11-azul-zulu-openjdk, 11.0.8-jdk17-azul-zulu-openjdk, 11.0-jdk17-azul-zulu-openjdk, 11-jdk17-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/11.0/jdk17
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 11.0.8-jdk11-azul-zulu-openjdk, 11.0-jdk11-azul-zulu-openjdk, 11-jdk11-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/11.0/jdk11
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 10.0.8-azul-zulu-openjdk, 10.0-azul-zulu-openjdk, 10-azul-zulu-openjdk, 10.0.8-jdk17-azul-zulu-openjdk, 10.0-jdk17-azul-zulu-openjdk, 10-jdk17-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/10.0/jdk17
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 10.0.8-jdk11-azul-zulu-openjdk, 10.0-jdk11-azul-zulu-openjdk, 10-jdk11-azul-zulu-openjdk
+Architectures: amd64, arm64v8
+Directory: azul/zulu-openjdk/10.0/jdk11
+GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
+
+Tags: 9.4.45-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk8-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk8
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk17-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.45-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk11-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 9.4.45-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/11.0/jdk17-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.8-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/11.0/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/11.0/jdk11-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 11.0.8-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/11.0/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/10.0/jdk17-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.8-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/10.0/jdk17
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/10.0/jdk11-alpine
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+
+Tags: 10.0.8-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/10.0/jdk11
+GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e

--- a/library/jetty
+++ b/library/jetty
@@ -57,12 +57,12 @@ GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 Tags: 9.3.30-jre8, 9.3-jre8, 9.3.30-jre8-openjdk, 9.3-jre8-openjdk, 9.3
 Architectures: amd64, arm64v8
 Directory: openjdk/9.3/jre8
-GitCommit: bd5eabf5fcd22aa849773576b0ccc5457121bf75
+GitCommit: 9b0e3ee09fdb1c466f8b39f93bc57bdaa33d4ba0
 
 Tags: 9.2.30-jre8, 9.2-jre8, 9.2.30-jre8-openjdk, 9.2-jre8-openjdk, 9.2
 Architectures: amd64, arm64v8
 Directory: openjdk/9.2/jre8
-GitCommit: bd5eabf5fcd22aa849773576b0ccc5457121bf75
+GitCommit: 9b0e3ee09fdb1c466f8b39f93bc57bdaa33d4ba0
 
 Tags: 11.0.8-jre11-slim, 11.0-jre11-slim, 11-jre11-slim, 11.0.8-jre11-slim-openjdk, 11.0-jre11-slim-openjdk, 11-jre11-slim-openjdk
 Architectures: amd64, arm64v8
@@ -188,76 +188,6 @@ Tags: 10.0.8-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
-
-Tags: 9.4.45-jdk8-azul-zulu-openjdk-alpine, 9.4-jdk8-azul-zulu-openjdk-alpine, 9-jdk8-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/9.4/jdk8
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 9.4.45-azul-zulu-openjdk-alpine, 9.4-azul-zulu-openjdk-alpine, 9-azul-zulu-openjdk-alpine, 9.4.45-jdk17-azul-zulu-openjdk-alpine, 9.4-jdk17-azul-zulu-openjdk-alpine, 9-jdk17-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/9.4/jdk17
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 9.4.45-jdk11-azul-zulu-openjdk-alpine, 9.4-jdk11-azul-zulu-openjdk-alpine, 9-jdk11-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/9.4/jdk11
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 11.0.8-azul-zulu-openjdk-alpine, 11.0-azul-zulu-openjdk-alpine, 11-azul-zulu-openjdk-alpine, 11.0.8-jdk17-azul-zulu-openjdk-alpine, 11.0-jdk17-azul-zulu-openjdk-alpine, 11-jdk17-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/11.0/jdk17
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 11.0.8-jdk11-azul-zulu-openjdk-alpine, 11.0-jdk11-azul-zulu-openjdk-alpine, 11-jdk11-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/11.0/jdk11
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 10.0.8-azul-zulu-openjdk-alpine, 10.0-azul-zulu-openjdk-alpine, 10-azul-zulu-openjdk-alpine, 10.0.8-jdk17-azul-zulu-openjdk-alpine, 10.0-jdk17-azul-zulu-openjdk-alpine, 10-jdk17-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/10.0/jdk17
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 10.0.8-jdk11-azul-zulu-openjdk-alpine, 10.0-jdk11-azul-zulu-openjdk-alpine, 10-jdk11-azul-zulu-openjdk-alpine
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk-alpine/10.0/jdk11
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 9.4.45-jdk8-azul-zulu-openjdk, 9.4-jdk8-azul-zulu-openjdk, 9-jdk8-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/9.4/jdk8
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 9.4.45-azul-zulu-openjdk, 9.4-azul-zulu-openjdk, 9-azul-zulu-openjdk, 9.4.45-jdk17-azul-zulu-openjdk, 9.4-jdk17-azul-zulu-openjdk, 9-jdk17-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/9.4/jdk17
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 9.4.45-jdk11-azul-zulu-openjdk, 9.4-jdk11-azul-zulu-openjdk, 9-jdk11-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/9.4/jdk11
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 11.0.8-azul-zulu-openjdk, 11.0-azul-zulu-openjdk, 11-azul-zulu-openjdk, 11.0.8-jdk17-azul-zulu-openjdk, 11.0-jdk17-azul-zulu-openjdk, 11-jdk17-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/11.0/jdk17
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 11.0.8-jdk11-azul-zulu-openjdk, 11.0-jdk11-azul-zulu-openjdk, 11-jdk11-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/11.0/jdk11
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 10.0.8-azul-zulu-openjdk, 10.0-azul-zulu-openjdk, 10-azul-zulu-openjdk, 10.0.8-jdk17-azul-zulu-openjdk, 10.0-jdk17-azul-zulu-openjdk, 10-jdk17-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/10.0/jdk17
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
-
-Tags: 10.0.8-jdk11-azul-zulu-openjdk, 10.0-jdk11-azul-zulu-openjdk, 10-jdk11-azul-zulu-openjdk
-Architectures: amd64, arm64v8
-Directory: azul/zulu-openjdk/10.0/jdk11
-GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
 
 Tags: 9.4.45-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64

--- a/library/jetty
+++ b/library/jetty
@@ -130,9 +130,9 @@ Directory: eclipse-temurin/9.4/jdk8
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 9.4.45-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 9.4.45-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.45-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -140,9 +140,9 @@ Directory: eclipse-temurin/9.4/jdk17
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 9.4.45-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 9.4.45-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -150,9 +150,9 @@ Directory: eclipse-temurin/9.4/jdk11
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 11.0.8-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 11.0.8-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.8-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -160,9 +160,9 @@ Directory: eclipse-temurin/11.0/jdk17
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 11.0.8-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 11.0.8-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -170,9 +170,9 @@ Directory: eclipse-temurin/11.0/jdk11
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 10.0.8-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 10.0.8-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.8-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -180,9 +180,9 @@ Directory: eclipse-temurin/10.0/jdk17
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 10.0.8-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 10.0.8-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -260,9 +260,9 @@ Directory: azul/zulu-openjdk/10.0/jdk11
 GitCommit: e1155af610eafd4f959b5ea4be892641c2f6b84d
 
 Tags: 9.4.45-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 9.4.45-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
@@ -270,9 +270,9 @@ Directory: amazoncorretto/9.4/jdk8
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 9.4.45-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 9.4.45-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.45-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
@@ -280,9 +280,9 @@ Directory: amazoncorretto/9.4/jdk17
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 9.4.45-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 9.4.45-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
@@ -290,9 +290,9 @@ Directory: amazoncorretto/9.4/jdk11
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 11.0.8-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 11.0.8-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.8-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
@@ -300,9 +300,9 @@ Directory: amazoncorretto/11.0/jdk17
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 11.0.8-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 11.0.8-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
@@ -310,9 +310,9 @@ Directory: amazoncorretto/11.0/jdk11
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 10.0.8-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 10.0.8-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.8-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
@@ -320,9 +320,9 @@ Directory: amazoncorretto/10.0/jdk17
 GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
 
 Tags: 10.0.8-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
-Architectures: amd64, arm64v8
+Architectures: amd64
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
 
 Tags: 10.0.8-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Add support for additional base images.

This adds new images based off `amazoncorretto`, ~~`azul/zulu`~~ and `eclipse-temurin` in addition to the previously existing images based on `openjdk`.

See work from:
- https://github.com/eclipse/jetty.docker/pull/77
- https://github.com/eclipse/jetty.docker/pull/89