### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.28-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.0.29-oracle, 8.0-oracle, 8-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 546838ab256ad36a9f6571e900deb7c4040cd383
+GitCommit: 68bc91b85ffde4ec9c0ca084b092acfb28463bfa
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.28, 8.0, 8, latest, 8.0.28-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.29, 8.0, 8, latest, 8.0.29-debian, 8.0-debian, 8-debian, debian
 Architectures: amd64
-GitCommit: 546838ab256ad36a9f6571e900deb7c4040cd383
+GitCommit: 68bc91b85ffde4ec9c0ca084b092acfb28463bfa
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.37-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.38-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: 546838ab256ad36a9f6571e900deb7c4040cd383
+GitCommit: 7c4eca3ee491d62d3aa5442c864c43355ab34f1b
 Directory: 5.7
 File: Dockerfile.oracle
 
-Tags: 5.7.37, 5.7, 5, 5.7.37-debian, 5.7-debian, 5-debian
+Tags: 5.7.38, 5.7, 5, 5.7.38-debian, 5.7-debian, 5-debian
 Architectures: amd64
-GitCommit: 546838ab256ad36a9f6571e900deb7c4040cd383
+GitCommit: 7c4eca3ee491d62d3aa5442c864c43355ab34f1b
 Directory: 5.7
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/7c4eca3: Update 5.7 to 5.7.38, debian 5.7.38-1debian10, mysql-shell 8.0.29-1.el7, oracle 5.7.38-1.el7
- https://github.com/docker-library/mysql/commit/68bc91b: Update 8.0 to 8.0.29, debian 8.0.29-1debian10, mysql-shell 8.0.29-1.el8, oracle 8.0.29-1.el8
- https://github.com/docker-library/mysql/commit/e4b225b: Fix Dockerfile linguist Git attributes