### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/c2d5621a6e8b09611a2d2025c3f5226ae778e80a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/a9906cafcd373d81cd73d85c7e2d1318bd3d2c13/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -66,53 +66,53 @@ GitCommit: 51f50b2a9ff19ae7ba3347e9158f1769f46a5461
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18.0.1.1-jdk-oraclelinux8, 18.0.1.1-oraclelinux8, 18.0.1-jdk-oraclelinux8, 18.0.1-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, 18.0.1.1-jdk-oracle, 18.0.1.1-oracle, 18.0.1-jdk-oracle, 18.0.1-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle
-SharedTags: 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18
+Tags: 18.0.1.1-jdk-oraclelinux8, 18.0.1.1-oraclelinux8, 18.0.1-jdk-oraclelinux8, 18.0.1-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.1.1-jdk-oracle, 18.0.1.1-oracle, 18.0.1-jdk-oracle, 18.0.1-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle
+SharedTags: 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: amd64, arm64v8
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18.0.1.1-jdk-oraclelinux7, 18.0.1.1-oraclelinux7, 18.0.1-jdk-oraclelinux7, 18.0.1-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7
+Tags: 18.0.1.1-jdk-oraclelinux7, 18.0.1.1-oraclelinux7, 18.0.1-jdk-oraclelinux7, 18.0.1-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18.0.1.1-jdk-bullseye, 18.0.1.1-bullseye, 18.0.1-jdk-bullseye, 18.0.1-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye
+Tags: 18.0.1.1-jdk-bullseye, 18.0.1.1-bullseye, 18.0.1-jdk-bullseye, 18.0.1-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye, jdk-bullseye, bullseye
 Architectures: amd64, arm64v8
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/bullseye
 
-Tags: 18.0.1.1-jdk-slim-bullseye, 18.0.1.1-slim-bullseye, 18.0.1-jdk-slim-bullseye, 18.0.1-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, 18.0.1.1-jdk-slim, 18.0.1.1-slim, 18.0.1-jdk-slim, 18.0.1-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim
+Tags: 18.0.1.1-jdk-slim-bullseye, 18.0.1.1-slim-bullseye, 18.0.1-jdk-slim-bullseye, 18.0.1-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 18.0.1.1-jdk-slim, 18.0.1.1-slim, 18.0.1-jdk-slim, 18.0.1-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18.0.1.1-jdk-buster, 18.0.1.1-buster, 18.0.1-jdk-buster, 18.0.1-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster
+Tags: 18.0.1.1-jdk-buster, 18.0.1.1-buster, 18.0.1-jdk-buster, 18.0.1-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/buster
 
-Tags: 18.0.1.1-jdk-slim-buster, 18.0.1.1-slim-buster, 18.0.1-jdk-slim-buster, 18.0.1-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster
+Tags: 18.0.1.1-jdk-slim-buster, 18.0.1.1-slim-buster, 18.0.1-jdk-slim-buster, 18.0.1-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster, jdk-slim-buster, slim-buster
 Architectures: amd64, arm64v8
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/slim-buster
 
-Tags: 18.0.1.1-jdk-windowsservercore-ltsc2022, 18.0.1.1-windowsservercore-ltsc2022, 18.0.1-jdk-windowsservercore-ltsc2022, 18.0.1-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022
-SharedTags: 18.0.1.1-jdk-windowsservercore, 18.0.1.1-windowsservercore, 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18
+Tags: 18.0.1.1-jdk-windowsservercore-ltsc2022, 18.0.1.1-windowsservercore-ltsc2022, 18.0.1-jdk-windowsservercore-ltsc2022, 18.0.1-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022, jdk-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 18.0.1.1-jdk-windowsservercore, 18.0.1.1-windowsservercore, 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: windows-amd64
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18.0.1.1-jdk-windowsservercore-1809, 18.0.1.1-windowsservercore-1809, 18.0.1-jdk-windowsservercore-1809, 18.0.1-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809
-SharedTags: 18.0.1.1-jdk-windowsservercore, 18.0.1.1-windowsservercore, 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18
+Tags: 18.0.1.1-jdk-windowsservercore-1809, 18.0.1.1-windowsservercore-1809, 18.0.1-jdk-windowsservercore-1809, 18.0.1-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 18.0.1.1-jdk-windowsservercore, 18.0.1.1-windowsservercore, 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: windows-amd64
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18.0.1.1-jdk-nanoserver-1809, 18.0.1.1-nanoserver-1809, 18.0.1-jdk-nanoserver-1809, 18.0.1-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809
-SharedTags: 18.0.1.1-jdk-nanoserver, 18.0.1.1-nanoserver, 18.0.1-jdk-nanoserver, 18.0.1-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver
+Tags: 18.0.1.1-jdk-nanoserver-1809, 18.0.1.1-nanoserver-1809, 18.0.1-jdk-nanoserver-1809, 18.0.1-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 18.0.1.1-jdk-nanoserver, 18.0.1.1-nanoserver, 18.0.1-jdk-nanoserver, 18.0.1-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
 Directory: 18/jdk/windows/nanoserver-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/a9906ca: Fix "latest" aliases