### PR TITLE
Update Jetty versions to 9.4.46, 10.0.9 & 11.0.9

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,55 +4,55 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 9.4.45-jre8-slim, 9.4-jre8-slim, 9-jre8-slim, 9.4.45-jre8-slim-openjdk, 9.4-jre8-slim-openjdk, 9-jre8-slim-openjdk
+Tags: 9.4.46-jre8-slim, 9.4-jre8-slim, 9-jre8-slim, 9.4.46-jre8-slim-openjdk, 9.4-jre8-slim-openjdk, 9-jre8-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre8-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jre8, 9.4-jre8, 9-jre8, 9.4.45-jre8-openjdk, 9.4-jre8-openjdk, 9-jre8-openjdk
+Tags: 9.4.46-jre8, 9.4-jre8, 9-jre8, 9.4.46-jre8-openjdk, 9.4-jre8-openjdk, 9-jre8-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre8
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jre11-slim, 9.4-jre11-slim, 9-jre11-slim, 9.4.45-jre11-slim-openjdk, 9.4-jre11-slim-openjdk, 9-jre11-slim-openjdk
+Tags: 9.4.46-jre11-slim, 9.4-jre11-slim, 9-jre11-slim, 9.4.46-jre11-slim-openjdk, 9.4-jre11-slim-openjdk, 9-jre11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre11-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jre11, 9.4-jre11, 9-jre11, 9.4.45-jre11-openjdk, 9.4-jre11-openjdk, 9-jre11-openjdk
+Tags: 9.4.46-jre11, 9.4-jre11, 9-jre11, 9.4.46-jre11-openjdk, 9.4-jre11-openjdk, 9-jre11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk-8-slim, 9.4-jdk-8-slim, 9-jdk-8-slim, 9.4.45-jdk-8-slim-openjdk, 9.4-jdk-8-slim-openjdk, 9-jdk-8-slim-openjdk
+Tags: 9.4.46-jdk-8-slim, 9.4-jdk-8-slim, 9-jdk-8-slim, 9.4.46-jdk-8-slim-openjdk, 9.4-jdk-8-slim-openjdk, 9-jdk-8-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk-8-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk8, 9.4-jdk8, 9-jdk8, 9.4.45-jdk8-openjdk, 9.4-jdk8-openjdk, 9-jdk8-openjdk
+Tags: 9.4.46-jdk8, 9.4-jdk8, 9-jdk8, 9.4.46-jdk8-openjdk, 9.4-jdk8-openjdk, 9-jdk8-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk8
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim, 9.4.45-jdk17-slim-openjdk, 9.4-jdk17-slim-openjdk, 9-jdk17-slim-openjdk
+Tags: 9.4.46-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim, 9.4.46-jdk17-slim-openjdk, 9.4-jdk17-slim-openjdk, 9-jdk17-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk17-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45, 9.4, 9, 9.4.45-jdk17, 9.4-jdk17, 9-jdk17, 9.4.45-openjdk, 9.4-openjdk, 9-openjdk, 9.4.45-jdk17-openjdk, 9.4-jdk17-openjdk, 9-jdk17-openjdk, latest, jdk17
+Tags: 9.4.46, 9.4, 9, 9.4.46-jdk17, 9.4-jdk17, 9-jdk17, 9.4.46-openjdk, 9.4-openjdk, 9-openjdk, 9.4.46-jdk17-openjdk, 9.4-jdk17-openjdk, 9-jdk17-openjdk, latest, jdk17
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim, 9.4.45-jdk11-slim-openjdk, 9.4-jdk11-slim-openjdk, 9-jdk11-slim-openjdk
+Tags: 9.4.46-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim, 9.4.46-jdk11-slim-openjdk, 9.4-jdk11-slim-openjdk, 9-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk11-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk11, 9.4-jdk11, 9-jdk11, 9.4.45-jdk11-openjdk, 9.4-jdk11-openjdk, 9-jdk11-openjdk
+Tags: 9.4.46-jdk11, 9.4-jdk11, 9-jdk11, 9.4.46-jdk11-openjdk, 9.4-jdk11-openjdk, 9-jdk11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
 Tags: 9.3.30-jre8, 9.3-jre8, 9.3.30-jre8-openjdk, 9.3-jre8-openjdk, 9.3
 Architectures: amd64, arm64v8
@@ -64,197 +64,197 @@ Architectures: amd64, arm64v8
 Directory: openjdk/9.2/jre8
 GitCommit: 9b0e3ee09fdb1c466f8b39f93bc57bdaa33d4ba0
 
-Tags: 11.0.8-jre11-slim, 11.0-jre11-slim, 11-jre11-slim, 11.0.8-jre11-slim-openjdk, 11.0-jre11-slim-openjdk, 11-jre11-slim-openjdk
+Tags: 11.0.9-jre11-slim, 11.0-jre11-slim, 11-jre11-slim, 11.0.9-jre11-slim-openjdk, 11.0-jre11-slim-openjdk, 11-jre11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jre11-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jre11, 11.0-jre11, 11-jre11, 11.0.8-jre11-openjdk, 11.0-jre11-openjdk, 11-jre11-openjdk
+Tags: 11.0.9-jre11, 11.0-jre11, 11-jre11, 11.0.9-jre11-openjdk, 11.0-jre11-openjdk, 11-jre11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jre11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim, 11.0.8-jdk17-slim-openjdk, 11.0-jdk17-slim-openjdk, 11-jdk17-slim-openjdk
+Tags: 11.0.9-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim, 11.0.9-jdk17-slim-openjdk, 11.0-jdk17-slim-openjdk, 11-jdk17-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jdk17-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8, 11.0, 11, 11.0.8-jdk17, 11.0-jdk17, 11-jdk17, 11.0.8-openjdk, 11.0-openjdk, 11-openjdk, 11.0.8-jdk17-openjdk, 11.0-jdk17-openjdk, 11-jdk17-openjdk
+Tags: 11.0.9, 11.0, 11, 11.0.9-jdk17, 11.0-jdk17, 11-jdk17, 11.0.9-openjdk, 11.0-openjdk, 11-openjdk, 11.0.9-jdk17-openjdk, 11.0-jdk17-openjdk, 11-jdk17-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim, 11.0.8-jdk11-slim-openjdk, 11.0-jdk11-slim-openjdk, 11-jdk11-slim-openjdk
+Tags: 11.0.9-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim, 11.0.9-jdk11-slim-openjdk, 11.0-jdk11-slim-openjdk, 11-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jdk11-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk11, 11.0-jdk11, 11-jdk11, 11.0.8-jdk11-openjdk, 11.0-jdk11-openjdk, 11-jdk11-openjdk
+Tags: 11.0.9-jdk11, 11.0-jdk11, 11-jdk11, 11.0.9-jdk11-openjdk, 11.0-jdk11-openjdk, 11-jdk11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jre11-slim, 10.0-jre11-slim, 10-jre11-slim, 10.0.8-jre11-slim-openjdk, 10.0-jre11-slim-openjdk, 10-jre11-slim-openjdk
+Tags: 10.0.9-jre11-slim, 10.0-jre11-slim, 10-jre11-slim, 10.0.9-jre11-slim-openjdk, 10.0-jre11-slim-openjdk, 10-jre11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jre11-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jre11, 10.0-jre11, 10-jre11, 10.0.8-jre11-openjdk, 10.0-jre11-openjdk, 10-jre11-openjdk
+Tags: 10.0.9-jre11, 10.0-jre11, 10-jre11, 10.0.9-jre11-openjdk, 10.0-jre11-openjdk, 10-jre11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jre11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim, 10.0.8-jdk17-slim-openjdk, 10.0-jdk17-slim-openjdk, 10-jdk17-slim-openjdk
+Tags: 10.0.9-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim, 10.0.9-jdk17-slim-openjdk, 10.0-jdk17-slim-openjdk, 10-jdk17-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jdk17-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8, 10.0, 10, 10.0.8-jdk17, 10.0-jdk17, 10-jdk17, 10.0.8-openjdk, 10.0-openjdk, 10-openjdk, 10.0.8-jdk17-openjdk, 10.0-jdk17-openjdk, 10-jdk17-openjdk
+Tags: 10.0.9, 10.0, 10, 10.0.9-jdk17, 10.0-jdk17, 10-jdk17, 10.0.9-openjdk, 10.0-openjdk, 10-openjdk, 10.0.9-jdk17-openjdk, 10.0-jdk17-openjdk, 10-jdk17-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim, 10.0.8-jdk11-slim-openjdk, 10.0-jdk11-slim-openjdk, 10-jdk11-slim-openjdk
+Tags: 10.0.9-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim, 10.0.9-jdk11-slim-openjdk, 10.0-jdk11-slim-openjdk, 10-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jdk11-slim
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk11, 10.0-jdk11, 10-jdk11, 10.0.8-jdk11-openjdk, 10.0-jdk11-openjdk, 10-jdk11-openjdk
+Tags: 10.0.9-jdk11, 10.0-jdk11, 10-jdk11, 10.0.9-jdk11-openjdk, 10.0-jdk11-openjdk, 10-jdk11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
+Tags: 9.4.46-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
+Tags: 9.4.46-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.45-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
+Tags: 9.4.46-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.46-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
+Tags: 9.4.46-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
+Tags: 9.4.46-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.9-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.8-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.9-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.9-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.9-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.9-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.9-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.8-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.9-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.9-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.9-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.9-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
+Tags: 9.4.46-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
+Tags: 9.4.46-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
+Tags: 9.4.46-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.45-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
+Tags: 9.4.46-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.46-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
+Tags: 9.4.46-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.45-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
+Tags: 9.4.46-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.9-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.8-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.9-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.9-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.9-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.8-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.9-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.9-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.8-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.9-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.9-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.9-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: c135be75f3ea9043051940f554ef92c04bc7c208
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.8-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.9-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: f2edbcccd621830603a6ceaf59bafc8c23a32a6e
+GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212


### PR DESCRIPTION
Updated Jetty Versions
- [9.4.45.v20220203](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.45.v20220203) -> [9.4.46.v20220331](https://github.com/eclipse/jetty.project/releases/tag/jetty-9.4.46.v20220331)
- [10.0.8](https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.8) -> [10.0.9](https://github.com/eclipse/jetty.project/releases/tag/jetty-10.0.9)
- [11.0.8](https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.8) -> [11.0.9](https://github.com/eclipse/jetty.project/releases/tag/jetty-11.0.9)