### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev7, 2.6-dev, 2.6-dev7-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev8, 2.6-dev, 2.6-dev8-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4106abb6da325657f55f6d5dc97cc9430964f1a
+GitCommit: 05a7796acc74b7307f06f4470c8424d4c038a2aa
 Directory: 2.6-rc
 
-Tags: 2.6-dev7-alpine, 2.6-dev-alpine, 2.6-dev7-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev8-alpine, 2.6-dev-alpine, 2.6-dev8-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4106abb6da325657f55f6d5dc97cc9430964f1a
+GitCommit: 05a7796acc74b7307f06f4470c8424d4c038a2aa
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.6, 2.5, latest, 2.5.6-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/05a7796: Update 2.6-rc to 2.6-dev8