### PR TITLE
archlinux: Release 20220417.0.53367

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220410.0.52530
-GitCommit: deb74ebf88cfd5fd8082b5486f4e3f9dc8cd8487
-GitFetch: refs/tags/v20220410.0.52530
+Tags: latest, base, base-20220417.0.53367
+GitCommit: d0f072ccf6f3899f3f8c022792f64c976c0d00fc
+GitFetch: refs/tags/v20220417.0.53367
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220410.0.52530
-GitCommit: deb74ebf88cfd5fd8082b5486f4e3f9dc8cd8487
-GitFetch: refs/tags/v20220410.0.52530
+Tags: base-devel, base-devel-20220417.0.53367
+GitCommit: d0f072ccf6f3899f3f8c022792f64c976c0d00fc
+GitFetch: refs/tags/v20220417.0.53367
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks