### PR TITLE
Update Amazon Linux 2022 images to 2022.0.20220315.0

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -7,12 +7,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Sean Kelly (@cbgbt),
              Tanu Rampal (@trampal),
              Kyle Gosselin-Harris (@kgharris),
-             Sam Thornton (@boostyc),
+             Sam Thornton (@mrthornazon),
              Preston Carpenter (@timidger),
              Richard Kelly (@rpkelly),
              Joseph Howell-Burke (@jhowell-burke)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: e3e844624affdec30b221d64fca178edbd58fe78
+GitCommit: ddc781764ced8c0921bb246a7475bc8e1f5b9c2d
 
 Tags: 2.0.20220316.0, 2, latest
 Architectures: amd64, arm64v8
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: b4ded7a10bda59b6315353ca0ad7c85befa0fd3f
 
-Tags: 2022.0.20220308.1, 2022, devel
+Tags: 2022.0.20220315.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: 6fa4bf1b19c77dfa6c49aed95207c334dcf72380
+amd64-GitCommit: b446ccb4166363a3df14286f83cfc74c99e230f4
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: ae590b62c98df7f0960cf60941f60ea7c9eefe2a
+arm64v8-GitCommit: 6ae71400af9fb876d3871fb4eaa61f2f7363d545
 
-Tags: 2022.0.20220308.1-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220315.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: e3ef4927440fb2902c40ca7ed2c984e64422a19e
+amd64-GitCommit: 87d9d1a07c4e5afd1f72df96f1c824a9facd15cc
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 7f706da12db4c5f7b62f9a9993bc7eece61ed27f
+arm64v8-GitCommit: 2c8a2941ab6c41f375b8bb245779d0ebdcb07c31


### PR DESCRIPTION
Hello,

Updating Amazon Linux 2022 Tech Preview Images to 2022.0.20220315.0.

Thanks,
Sumit