### PR TITLE
Update MediaWiki

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,36 +2,36 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: daebab6abd474474deb62c5544127f86dd507172
+GitCommit: ce983a609daf0e23070931a55f892e3d7d0924a3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.37.1, 1.37, stable, latest
+Tags: 1.37.2, 1.37, stable, latest
 Directory: 1.37/apache
 
-Tags: 1.37.1-fpm, 1.37-fpm, stable-fpm
+Tags: 1.37.2-fpm, 1.37-fpm, stable-fpm
 Directory: 1.37/fpm
 
-Tags: 1.37.1-fpm-alpine, 1.37-fpm-alpine, stable-fpm-alpine
+Tags: 1.37.2-fpm-alpine, 1.37-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.37/fpm-alpine
 
-Tags: 1.36.3, 1.36, legacy
+Tags: 1.36.4, 1.36, legacy
 Directory: 1.36/apache
 
-Tags: 1.36.3-fpm, 1.36-fpm, legacy-fpm
+Tags: 1.36.4-fpm, 1.36-fpm, legacy-fpm
 Directory: 1.36/fpm
 
-Tags: 1.36.3-fpm-alpine, 1.36-fpm-alpine, legacy-fpm-alpine
+Tags: 1.36.4-fpm-alpine, 1.36-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.36/fpm-alpine
 
-Tags: 1.35.5, 1.35, lts, legacylts
+Tags: 1.35.6, 1.35, lts, legacylts
 Directory: 1.35/apache
 
-Tags: 1.35.5-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
+Tags: 1.35.6-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.5-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.35.6-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 


### PR DESCRIPTION
Updates to 1.35.6, 1.36.4 & 1.37.2 security releases.

https://github.com/wikimedia/mediawiki-docker/pull/107