### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,77 +4,62 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.1.0-php7.4-apache, 4.1-php7.4-apache, 4-php7.4-apache, php7.4-apache
+Tags: 4.1.2-php7.4-apache, 4.1-php7.4-apache, 4-php7.4-apache, php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php7.4/apache
 
-Tags: 4.1.0-php7.4-fpm-alpine, 4.1-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 4.1.2-php7.4-fpm-alpine, 4.1-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php7.4/fpm-alpine
 
-Tags: 4.1.0-php7.4-fpm, 4.1-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
+Tags: 4.1.2-php7.4-fpm, 4.1-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php7.4/fpm
 
-Tags: 4.1.0, 4.1, 4, latest, 4.1.0-apache, 4.1-apache, 4-apache, apache, 4.1.0-php8.0, 4.1-php8.0, 4-php8.0, php8.0, 4.1.0-php8.0-apache, 4.1-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.1.2, 4.1, 4, latest, 4.1.2-apache, 4.1-apache, 4-apache, apache, 4.1.2-php8.0, 4.1-php8.0, 4-php8.0, php8.0, 4.1.2-php8.0-apache, 4.1-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php8.0/apache
 
-Tags: 4.1.0-php8.0-fpm-alpine, 4.1-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.1.2-php8.0-fpm-alpine, 4.1-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php8.0/fpm-alpine
 
-Tags: 4.1.0-php8.0-fpm, 4.1-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.1.2-php8.0-fpm, 4.1-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php8.0/fpm
 
-Tags: 4.1.0-php8.1-apache, 4.1-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.1.2-php8.1-apache, 4.1-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php8.1/apache
 
-Tags: 4.1.0-php8.1-fpm-alpine, 4.1-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.1.2-php8.1-fpm-alpine, 4.1-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php8.1/fpm-alpine
 
-Tags: 4.1.0-php8.1-fpm, 4.1-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.1.2-php8.1-fpm, 4.1-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 94faec5bbf615657d27fc4e4db4d21a36cad88e5
+GitCommit: 5b1841e0b1857e51a069d58ae13532846ac19746
 Directory: 4.1/php8.1/fpm
 
-Tags: 3.10.6-php7.3-apache, 3.10-php7.3-apache, 3-php7.3-apache
+Tags: 3.10.8, 3.10, 3, 3.10.8-apache, 3.10-apache, 3-apache, 3.10.8-php7.4, 3.10-php7.4, 3-php7.4, 3.10.8-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
-Directory: 3.10/php7.3/apache
-
-Tags: 3.10.6-php7.3-fpm-alpine, 3.10-php7.3-fpm-alpine, 3-php7.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
-Directory: 3.10/php7.3/fpm-alpine
-
-Tags: 3.10.6-php7.3-fpm, 3.10-php7.3-fpm, 3-php7.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
-Directory: 3.10/php7.3/fpm
-
-Tags: 3.10.6, 3.10, 3, 3.10.6-apache, 3.10-apache, 3-apache, 3.10.6-php7.4, 3.10-php7.4, 3-php7.4, 3.10.6-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
+GitCommit: 9221236814563754504cac96bb07fd2d6d1ee2fa
 Directory: 3.10/php7.4/apache
 
-Tags: 3.10.6-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
+Tags: 3.10.8-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
+GitCommit: 9221236814563754504cac96bb07fd2d6d1ee2fa
 Directory: 3.10/php7.4/fpm-alpine
 
-Tags: 3.10.6-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
+Tags: 3.10.8-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 335a8cbae3bc9b7940ac718da430c92d95850914
+GitCommit: 9221236814563754504cac96bb07fd2d6d1ee2fa
 Directory: 3.10/php7.4/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@5b1841e: Update images of Joomla! 4.1.0 to 4.1.2
- joomla-docker/docker-joomla@05edabf: Update version of Joomla! 4.1.0 to 4.1.2
- joomla-docker/docker-joomla@9221236: Update images of Joomla! 3.10.6 to 3.10.8
- joomla-docker/docker-joomla@6eabd83: Update version of Joomla! 3.10.6 to 3.10.8
- joomla-docker/docker-joomla@9275e96: Drop PHP 7.3
- joomla-docker/docker-joomla@741b76c: Update to memcached 3.2.0 and redis 5.3.7