### PR TITLE
Use eclipse-temurin base for jdk 17+ clojure images

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -1,182 +1,123 @@
 Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
-Architectures: amd64, arm64v8
+Architectures: arm64v8, amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: d3cc949609f6e3c0bc5e0c08706a93b999cbbe25
+GitCommit: 4da02b2ff2b1a6aa4534ac7f7695989d6075d4c8
+
 
 Tags: latest
-Directory: target/openjdk-17-slim-bullseye/latest
+Directory: target/eclipse-temurin-17-jdk-focal/latest
+
+Tags: openjdk-8-boot-2.8.3-bullseye, openjdk-8-boot-bullseye
+Directory: target/openjdk-8-bullseye/boot
+
+Tags: openjdk-8-boot-2.8.3-buster, openjdk-8-boot-buster
+Directory: target/openjdk-8-buster/boot
+
+Tags: openjdk-8-boot-2.8.3, openjdk-8-boot-2.8.3-slim-bullseye, openjdk-8-boot-slim-bullseye
+Directory: target/openjdk-8-slim-bullseye/boot
+
+Tags: openjdk-8-boot-2.8.3-slim-buster, openjdk-8-boot-slim-buster
+Directory: target/openjdk-8-slim-buster/boot
+
+Tags: openjdk-8-lein-2.9.8-bullseye, openjdk-8-lein-bullseye
+Directory: target/openjdk-8-bullseye/lein
 
 Tags: openjdk-8-lein-buster, openjdk-8-lein-2.9.8-buster
 Directory: target/openjdk-8-buster/lein
 
+Tags: openjdk-8-lein-2.9.8-slim-bullseye, openjdk-8-lein-2.9.8, openjdk-8-lein-slim-bullseye
+Directory: target/openjdk-8-slim-bullseye/lein
+
 Tags: openjdk-8-lein-slim-buster, openjdk-8-lein-2.9.8-slim-buster
 Directory: target/openjdk-8-slim-buster/lein
 
-Tags: openjdk-8-boot-buster, openjdk-8-boot-2.8.3-buster
-Directory: target/openjdk-8-buster/boot
+Tags: openjdk-8-tools-deps-1.11.1.1113-bullseye, openjdk-8-bullseye, openjdk-8-tools-deps-bullseye
+Directory: target/openjdk-8-bullseye/tools-deps
 
-Tags: openjdk-8-boot-slim-buster, openjdk-8-boot-2.8.3-slim-buster
-Directory: target/openjdk-8-slim-buster/boot
-
-Tags: openjdk-8-buster, openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.11.1.1113-buster
+Tags: openjdk-8-tools-deps-buster, openjdk-8-tools-deps-1.11.1.1113-buster, openjdk-8-buster
 Directory: target/openjdk-8-buster/tools-deps
 
-Tags: openjdk-8-slim-buster, openjdk-8-tools-deps-slim-buster, openjdk-8-tools-deps-1.11.1.1113-slim-buster
+Tags: openjdk-8-tools-deps-slim-bullseye, openjdk-8-slim-bullseye, openjdk-8-tools-deps-1.11.1.1113, openjdk-8-tools-deps-1.11.1.1113-slim-bullseye
+Directory: target/openjdk-8-slim-bullseye/tools-deps
+
+Tags: openjdk-8-tools-deps-1.11.1.1113-slim-buster, openjdk-8-tools-deps-slim-buster, openjdk-8-slim-buster
 Directory: target/openjdk-8-slim-buster/tools-deps
 
-Tags: openjdk-11-lein-buster, openjdk-11-lein-2.9.8-buster
-Directory: target/openjdk-11-buster/lein
-
-Tags: openjdk-11-lein-slim-buster, openjdk-11-lein-2.9.8-slim-buster
-Directory: target/openjdk-11-slim-buster/lein
+Tags: openjdk-11-boot-2.8.3-bullseye, openjdk-11-boot-bullseye
+Directory: target/openjdk-11-bullseye/boot
 
 Tags: openjdk-11-boot-buster, openjdk-11-boot-2.8.3-buster
 Directory: target/openjdk-11-buster/boot
 
+Tags: openjdk-11-boot-2.8.3-slim-bullseye, openjdk-11-boot-2.8.3, openjdk-11-boot-slim-bullseye
+Directory: target/openjdk-11-slim-bullseye/boot
+
 Tags: openjdk-11-boot-slim-buster, openjdk-11-boot-2.8.3-slim-buster
 Directory: target/openjdk-11-slim-buster/boot
-
-Tags: openjdk-11-buster, openjdk-11-tools-deps-buster, openjdk-11-tools-deps-1.11.1.1113-buster
-Directory: target/openjdk-11-buster/tools-deps
-
-Tags: openjdk-11-slim-buster, openjdk-11-tools-deps-slim-buster, openjdk-11-tools-deps-1.11.1.1113-slim-buster
-Directory: target/openjdk-11-slim-buster/tools-deps
-
-Tags: openjdk-17-lein-slim-buster, openjdk-17-lein-2.9.8-slim-buster, lein-slim-buster, lein-2.9.8-slim-buster
-Directory: target/openjdk-17-slim-buster/lein
-
-Tags: openjdk-17-lein-buster, openjdk-17-lein-2.9.8-buster, lein-buster, lein-2.9.8-buster
-Directory: target/openjdk-17-buster/lein
-
-Tags: openjdk-17-boot-slim-buster, openjdk-17-boot-2.8.3-slim-buster, boot-slim-buster, boot-2.8.3-slim-buster
-Directory: target/openjdk-17-slim-buster/boot
-
-Tags: openjdk-17-boot-buster, openjdk-17-boot-2.8.3-buster, boot-buster, boot-2.8.3-buster
-Directory: target/openjdk-17-buster/boot
-
-Tags: openjdk-17-slim-buster, openjdk-17-tools-deps-slim-buster, openjdk-17-tools-deps-1.11.1.1113-slim-buster, tools-deps-1.11.1.1113-slim-buster, tools-deps-slim-buster
-Directory: target/openjdk-17-slim-buster/tools-deps
-
-Tags: openjdk-17-buster, openjdk-17-tools-deps-buster, openjdk-17-tools-deps-1.11.1.1113-buster, tools-deps-buster, tools-deps-1.11.1.1113-buster
-Directory: target/openjdk-17-buster/tools-deps
-
-Tags: openjdk-18-lein-slim-buster, openjdk-18-lein-2.9.8-slim-buster
-Directory: target/openjdk-18-slim-buster/lein
-
-Tags: openjdk-18-lein-buster, openjdk-18-lein-2.9.8-buster
-Directory: target/openjdk-18-buster/lein
-
-Tags: openjdk-18-boot-slim-buster, openjdk-18-boot-2.8.3-slim-buster
-Directory: target/openjdk-18-slim-buster/boot
-
-Tags: openjdk-18-boot-buster, openjdk-18-boot-2.8.3-buster
-Directory: target/openjdk-18-buster/boot
-
-Tags: openjdk-18-slim-buster, openjdk-18-tools-deps-slim-buster, openjdk-18-tools-deps-1.11.1.1113-slim-buster
-Directory: target/openjdk-18-slim-buster/tools-deps
-
-Tags: openjdk-18-buster, openjdk-18-tools-deps-buster, openjdk-18-tools-deps-1.11.1.1113-buster
-Directory: target/openjdk-18-buster/tools-deps
-
-Tags: openjdk-8-lein-bullseye, openjdk-8-lein-2.9.8-bullseye
-Directory: target/openjdk-8-bullseye/lein
-
-Tags: openjdk-8-lein, openjdk-8-lein-2.9.8, openjdk-8-lein-slim-bullseye, openjdk-8-lein-2.9.8-slim-bullseye
-Directory: target/openjdk-8-slim-bullseye/lein
-
-Tags: openjdk-8-boot-bullseye, openjdk-8-boot-2.8.3-bullseye
-Directory: target/openjdk-8-bullseye/boot
-
-Tags: openjdk-8-boot, openjdk-8-boot-2.8.3, openjdk-8-boot-slim-bullseye, openjdk-8-boot-2.8.3-slim-bullseye
-Directory: target/openjdk-8-slim-bullseye/boot
-
-Tags: openjdk-8-bullseye, openjdk-8-tools-deps-bullseye, openjdk-8-tools-deps-1.11.1.1113-bullseye
-Directory: target/openjdk-8-bullseye/tools-deps
-
-Tags: openjdk-8, openjdk-8-slim-bullseye, openjdk-8-tools-deps, openjdk-8-tools-deps-1.11.1.1113, openjdk-8-tools-deps-slim-bullseye, openjdk-8-tools-deps-1.11.1.1113-slim-bullseye
-Directory: target/openjdk-8-slim-bullseye/tools-deps
 
 Tags: openjdk-11-lein-bullseye, openjdk-11-lein-2.9.8-bullseye
 Directory: target/openjdk-11-bullseye/lein
 
-Tags: openjdk-11-lein, openjdk-11-lein-2.9.8, openjdk-11-lein-slim-bullseye, openjdk-11-lein-2.9.8-slim-bullseye
+Tags: openjdk-11-lein-2.9.8-buster, openjdk-11-lein-buster
+Directory: target/openjdk-11-buster/lein
+
+Tags: openjdk-11-lein-2.9.8-slim-bullseye, openjdk-11-lein-2.9.8, openjdk-11-lein-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/lein
 
-Tags: openjdk-11-boot-bullseye, openjdk-11-boot-2.8.3-bullseye
-Directory: target/openjdk-11-bullseye/boot
+Tags: openjdk-11-lein-2.9.8-slim-buster, openjdk-11-lein-slim-buster
+Directory: target/openjdk-11-slim-buster/lein
 
-Tags: openjdk-11-boot, openjdk-11-boot-2.8.3, openjdk-11-boot-slim-bullseye, openjdk-11-boot-2.8.3-slim-bullseye
-Directory: target/openjdk-11-slim-bullseye/boot
-
-Tags: openjdk-11-bullseye, openjdk-11-tools-deps-bullseye, openjdk-11-tools-deps-1.11.1.1113-bullseye
+Tags: openjdk-11-tools-deps-bullseye, openjdk-11-bullseye, openjdk-11-tools-deps-1.11.1.1113-bullseye
 Directory: target/openjdk-11-bullseye/tools-deps
 
-Tags: openjdk-11, openjdk-11-slim-bullseye, openjdk-11-tools-deps, openjdk-11-tools-deps-1.11.1.1113, openjdk-11-tools-deps-slim-bullseye, openjdk-11-tools-deps-1.11.1.1113-slim-bullseye
+Tags: openjdk-11-tools-deps-1.11.1.1113-buster, openjdk-11-tools-deps-buster, openjdk-11-buster
+Directory: target/openjdk-11-buster/tools-deps
+
+Tags: openjdk-11-tools-deps-1.11.1.1113-slim-bullseye, openjdk-11-tools-deps-1.11.1.1113, openjdk-11-slim-bullseye, openjdk-11-tools-deps-slim-bullseye
 Directory: target/openjdk-11-slim-bullseye/tools-deps
 
-Tags: openjdk-17-lein, openjdk-17-lein-2.9.8, openjdk-17-lein-slim-bullseye, openjdk-17-lein-2.9.8-slim-bullseye, lein-slim-bullseye, lein-2.9.8-slim-bullseye, lein, lein-2.9.8
-Directory: target/openjdk-17-slim-bullseye/lein
+Tags: openjdk-11-tools-deps-1.11.1.1113-slim-buster, openjdk-11-tools-deps-slim-buster, openjdk-11-slim-buster
+Directory: target/openjdk-11-slim-buster/tools-deps
 
-Tags: openjdk-17-lein-bullseye, openjdk-17-lein-2.9.8-bullseye, lein-bullseye, lein-2.9.8-bullseye
-Directory: target/openjdk-17-bullseye/lein
-
-Tags: openjdk-17-boot, openjdk-17-boot-2.8.3, openjdk-17-boot-slim-bullseye, openjdk-17-boot-2.8.3-slim-bullseye, boot, boot-2.8.3, boot-slim-bullseye, boot-2.8.3-slim-bullseye
-Directory: target/openjdk-17-slim-bullseye/boot
-
-Tags: openjdk-17-boot-bullseye, openjdk-17-boot-2.8.3-bullseye, boot-bullseye, boot-2.8.3-bullseye
-Directory: target/openjdk-17-bullseye/boot
-
-Tags: openjdk-17, openjdk-17-slim-bullseye, tools-deps, tools-deps-1.11.1.1113, tools-deps-1.11.1.1113-slim-bullseye, openjdk-17-tools-deps, openjdk-17-tools-deps-1.11.1.1113, openjdk-17-tools-deps-slim-bullseye, openjdk-17-tools-deps-1.11.1.1113-slim-bullseye
-Directory: target/openjdk-17-slim-bullseye/tools-deps
-
-Tags: openjdk-17-bullseye, openjdk-17-tools-deps-bullseye, openjdk-17-tools-deps-1.11.1.1113-bullseye, tools-deps-bullseye, tools-deps-1.11.1.1113-bullseye
-Directory: target/openjdk-17-bullseye/tools-deps
-
-Tags: openjdk-18-lein, openjdk-18-lein-2.9.8, openjdk-18-lein-slim-bullseye, openjdk-18-lein-2.9.8-slim-bullseye
-Directory: target/openjdk-18-slim-bullseye/lein
-
-Tags: openjdk-18-lein-bullseye, openjdk-18-lein-2.9.8-bullseye
-Directory: target/openjdk-18-bullseye/lein
-
-Tags: openjdk-18-boot, openjdk-18-boot-2.8.3, openjdk-18-boot-slim-bullseye, openjdk-18-boot-2.8.3-slim-bullseye
-Directory: target/openjdk-18-slim-bullseye/boot
-
-Tags: openjdk-18-boot-bullseye, openjdk-18-boot-2.8.3-bullseye
-Directory: target/openjdk-18-bullseye/boot
-
-Tags: openjdk-18, openjdk-18-slim-bullseye, openjdk-18-tools-deps, openjdk-18-tools-deps-1.11.1.1113, openjdk-18-tools-deps-slim-bullseye, openjdk-18-tools-deps-1.11.1.1113-slim-bullseye
-Directory: target/openjdk-18-slim-bullseye/tools-deps
-
-Tags: openjdk-18-bullseye, openjdk-18-tools-deps-bullseye, openjdk-18-tools-deps-1.11.1.1113-bullseye
-Directory: target/openjdk-18-bullseye/tools-deps
-
-Tags: openjdk-19-lein, openjdk-19-lein-2.9.8, openjdk-19-lein-slim-bullseye, openjdk-19-lein-2.9.8-slim-bullseye
-Directory: target/openjdk-19-slim-bullseye/lein
-
-Tags: openjdk-19-lein-bullseye, openjdk-19-lein-2.9.8-bullseye
-Directory: target/openjdk-19-bullseye/lein
-
-Tags: openjdk-19-boot, openjdk-19-boot-2.8.3, openjdk-19-boot-slim-bullseye, openjdk-19-boot-2.8.3-slim-bullseye
-Directory: target/openjdk-19-slim-bullseye/boot
-
-Tags: openjdk-19-boot-bullseye, openjdk-19-boot-2.8.3-bullseye
-Directory: target/openjdk-19-bullseye/boot
-
-Tags: openjdk-19, openjdk-19-slim-bullseye, openjdk-19-tools-deps, openjdk-19-tools-deps-1.11.1.1113, openjdk-19-tools-deps-slim-bullseye, openjdk-19-tools-deps-1.11.1.1113-slim-bullseye
-Directory: target/openjdk-19-slim-bullseye/tools-deps
-
-Tags: openjdk-19-bullseye, openjdk-19-tools-deps-bullseye, openjdk-19-tools-deps-1.11.1.1113-bullseye
-Directory: target/openjdk-19-bullseye/tools-deps
-
-Tags: openjdk-19-lein-alpine, openjdk-19-lein-2.9.8-alpine
+Tags: boot-2.8.3-alpine, temurin-17-boot-alpine, temurin-17-boot-2.8.3-alpine
 Architectures: amd64
-Directory: target/openjdk-19-alpine/lein
+Directory: target/eclipse-temurin-17-jdk-alpine/boot
 
-Tags: openjdk-19-boot-alpine, openjdk-19-boot-2.8.3-alpine
-Architectures: amd64
-Directory: target/openjdk-19-alpine/boot
+Tags: boot-2.8.3, temurin-17-boot-2.8.3, boot-2.8.3-focal, temurin-17-boot-focal, temurin-17-boot-2.8.3-focal
+Directory: target/eclipse-temurin-17-jdk-focal/boot
 
-Tags: openjdk-19-alpine, openjdk-19-tools-deps-alpine, openjdk-19-tools-deps-1.11.1.1113-alpine
+Tags: temurin-17-lein-2.9.8-alpine, lein-2.9.8-alpine, temurin-17-lein-alpine
 Architectures: amd64
-Directory: target/openjdk-19-alpine/tools-deps
+Directory: target/eclipse-temurin-17-jdk-alpine/lein
+
+Tags: temurin-17-lein-focal, lein-2.9.8, temurin-17-lein-2.9.8-focal, lein-2.9.8-focal, temurin-17-lein-2.9.8
+Directory: target/eclipse-temurin-17-jdk-focal/lein
+
+Tags: temurin-17-alpine, temurin-17-tools-deps-alpine, temurin-17-tools-deps-1.11.1.1113-alpine, tools-deps-1.11.1.1113-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-17-jdk-alpine/tools-deps
+
+Tags: tools-deps-1.11.1.1113-focal, tools-deps-1.11.1.1113, temurin-17-focal, temurin-17-tools-deps-focal, temurin-17-tools-deps-1.11.1.1113, temurin-17-tools-deps-1.11.1.1113-focal
+Directory: target/eclipse-temurin-17-jdk-focal/tools-deps
+
+Tags: temurin-18-boot-alpine, temurin-18-boot-2.8.3-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-18-jdk-alpine/boot
+
+Tags: temurin-18-boot-2.8.3, temurin-18-boot-focal, temurin-18-boot-2.8.3-focal
+Directory: target/eclipse-temurin-18-jdk-focal/boot
+
+Tags: temurin-18-lein-2.9.8-alpine, temurin-18-lein-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-18-jdk-alpine/lein
+
+Tags: temurin-18-lein-2.9.8-focal, temurin-18-lein-focal, temurin-18-lein-2.9.8
+Directory: target/eclipse-temurin-18-jdk-focal/lein
+
+Tags: temurin-18-tools-deps-1.11.1.1113-alpine, temurin-18-tools-deps-alpine, temurin-18-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-18-jdk-alpine/tools-deps
+
+Tags: temurin-18-tools-deps-1.11.1.1113, temurin-18-tools-deps-1.11.1.1113-focal, temurin-18-tools-deps-focal, temurin-18-focal
+Directory: target/eclipse-temurin-18-jdk-focal/tools-deps


### PR DESCRIPTION
Also drops jdk 19 for now because eclipse-temurin upstream doesn't seem to have that version yet.