### PR TITLE
archlinux: Release 20220424.0.54084

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220417.0.53367
-GitCommit: d0f072ccf6f3899f3f8c022792f64c976c0d00fc
-GitFetch: refs/tags/v20220417.0.53367
+Tags: latest, base, base-20220424.0.54084
+GitCommit: 8b4b8fc6d7311e9cc080c8e90cb8d87a3dd8ddb7
+GitFetch: refs/tags/v20220424.0.54084
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220417.0.53367
-GitCommit: d0f072ccf6f3899f3f8c022792f64c976c0d00fc
-GitFetch: refs/tags/v20220417.0.53367
+Tags: base-devel, base-devel-20220424.0.54084
+GitCommit: 8b4b8fc6d7311e9cc080c8e90cb8d87a3dd8ddb7
+GitFetch: refs/tags/v20220424.0.54084
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks