### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.1.1
+Tags: 8.1.2
 Architectures: amd64, arm64v8
-GitCommit: 70d9beec187b48296fb5cb4ac75d54f91cdc8450
+GitCommit: 9811da3cb96247c527134576365b04d2d993a8e4
 Directory: 8
 
-Tags: 7.17.1
+Tags: 7.17.2
 Architectures: amd64, arm64v8
-GitCommit: 868891ad3e2582c1de1c05467a944d0b45c011b9
+GitCommit: fd9bd5e8f13affae1c2b335af8c4c2fa69e5ad83
 Directory: 7
 
 Tags: 6.8.23

--- a/library/kibana
+++ b/library/kibana
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.1.1
+Tags: 8.1.2
 Architectures: amd64, arm64v8
-GitCommit: 6240b6f48e720273578de94fc76feccec5cca0d7
+GitCommit: c5bb85683eb07b40bf0d159bbd578e0046bb92e2
 Directory: 8
 
-Tags: 7.17.1
+Tags: 7.17.2
 Architectures: amd64, arm64v8
-GitCommit: e3c2cc2bcd49b4434e0cef38159bb4ceddb5acf2
+GitCommit: ea34e83a24be36fe920666adf2410a2ddc17c35c
 Directory: 7
 
 Tags: 6.8.23

--- a/library/logstash
+++ b/library/logstash
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.1.1
+Tags: 8.1.2
 Architectures: amd64, arm64v8
-GitCommit: abf29e781b1f12a93460376601d8b1864acd20f1
+GitCommit: 9a0aa8303b734597353588493aeb314456b05328
 Directory: 8
 
-Tags: 7.17.1
+Tags: 7.17.2
 Architectures: amd64, arm64v8
-GitCommit: 03c6a42b2a7dcca6d4346b0b73e95d2a25aea819
+GitCommit: 601905e33e09f3b2d17c98387183b13c97e43896
 Directory: 7
 
 Tags: 6.8.23


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/9811da3: Update to 8.1.2
- https://github.com/docker-library/elasticsearch/commit/fd9bd5e: Update to 7.17.2

logstash:
- https://github.com/docker-library/logstash/commit/9a0aa83: Update to 8.1.2
- https://github.com/docker-library/logstash/commit/601905e: Update to 7.17.2

kibana:
- https://github.com/docker-library/kibana/commit/c5bb856: Update to 8.1.2
- https://github.com/docker-library/kibana/commit/ea34e83: Update to 7.17.2