### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e4106abb6da325657f55f6d5dc97cc9430964f1a
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.5, 2.5, latest, 2.5.5-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.6, 2.5, latest, 2.5.6-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f70bee43595199d470ce5c711807c32417e04463
+GitCommit: 337b65c7bbffcf02c8cf50c37d6837495fd32015
 Directory: 2.5
 
-Tags: 2.5.5-alpine, 2.5-alpine, alpine, 2.5.5-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.6-alpine, 2.5-alpine, alpine, 2.5.6-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f70bee43595199d470ce5c711807c32417e04463
+GitCommit: 337b65c7bbffcf02c8cf50c37d6837495fd32015
 Directory: 2.5/alpine
 
 Tags: 2.4.15, 2.4, lts, 2.4.15-bullseye, 2.4-bullseye, lts-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/337b65c: Update 2.5 to 2.5.6