### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,14 +44,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d0bf4675441b426432378072e248f2379784d60d
 Directory: 2.3/alpine
 
-Tags: 2.2.22, 2.2, 2.2.22-bullseye, 2.2-bullseye
+Tags: 2.2.23, 2.2, 2.2.23-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f72759101407613038d819bd1404a9b3bbb24baa
+GitCommit: 80b78bda6678279f33f46131abdf905917f6c6dc
 Directory: 2.2
 
-Tags: 2.2.22-alpine, 2.2-alpine, 2.2.22-alpine3.15, 2.2-alpine3.15
+Tags: 2.2.23-alpine, 2.2-alpine, 2.2.23-alpine3.15, 2.2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f72759101407613038d819bd1404a9b3bbb24baa
+GitCommit: 80b78bda6678279f33f46131abdf905917f6c6dc
 Directory: 2.2/alpine
 
 Tags: 2.0.28, 2.0, 2.0.28-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/80b78bd: Update 2.2 to 2.2.23