### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -4,80 +4,80 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.11.0a6-bullseye, 3.11-rc-bullseye
-SharedTags: 3.11.0a6, 3.11-rc
+Tags: 3.11.0a7-bullseye, 3.11-rc-bullseye
+SharedTags: 3.11.0a7, 3.11-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/bullseye
 
-Tags: 3.11.0a6-slim-bullseye, 3.11-rc-slim-bullseye, 3.11.0a6-slim, 3.11-rc-slim
+Tags: 3.11.0a7-slim-bullseye, 3.11-rc-slim-bullseye, 3.11.0a7-slim, 3.11-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/slim-bullseye
 
-Tags: 3.11.0a6-buster, 3.11-rc-buster
+Tags: 3.11.0a7-buster, 3.11-rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/buster
 
-Tags: 3.11.0a6-slim-buster, 3.11-rc-slim-buster
+Tags: 3.11.0a7-slim-buster, 3.11-rc-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/slim-buster
 
-Tags: 3.11.0a6-alpine3.15, 3.11-rc-alpine3.15, 3.11.0a6-alpine, 3.11-rc-alpine
+Tags: 3.11.0a7-alpine3.15, 3.11-rc-alpine3.15, 3.11.0a7-alpine, 3.11-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/alpine3.15
 
-Tags: 3.11.0a6-alpine3.14, 3.11-rc-alpine3.14
+Tags: 3.11.0a7-alpine3.14, 3.11-rc-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/alpine3.14
 
-Tags: 3.11.0a6-windowsservercore-ltsc2022, 3.11-rc-windowsservercore-ltsc2022
-SharedTags: 3.11.0a6-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a6, 3.11-rc
+Tags: 3.11.0a7-windowsservercore-ltsc2022, 3.11-rc-windowsservercore-ltsc2022
+SharedTags: 3.11.0a7-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a7, 3.11-rc
 Architectures: windows-amd64
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.11.0a6-windowsservercore-1809, 3.11-rc-windowsservercore-1809
-SharedTags: 3.11.0a6-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a6, 3.11-rc
+Tags: 3.11.0a7-windowsservercore-1809, 3.11-rc-windowsservercore-1809
+SharedTags: 3.11.0a7-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a7, 3.11-rc
 Architectures: windows-amd64
-GitCommit: 0047f00c0967161e731c9bab7d50fd95c7c09d46
+GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
 Directory: 3.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.4-bullseye, 3.10-bullseye, 3-bullseye, bullseye
 SharedTags: 3.10.4, 3.10, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.10/bullseye
 
 Tags: 3.10.4-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.4-slim, 3.10-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.4-buster, 3.10-buster, 3-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.10/buster
 
 Tags: 3.10.4-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.10/slim-buster
 
 Tags: 3.10.4-alpine3.15, 3.10-alpine3.15, 3-alpine3.15, alpine3.15, 3.10.4-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.10/alpine3.15
 
 Tags: 3.10.4-alpine3.14, 3.10-alpine3.14, 3-alpine3.14, alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: acf9b9003f54003c4ebace7d501dae04eb410518
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.10/alpine3.14
 
 Tags: 3.10.4-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
@@ -97,32 +97,32 @@ Constraints: windowsservercore-1809
 Tags: 3.9.12-bullseye, 3.9-bullseye
 SharedTags: 3.9.12, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.9/bullseye
 
 Tags: 3.9.12-slim-bullseye, 3.9-slim-bullseye, 3.9.12-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.9/slim-bullseye
 
 Tags: 3.9.12-buster, 3.9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.9/buster
 
 Tags: 3.9.12-slim-buster, 3.9-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.9/slim-buster
 
 Tags: 3.9.12-alpine3.15, 3.9-alpine3.15, 3.9.12-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.9/alpine3.15
 
 Tags: 3.9.12-alpine3.14, 3.9-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e3f954f284ab822e939d99bddb3bfb25574f585e
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.9/alpine3.14
 
 Tags: 3.9.12-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
@@ -142,61 +142,61 @@ Constraints: windowsservercore-1809
 Tags: 3.8.13-bullseye, 3.8-bullseye
 SharedTags: 3.8.13, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.8/bullseye
 
 Tags: 3.8.13-slim-bullseye, 3.8-slim-bullseye, 3.8.13-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.8/slim-bullseye
 
 Tags: 3.8.13-buster, 3.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.8/buster
 
 Tags: 3.8.13-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.8/slim-buster
 
 Tags: 3.8.13-alpine3.15, 3.8-alpine3.15, 3.8.13-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.8/alpine3.15
 
 Tags: 3.8.13-alpine3.14, 3.8-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6b9719086775ddce2dde10871da97cbeb87b81ad
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.8/alpine3.14
 
 Tags: 3.7.13-bullseye, 3.7-bullseye
 SharedTags: 3.7.13, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.7/bullseye
 
 Tags: 3.7.13-slim-bullseye, 3.7-slim-bullseye, 3.7.13-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.7/slim-bullseye
 
 Tags: 3.7.13-buster, 3.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.7/buster
 
 Tags: 3.7.13-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.7/slim-buster
 
 Tags: 3.7.13-alpine3.15, 3.7-alpine3.15, 3.7.13-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.7/alpine3.15
 
 Tags: 3.7.13-alpine3.14, 3.7-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a9815ead3ae016edf7039285cb267b14a5700169
+GitCommit: 0a9ee3e64588bb1144d6e4e413a0c5dd5cd48651
 Directory: 3.7/alpine3.14


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/37e4721: Update 3.11-rc to 3.11.0a7, pip 22.0.4
- https://github.com/docker-library/python/commit/0a9ee3e: Prevent removing unexpected .a files in case of re-using the Dockerfile to build custom image (https://github.com/docker-library/python/pull/706)