### PR TITLE
Jetty - remove openjdk17 images and make eclipse-temurin default

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,187 +4,157 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 9.4.46-jre8-slim, 9.4-jre8-slim, 9-jre8-slim, 9.4.46-jre8-slim-openjdk, 9.4-jre8-slim-openjdk, 9-jre8-slim-openjdk
+Tags: 9.4.46-jre8-slim-openjdk, 9.4-jre8-slim-openjdk, 9-jre8-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre8-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jre8, 9.4-jre8, 9-jre8, 9.4.46-jre8-openjdk, 9.4-jre8-openjdk, 9-jre8-openjdk
+Tags: 9.4.46-jre8-openjdk, 9.4-jre8-openjdk, 9-jre8-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre8
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jre11-slim, 9.4-jre11-slim, 9-jre11-slim, 9.4.46-jre11-slim-openjdk, 9.4-jre11-slim-openjdk, 9-jre11-slim-openjdk
+Tags: 9.4.46-jre11-slim-openjdk, 9.4-jre11-slim-openjdk, 9-jre11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre11-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jre11, 9.4-jre11, 9-jre11, 9.4.46-jre11-openjdk, 9.4-jre11-openjdk, 9-jre11-openjdk
+Tags: 9.4.46-jre11-openjdk, 9.4-jre11-openjdk, 9-jre11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jre11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk-8-slim, 9.4-jdk-8-slim, 9-jdk-8-slim, 9.4.46-jdk-8-slim-openjdk, 9.4-jdk-8-slim-openjdk, 9-jdk-8-slim-openjdk
+Tags: 9.4.46-jdk-8-slim-openjdk, 9.4-jdk-8-slim-openjdk, 9-jdk-8-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk-8-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk8, 9.4-jdk8, 9-jdk8, 9.4.46-jdk8-openjdk, 9.4-jdk8-openjdk, 9-jdk8-openjdk
+Tags: 9.4.46-jdk8-openjdk, 9.4-jdk8-openjdk, 9-jdk8-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk8
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk17-slim, 9.4-jdk17-slim, 9-jdk17-slim, 9.4.46-jdk17-slim-openjdk, 9.4-jdk17-slim-openjdk, 9-jdk17-slim-openjdk
-Architectures: amd64, arm64v8
-Directory: openjdk/9.4/jdk17-slim
-GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
-
-Tags: 9.4.46, 9.4, 9, 9.4.46-jdk17, 9.4-jdk17, 9-jdk17, 9.4.46-openjdk, 9.4-openjdk, 9-openjdk, 9.4.46-jdk17-openjdk, 9.4-jdk17-openjdk, 9-jdk17-openjdk, latest, jdk17
-Architectures: amd64, arm64v8
-Directory: openjdk/9.4/jdk17
-GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
-
-Tags: 9.4.46-jdk11-slim, 9.4-jdk11-slim, 9-jdk11-slim, 9.4.46-jdk11-slim-openjdk, 9.4-jdk11-slim-openjdk, 9-jdk11-slim-openjdk
+Tags: 9.4.46-jdk11-slim-openjdk, 9.4-jdk11-slim-openjdk, 9-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk11-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk11, 9.4-jdk11, 9-jdk11, 9.4.46-jdk11-openjdk, 9.4-jdk11-openjdk, 9-jdk11-openjdk
+Tags: 9.4.46-jdk11-openjdk, 9.4-jdk11-openjdk, 9-jdk11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/9.4/jdk11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.3.30-jre8, 9.3-jre8, 9.3.30-jre8-openjdk, 9.3-jre8-openjdk, 9.3
+Tags: 9.3.30-jre8-openjdk, 9.3-jre8-openjdk, 9.3
 Architectures: amd64, arm64v8
 Directory: openjdk/9.3/jre8
 GitCommit: 9b0e3ee09fdb1c466f8b39f93bc57bdaa33d4ba0
 
-Tags: 9.2.30-jre8, 9.2-jre8, 9.2.30-jre8-openjdk, 9.2-jre8-openjdk, 9.2
+Tags: 9.2.30-jre8-openjdk, 9.2-jre8-openjdk, 9.2
 Architectures: amd64, arm64v8
 Directory: openjdk/9.2/jre8
 GitCommit: 9b0e3ee09fdb1c466f8b39f93bc57bdaa33d4ba0
 
-Tags: 11.0.9-jre11-slim, 11.0-jre11-slim, 11-jre11-slim, 11.0.9-jre11-slim-openjdk, 11.0-jre11-slim-openjdk, 11-jre11-slim-openjdk
+Tags: 11.0.9-jre11-slim-openjdk, 11.0-jre11-slim-openjdk, 11-jre11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jre11-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-jre11, 11.0-jre11, 11-jre11, 11.0.9-jre11-openjdk, 11.0-jre11-openjdk, 11-jre11-openjdk
+Tags: 11.0.9-jre11-openjdk, 11.0-jre11-openjdk, 11-jre11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jre11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-jdk17-slim, 11.0-jdk17-slim, 11-jdk17-slim, 11.0.9-jdk17-slim-openjdk, 11.0-jdk17-slim-openjdk, 11-jdk17-slim-openjdk
-Architectures: amd64, arm64v8
-Directory: openjdk/11.0/jdk17-slim
-GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
-
-Tags: 11.0.9, 11.0, 11, 11.0.9-jdk17, 11.0-jdk17, 11-jdk17, 11.0.9-openjdk, 11.0-openjdk, 11-openjdk, 11.0.9-jdk17-openjdk, 11.0-jdk17-openjdk, 11-jdk17-openjdk
-Architectures: amd64, arm64v8
-Directory: openjdk/11.0/jdk17
-GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
-
-Tags: 11.0.9-jdk11-slim, 11.0-jdk11-slim, 11-jdk11-slim, 11.0.9-jdk11-slim-openjdk, 11.0-jdk11-slim-openjdk, 11-jdk11-slim-openjdk
+Tags: 11.0.9-jdk11-slim-openjdk, 11.0-jdk11-slim-openjdk, 11-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jdk11-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-jdk11, 11.0-jdk11, 11-jdk11, 11.0.9-jdk11-openjdk, 11.0-jdk11-openjdk, 11-jdk11-openjdk
+Tags: 11.0.9-jdk11-openjdk, 11.0-jdk11-openjdk, 11-jdk11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/11.0/jdk11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jre11-slim, 10.0-jre11-slim, 10-jre11-slim, 10.0.9-jre11-slim-openjdk, 10.0-jre11-slim-openjdk, 10-jre11-slim-openjdk
+Tags: 10.0.9-jre11-slim-openjdk, 10.0-jre11-slim-openjdk, 10-jre11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jre11-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jre11, 10.0-jre11, 10-jre11, 10.0.9-jre11-openjdk, 10.0-jre11-openjdk, 10-jre11-openjdk
+Tags: 10.0.9-jre11-openjdk, 10.0-jre11-openjdk, 10-jre11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jre11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jdk17-slim, 10.0-jdk17-slim, 10-jdk17-slim, 10.0.9-jdk17-slim-openjdk, 10.0-jdk17-slim-openjdk, 10-jdk17-slim-openjdk
-Architectures: amd64, arm64v8
-Directory: openjdk/10.0/jdk17-slim
-GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
-
-Tags: 10.0.9, 10.0, 10, 10.0.9-jdk17, 10.0-jdk17, 10-jdk17, 10.0.9-openjdk, 10.0-openjdk, 10-openjdk, 10.0.9-jdk17-openjdk, 10.0-jdk17-openjdk, 10-jdk17-openjdk
-Architectures: amd64, arm64v8
-Directory: openjdk/10.0/jdk17
-GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
-
-Tags: 10.0.9-jdk11-slim, 10.0-jdk11-slim, 10-jdk11-slim, 10.0.9-jdk11-slim-openjdk, 10.0-jdk11-slim-openjdk, 10-jdk11-slim-openjdk
+Tags: 10.0.9-jdk11-slim-openjdk, 10.0-jdk11-slim-openjdk, 10-jdk11-slim-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jdk11-slim
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jdk11, 10.0-jdk11, 10-jdk11, 10.0.9-jdk11-openjdk, 10.0-jdk11-openjdk, 10-jdk11-openjdk
+Tags: 10.0.9-jdk11-openjdk, 10.0-jdk11-openjdk, 10-jdk11-openjdk
 Architectures: amd64, arm64v8
 Directory: openjdk/10.0/jdk11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
+Tags: 9.4.46-jdk8, 9.4-jdk8, 9-jdk8, 9.4.46-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
+Tags: 9.4.46-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.46-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.46-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
+Tags: 9.4.46, 9.4, 9, 9.4.46-jdk17, 9.4-jdk17, 9-jdk17, 9.4.46-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.46-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
+Tags: 9.4.46-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.46-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 9.4.46-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
+Tags: 9.4.46-jdk11, 9.4-jdk11, 9-jdk11, 9.4.46-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.9-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.9-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.9-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.9, 11.0, 11, 11.0.9-jdk17, 11.0-jdk17, 11-jdk17, 11.0.9-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.9-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin, latest, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.9-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.9-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 11.0.9-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.9-jdk11, 11.0-jdk11, 11-jdk11, 11.0.9-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.9-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.9-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.9-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.9, 10.0, 10, 10.0.9-jdk17, 10.0-jdk17, 10-jdk17, 10.0.9-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.9-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.9-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.9-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212
 
-Tags: 10.0.9-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.9-jdk11, 10.0-jdk11, 10-jdk11, 10.0.9-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
 GitCommit: c53402b36627a6b6f97f9462c7ab24fadc587212


### PR DESCRIPTION
- Remove all Jetty images based on OpenJDK 17.
- The more generic tags now point to images based on `eclipse-temurin` instead of `openjdk`.

see https://github.com/docker-library/openjdk/pull/495
see https://github.com/eclipse/jetty.docker/pull/99