### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,72 +1,72 @@
-# this file is generated via https://github.com/docker-library/python/blob/c484e1ba82213c6a2e8785342630e5383d943d02/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/3036c713d8fd071102dacf91dbf1d536354cd476/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.11.0a7-bullseye, 3.11-rc-bullseye
-SharedTags: 3.11.0a7, 3.11-rc
+Tags: 3.11.0b1-bullseye, 3.11-rc-bullseye
+SharedTags: 3.11.0b1, 3.11-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/bullseye
 
-Tags: 3.11.0a7-slim-bullseye, 3.11-rc-slim-bullseye, 3.11.0a7-slim, 3.11-rc-slim
+Tags: 3.11.0b1-slim-bullseye, 3.11-rc-slim-bullseye, 3.11.0b1-slim, 3.11-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/slim-bullseye
 
-Tags: 3.11.0a7-buster, 3.11-rc-buster
+Tags: 3.11.0b1-buster, 3.11-rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/buster
 
-Tags: 3.11.0a7-slim-buster, 3.11-rc-slim-buster
+Tags: 3.11.0b1-slim-buster, 3.11-rc-slim-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/slim-buster
 
-Tags: 3.11.0a7-alpine3.15, 3.11-rc-alpine3.15, 3.11.0a7-alpine, 3.11-rc-alpine
+Tags: 3.11.0b1-alpine3.15, 3.11-rc-alpine3.15, 3.11.0b1-alpine, 3.11-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/alpine3.15
 
-Tags: 3.11.0a7-alpine3.14, 3.11-rc-alpine3.14
+Tags: 3.11.0b1-alpine3.14, 3.11-rc-alpine3.14
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/alpine3.14
 
-Tags: 3.11.0a7-windowsservercore-ltsc2022, 3.11-rc-windowsservercore-ltsc2022
-SharedTags: 3.11.0a7-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a7, 3.11-rc
+Tags: 3.11.0b1-windowsservercore-ltsc2022, 3.11-rc-windowsservercore-ltsc2022
+SharedTags: 3.11.0b1-windowsservercore, 3.11-rc-windowsservercore, 3.11.0b1, 3.11-rc
 Architectures: windows-amd64
-GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.11.0a7-windowsservercore-1809, 3.11-rc-windowsservercore-1809
-SharedTags: 3.11.0a7-windowsservercore, 3.11-rc-windowsservercore, 3.11.0a7, 3.11-rc
+Tags: 3.11.0b1-windowsservercore-1809, 3.11-rc-windowsservercore-1809
+SharedTags: 3.11.0b1-windowsservercore, 3.11-rc-windowsservercore, 3.11.0b1, 3.11-rc
 Architectures: windows-amd64
-GitCommit: 37e4721d30f5f6111015aa21061ec2961040fe8f
+GitCommit: 2c24e6c0386f6bdff5f4dc7db5372a04c9ead054
 Directory: 3.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.4-bullseye, 3.10-bullseye, 3-bullseye, bullseye
 SharedTags: 3.10.4, 3.10, 3, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
 Directory: 3.10/bullseye
 
 Tags: 3.10.4-slim-bullseye, 3.10-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.10.4-slim, 3.10-slim, 3-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.4-buster, 3.10-buster, 3-buster, buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
 Directory: 3.10/buster
 
 Tags: 3.10.4-slim-buster, 3.10-slim-buster, 3-slim-buster, slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f871d0435e7f35a693fa1b60aa159e6a1a4c6a2e
 Directory: 3.10/slim-buster
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/af2a432: Merge pull request https://github.com/docker-library/python/pull/726 from docker-library/revert-683-mips64le
- https://github.com/docker-library/python/commit/3036c71: Revert "Remove mips64le from 3.10"
- https://github.com/docker-library/python/commit/2c24e6c: Update 3.11-rc to 3.11.0b1