### PR TITLE
update r-base to 4.2.0 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.1.3, latest
+Tags: 4.2.0, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 2fb991537d60c20bc11a93a76587d6e25bb3a054
-Directory: r-base/4.1.3
+GitCommit: f69d608f08f472438672ec34f430141ea84c509a
+Directory: r-base/4.2.0
 


### PR DESCRIPTION
Standard update of r-base to the new upstream release 4.2.0 made earlier today using the updated Debian binaries

No other container changes