### PR TITLE
archlinux: Release 20220410.0.52530

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220403.0.51871
-GitCommit: 4217f5b9f1a5756e864e46e7783c92a22ad322ce
-GitFetch: refs/tags/v20220403.0.51871
+Tags: latest, base, base-20220410.0.52530
+GitCommit: deb74ebf88cfd5fd8082b5486f4e3f9dc8cd8487
+GitFetch: refs/tags/v20220410.0.52530
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220403.0.51871
-GitCommit: 4217f5b9f1a5756e864e46e7783c92a22ad322ce
-GitFetch: refs/tags/v20220403.0.51871
+Tags: base-devel, base-devel-20220410.0.52530
+GitCommit: deb74ebf88cfd5fd8082b5486f4e3f9dc8cd8487
+GitFetch: refs/tags/v20220410.0.52530
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks