### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -123,33 +123,3 @@ Tags: 2.7.6-alpine3.14, 2.7-alpine3.14, 2-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2c3e1e09e881f8a1f24d1ddfe1d5c6117aaa62de
 Directory: 2.7/alpine3.14
-
-Tags: 2.6.10-bullseye, 2.6-bullseye, 2.6.10, 2.6
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633eef5268b596356ee6674164599ebfc50aa8b
-Directory: 2.6/bullseye
-
-Tags: 2.6.10-slim-bullseye, 2.6-slim-bullseye, 2.6.10-slim, 2.6-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633eef5268b596356ee6674164599ebfc50aa8b
-Directory: 2.6/slim-bullseye
-
-Tags: 2.6.10-buster, 2.6-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633eef5268b596356ee6674164599ebfc50aa8b
-Directory: 2.6/buster
-
-Tags: 2.6.10-slim-buster, 2.6-slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b633eef5268b596356ee6674164599ebfc50aa8b
-Directory: 2.6/slim-buster
-
-Tags: 2.6.10-alpine3.15, 2.6-alpine3.15, 2.6.10-alpine, 2.6-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b633eef5268b596356ee6674164599ebfc50aa8b
-Directory: 2.6/alpine3.15
-
-Tags: 2.6.10-alpine3.14, 2.6-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b633eef5268b596356ee6674164599ebfc50aa8b
-Directory: 2.6/alpine3.14


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/ac24ae0: Remove Ruby 2.6 (EOL)