### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -21,25 +21,10 @@ Directory: 4.2
 
 Tags: 4.2.5-passenger, 4.2-passenger, 4-passenger
 Architectures: amd64
-GitCommit: 5444fd564ffba5c871a4d964b54c5559ee52e61e
+GitCommit: d7c75be048a002fbed8dc457462056c1fd4c255f
 Directory: 4.2/passenger
 
 Tags: 4.2.5-alpine, 4.2-alpine, 4-alpine, 4.2.5-alpine3.15, 4.2-alpine3.15, 4-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 540786b2e371dcfb74be6da6bc2a77f75d9d6b07
 Directory: 4.2/alpine
-
-Tags: 4.1.7, 4.1, 4.1.7-bullseye, 4.1-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 540786b2e371dcfb74be6da6bc2a77f75d9d6b07
-Directory: 4.1
-
-Tags: 4.1.7-passenger, 4.1-passenger
-Architectures: amd64
-GitCommit: 5444fd564ffba5c871a4d964b54c5559ee52e61e
-Directory: 4.1/passenger
-
-Tags: 4.1.7-alpine, 4.1-alpine, 4.1.7-alpine3.15, 4.1-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 540786b2e371dcfb74be6da6bc2a77f75d9d6b07
-Directory: 4.1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/8742870: Merge pull request https://github.com/docker-library/redmine/pull/263 from infosiftr/ruby-eol
- https://github.com/docker-library/redmine/commit/cb8e861: Remove 4.1 since ruby 2.6 is eol
- https://github.com/docker-library/redmine/commit/d7c75be: Update to passenger 6.0.13