### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -63,3 +63,48 @@ Tags: cli-2.6.0-php8.1, cli-2.6-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php8.1/alpine
+
+Tags: beta-6.0-beta1-apache, beta-6.0-apache, beta-6-apache, beta-apache, beta-6.0-beta1, beta-6.0, beta-6, beta, beta-6.0-beta1-php7.4-apache, beta-6.0-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.0-beta1-php7.4, beta-6.0-php7.4, beta-6-php7.4, beta-php7.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php7.4/apache
+
+Tags: beta-6.0-beta1-fpm, beta-6.0-fpm, beta-6-fpm, beta-fpm, beta-6.0-beta1-php7.4-fpm, beta-6.0-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php7.4/fpm
+
+Tags: beta-6.0-beta1-fpm-alpine, beta-6.0-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.0-beta1-php7.4-fpm-alpine, beta-6.0-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php7.4/fpm-alpine
+
+Tags: beta-6.0-beta1-php8.0-apache, beta-6.0-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.0-beta1-php8.0, beta-6.0-php8.0, beta-6-php8.0, beta-php8.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php8.0/apache
+
+Tags: beta-6.0-beta1-php8.0-fpm, beta-6.0-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php8.0/fpm
+
+Tags: beta-6.0-beta1-php8.0-fpm-alpine, beta-6.0-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php8.0/fpm-alpine
+
+Tags: beta-6.0-beta1-php8.1-apache, beta-6.0-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.0-beta1-php8.1, beta-6.0-php8.1, beta-6-php8.1, beta-php8.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php8.1/apache
+
+Tags: beta-6.0-beta1-php8.1-fpm, beta-6.0-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php8.1/fpm
+
+Tags: beta-6.0-beta1-php8.1-fpm-alpine, beta-6.0-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 97c844fa77618f6d4106134ef50e81594d5e501d
+Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/97c844f: Update beta to 6.0-beta1