### PR TITLE
[nats-streaming] Release v0.24.4

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,25 +1,26 @@
-Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
+Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
+             Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
 GitFetch: refs/heads/main
-GitCommit: aeaadde041dd34146cb3186b04c81fc81bfcaf10
+GitCommit: 04a500b4ff5eab07d00222d67c302acf1b6122df
 
-Tags: 0.24.3-alpine3.15, 0.24-alpine3.15, alpine3.15, 0.24.3-alpine, 0.24-alpine, alpine
+Tags: 0.24.4-alpine3.15, 0.24-alpine3.15, alpine3.15, 0.24.4-alpine, 0.24-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.24.3/alpine3.15
+Directory: 0.24.4/alpine3.15
 
-Tags: 0.24.3-scratch, 0.24-scratch, scratch, 0.24.3-linux, 0.24-linux, linux
-SharedTags: 0.24.3, 0.24, latest
+Tags: 0.24.4-scratch, 0.24-scratch, scratch, 0.24.4-linux, 0.24-linux, linux
+SharedTags: 0.24.4, 0.24, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.24.3/scratch
+Directory: 0.24.4/scratch
 
-Tags: 0.24.3-windowsservercore-1809, 0.24-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.24.3-windowsservercore, 0.24-windowsservercore, windowsservercore
+Tags: 0.24.4-windowsservercore-1809, 0.24-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.24.4-windowsservercore, 0.24-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.24.3/windowsservercore-1809
+Directory: 0.24.4/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 0.24.3-nanoserver-1809, 0.24-nanoserver-1809, nanoserver-1809
-SharedTags: 0.24.3-nanoserver, 0.24-nanoserver, nanoserver, 0.24.3, 0.24, latest
+Tags: 0.24.4-nanoserver-1809, 0.24-nanoserver-1809, nanoserver-1809
+SharedTags: 0.24.4-nanoserver, 0.24-nanoserver, nanoserver, 0.24.4, 0.24, latest
 Architectures: windows-amd64
-Directory: 0.24.3/nanoserver-1809
+Directory: 0.24.4/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Added Phil Pennock as a maintainer too.

Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.24.4)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>