### PR TITLE
archlinux: Release 20220515.0.56491

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220508.0.55614
-GitCommit: 0a1cd30d09f233d13d0d8fb8931b4e2440334a93
-GitFetch: refs/tags/v20220508.0.55614
+Tags: latest, base, base-20220515.0.56491
+GitCommit: c97fb71c4ff5cf5c465c374c3d5572b2c472b88a
+GitFetch: refs/tags/v20220515.0.56491
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220508.0.55614
-GitCommit: 0a1cd30d09f233d13d0d8fb8931b4e2440334a93
-GitFetch: refs/tags/v20220508.0.55614
+Tags: base-devel, base-devel-20220515.0.56491
+GitCommit: c97fb71c4ff5cf5c465c374c3d5572b2c472b88a
+GitFetch: refs/tags/v20220515.0.56491
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks