### PR TITLE
Update Postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 14.2, 14, latest, 14.2-bullseye, 14-bullseye, bullseye
+Tags: 14.3, 14, latest, 14.3-bullseye, 14-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: 4e56664f1797ba4cc0f5917b6d794792a5571b45
 Directory: 14/bullseye
 
-Tags: 14.2-alpine, 14-alpine, alpine, 14.2-alpine3.15, 14-alpine3.15, alpine3.15
+Tags: 14.3-alpine, 14-alpine, alpine, 14.3-alpine3.15, 14-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e483778176ca34bcbe83ee17000820d4f6e64c28
+GitCommit: 4e56664f1797ba4cc0f5917b6d794792a5571b45
 Directory: 14/alpine
 
-Tags: 13.6, 13, 13.6-bullseye, 13-bullseye
+Tags: 13.7, 13, 13.7-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: f060d1236051da2205da24f7caa6ff5301c6be9a
 Directory: 13/bullseye
 
-Tags: 13.6-alpine, 13-alpine, 13.6-alpine3.15, 13-alpine3.15
+Tags: 13.7-alpine, 13-alpine, 13.7-alpine3.15, 13-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e483778176ca34bcbe83ee17000820d4f6e64c28
+GitCommit: f060d1236051da2205da24f7caa6ff5301c6be9a
 Directory: 13/alpine
 
-Tags: 12.10, 12, 12.10-bullseye, 12-bullseye
+Tags: 12.11, 12, 12.11-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: 88ad1cf976b063850bdd7f87d5f9c7a7f1c6e778
 Directory: 12/bullseye
 
-Tags: 12.10-alpine, 12-alpine, 12.10-alpine3.15, 12-alpine3.15
+Tags: 12.11-alpine, 12-alpine, 12.11-alpine3.15, 12-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e483778176ca34bcbe83ee17000820d4f6e64c28
+GitCommit: 88ad1cf976b063850bdd7f87d5f9c7a7f1c6e778
 Directory: 12/alpine
 
-Tags: 11.15-bullseye, 11-bullseye
+Tags: 11.16-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: e97d27525d5949b25ca70687f42f1874210452dc
 Directory: 11/bullseye
 
-Tags: 11.15, 11, 11.15-stretch, 11-stretch
+Tags: 11.16, 11, 11.16-stretch, 11-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: e97d27525d5949b25ca70687f42f1874210452dc
 Directory: 11/stretch
 
-Tags: 11.15-alpine, 11-alpine, 11.15-alpine3.15, 11-alpine3.15
+Tags: 11.16-alpine, 11-alpine, 11.16-alpine3.15, 11-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e483778176ca34bcbe83ee17000820d4f6e64c28
+GitCommit: e97d27525d5949b25ca70687f42f1874210452dc
 Directory: 11/alpine
 
-Tags: 10.20-bullseye, 10-bullseye
+Tags: 10.21-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: 780680ebfa85d8220627985c0a16ecfd79d44a0f
 Directory: 10/bullseye
 
-Tags: 10.20, 10, 10.20-stretch, 10-stretch
+Tags: 10.21, 10, 10.21-stretch, 10-stretch
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: e8ebf74e50128123a8d0220b85e357ef2d73a7ec
+GitCommit: 780680ebfa85d8220627985c0a16ecfd79d44a0f
 Directory: 10/stretch
 
-Tags: 10.20-alpine, 10-alpine, 10.20-alpine3.15, 10-alpine3.15
+Tags: 10.21-alpine, 10-alpine, 10.21-alpine3.15, 10-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e483778176ca34bcbe83ee17000820d4f6e64c28
+GitCommit: 780680ebfa85d8220627985c0a16ecfd79d44a0f
 Directory: 10/alpine


### PR DESCRIPTION
Changes:

- docker-library/postgres@780680e: Update 10 to 10.21, bullseye 10.21-1.pgdg110+1, stretch 10.21-1.pgdg90+1
- docker-library/postgres@4e56664: Update 14 to 14.3, bullseye 14.3-1.pgdg110+1
- docker-library/postgres@f060d12: Update 13 to 13.7, bullseye 13.7-1.pgdg110+1
- docker-library/postgres@88ad1cf: Update 12 to 12.11, bullseye 12.11-1.pgdg110+1
- docker-library/postgres@e97d275: Update 11 to 11.16, bullseye 11.16-1.pgdg110+1, stretch 11.16-1.pgdg90+1