### PR TITLE
Alpine CVE-2022-28391 fixes

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -50,10 +50,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.12.11, 3.12
+Tags: 3.12.12, 3.12
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.12
-GitCommit: e96e8f65de007ba5ba379f5e282750250df404f4
+GitCommit: 0cc7fea5828303fa14d754bab4f9161a8cac4ba1
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.15.3, 3.15, 3, latest
+Tags: 3.15.4, 3.15, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.15
-GitCommit: d44f831f0e99ace2b6d9d59b9123de27fd061a0f
+GitCommit: fc965e3222f368bea8e07c1c1da70b6928281a76
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -26,10 +26,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.14.5, 3.14
+Tags: 3.14.6, 3.14
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.14
-GitCommit: 06e90a96650dc17f6d8f66655d3914c6dc25a0b4
+GitCommit: acdada9286850d1b48abd8944ca4f8f8ea909372
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -38,10 +38,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.13.9, 3.13
+Tags: 3.13.10, 3.13
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.13
-GitCommit: ed36cc54c3083ad4f1a84b2c8f63431cca2768cb
+GitCommit: 52cb02afe883694d7b711735e66e1a08fb139011
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
bump alpine stable releases for busybox CVE-2022-28391

