### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ELSA-2022-2191 and ELSA-2022-2213

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c14da343a3b3d435746ee3179f8bbb33ad0a8ad5
+amd64-GitCommit: b2631b4c3944ae70c9463ae62aaa75a1a4877a16
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4bf46ba69216b84ebb385e61f1ebfb7a2de70c1d
+arm64v8-GitCommit: ae688d9eef59795cd485bd9d9f43ce9015c3c461
 
 Tags: 8.5, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1271 and CVE-2018-25032.

See the following for details:
https://linux.oracle.com/errata/ELSA-2022-2191.html
https://linux.oracle.com/errata/ELSA-2022-2213.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>