### PR TITLE
Odoo: update 13.0-15.0 to release 20220425

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: f2933c515831713d96614add0d0c5fd073a6153f
+GitCommit: 1649d6cc0e474a19c1169439c334bd3507fd71cc
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks