### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev9, 2.6-dev, 2.6-dev9-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev10, 2.6-dev, 2.6-dev10-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0dc7b07842cc9633fc1c5d1dd212f9639cbdc6c2
+GitCommit: eef6393563cb038926e47aa06c1b4c6960cca49d
 Directory: 2.6-rc
 
-Tags: 2.6-dev9-alpine, 2.6-dev-alpine, 2.6-dev9-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev10-alpine, 2.6-dev-alpine, 2.6-dev10-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0dc7b07842cc9633fc1c5d1dd212f9639cbdc6c2
+GitCommit: eef6393563cb038926e47aa06c1b4c6960cca49d
 Directory: 2.6-rc/alpine
 
-Tags: 2.5.6, 2.5, latest, 2.5.6-bullseye, 2.5-bullseye, bullseye
+Tags: 2.5.7, 2.5, latest, 2.5.7-bullseye, 2.5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 337b65c7bbffcf02c8cf50c37d6837495fd32015
+GitCommit: 2a634b815ba26e961f0e63501996c7bb224a9617
 Directory: 2.5
 
-Tags: 2.5.6-alpine, 2.5-alpine, alpine, 2.5.6-alpine3.15, 2.5-alpine3.15, alpine3.15
+Tags: 2.5.7-alpine, 2.5-alpine, alpine, 2.5.7-alpine3.15, 2.5-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 337b65c7bbffcf02c8cf50c37d6837495fd32015
+GitCommit: 2a634b815ba26e961f0e63501996c7bb224a9617
 Directory: 2.5/alpine
 
-Tags: 2.4.16, 2.4, lts, 2.4.16-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.17, 2.4, lts, 2.4.17-bullseye, 2.4-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3e359a419040d46fa312296e8cd9b4edc1dedd2a
+GitCommit: c1ad6f1a7cf6cb8bc3baca2d490ce2c30ca58652
 Directory: 2.4
 
-Tags: 2.4.16-alpine, 2.4-alpine, lts-alpine, 2.4.16-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
+Tags: 2.4.17-alpine, 2.4-alpine, lts-alpine, 2.4.17-alpine3.15, 2.4-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e359a419040d46fa312296e8cd9b4edc1dedd2a
+GitCommit: c1ad6f1a7cf6cb8bc3baca2d490ce2c30ca58652
 Directory: 2.4/alpine
 
 Tags: 2.3.20, 2.3, 2.3.20-bullseye, 2.3-bullseye
@@ -44,24 +44,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: d0bf4675441b426432378072e248f2379784d60d
 Directory: 2.3/alpine
 
-Tags: 2.2.23, 2.2, 2.2.23-bullseye, 2.2-bullseye
+Tags: 2.2.24, 2.2, 2.2.24-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 80b78bda6678279f33f46131abdf905917f6c6dc
+GitCommit: 56be0cf2562116cc7d256a9ad4687cb7611844bf
 Directory: 2.2
 
-Tags: 2.2.23-alpine, 2.2-alpine, 2.2.23-alpine3.15, 2.2-alpine3.15
+Tags: 2.2.24-alpine, 2.2-alpine, 2.2.24-alpine3.15, 2.2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 80b78bda6678279f33f46131abdf905917f6c6dc
+GitCommit: 56be0cf2562116cc7d256a9ad4687cb7611844bf
 Directory: 2.2/alpine
 
-Tags: 2.0.28, 2.0, 2.0.28-buster, 2.0-buster
+Tags: 2.0.29, 2.0, 2.0.29-buster, 2.0-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a421e7e758d512cb77364d2a1a232f3bda28c066
+GitCommit: dbe220ea2f7df73b4ac848b3b63af0ec7651cb26
 Directory: 2.0
 
-Tags: 2.0.28-alpine, 2.0-alpine, 2.0.28-alpine3.15, 2.0-alpine3.15
+Tags: 2.0.29-alpine, 2.0-alpine, 2.0.29-alpine3.15, 2.0-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a421e7e758d512cb77364d2a1a232f3bda28c066
+GitCommit: dbe220ea2f7df73b4ac848b3b63af0ec7651cb26
 Directory: 2.0/alpine
 
 Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/eef6393: Update 2.6-rc to 2.6-dev10
- https://github.com/docker-library/haproxy/commit/2a634b8: Update 2.5 to 2.5.7
- https://github.com/docker-library/haproxy/commit/c1ad6f1: Update 2.4 to 2.4.17
- https://github.com/docker-library/haproxy/commit/56be0cf: Update 2.2 to 2.2.24
- https://github.com/docker-library/haproxy/commit/dbe220e: Update 2.0 to 2.0.29