### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.1.2
+Tags: 8.1.3
 Architectures: amd64, arm64v8
-GitCommit: 9811da3cb96247c527134576365b04d2d993a8e4
+GitCommit: 1632044032655e32bbefed5993a3a512bb8e141c
 Directory: 8
 
-Tags: 7.17.2
+Tags: 7.17.3
 Architectures: amd64, arm64v8
-GitCommit: fd9bd5e8f13affae1c2b335af8c4c2fa69e5ad83
+GitCommit: f82097fb479c4d4b64eafcd6982fb99ef5919d5c
 Directory: 7
 
 Tags: 6.8.23

--- a/library/kibana
+++ b/library/kibana
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.1.2
+Tags: 8.1.3
 Architectures: amd64, arm64v8
-GitCommit: c5bb85683eb07b40bf0d159bbd578e0046bb92e2
+GitCommit: 8226cf37a52dcfcd0e56e34b36f8d0e771c0dbd5
 Directory: 8
 
-Tags: 7.17.2
+Tags: 7.17.3
 Architectures: amd64, arm64v8
-GitCommit: ea34e83a24be36fe920666adf2410a2ddc17c35c
+GitCommit: bab70d6340c944eb961dd3ab54da6814969e8f01
 Directory: 7
 
 Tags: 6.8.23

--- a/library/logstash
+++ b/library/logstash
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.1.2
+Tags: 8.1.3
 Architectures: amd64, arm64v8
-GitCommit: 9a0aa8303b734597353588493aeb314456b05328
+GitCommit: 8ce7aeb9627debc82736b52a9b178b8d79bf4fdf
 Directory: 8
 
-Tags: 7.17.2
+Tags: 7.17.3
 Architectures: amd64, arm64v8
-GitCommit: 601905e33e09f3b2d17c98387183b13c97e43896
+GitCommit: 74c9384f34112e5ee37a0725b71077558bd97a1d
 Directory: 7
 
 Tags: 6.8.23


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/1632044: Update to 8.1.3
- https://github.com/docker-library/elasticsearch/commit/f82097f: Update to 7.17.3

logstash:
- https://github.com/docker-library/logstash/commit/8ce7aeb: Update to 8.1.3
- https://github.com/docker-library/logstash/commit/74c9384: Update to 7.17.3

kibana:
- https://github.com/docker-library/kibana/commit/8226cf3: Update to 8.1.3
- https://github.com/docker-library/kibana/commit/bab70d6: Update to 7.17.3