### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
 Directory: cli/php8.1/alpine
 
-Tags: beta-6.0-beta3-apache, beta-6.0-apache, beta-6-apache, beta-apache, beta-6.0-beta3, beta-6.0, beta-6, beta, beta-6.0-beta3-php7.4-apache, beta-6.0-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.0-beta3-php7.4, beta-6.0-php7.4, beta-6-php7.4, beta-php7.4
+Tags: beta-6.0-beta4-apache, beta-6.0-apache, beta-6-apache, beta-apache, beta-6.0-beta4, beta-6.0, beta-6, beta, beta-6.0-beta4-php7.4-apache, beta-6.0-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.0-beta4-php7.4, beta-6.0-php7.4, beta-6-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php7.4/apache
 
-Tags: beta-6.0-beta3-fpm, beta-6.0-fpm, beta-6-fpm, beta-fpm, beta-6.0-beta3-php7.4-fpm, beta-6.0-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-6.0-beta4-fpm, beta-6.0-fpm, beta-6-fpm, beta-fpm, beta-6.0-beta4-php7.4-fpm, beta-6.0-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php7.4/fpm
 
-Tags: beta-6.0-beta3-fpm-alpine, beta-6.0-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.0-beta3-php7.4-fpm-alpine, beta-6.0-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-6.0-beta4-fpm-alpine, beta-6.0-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.0-beta4-php7.4-fpm-alpine, beta-6.0-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-6.0-beta3-php8.0-apache, beta-6.0-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.0-beta3-php8.0, beta-6.0-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.0-beta4-php8.0-apache, beta-6.0-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.0-beta4-php8.0, beta-6.0-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php8.0/apache
 
-Tags: beta-6.0-beta3-php8.0-fpm, beta-6.0-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.0-beta4-php8.0-fpm, beta-6.0-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.0-beta3-php8.0-fpm-alpine, beta-6.0-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.0-beta4-php8.0-fpm-alpine, beta-6.0-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.0-beta3-php8.1-apache, beta-6.0-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.0-beta3-php8.1, beta-6.0-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.0-beta4-php8.1-apache, beta-6.0-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.0-beta4-php8.1, beta-6.0-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php8.1/apache
 
-Tags: beta-6.0-beta3-php8.1-fpm, beta-6.0-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.0-beta4-php8.1-fpm, beta-6.0-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.0-beta3-php8.1-fpm-alpine, beta-6.0-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.0-beta4-php8.1-fpm-alpine, beta-6.0-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cff66681737af5c5c43ef270ee133e641c924380
+GitCommit: 2b3e0222e8006186aa7db3ea7859ed35a77a73db
 Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/2b3e022: Update beta to 6.0-beta4