### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.1.3
+Tags: 8.2.0
 Architectures: amd64, arm64v8
-GitCommit: 1632044032655e32bbefed5993a3a512bb8e141c
+GitCommit: c424be7c85ac270fb8cb37c858783f619af7efa6
 Directory: 8
 
 Tags: 7.17.3

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.1.3
+Tags: 8.2.0
 Architectures: amd64, arm64v8
-GitCommit: 8226cf37a52dcfcd0e56e34b36f8d0e771c0dbd5
+GitCommit: bbe04d23f47f031789806a41d768eacf53e7a255
 Directory: 8
 
 Tags: 7.17.3

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.1.3
+Tags: 8.2.0
 Architectures: amd64, arm64v8
-GitCommit: 8ce7aeb9627debc82736b52a9b178b8d79bf4fdf
+GitCommit: dc08e4112fe8c01795dd1bac43ce82d21d280247
 Directory: 8
 
 Tags: 7.17.3


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/c424be7: Update to 8.2.0

logstash:
- https://github.com/docker-library/logstash/commit/dc08e41: Update to 8.2.0

kibana:
- https://github.com/docker-library/kibana/commit/bbe04d2: Update to 8.2.0