### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.47.0, 4.47, 4, latest
+Tags: 4.47.1, 4.47, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fe6385dbbca695f9207da7c2fc6e0b38c8fbd52d
+GitCommit: 91bb26466eba6ff3409bb3eb4a2997cdcf0bd420
 Directory: 4/debian
 
-Tags: 4.47.0-alpine, 4.47-alpine, 4-alpine, alpine
+Tags: 4.47.1-alpine, 4.47-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: fe6385dbbca695f9207da7c2fc6e0b38c8fbd52d
+GitCommit: 91bb26466eba6ff3409bb3eb4a2997cdcf0bd420
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/91bb264: Update to 4.47.1, ghost-cli 1.19.3