### PR TITLE
[oraclelinux] Updating 7, 7-slim, 8, 8-slim for ELSA-2022-1065, ELSA-2022-1066, ELSA-2022-1069

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9edbd4c6161d2e4cb38f4ca220fa0307e616bf39
+amd64-GitCommit: 6cc53ba86d8d6d69c3109f48bca9a91a46746528
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d540d67e1c1602be0b9afc4b44f21c36bd140481
+arm64v8-GitCommit: 8cfa92966df0e60e319dac24856b31cb7504d16f
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for the following CVEs:

CVE-2022-0778
CVE-2021-45960
CVE-2021-46143
CVE-2022-22822
CVE-2022-22823
CVE-2022-22824
CVE-2022-22825
CVE-2022-22826
CVE-2022-22827
CVE-2022-23852
CVE-2022-25235
CVE-2022-25236
CVE-2022-25315

See the following for details:
https://linux.oracle.com/errata/ELSA-2022-1065.html
https://linux.oracle.com/errata/ELSA-2022-1066.html
https://linux.oracle.com/errata/ELSA-2022-1069.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>