### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,35 +4,35 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 19-ea-18-jdk-oraclelinux8, 19-ea-18-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-18-jdk-oracle, 19-ea-18-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-ea-18-jdk, 19-ea-18, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-19-jdk-oraclelinux8, 19-ea-19-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-19-jdk-oracle, 19-ea-19-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
+SharedTags: 19-ea-19-jdk, 19-ea-19, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: amd64, arm64v8
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/oraclelinux8
 
-Tags: 19-ea-18-jdk-oraclelinux7, 19-ea-18-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
+Tags: 19-ea-19-jdk-oraclelinux7, 19-ea-19-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/oraclelinux7
 
-Tags: 19-ea-18-jdk-bullseye, 19-ea-18-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
+Tags: 19-ea-19-jdk-bullseye, 19-ea-19-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/bullseye
 
-Tags: 19-ea-18-jdk-slim-bullseye, 19-ea-18-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-18-jdk-slim, 19-ea-18-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
+Tags: 19-ea-19-jdk-slim-bullseye, 19-ea-19-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-19-jdk-slim, 19-ea-19-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
 Architectures: amd64, arm64v8
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/slim-bullseye
 
-Tags: 19-ea-18-jdk-buster, 19-ea-18-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
+Tags: 19-ea-19-jdk-buster, 19-ea-19-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
 Architectures: amd64, arm64v8
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/buster
 
-Tags: 19-ea-18-jdk-slim-buster, 19-ea-18-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
+Tags: 19-ea-19-jdk-slim-buster, 19-ea-19-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/slim-buster
 
 Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
@@ -45,24 +45,24 @@ Architectures: amd64
 GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
 Directory: 19/jdk/alpine3.14
 
-Tags: 19-ea-18-jdk-windowsservercore-ltsc2022, 19-ea-18-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-ea-18-jdk-windowsservercore, 19-ea-18-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-18-jdk, 19-ea-18, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-19-jdk-windowsservercore-ltsc2022, 19-ea-19-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19-ea-19-jdk-windowsservercore, 19-ea-19-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-19-jdk, 19-ea-19, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19-ea-18-jdk-windowsservercore-1809, 19-ea-18-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-ea-18-jdk-windowsservercore, 19-ea-18-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-18-jdk, 19-ea-18, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-ea-19-jdk-windowsservercore-1809, 19-ea-19-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19-ea-19-jdk-windowsservercore, 19-ea-19-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-19-jdk, 19-ea-19, 19-ea-jdk, 19-ea, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-18-jdk-nanoserver-1809, 19-ea-18-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-ea-18-jdk-nanoserver, 19-ea-18-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19-ea-19-jdk-nanoserver-1809, 19-ea-19-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19-ea-19-jdk-nanoserver, 19-ea-19-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: 18fe63697e4bc334d793ba174d81b0a953c1b95d
+GitCommit: bd34cbc6b7f76f5988d6f08f81bf31d5d4925c94
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -170,97 +170,97 @@ GitCommit: f8d1fd911fdcad985d7a534e3470a9c54c87d45f
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.14.1-jdk-oraclelinux8, 11.0.14.1-oraclelinux8, 11.0.14-jdk-oraclelinux8, 11.0.14-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.14.1-jdk-oracle, 11.0.14.1-oracle, 11.0.14-jdk-oracle, 11.0.14-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
+Tags: 11.0.15-jdk-oraclelinux8, 11.0.15-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.15-jdk-oracle, 11.0.15-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/oraclelinux8
 
-Tags: 11.0.14.1-jdk-oraclelinux7, 11.0.14.1-oraclelinux7, 11.0.14-jdk-oraclelinux7, 11.0.14-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
+Tags: 11.0.15-jdk-oraclelinux7, 11.0.15-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/oraclelinux7
 
-Tags: 11.0.14.1-jdk-bullseye, 11.0.14.1-bullseye, 11.0.14-jdk-bullseye, 11.0.14-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
-SharedTags: 11.0.14.1-jdk, 11.0.14.1, 11.0.14-jdk, 11.0.14, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.15-jdk-bullseye, 11.0.15-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
+SharedTags: 11.0.15-jdk, 11.0.15, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/bullseye
 
-Tags: 11.0.14.1-jdk-slim-bullseye, 11.0.14.1-slim-bullseye, 11.0.14-jdk-slim-bullseye, 11.0.14-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.14.1-jdk-slim, 11.0.14.1-slim, 11.0.14-jdk-slim, 11.0.14-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.15-jdk-slim-bullseye, 11.0.15-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.15-jdk-slim, 11.0.15-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/slim-bullseye
 
-Tags: 11.0.14.1-jdk-buster, 11.0.14.1-buster, 11.0.14-jdk-buster, 11.0.14-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
+Tags: 11.0.15-jdk-buster, 11.0.15-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/buster
 
-Tags: 11.0.14.1-jdk-slim-buster, 11.0.14.1-slim-buster, 11.0.14-jdk-slim-buster, 11.0.14-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
+Tags: 11.0.15-jdk-slim-buster, 11.0.15-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/slim-buster
 
-Tags: 11.0.14.1-jdk-windowsservercore-ltsc2022, 11.0.14.1-windowsservercore-ltsc2022, 11.0.14-jdk-windowsservercore-ltsc2022, 11.0.14-windowsservercore-ltsc2022, 11.0-jdk-windowsservercore-ltsc2022, 11.0-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.14.1-jdk-windowsservercore, 11.0.14.1-windowsservercore, 11.0.14-jdk-windowsservercore, 11.0.14-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.14.1-jdk, 11.0.14.1, 11.0.14-jdk, 11.0.14, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.15-jdk-windowsservercore-ltsc2022, 11.0.15-windowsservercore-ltsc2022, 11.0-jdk-windowsservercore-ltsc2022, 11.0-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.15-jdk-windowsservercore, 11.0.15-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.15-jdk, 11.0.15, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.14.1-jdk-windowsservercore-1809, 11.0.14.1-windowsservercore-1809, 11.0.14-jdk-windowsservercore-1809, 11.0.14-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.14.1-jdk-windowsservercore, 11.0.14.1-windowsservercore, 11.0.14-jdk-windowsservercore, 11.0.14-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.14.1-jdk, 11.0.14.1, 11.0.14-jdk, 11.0.14, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.15-jdk-windowsservercore-1809, 11.0.15-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.15-jdk-windowsservercore, 11.0.15-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.15-jdk, 11.0.15, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.14.1-jdk-nanoserver-1809, 11.0.14.1-nanoserver-1809, 11.0.14-jdk-nanoserver-1809, 11.0.14-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.14.1-jdk-nanoserver, 11.0.14.1-nanoserver, 11.0.14-jdk-nanoserver, 11.0.14-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.15-jdk-nanoserver-1809, 11.0.15-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.15-jdk-nanoserver, 11.0.15-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.14.1-jre-bullseye, 11.0.14-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
-SharedTags: 11.0.14.1-jre, 11.0.14-jre, 11.0-jre, 11-jre
+Tags: 11.0.15-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
+SharedTags: 11.0.15-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/bullseye
 
-Tags: 11.0.14.1-jre-slim-bullseye, 11.0.14-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.14.1-jre-slim, 11.0.14-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.15-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.15-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/slim-bullseye
 
-Tags: 11.0.14.1-jre-buster, 11.0.14-jre-buster, 11.0-jre-buster, 11-jre-buster
+Tags: 11.0.15-jre-buster, 11.0-jre-buster, 11-jre-buster
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/buster
 
-Tags: 11.0.14.1-jre-slim-buster, 11.0.14-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
+Tags: 11.0.15-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/slim-buster
 
-Tags: 11.0.14.1-jre-windowsservercore-ltsc2022, 11.0.14-jre-windowsservercore-ltsc2022, 11.0-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.14.1-jre-windowsservercore, 11.0.14-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.14.1-jre, 11.0.14-jre, 11.0-jre, 11-jre
+Tags: 11.0.15-jre-windowsservercore-ltsc2022, 11.0-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.15-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.15-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.14.1-jre-windowsservercore-1809, 11.0.14-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.14.1-jre-windowsservercore, 11.0.14-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.14.1-jre, 11.0.14-jre, 11.0-jre, 11-jre
+Tags: 11.0.15-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.15-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.15-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.14.1-jre-nanoserver-1809, 11.0.14-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.14.1-jre-nanoserver, 11.0.14-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.15-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.15-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: e4d50e3b9a43c44619c34e98deeb5e0c75405844
+GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8735213: Update 11 to 11.0.15
- https://github.com/docker-library/openjdk/commit/3e9323c: Add a simple hack to account for downstream naming inconsistency
- https://github.com/docker-library/openjdk/commit/bd34cbc: Update 19 to 19-ea+19