### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 337b65c7bbffcf02c8cf50c37d6837495fd32015
 Directory: 2.5/alpine
 
-Tags: 2.4.15, 2.4, lts, 2.4.15-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.16, 2.4, lts, 2.4.16-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f7756832603d518d07c2354a7c35d7a6c1c5a6da
+GitCommit: 3e359a419040d46fa312296e8cd9b4edc1dedd2a
 Directory: 2.4
 
-Tags: 2.4.15-alpine, 2.4-alpine, lts-alpine, 2.4.15-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.16-alpine, 2.4-alpine, lts-alpine, 2.4.16-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7756832603d518d07c2354a7c35d7a6c1c5a6da
+GitCommit: 3e359a419040d46fa312296e8cd9b4edc1dedd2a
 Directory: 2.4/alpine
 
-Tags: 2.3.19, 2.3, 2.3.19-bullseye, 2.3-bullseye
+Tags: 2.3.20, 2.3, 2.3.20-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b429a6f005908205a0635e12a41d957ba87ad8fd
+GitCommit: d0bf4675441b426432378072e248f2379784d60d
 Directory: 2.3
 
-Tags: 2.3.19-alpine, 2.3-alpine, 2.3.19-alpine3.15, 2.3-alpine3.15
+Tags: 2.3.20-alpine, 2.3-alpine, 2.3.20-alpine3.15, 2.3-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b429a6f005908205a0635e12a41d957ba87ad8fd
+GitCommit: d0bf4675441b426432378072e248f2379784d60d
 Directory: 2.3/alpine
 
 Tags: 2.2.22, 2.2, 2.2.22-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3e359a4: Update 2.4 to 2.4.16
- https://github.com/docker-library/haproxy/commit/d0bf467: Update 2.3 to 2.3.20