### PR TITLE
Bump Traefik to v2.6.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -21,7 +21,7 @@ Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.6.6, 2.6.6, v2.6, 2.6, rocamadour, latest
-Architectures: amd64, arm32v6, arm64v8
+Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622
 Directory: alpine

--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 525b8f19920873224fc5546e8f8b1e360a81a93f
 Directory: alpine
 
-Tags: v2.6.3-windowsservercore-1809, 2.6.3-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
+Tags: v2.6.6-windowsservercore-1809, 2.6.6-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 03d6917edbf3cf18c112ee608162eb083273971c
+GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.3, 2.6.3, v2.6, 2.6, rocamadour, latest
-Architectures: amd64, arm32v6, arm64v8, s390x
+Tags: v2.6.6, 2.6.6, v2.6, 2.6, rocamadour, latest
+Architectures: amd64, arm32v6, arm64v8
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 03d6917edbf3cf18c112ee608162eb083273971c
+GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.6.6](https://github.com/traefik/traefik/releases/tag/v2.6.6).

/cc @ddtmachado @ldez @rtribotte

Cheers
