### PR TITLE
Temporarily downgrade Notary to Alpine 3.12

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,6 +1,6 @@
 Maintainers: Justin Cormack (@justincormack)
 GitRepo: https://github.com/docker/notary-official-images.git
-GitCommit: 297f548a568a8bcf8177c10e05165f11c9557dfc
+GitCommit: 16219dbe3c1433a6fc93e016cf421b230f681a2f
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: server-0.7.0, server


### PR DESCRIPTION
We need to build Notary 0.7.0 with an older version of Go, and Alpine 3.12 has an old enough version.  There *should* be a new release of Notary soon which will fix the incompatibility and allow us to go back to Alpine 3.15.

See https://github.com/docker/notary-official-images/pull/28