### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -66,55 +66,55 @@ GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18-jdk-oraclelinux8, 18-oraclelinux8, 18-jdk-oracle, 18-oracle
-SharedTags: 18-jdk, 18
+Tags: 18.0.1-jdk-oraclelinux8, 18.0.1-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18.0.1-jdk-oracle, 18.0.1-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle
+SharedTags: 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18
 Architectures: amd64, arm64v8
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18.0.1-jdk-oraclelinux7, 18.0.1-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18-jdk-bullseye, 18-bullseye
+Tags: 18.0.1-jdk-bullseye, 18.0.1-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/bullseye
 
-Tags: 18-jdk-slim-bullseye, 18-slim-bullseye, 18-jdk-slim, 18-slim
+Tags: 18.0.1-jdk-slim-bullseye, 18.0.1-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18.0.1-jdk-slim, 18.0.1-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim
 Architectures: amd64, arm64v8
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18-jdk-buster, 18-buster
+Tags: 18.0.1-jdk-buster, 18.0.1-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster
 Architectures: amd64, arm64v8
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/buster
 
-Tags: 18-jdk-slim-buster, 18-slim-buster
+Tags: 18.0.1-jdk-slim-buster, 18.0.1-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/slim-buster
 
-Tags: 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
-SharedTags: 18-jdk-windowsservercore, 18-windowsservercore, 18-jdk, 18
+Tags: 18.0.1-jdk-windowsservercore-ltsc2022, 18.0.1-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
+SharedTags: 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18-jdk-windowsservercore, 18-windowsservercore, 18-jdk, 18
+Tags: 18.0.1-jdk-windowsservercore-1809, 18.0.1-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
+SharedTags: 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18
 Architectures: windows-amd64
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18-jdk-nanoserver, 18-nanoserver
+Tags: 18.0.1-jdk-nanoserver-1809, 18.0.1-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
+SharedTags: 18.0.1-jdk-nanoserver, 18.0.1-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver
 Architectures: windows-amd64
-GitCommit: ce82579fcff27d724a50ceaa4f1c140ac0102f39
+GitCommit: 8a2f76391892edf7552ac3cb3273573d935bdc7c
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8a2f763: Update 18 to 18.0.1