### PR TITLE
archlinux: Release 20220508.0.55614

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220501.0.54834
-GitCommit: 0c48fcb005b8c16e79bfab9f7fb5aa53582284e0
-GitFetch: refs/tags/v20220501.0.54834
+Tags: latest, base, base-20220508.0.55614
+GitCommit: 0a1cd30d09f233d13d0d8fb8931b4e2440334a93
+GitFetch: refs/tags/v20220508.0.55614
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220501.0.54834
-GitCommit: 0c48fcb005b8c16e79bfab9f7fb5aa53582284e0
-GitFetch: refs/tags/v20220501.0.54834
+Tags: base-devel, base-devel-20220508.0.55614
+GitCommit: 0a1cd30d09f233d13d0d8fb8931b4e2440334a93
+GitFetch: refs/tags/v20220508.0.55614
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks