### PR TITLE
Update Clear Linux OS to 36270

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 4ae0f2d575e94285a266cdc4fbe3d26dac25fd9f
-GitFetch: refs/heads/base-36250
+GitCommit: 9b3d6bec28b4274eee7dd7e04893f500df8d0c8c
+GitFetch: refs/heads/base-36270


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36270

@bryteise @djklimes @bryteise