### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.46.0, 4.46, 4, latest
+Tags: 4.46.2, 4.46, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d37e4ccf7e47c08f812020eda4894466cd28f506
+GitCommit: 0cdbcc8883fcc250af9fba822a3ceb842d0be9cc
 Directory: 4/debian
 
-Tags: 4.46.0-alpine, 4.46-alpine, 4-alpine, alpine
+Tags: 4.46.2-alpine, 4.46-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d37e4ccf7e47c08f812020eda4894466cd28f506
+GitCommit: 0cdbcc8883fcc250af9fba822a3ceb842d0be9cc
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/0cdbcc8: Update to 4.46.2, ghost-cli 1.19.3