### PR TITLE
Add arm64v8 for JRuby 9.3

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -6,23 +6,23 @@ GitFetch: refs/heads/master
 GitCommit: fae50010fae73e3cbed04c660747419413096767
 
 Tags: latest, 9, 9.3, 9.3.4, 9.3-jre, 9.3-jre8, 9.3.4-jre, 9.3.4-jre8, 9.3.4.0, 9.3.4.0-jre, 9.3.4.0-jre8
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 9.3/jre8
 
 Tags: 9-jdk, 9-jdk8, 9.3-jdk, 9.3-jdk8, 9.3.4-jdk, 9.3.4-jdk8, 9.3.4.0-jdk, 9.3.4.0-jdk8
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 9.3/jdk8
 
 Tags: 9.3-jre11, 9.3.4-jre11, 9.3.4.0-jre11
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 9.3/jre11
 
 Tags: 9.3-jdk11, 9.3.4-jdk11, 9.3.4.0-jdk11
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 9.3/jdk11
 
 Tags: 9.3-jdk17, 9.3.4-jdk17, 9.3.4.0-jdk17
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 9.3/jdk17
 
 Tags: 9.2, 9.2.20, 9.2-jre, 9.2-jre8, 9.2.20-jre, 9.2.20-jre8, 9.2.20.1, 9.2.20.0-jre, 9.2.20.0-jre8


### PR DESCRIPTION
Ref https://github.com/jruby/docker-jruby/issues/78