### PR TITLE
Update to Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -10,23 +10,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Sam Thornton (@mrthornazon),
              Preston Carpenter (@timidger),
              Richard Kelly (@rpkelly),
-             Joseph Howell-Burke (@jhowell-burke)
+             Joseph Howell-Burke (@jhowell-burke),
+	     Joe Gawrieh (@theOtherJoe)
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: ddc781764ced8c0921bb246a7475bc8e1f5b9c2d
 
-Tags: 2.0.20220316.0, 2, latest
+Tags: 2.0.20220406.1, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: d55c04f219a765500b97b89955a6a628ce9e9857
+amd64-GitCommit: 855e8618199d3685034163c317caf5bbebbaefa4
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: b79f0187938600484e468f34db86a3b37d0377c2
+arm64v8-GitCommit: 11ea9eba165fa1aa0677a684a50e70533b7e56a4
 
-Tags: 2.0.20220316.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20220406.1-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: eb34529fd15e21a1fc455dbcbc486ea26cafebbe
+amd64-GitCommit: f7aff7da9863550e0b0d814d002643bd615227b8
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: db6711b34aa4a7424f55f551d55377668e78b3e6
+arm64v8-GitCommit: 5c07d68342510ab3d929f6f2b1a10a90527275ba
 
 Tags: 2018.03.0.20220315.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This will bring docker-library up to date with AWS ECR.
This also adds a new maintainer (Joe Gawrieh (@theOtherJoe))

Thank you,
Sam