### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ELSA-2022-9358

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2190ef249f644a54672562adab58500744619a38
+amd64-GitCommit: d9b16065085e8144f633afea0fc542a5dd88c77c
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2b89de16f2d760fb883964fcec81b1281ae8e6c5
+arm64v8-GitCommit: 0a7086c671db55c37a38c7eda5ed5e13329134a9
 
 Tags: 8.6, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-23219 and CVE-2022-23218.

See https://linux.oracle.com/errata/ELSA-2022-9358.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>