### PR TITLE
Update rethinkdb tags

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,7 +1,7 @@
 Maintainers: RethinkDB <services@rethinkdb.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 
-Tags: 2.4.2-buster-slim, 2.4-buster-slim, 2-buster-slim, buster-slim, 2.4.2, 2.4, 2, latest
-Directory: buster/2.4.2
+Tags: 2.4.2-bullseye-slim, 2.4-bullseye-slim, 2-bullseye-slim, bullseye-slim, 2.4.2, 2.4, 2, latest
+Directory: bullseye/2.4.2
 GitCommit: eda09076e55ff437fcb57ae7d52146f2bd5bc46b
 Architectures: amd64, arm64v8

--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,10 +1,7 @@
 Maintainers: RethinkDB <services@rethinkdb.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 
-Tags: 2.4.1-buster-slim, 2.4-buster-slim, 2-buster-slim, buster-slim, 2.4.1, 2.4, 2, latest
-Directory: buster/2.4.1
-GitCommit: bfe019bd289169c95503283d73a0fc223576b0ae
-
-Tags: 2.4.1-centos, 2.4-centos, 2-centos, centos
-Directory: centos8/2.4.1
-GitCommit: bfe019bd289169c95503283d73a0fc223576b0ae
+Tags: 2.4.2-buster-slim, 2.4-buster-slim, 2-buster-slim, buster-slim, 2.4.2, 2.4, 2, latest
+Directory: buster/2.4.2
+GitCommit: eda09076e55ff437fcb57ae7d52146f2bd5bc46b
+Architectures: amd64, arm64v8

--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -3,5 +3,5 @@ GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 
 Tags: 2.4.2-bullseye-slim, 2.4-bullseye-slim, 2-bullseye-slim, bullseye-slim, 2.4.2, 2.4, 2, latest
 Directory: bullseye/2.4.2
-GitCommit: eda09076e55ff437fcb57ae7d52146f2bd5bc46b
+GitCommit: 826a4193366e7d0ff176d101679385125b8fa4f1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
## Description

This PR updates the rethinkdb tags. Also, it removes Centos8 as we didn't build packages for that.