### PR TITLE
Odoo: update 13.0-15.0 to release 20220506

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 1649d6cc0e474a19c1169439c334bd3507fd71cc
+GitCommit: 9264df22a694b66cc3b866f92d180e3b084a015e
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thank you.