### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-1552 and ELSA-2022-1642

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 55c34418ea00e2e09b2cfe2a6a5518eef4fbcad6
+amd64-GitCommit: c14da343a3b3d435746ee3179f8bbb33ad0a8ad5
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d21214cbab4199519e6a54364ce190522506112b
+arm64v8-GitCommit: 4bf46ba69216b84ebb385e61f1ebfb7a2de70c1d
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1154 and CVE-2018-25032.

See the following for details:
https://linux.oracle.com/errata/ELSA-2022-1552.html

https://linux.oracle.com/errata/ELSA-2022-1642.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>