### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev8, 2.6-dev, 2.6-dev8-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev9, 2.6-dev, 2.6-dev9-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05a7796acc74b7307f06f4470c8424d4c038a2aa
+GitCommit: 0dc7b07842cc9633fc1c5d1dd212f9639cbdc6c2
 Directory: 2.6-rc
 
-Tags: 2.6-dev8-alpine, 2.6-dev-alpine, 2.6-dev8-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev9-alpine, 2.6-dev-alpine, 2.6-dev9-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 05a7796acc74b7307f06f4470c8424d4c038a2aa
+GitCommit: 0dc7b07842cc9633fc1c5d1dd212f9639cbdc6c2
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.6, 2.5, latest, 2.5.6-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/0dc7b07: Update 2.6-rc to 2.6-dev9