### PR TITLE
Update eclipse-temurin for new releases (part 1)

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -115,16 +115,16 @@ GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
 Directory: 11/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.14.1_1-jdk-focal, 11-jdk-focal, 11-focal
-SharedTags: 11.0.14.1_1-jdk, 11-jdk, 11
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
+Tags: 11.0.15_10-jdk-focal, 11-jdk-focal, 11-focal
+SharedTags: 11.0.15_10-jdk, 11-jdk, 11
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 11.0.14.1_1-jdk-centos7, 11-jdk-centos7, 11-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+Tags: 11.0.15_10-jdk-centos7, 11-jdk-centos7, 11-centos7
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
@@ -166,16 +166,16 @@ GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
 Directory: 11/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.14.1_1-jre-focal, 11-jre-focal
-SharedTags: 11.0.14.1_1-jre, 11-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
+Tags: 11.0.15_10-jre-focal, 11-jre-focal
+SharedTags: 11.0.15_10-jre, 11-jre
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 11/jre/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 11.0.14.1_1-jre-centos7, 11-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+Tags: 11.0.15_10-jre-centos7, 11-jre-centos7
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
@@ -256,16 +256,16 @@ GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
 Directory: 17/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 17.0.2_8-jdk-focal, 17-jdk-focal, 17-focal
-SharedTags: 17.0.2_8-jdk, 17-jdk, 17
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
+Tags: 17.0.3_7-jdk-focal, 17-jdk-focal, 17-focal
+SharedTags: 17.0.3_7-jdk, 17-jdk, 17
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 17/jdk/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 17.0.2_8-jdk-centos7, 17-jdk-centos7, 17-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+Tags: 17.0.3_7-jdk-centos7, 17-jdk-centos7, 17-centos7
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 17/jdk/centos
 File: Dockerfile.releases.full
 
@@ -307,16 +307,16 @@ GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
 Directory: 17/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 17.0.2_8-jre-focal, 17-jre-focal
-SharedTags: 17.0.2_8-jre, 17-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
+Tags: 17.0.3_7-jre-focal, 17-jre-focal
+SharedTags: 17.0.3_7-jre, 17-jre
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 17/jre/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 17.0.2_8-jre-centos7, 17-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+Tags: 17.0.3_7-jre-centos7, 17-jre-centos7
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 17/jre/centos
 File: Dockerfile.releases.full
 
@@ -360,16 +360,16 @@ GitCommit: 535e41304f7bd6c0d45b42bf2af0f320323825da
 Directory: 18/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 18_36-jdk-focal, 18-jdk-focal, 18-focal
-SharedTags: 18_36-jdk, 18-jdk, 18, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 535e41304f7bd6c0d45b42bf2af0f320323825da
+Tags: 18.0.1_10-jdk-focal, 18-jdk-focal, 18-focal
+SharedTags: 18.0.1_10-jdk, 18-jdk, 18, latest
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 18/jdk/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 18_36-jdk-centos7, 18-jdk-centos7, 18-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: ea1b744d6836852780c71306f923eb2674348595
+Tags: 18.0.1_10-jdk-centos7, 18-jdk-centos7, 18-centos7
+Architectures: amd64
+GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
 Directory: 18/jdk/centos
 File: Dockerfile.releases.full
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -109,104 +109,104 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.14.1_1-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.15_10-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 11.0.15_10-jdk-focal, 11-jdk-focal, 11-focal
 SharedTags: 11.0.15_10-jdk, 11-jdk, 11
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.15_10-jdk-centos7, 11-jdk-centos7, 11-centos7
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.14.1_1-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.14.1_1-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.14.1_1-jdk, 11-jdk, 11
+Tags: 11.0.15_10-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.15_10-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.15_10-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.14.1_1-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.14.1_1-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.15_10-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.15_10-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.14.1_1-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.14.1_1-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.14.1_1-jdk, 11-jdk, 11
+Tags: 11.0.15_10-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.15_10-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.15_10-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.14.1_1-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.14.1_1-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.15_10-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.15_10-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.14.1_1-jre-alpine, 11-jre-alpine
+Tags: 11.0.15_10-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 78a1d4d015ee0759f269888a9d085ddc03f20b95
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 11.0.15_10-jre-focal, 11-jre-focal
 SharedTags: 11.0.15_10-jre, 11-jre
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 11.0.15_10-jre-centos7, 11-jre-centos7
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.14.1_1-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.14.1_1-jre-windowsservercore, 11-jre-windowsservercore, 11.0.14.1_1-jre, 11-jre
+Tags: 11.0.15_10-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.15_10-jre-windowsservercore, 11-jre-windowsservercore, 11.0.15_10-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.14.1_1-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.14.1_1-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.15_10-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.15_10-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.14.1_1-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.14.1_1-jre-windowsservercore, 11-jre-windowsservercore, 11.0.14.1_1-jre, 11-jre
+Tags: 11.0.15_10-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.15_10-jre-windowsservercore, 11-jre-windowsservercore, 11.0.15_10-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.14.1_1-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.14.1_1-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.15_10-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.15_10-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 0cf76e40e5f3aab1257d66b739654345803df940
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 11/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -250,104 +250,104 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.2_8-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.3_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 17.0.3_7-jdk-focal, 17-jdk-focal, 17-focal
 SharedTags: 17.0.3_7-jdk, 17-jdk, 17
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 17.0.3_7-jdk-centos7, 17-jdk-centos7, 17-centos7
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 17.0.2_8-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.2_8-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.2_8-jdk, 17-jdk, 17
+Tags: 17.0.3_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.3_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.3_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.2_8-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.2_8-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.3_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.3_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.2_8-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.2_8-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.2_8-jdk, 17-jdk, 17
+Tags: 17.0.3_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.3_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.3_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.2_8-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.2_8-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.3_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.3_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17.0.2_8-jre-alpine, 17-jre-alpine
+Tags: 17.0.3_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 17.0.3_7-jre-focal, 17-jre-focal
 SharedTags: 17.0.3_7-jre, 17-jre
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/ubuntu
 File: Dockerfile.releases.full
 
 Tags: 17.0.3_7-jre-centos7, 17-jre-centos7
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 17.0.2_8-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.2_8-jre-windowsservercore, 17-jre-windowsservercore, 17.0.2_8-jre, 17-jre
+Tags: 17.0.3_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.3_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.3_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.2_8-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.2_8-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.3_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.3_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.2_8-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.2_8-jre-windowsservercore, 17-jre-windowsservercore, 17.0.2_8-jre, 17-jre
+Tags: 17.0.3_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.3_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.3_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.2_8-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.2_8-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.3_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.3_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 130db1e5356f5a86868b70809c8311b0aad0c756
+GitCommit: 5a7c9b25bbca1cde27828e819f765614f7daf774
 Directory: 17/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -360,16 +360,16 @@ GitCommit: 535e41304f7bd6c0d45b42bf2af0f320323825da
 Directory: 18/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 18.0.1_10-jdk-focal, 18-jdk-focal, 18-focal
-SharedTags: 18.0.1_10-jdk, 18-jdk, 18, latest
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Tags: 18_36-jdk-focal, 18-jdk-focal, 18-focal
+SharedTags: 18_36-jdk, 18-jdk, 18, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 535e41304f7bd6c0d45b42bf2af0f320323825da
 Directory: 18/jdk/ubuntu
 File: Dockerfile.releases.full
 
-Tags: 18.0.1_10-jdk-centos7, 18-jdk-centos7, 18-centos7
-Architectures: amd64
-GitCommit: 1c2bc74272de764359d9840d73a6caa2d423b438
+Tags: 18_36-jdk-centos7, 18-jdk-centos7, 18-centos7
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: ea1b744d6836852780c71306f923eb2674348595
 Directory: 18/jdk/centos
 File: Dockerfile.releases.full
 
@@ -404,4 +404,5 @@ GitCommit: ea1b744d6836852780c71306f923eb2674348595
 Directory: 18/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
+
 


### PR DESCRIPTION
Updates to new quarterly release for  JDK11.0.15 and 17.0.3