### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0.3, 4.0, 4, latest
+Tags: 4.0.4, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: ac4975fcd60b47291ca4772d8cce8047f10674b4
+GitCommit: e78718f9e87bc48ec55d367b91f1b4ab4534dbf2
 Directory: 4.0
 
-Tags: 3.11.12, 3.11, 3
+Tags: 3.11.13, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 70ecd6c8d9ef280b967db295e1ee3463b7a08ed2
+GitCommit: dd116c4542c20c0cb34df6db706230cb7872c51d
 Directory: 3.11
 
-Tags: 3.0.26, 3.0
+Tags: 3.0.27, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4514513f79f99f5c57184b57a42171ef3e5f7984
+GitCommit: d6898545a7629b1a7ee7e719379e26fab9bc29de
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/e78718f: Update 4.0 to 4.0.4
- https://github.com/docker-library/cassandra/commit/dd116c4: Update 3.11 to 3.11.13
- https://github.com/docker-library/cassandra/commit/d689854: Update 3.0 to 3.0.27