### PR TITLE
Update Clear Linux OS to 36220

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 488c6dfb1e8d2d10e4e82197ac1cb5eca17154e4
-GitFetch: refs/heads/base-36190
+GitCommit: fd62058660cf7853178abe4017b2944de7d0e0b4
+GitFetch: refs/heads/base-36220


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36220

@bryteise @djklimes @bryteise