### PR TITLE
Update Amazon Linux 2022 images to 2022.0.20220504.1

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -10,9 +10,10 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Preston Carpenter (@timidger),
              Richard Kelly (@rpkelly),
              Joseph Howell-Burke (@jhowell-burke),
-	     Joe Gawrieh (@theOtherJoe)
+	     Joe Gawrieh (@theOtherJoe),
+	     CJ Harris (@mrcjplease)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: e6381231b27976d988860e2e04b45e2ceb5d4c0d
+GitCommit: 0ce5724417d1fea4ad681d8683bea4237ce980c6
 
 Tags: 2.0.20220419.0, 2, latest
 Architectures: amd64, arm64v8
@@ -38,16 +39,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 65a61e56bdf1f42e0e97d6b777a9ac5d0244825f
 
-Tags: 2022.0.20220419.0, 2022, devel
+Tags: 2022.0.20220504.1, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: a07530f75eac5d4bfa71afb95df813f5b9fd051f
+amd64-GitCommit: c82726861f7bb251c75a9af7011010e57d08d82f
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: 5cb2b653dab2e77d0b1e0d88375fa1512c87c465
+arm64v8-GitCommit: 2146571fc243d43b83fbd1df513096361b8d5d55
 
-Tags: 2022.0.20220419.0-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220504.1-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 3fc05e71314d8a5065c7fbee738c3b64a72da5fa
+amd64-GitCommit: f0672b0c0d6e33d420f4013236a584b7ba9e8e6e
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 8fe276fc79ef9951e7682a4708ba9fbb18bda02d
+arm64v8-GitCommit: 68a2706a6db8d24243ea75d930342e711e122f31


### PR DESCRIPTION
Hello,

Please merge the update to latest Amazon Linux 2022 (5/4) docker images.

Thanks,
Sumit