### PR TITLE
archlinux: Release 20220501.0.54834

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220424.0.54084
-GitCommit: 8b4b8fc6d7311e9cc080c8e90cb8d87a3dd8ddb7
-GitFetch: refs/tags/v20220424.0.54084
+Tags: latest, base, base-20220501.0.54834
+GitCommit: 0c48fcb005b8c16e79bfab9f7fb5aa53582284e0
+GitFetch: refs/tags/v20220501.0.54834
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220424.0.54084
-GitCommit: 8b4b8fc6d7311e9cc080c8e90cb8d87a3dd8ddb7
-GitFetch: refs/tags/v20220424.0.54084
+Tags: base-devel, base-devel-20220501.0.54834
+GitCommit: 0c48fcb005b8c16e79bfab9f7fb5aa53582284e0
+GitFetch: refs/tags/v20220501.0.54834
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks