### PR TITLE
Update Amazon Linux 2022 Images to 2022.0.20220419.0

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,6 +1,5 @@
 Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Frédérick Lefebvre (@fred-lefebvre),
-             Samuel Karp (@samuelkarp),
              Stewart Smith (@stewartsmith),
              Christopher Miller (@mysteriouspants),
              Sumit Tomer (@sktomer),
@@ -13,7 +12,7 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Joseph Howell-Burke (@jhowell-burke),
 	     Joe Gawrieh (@theOtherJoe)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: ddc781764ced8c0921bb246a7475bc8e1f5b9c2d
+GitCommit: e6381231b27976d988860e2e04b45e2ceb5d4c0d
 
 Tags: 2.0.20220419.0, 2, latest
 Architectures: amd64, arm64v8
@@ -39,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 65a61e56bdf1f42e0e97d6b777a9ac5d0244825f
 
-Tags: 2022.0.20220315.0, 2022, devel
+Tags: 2022.0.20220419.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: b446ccb4166363a3df14286f83cfc74c99e230f4
+amd64-GitCommit: a07530f75eac5d4bfa71afb95df813f5b9fd051f
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: 6ae71400af9fb876d3871fb4eaa61f2f7363d545
+arm64v8-GitCommit: 5cb2b653dab2e77d0b1e0d88375fa1512c87c465
 
-Tags: 2022.0.20220315.0-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220419.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 87d9d1a07c4e5afd1f72df96f1c824a9facd15cc
+amd64-GitCommit: 3fc05e71314d8a5065c7fbee738c3b64a72da5fa
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 2c8a2941ab6c41f375b8bb245779d0ebdcb07c31
+arm64v8-GitCommit: 8fe276fc79ef9951e7682a4708ba9fbb18bda02d


### PR DESCRIPTION
Hi,

Please update the AL 2022 Tech Preview images to the latest release.

(also remove Samuel from list of maintainers)

Thanks,
Sumit