### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/123138a63e6b63b46162a1e1920775374ef055a8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/fd8ba387fcd0d6ca617d47362138a80558e8f058/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 123138a63e6b63b46162a1e1920775374ef055a8
+GitCommit: fd8ba387fcd0d6ca617d47362138a80558e8f058
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d85fda50cddcc15cdafc78d61f9d9fc39638453c
+amd64-GitCommit: 8822d69939aa6c41b50c66d0a4c5a5f8729f2178
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: a707af58576e309aa1a214e1d367952eb26078a5
+arm32v5-GitCommit: 7e5e3e23fcd51aa88a9b4bd42112f3ec80e4bc8d
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: c8993db1eadf472c6c2865c770213a5d1811a344
+arm32v6-GitCommit: 26fdeb053d35bf2ccaa254b2fccf3da65ebef954
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 154694c406e4a36b1de24587c1a18f64b844e141
+arm32v7-GitCommit: f777459bbe8d72cdb610ebbf0840f498668fc851
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f295bf141c44527a937a52e872cc83e5b37e9225
+arm64v8-GitCommit: 81ac7d725a0e19cb717460a55b1ff7d1bb7860f2
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 3f852a174c6ef05097c116c042201cae67abcb1e
+i386-GitCommit: bab588eefef91359aa7360aaeb33508c29ae1bb8
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: ecde8a784018049c682d14209e70e6dfb96b5fb8
+mips64le-GitCommit: 02ed0b4d7f17434c0a567cbf2d4d62c5268804d7
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: cf661c0bc94ed507c9ff54b49d3ee289fcff8dec
+ppc64le-GitCommit: 9b0e91f08b4b0947ba9e6a9969037ffe284c205c
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: d3749146704e4e070e1d60bfa6a9ceabc2a821c6
+riscv64-GitCommit: 33bf8527880d4279d7492f89e0dd6e6c9de43a49
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: b827c918a4ac01219bc0fb119fedae03dcfcad73
+s390x-GitCommit: 0f9537ec7afa3b8b7e320262737ef884abe00691
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/fd8ba38: Merge pull request https://github.com/docker-library/busybox/pull/132 from infosiftr/buildroot-2022.02.1
- https://github.com/docker-library/busybox/commit/8d29939: Update buildroot to 2022.02.1