### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev5, 2.6-dev, 2.6-dev5-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev6, 2.6-dev, 2.6-dev6-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3c8bf51aaf09ff498ee5fed9d564d58853cb2330
+GitCommit: 25821e6b52af353dcd6ecb4ec5603cded0be881c
 Directory: 2.6-rc
 
-Tags: 2.6-dev5-alpine, 2.6-dev-alpine, 2.6-dev5-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev6-alpine, 2.6-dev-alpine, 2.6-dev6-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c8bf51aaf09ff498ee5fed9d564d58853cb2330
+GitCommit: 25821e6b52af353dcd6ecb4ec5603cded0be881c
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.5, 2.5, latest, 2.5.5-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/25821e6: Update 2.6-rc to 2.6-dev6