### PR TITLE
Update Clear Linux OS to 36250

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: fd62058660cf7853178abe4017b2944de7d0e0b4
-GitFetch: refs/heads/base-36220
+GitCommit: 4ae0f2d575e94285a266cdc4fbe3d26dac25fd9f
+GitFetch: refs/heads/base-36250


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36250

@bryteise @djklimes @bryteise