### PR TITLE
Odoo: update 13.0-15.0 to release 20220520

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 9264df22a694b66cc3b866f92d180e3b084a015e
+GitCommit: 545e19bca196adead368bc895ebd2860dbc4cd9a
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

as usual, here are the latest update for Odoo supported versions.

Thx