### PR TITLE
Bump Traefik to v2.6.3 and v2.7.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 66e04d219e530aad21ce7790ea3b1e468b67bf9a
 Directory: alpine
 
-Tags: v2.6.2-windowsservercore-1809, 2.6.2-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
+Tags: v2.6.3-windowsservercore-1809, 2.6.3-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 13aacd8673cad57629756c238fdec92cddd42ddb
+GitCommit: 03d6917edbf3cf18c112ee608162eb083273971c
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.2, 2.6.2, v2.6, 2.6, rocamadour, latest
+Tags: v2.6.3, 2.6.3, v2.6, 2.6, rocamadour, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 13aacd8673cad57629756c238fdec92cddd42ddb
+GitCommit: 03d6917edbf3cf18c112ee608162eb083273971c
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.7.0-rc1-windowsservercore-1809, 2.7.0-rc1-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809
+Tags: v2.7.0-rc2-windowsservercore-1809, 2.7.0-rc2-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66e04d219e530aad21ce7790ea3b1e468b67bf9a
+GitCommit: 525b8f19920873224fc5546e8f8b1e360a81a93f
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.7.0-rc1, 2.7.0-rc1, v2.7, 2.7, epoisses
+Tags: v2.7.0-rc2, 2.7.0-rc2, v2.7, 2.7, epoisses
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66e04d219e530aad21ce7790ea3b1e468b67bf9a
+GitCommit: 525b8f19920873224fc5546e8f8b1e360a81a93f
 Directory: alpine
 
 Tags: v2.6.3-windowsservercore-1809, 2.6.3-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.6.3](https://github.com/traefik/traefik/releases/tag/v2.6.3) and to [v2.7.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.7.0-rc2).

/cc @mpl @kevinpollet @tomMoulard

Cheers
