### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2021-07-28
-Tags: 11.2.0, 11.2, 11, latest, 11.2.0-bullseye, 11.2-bullseye, 11-bullseye, bullseye
+# Last Modified: 2022-04-21
+Tags: 11.3.0, 11.3, 11, latest, 11.3.0-bullseye, 11.3-bullseye, 11-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c2c4e3ac9245fa9e5789512969cf3209e0c56136
+GitCommit: b3d0691e428cf7da4a983c91a772cc5b5ee2d6b4
 Directory: 11
-# Docker EOL: 2023-01-28
+# Docker EOL: 2023-10-21
 
 # Last Modified: 2021-04-08
 Tags: 10.3.0, 10.3, 10, 10.3.0-buster, 10.3-buster, 10-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/b3d0691: Update 11 to 11.3.0