### PR TITLE
archlinux: Release 20220522.0.57327

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220515.0.56491
-GitCommit: c97fb71c4ff5cf5c465c374c3d5572b2c472b88a
-GitFetch: refs/tags/v20220515.0.56491
+Tags: latest, base, base-20220522.0.57327
+GitCommit: 16d4be059eac04acaafd2f11fcec0e6afb40d123
+GitFetch: refs/tags/v20220522.0.57327
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220515.0.56491
-GitCommit: c97fb71c4ff5cf5c465c374c3d5572b2c472b88a
-GitFetch: refs/tags/v20220515.0.56491
+Tags: base-devel, base-devel-20220522.0.57327
+GitCommit: 16d4be059eac04acaafd2f11fcec0e6afb40d123
+GitFetch: refs/tags/v20220522.0.57327
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks