### PR TITLE
Add s390x for RethinkDB

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -4,4 +4,4 @@ GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 Tags: 2.4.2-bullseye-slim, 2.4-bullseye-slim, 2-bullseye-slim, bullseye-slim, 2.4.2, 2.4, 2, latest
 Directory: bullseye/2.4.2
 GitCommit: 826a4193366e7d0ff176d101679385125b8fa4f1
-Architectures: amd64, arm64v8
+Architectures: amd64, arm64v8, s390x


### PR DESCRIPTION
## Description

This PR adds s390x architecture to the RethinkDB image.