### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -139,6 +139,21 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
 Directory: ubuntu/jammy
 
+Tags: kinetic-curl, 22.10-curl
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
+Directory: ubuntu/kinetic/curl
+
+Tags: kinetic-scm, 22.10-scm
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
+Directory: ubuntu/kinetic/scm
+
+Tags: kinetic, 22.10
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
+Directory: ubuntu/kinetic
+
 Tags: xenial-curl, 16.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/b135e96: Merge pull request https://github.com/docker-library/buildpack-deps/pull/130 from vicamo/for-upstream/add-kinetic
- https://github.com/docker-library/buildpack-deps/commit/c96f4f3: Add Ubuntu Kinetic 22.10