### PR TITLE
Update Clear Linux OS to 36120

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: e159d1b8a1503af008fe8586f4dabf8e784ad514
-GitFetch: refs/heads/base-36070
+GitCommit: 6bef694045e4da5eb301ba151a07d28fdd219c3f
+GitFetch: refs/heads/base-36120


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36120

@bryteise @djklimes @bryteise