### PR TITLE
haxe 4.2.5

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,49 +1,49 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 4.2.4-bullseye, 4.2-bullseye
-SharedTags: 4.2.4, 4.2, latest
+Tags: 4.2.5-bullseye, 4.2-bullseye
+SharedTags: 4.2.5, 4.2, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 0292fae1a29c23dee119205b3b75ad9e27f6cf32
+GitCommit: 83789c10dc601064a234fd559206d1ec252228d7
 Directory: 4.2/bullseye
 
-Tags: 4.2.4-buster, 4.2-buster
+Tags: 4.2.5-buster, 4.2-buster
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 3ef7cb9a5509396e576e5ee77cf112fb91545fd0
+GitCommit: 83789c10dc601064a234fd559206d1ec252228d7
 Directory: 4.2/buster
 
-Tags: 4.2.4-windowsservercore-ltsc2022, 4.2-windowsservercore-ltsc2022
-SharedTags: 4.2.4-windowsservercore, 4.2-windowsservercore, 4.2.4, 4.2, latest
+Tags: 4.2.5-windowsservercore-ltsc2022, 4.2-windowsservercore-ltsc2022
+SharedTags: 4.2.5-windowsservercore, 4.2-windowsservercore, 4.2.5, 4.2, latest
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.2/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 4.2.4-windowsservercore-1809, 4.2-windowsservercore-1809
-SharedTags: 4.2.4-windowsservercore, 4.2-windowsservercore, 4.2.4, 4.2, latest
+Tags: 4.2.5-windowsservercore-1809, 4.2-windowsservercore-1809
+SharedTags: 4.2.5-windowsservercore, 4.2-windowsservercore, 4.2.5, 4.2, latest
 Architectures: windows-amd64
-GitCommit: 3ef7cb9a5509396e576e5ee77cf112fb91545fd0
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.2/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.2.4-alpine3.15, 4.2-alpine3.15, 4.2.4-alpine, 4.2-alpine
+Tags: 4.2.5-alpine3.15, 4.2-alpine3.15, 4.2.5-alpine, 4.2-alpine
 Architectures: amd64, arm64v8
-GitCommit: b0098b4b730d0d9ff21dbf3d543464228d6b7e99
+GitCommit: 83789c10dc601064a234fd559206d1ec252228d7
 Directory: 4.2/alpine3.15
 
-Tags: 4.2.4-alpine3.14, 4.2-alpine3.14
+Tags: 4.2.5-alpine3.14, 4.2-alpine3.14
 Architectures: amd64, arm64v8
-GitCommit: 3ef7cb9a5509396e576e5ee77cf112fb91545fd0
+GitCommit: 83789c10dc601064a234fd559206d1ec252228d7
 Directory: 4.2/alpine3.14
 
-Tags: 4.2.4-alpine3.13, 4.2-alpine3.13
+Tags: 4.2.5-alpine3.13, 4.2-alpine3.13
 Architectures: amd64, arm64v8
-GitCommit: 3ef7cb9a5509396e576e5ee77cf112fb91545fd0
+GitCommit: 83789c10dc601064a234fd559206d1ec252228d7
 Directory: 4.2/alpine3.13
 
-Tags: 4.2.4-alpine3.12, 4.2-alpine3.12
+Tags: 4.2.5-alpine3.12, 4.2-alpine3.12
 Architectures: amd64, arm64v8
-GitCommit: 3ef7cb9a5509396e576e5ee77cf112fb91545fd0
+GitCommit: 83789c10dc601064a234fd559206d1ec252228d7
 Directory: 4.2/alpine3.12
 
 Tags: 4.1.5-bullseye, 4.1-bullseye
@@ -60,14 +60,14 @@ Directory: 4.1/buster
 Tags: 4.1.5-windowsservercore-ltsc2022, 4.1-windowsservercore-ltsc2022
 SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.1/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 4.1.5-windowsservercore-1809, 4.1-windowsservercore-1809
 SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1
 Architectures: windows-amd64
-GitCommit: c01eea28361debd68bc2e1f5318aa0bf28ebb05a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.1/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -110,14 +110,14 @@ Directory: 4.0/stretch
 Tags: 4.0.5-windowsservercore-ltsc2022, 4.0-windowsservercore-ltsc2022
 SharedTags: 4.0.5-windowsservercore, 4.0-windowsservercore, 4.0.5, 4.0
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.0/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 4.0.5-windowsservercore-1809, 4.0-windowsservercore-1809
 SharedTags: 4.0.5-windowsservercore, 4.0-windowsservercore, 4.0.5, 4.0
 Architectures: windows-amd64
-GitCommit: 38b1ceb14a5692ae2c655c056baaff79d963da33
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.0/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -155,14 +155,14 @@ Directory: 3.4/stretch
 Tags: 3.4.7-windowsservercore-ltsc2022, 3.4-windowsservercore-ltsc2022
 SharedTags: 3.4.7-windowsservercore, 3.4-windowsservercore, 3.4.7, 3.4
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.4/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.4.7-windowsservercore-1809, 3.4-windowsservercore-1809
 SharedTags: 3.4.7-windowsservercore, 3.4-windowsservercore, 3.4.7, 3.4
 Architectures: windows-amd64
-GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.4/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -190,14 +190,14 @@ Directory: 3.3/stretch
 Tags: 3.3.0-rc.1-windowsservercore-ltsc2022, 3.3.0-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022
 SharedTags: 3.3.0-rc.1-windowsservercore, 3.3.0-windowsservercore, 3.3-windowsservercore, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.3/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.3.0-rc.1-windowsservercore-1809, 3.3.0-windowsservercore-1809, 3.3-windowsservercore-1809
 SharedTags: 3.3.0-rc.1-windowsservercore, 3.3.0-windowsservercore, 3.3-windowsservercore, 3.3.0-rc.1, 3.3.0, 3.3
 Architectures: windows-amd64
-GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.3/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -225,14 +225,14 @@ Directory: 3.2/stretch
 Tags: 3.2.1-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022
 SharedTags: 3.2.1-windowsservercore, 3.2-windowsservercore, 3.2.1, 3.2
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.2/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.2.1-windowsservercore-1809, 3.2-windowsservercore-1809
 SharedTags: 3.2.1-windowsservercore, 3.2-windowsservercore, 3.2.1, 3.2
 Architectures: windows-amd64
-GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.2/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -255,14 +255,14 @@ Directory: 3.1/stretch
 Tags: 3.1.3-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022
 SharedTags: 3.1.3-windowsservercore, 3.1-windowsservercore, 3.1.3, 3.1
 Architectures: windows-amd64
-GitCommit: f881b3f9455c4698e27163777b3aebe16be0dc1a
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.1/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.1.3-windowsservercore-1809, 3.1-windowsservercore-1809
 SharedTags: 3.1.3-windowsservercore, 3.1-windowsservercore, 3.1.3, 3.1
 Architectures: windows-amd64
-GitCommit: 7df74d220cce33998dde7623f8c9176d7fa938f7
+GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 3.1/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
update haxe 4.2.4 -> 4.2.5
update the windows varients with a better https cert pre-fetch url