### PR TITLE
Update phpMyAdmin to version 5.2.0

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -3,17 +3,17 @@ Maintainers: Isaac Bennetch <bennetch@gmail.com> (@ibennetch),
              William Desportes <williamdes@wdes.fr> (@williamdes)
 GitRepo: https://github.com/phpmyadmin/docker.git
 
-Tags: 5.1.3-apache, 5.1-apache, 5-apache, apache, 5.1.3, 5.1, 5, latest
+Tags: 5.2.0-apache, 5.2-apache, 5-apache, apache, 5.2.0, 5.2, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b79d7100216ec96d18e0b89508a48fa89c11dd8
+GitCommit: b057ee3d899f98c871f16bdd112ffa411d8ef6ff
 Directory: apache
 
-Tags: 5.1.3-fpm, 5.1-fpm, 5-fpm, fpm
+Tags: 5.2.0-fpm, 5.2-fpm, 5-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b79d7100216ec96d18e0b89508a48fa89c11dd8
+GitCommit: b057ee3d899f98c871f16bdd112ffa411d8ef6ff
 Directory: fpm
 
-Tags: 5.1.3-fpm-alpine, 5.1-fpm-alpine, 5-fpm-alpine, fpm-alpine
+Tags: 5.2.0-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2b79d7100216ec96d18e0b89508a48fa89c11dd8
+GitCommit: b057ee3d899f98c871f16bdd112ffa411d8ef6ff
 Directory: fpm-alpine


### PR DESCRIPTION
I've just released phpMyAdmin 5.2.0, so bump the Docker image to match.

Signed-off-by: Isaac Bennetch <bennetch@gmail.com>