### PR TITLE
[varnish] fix 7.1 armv8 build errors

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,16 +1,16 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/693cddb1140d5c0e042793cbb92b6906fb8425a5/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/e507d06e425154234046ed779dc72dd449c178ac/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 7.1.0, 7.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: bb05db3ed5d75a1d8402309336823e2d58330b1b
+GitCommit: e507d06e425154234046ed779dc72dd449c178ac
 
 Tags: fresh-alpine, 7.1.0-alpine, 7.1-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: 2ac414bf99af92cabbf4a924108f0c3af190f47f
+GitCommit: e507d06e425154234046ed779dc72dd449c178ac
 
 Tags: old, 7.0.2, 7.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
this needed a little bit of autotool magic. I'm talking to upstream to fix this, but in the meantime, the patch is fairly simple, so I went for that

Closes #12141