### PR TITLE
Update phpMyAdmin, fixing Docker errors

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -5,15 +5,15 @@ GitRepo: https://github.com/phpmyadmin/docker.git
 
 Tags: 5.2.0-apache, 5.2-apache, 5-apache, apache, 5.2.0, 5.2, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b057ee3d899f98c871f16bdd112ffa411d8ef6ff
+GitCommit: 326191915b3502f19b331f6961581bfd2f858531
 Directory: apache
 
 Tags: 5.2.0-fpm, 5.2-fpm, 5-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b057ee3d899f98c871f16bdd112ffa411d8ef6ff
+GitCommit: 326191915b3502f19b331f6961581bfd2f858531
 Directory: fpm
 
 Tags: 5.2.0-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b057ee3d899f98c871f16bdd112ffa411d8ef6ff
+GitCommit: 326191915b3502f19b331f6961581bfd2f858531
 Directory: fpm-alpine


### PR DESCRIPTION
We recently released phpMyAdmin 5.2.0, which changed the configuration system a bit. Those changes were not compatible with how we package Docker, so for the past day or so, users have not been able to import custom settings to their docker containers.

Correct some errors with phpMyAdmin that were preventing custom settings from being loaded, fixing https://github.com/phpmyadmin/docker/issues/361.

Signed-off-by: Isaac Bennetch <bennetch@gmail.com>