### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -63,3 +63,48 @@ Tags: cli-2.6.0-php8.1, cli-2.6-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php8.1/alpine
+
+Tags: beta-5.9.3-RC1-apache, beta-5.9.3-apache, beta-5.9-apache, beta-5-apache, beta-apache, beta-5.9.3-RC1, beta-5.9.3, beta-5.9, beta-5, beta, beta-5.9.3-RC1-php7.4-apache, beta-5.9.3-php7.4-apache, beta-5.9-php7.4-apache, beta-5-php7.4-apache, beta-php7.4-apache, beta-5.9.3-RC1-php7.4, beta-5.9.3-php7.4, beta-5.9-php7.4, beta-5-php7.4, beta-php7.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php7.4/apache
+
+Tags: beta-5.9.3-RC1-fpm, beta-5.9.3-fpm, beta-5.9-fpm, beta-5-fpm, beta-fpm, beta-5.9.3-RC1-php7.4-fpm, beta-5.9.3-php7.4-fpm, beta-5.9-php7.4-fpm, beta-5-php7.4-fpm, beta-php7.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php7.4/fpm
+
+Tags: beta-5.9.3-RC1-fpm-alpine, beta-5.9.3-fpm-alpine, beta-5.9-fpm-alpine, beta-5-fpm-alpine, beta-fpm-alpine, beta-5.9.3-RC1-php7.4-fpm-alpine, beta-5.9.3-php7.4-fpm-alpine, beta-5.9-php7.4-fpm-alpine, beta-5-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php7.4/fpm-alpine
+
+Tags: beta-5.9.3-RC1-php8.0-apache, beta-5.9.3-php8.0-apache, beta-5.9-php8.0-apache, beta-5-php8.0-apache, beta-php8.0-apache, beta-5.9.3-RC1-php8.0, beta-5.9.3-php8.0, beta-5.9-php8.0, beta-5-php8.0, beta-php8.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php8.0/apache
+
+Tags: beta-5.9.3-RC1-php8.0-fpm, beta-5.9.3-php8.0-fpm, beta-5.9-php8.0-fpm, beta-5-php8.0-fpm, beta-php8.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php8.0/fpm
+
+Tags: beta-5.9.3-RC1-php8.0-fpm-alpine, beta-5.9.3-php8.0-fpm-alpine, beta-5.9-php8.0-fpm-alpine, beta-5-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php8.0/fpm-alpine
+
+Tags: beta-5.9.3-RC1-php8.1-apache, beta-5.9.3-php8.1-apache, beta-5.9-php8.1-apache, beta-5-php8.1-apache, beta-php8.1-apache, beta-5.9.3-RC1-php8.1, beta-5.9.3-php8.1, beta-5.9-php8.1, beta-5-php8.1, beta-php8.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php8.1/apache
+
+Tags: beta-5.9.3-RC1-php8.1-fpm, beta-5.9.3-php8.1-fpm, beta-5.9-php8.1-fpm, beta-5-php8.1-fpm, beta-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php8.1/fpm
+
+Tags: beta-5.9.3-RC1-php8.1-fpm-alpine, beta-5.9.3-php8.1-fpm-alpine, beta-5.9-php8.1-fpm-alpine, beta-5-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 8eb3692723bcb062813869361a156413eb4a6656
+Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/8eb3692: Update beta to 5.9.3-RC1