### PR TITLE
Release SonarQube 8.9.8 and 9.4.0, and update the image maintainers

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,21 +4,21 @@ Maintainers: Christophe Levis <christophe.levis@sonarsource.com> (@christophelev
              Klaudio Sinani <klaudio.sinani@sonarsource.com> (@klaudio-sinani-sonarsource),
              Wouter Admiraal <wouter.admiraal@sonarsource.com> (@wouter-admiraal-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 34d56b9d9b3845002c5a316d04e7709ec59db851
+GitCommit: eff0ac120a8f216d5a132f1467497eeab2a403ed
 
-Tags: 8.9.7-community, 8.9-community, 8-community, lts, lts-community
+Tags: 8.9.8-community, 8.9-community, 8-community, lts, lts-community
 Directory: 8/community
 
-Tags: 8.9.7-developer, 8.9-developer, 8-developer, lts-developer
+Tags: 8.9.8-developer, 8.9-developer, 8-developer, lts-developer
 Directory: 8/developer
 
-Tags: 8.9.7-enterprise, 8.9-enterprise, 8-enterprise, lts-enterprise
+Tags: 8.9.8-enterprise, 8.9-enterprise, 8-enterprise, lts-enterprise
 Directory: 8/enterprise
 
-Tags: 8.9.7-datacenter-app, 8.9-datacenter-app, 8-datacenter-app, lts-datacenter-app
+Tags: 8.9.8-datacenter-app, 8.9-datacenter-app, 8-datacenter-app, lts-datacenter-app
 Directory: 8/datacenter/app
 
-Tags: 8.9.7-datacenter-search, 8.9-datacenter-search, 8-datacenter-search, lts-datacenter-search
+Tags: 8.9.8-datacenter-search, 8.9-datacenter-search, 8-datacenter-search, lts-datacenter-search
 Directory: 8/datacenter/search
 
 Tags: 9.4.0-community, 9.4-community, 9-community, community, latest

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -1,9 +1,10 @@
 Maintainers: Christophe Levis <christophe.levis@sonarsource.com> (@christophelevis),
              Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-sonarsource),
-             Tobias Trabelsi <tobias.trabelsi@sonarsource.com> (@tobias-trabelsi-sonarsource),
-             Lukasz Jarocki <lukasz.jarocki@sonarsource.com> (@lukasz-jarocki-sonarsource)
+             Lukasz Jarocki <lukasz.jarocki@sonarsource.com> (@lukasz-jarocki-sonarsource),
+             Klaudio Sinani <klaudio.sinani@sonarsource.com> (@klaudio-sinani-sonarsource),
+             Wouter Admiraal <wouter.admiraal@sonarsource.com> (@wouter-admiraal-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
-GitCommit: 3f19b396006f2a8466854cae90329a55692fa073
+GitCommit: 34d56b9d9b3845002c5a316d04e7709ec59db851
 
 Tags: 8.9.7-community, 8.9-community, 8-community, lts, lts-community
 Directory: 8/community
@@ -20,17 +21,17 @@ Directory: 8/datacenter/app
 Tags: 8.9.7-datacenter-search, 8.9-datacenter-search, 8-datacenter-search, lts-datacenter-search
 Directory: 8/datacenter/search
 
-Tags: 9.3.0-community, 9.3-community, 9-community, community, latest
+Tags: 9.4.0-community, 9.4-community, 9-community, community, latest
 Directory: 9/community
 
-Tags: 9.3.0-developer, 9.3-developer, 9-developer, developer
+Tags: 9.4.0-developer, 9.4-developer, 9-developer, developer
 Directory: 9/developer
 
-Tags: 9.3.0-enterprise, 9.3-enterprise, 9-enterprise, enterprise
+Tags: 9.4.0-enterprise, 9.4-enterprise, 9-enterprise, enterprise
 Directory: 9/enterprise
 
-Tags: 9.3.0-datacenter-app, 9.3-datacenter-app, 9-datacenter-app, datacenter-app
+Tags: 9.4.0-datacenter-app, 9.4-datacenter-app, 9-datacenter-app, datacenter-app
 Directory: 9/datacenter/app
 
-Tags: 9.3.0-datacenter-search, 9.3-datacenter-search, 9-datacenter-search, datacenter-search
+Tags: 9.4.0-datacenter-search, 9.4-datacenter-search, 9-datacenter-search, datacenter-search
 Directory: 9/datacenter/search


### PR DESCRIPTION
We release LTS and current version of SonarQube.

After the departure of one of our colleagues (Tobias Trabelsi), we would also like to add 2 new maintainers:
- Klaudio Sinani
- Wouter Admiraal