### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,52 +1,52 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/e2da87e7e6c37702fbe0f8b736ad3261c697df7c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/6e226fe8e99702c8726d5e7d5c5864e69548048d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/rabbitmq.git
 
-Tags: 3.10.0-rc.6, 3.10-rc
+Tags: 3.10.0, 3.10, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 1e71ba8632dd3fbad8ea94d25ca45b8f8e3bf871
-Directory: 3.10-rc/ubuntu
+GitCommit: 89b0f2b279f66b8bd8352ad0f1046d70dd44451f
+Directory: 3.10/ubuntu
 
-Tags: 3.10.0-rc.6-management, 3.10-rc-management
+Tags: 3.10.0-management, 3.10-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: b00aa90cc6b16b7e67e18f336d5fd9ef2bde5165
-Directory: 3.10-rc/ubuntu/management
+GitCommit: 6e226fe8e99702c8726d5e7d5c5864e69548048d
+Directory: 3.10/ubuntu/management
 
-Tags: 3.10.0-rc.6-alpine, 3.10-rc-alpine
+Tags: 3.10.0-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e71ba8632dd3fbad8ea94d25ca45b8f8e3bf871
-Directory: 3.10-rc/alpine
+GitCommit: 89b0f2b279f66b8bd8352ad0f1046d70dd44451f
+Directory: 3.10/alpine
 
-Tags: 3.10.0-rc.6-management-alpine, 3.10-rc-management-alpine
+Tags: 3.10.0-management-alpine, 3.10-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b00aa90cc6b16b7e67e18f336d5fd9ef2bde5165
-Directory: 3.10-rc/alpine/management
+GitCommit: 6e226fe8e99702c8726d5e7d5c5864e69548048d
+Directory: 3.10/alpine/management
 
-Tags: 3.9.16, 3.9, 3, latest
+Tags: 3.9.16, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 6c36dd3afdc25212f4b3a6aa27b5337ea05a2db3
+GitCommit: 7cefe056b5fc2e0cbeb5fac1cd02a75aacefaaf8
 Directory: 3.9/ubuntu
 
-Tags: 3.9.16-management, 3.9-management, 3-management, management
+Tags: 3.9.16-management, 3.9-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/ubuntu/management
 
-Tags: 3.9.16-alpine, 3.9-alpine, 3-alpine, alpine
+Tags: 3.9.16-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6c36dd3afdc25212f4b3a6aa27b5337ea05a2db3
+GitCommit: 7cefe056b5fc2e0cbeb5fac1cd02a75aacefaaf8
 Directory: 3.9/alpine
 
-Tags: 3.9.16-management-alpine, 3.9-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.9.16-management-alpine, 3.9-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/alpine/management
 
 Tags: 3.8.30, 3.8
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 92a2a8b9aae8cb0f7d723d3a6858707e66983289
+GitCommit: 254f0cb93fd7e0c7f7a149a87ba76b11d9b4852f
 Directory: 3.8/ubuntu
 
 Tags: 3.8.30-management, 3.8-management
@@ -56,7 +56,7 @@ Directory: 3.8/ubuntu/management
 
 Tags: 3.8.30-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92a2a8b9aae8cb0f7d723d3a6858707e66983289
+GitCommit: 254f0cb93fd7e0c7f7a149a87ba76b11d9b4852f
 Directory: 3.8/alpine
 
 Tags: 3.8.30-management-alpine, 3.8-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7cefe05: Update 3.9 to openssl 1.1.1o
- https://github.com/docker-library/rabbitmq/commit/254f0cb: Update 3.8 to openssl 1.1.1o
- https://github.com/docker-library/rabbitmq/commit/89b0f2b: Update 3.10 to openssl 1.1.1o
- https://github.com/docker-library/rabbitmq/commit/6e226fe: Update to 3.10.0 (GA)
- https://github.com/docker-library/rabbitmq/commit/671da8a: Update 3.9 to otp 24.3.4
- https://github.com/docker-library/rabbitmq/commit/b1ee581: Update 3.8 to otp 24.3.4
- https://github.com/docker-library/rabbitmq/commit/0e0de34: Update 3.10-rc to otp 24.3.4