### PR TITLE
MediaWiki: Add PHP calendar extension

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,7 +2,7 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: ce983a609daf0e23070931a55f892e3d7d0924a3
+GitCommit: bc248a718e85005b966c4f84ccebc92bdce58c4f
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 Tags: 1.37.2, 1.37, stable, latest


### PR DESCRIPTION
This has been needed for a while, but only noticed recently.

Refs:
* https://github.com/wikimedia/mediawiki-docker/pull/108
* https://github.com/wikimedia/mediawiki-docker/pull/109