### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-1537

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6cc53ba86d8d6d69c3109f48bca9a91a46746528
+amd64-GitCommit: 55c34418ea00e2e09b2cfe2a6a5518eef4fbcad6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8cfa92966df0e60e319dac24856b31cb7504d16f
+arm64v8-GitCommit: d21214cbab4199519e6a54364ce190522506112b
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1271.

See https://linux.oracle.com/errata/ELSA-2022-1537.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>