### PR TITLE
Updated mainline and stable nginx tags.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -5,40 +5,40 @@ GitRepo: https://github.com/nginxinc/docker-nginx.git
 
 Tags: 1.21.6, mainline, 1, 1.21, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6f0396c1e06837672698bc97865ffcea9dc841d5
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: mainline/debian
 
 Tags: 1.21.6-perl, mainline-perl, 1-perl, 1.21-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6f0396c1e06837672698bc97865ffcea9dc841d5
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: mainline/debian-perl
 
 Tags: 1.21.6-alpine, mainline-alpine, 1-alpine, 1.21-alpine, alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 6f0396c1e06837672698bc97865ffcea9dc841d5
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: mainline/alpine
 
 Tags: 1.21.6-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.21-alpine-perl, alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 6f0396c1e06837672698bc97865ffcea9dc841d5
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: mainline/alpine-perl
 
 Tags: 1.20.2, stable, 1.20
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: stable/debian
 
 Tags: 1.20.2-perl, stable-perl, 1.20-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: stable/debian-perl
 
 Tags: 1.20.2-alpine, stable-alpine, 1.20-alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: stable/alpine
 
 Tags: 1.20.2-alpine-perl, stable-alpine-perl, 1.20-alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: b0e153a1b644ca8b2bd378b14913fff316e07cf2
+GitCommit: d039609e3a537df4e15a454fdb5a004d519e9a11
 Directory: stable/alpine-perl


### PR DESCRIPTION
This is to update njs version used in both variants due to a number of CVEs: https://github.com/nginxinc/docker-nginx/issues/662