### PR TITLE
Add official image for SATOSA

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -1,4 +1,4 @@
-# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/ce9ed1fe9762516c42b0315fd2c7ac7b01809f5a/generate-stackbrew-library.sh
+# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/f39d2b97aee3a36753e40a486f531f421d328d43/generate-stackbrew-library.sh
 
 Maintainers: Matthew X. Economou <economoum@niaid.nih.gov> (@niheconomoum)
 GitRepo: https://github.com/IdentityPython/satosa-docker.git
@@ -7,15 +7,10 @@ GitFetch: refs/heads/main
 Tags: 8.1.1-bullseye, 8.1-bullseye, 8-bullseye, bullseye
 SharedTags: 8.1.1, 8.1, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f19ecfded89178f2a90626b87c16ebc8c3ffa94f
+GitCommit: ae2f317df322553b13fc07042348828969868bfa
 Directory: 8.1/bullseye
-
-Tags: 8.1.1-slim-bullseye, 8.1-slim-bullseye, 8-slim-bullseye, slim-bullseye, 8.1.1-slim, 8.1-slim, 8-slim, slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f19ecfded89178f2a90626b87c16ebc8c3ffa94f
-Directory: 8.1/slim-bullseye
 
 Tags: 8.1.1-alpine3.16, 8.1-alpine3.16, 8-alpine3.16, alpine3.16, 8.1.1-alpine, 8.1-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f19ecfded89178f2a90626b87c16ebc8c3ffa94f
+GitCommit: ae2f317df322553b13fc07042348828969868bfa
 Directory: 8.1/alpine3.16

--- a/library/satosa
+++ b/library/satosa
@@ -25,15 +25,15 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.10-slim-buster
 
+Tags: 8.1.0-py3.10-alpine3.16, 8.1-py3.10-alpine3.16, 8-py3.10-alpine3.16, py3.10-alpine3.16
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
+Directory: 8.1/py3.10-alpine3.16
+
 Tags: 8.1.0-py3.10-alpine3.15, 8.1-py3.10-alpine3.15, 8-py3.10-alpine3.15, py3.10-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.10-alpine3.15
-
-Tags: 8.1.0-py3.10-alpine3.14, 8.1-py3.10-alpine3.14, 8-py3.10-alpine3.14, py3.10-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.10-alpine3.14
 
 Tags: 8.1.0-py3.11-rc-bullseye, 8.1-py3.11-rc-bullseye, 8-py3.11-rc-bullseye, py3.11-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -55,15 +55,15 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.11-rc-slim-buster
 
+Tags: 8.1.0-py3.11-rc-alpine3.16, 8.1-py3.11-rc-alpine3.16, 8-py3.11-rc-alpine3.16, py3.11-rc-alpine3.16
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
+Directory: 8.1/py3.11-rc-alpine3.16
+
 Tags: 8.1.0-py3.11-rc-alpine3.15, 8.1-py3.11-rc-alpine3.15, 8-py3.11-rc-alpine3.15, py3.11-rc-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.11-rc-alpine3.15
-
-Tags: 8.1.0-py3.11-rc-alpine3.14, 8.1-py3.11-rc-alpine3.14, 8-py3.11-rc-alpine3.14, py3.11-rc-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.11-rc-alpine3.14
 
 Tags: 8.1.0-py3.7-bullseye, 8.1-py3.7-bullseye, 8-py3.7-bullseye, py3.7-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -85,15 +85,15 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.7-slim-buster
 
+Tags: 8.1.0-py3.7-alpine3.16, 8.1-py3.7-alpine3.16, 8-py3.7-alpine3.16, py3.7-alpine3.16
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
+Directory: 8.1/py3.7-alpine3.16
+
 Tags: 8.1.0-py3.7-alpine3.15, 8.1-py3.7-alpine3.15, 8-py3.7-alpine3.15, py3.7-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.7-alpine3.15
-
-Tags: 8.1.0-py3.7-alpine3.14, 8.1-py3.7-alpine3.14, 8-py3.7-alpine3.14, py3.7-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.7-alpine3.14
 
 Tags: 8.1.0-py3.8-bullseye, 8.1-py3.8-bullseye, 8-py3.8-bullseye, py3.8-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -115,15 +115,15 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.8-slim-buster
 
+Tags: 8.1.0-py3.8-alpine3.16, 8.1-py3.8-alpine3.16, 8-py3.8-alpine3.16, py3.8-alpine3.16
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
+Directory: 8.1/py3.8-alpine3.16
+
 Tags: 8.1.0-py3.8-alpine3.15, 8.1-py3.8-alpine3.15, 8-py3.8-alpine3.15, py3.8-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.8-alpine3.15
-
-Tags: 8.1.0-py3.8-alpine3.14, 8.1-py3.8-alpine3.14, 8-py3.8-alpine3.14, py3.8-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.8-alpine3.14
 
 Tags: 8.1.0-py3.9-bullseye, 8.1-py3.9-bullseye, 8-py3.9-bullseye, py3.9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -145,12 +145,12 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.9-slim-buster
 
+Tags: 8.1.0-py3.9-alpine3.16, 8.1-py3.9-alpine3.16, 8-py3.9-alpine3.16, py3.9-alpine3.16
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
+Directory: 8.1/py3.9-alpine3.16
+
 Tags: 8.1.0-py3.9-alpine3.15, 8.1-py3.9-alpine3.15, 8-py3.9-alpine3.15, py3.9-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
 Directory: 8.1/py3.9-alpine3.15
-
-Tags: 8.1.0-py3.9-alpine3.14, 8.1-py3.9-alpine3.14, 8-py3.9-alpine3.14, py3.9-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.9-alpine3.14

--- a/library/satosa
+++ b/library/satosa
@@ -1,0 +1,155 @@
+# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/07ddf375d715975fec53b01f93dc6422b391701f/generate-stackbrew-library.sh
+
+Maintainers: Matthew X. Economou <economoum@niaid.nih.gov> (@niheconomoum)
+GitRepo: https://github.com/IdentityPython/satosa-docker.git
+
+Tags: 8.1.0-py3.10-bullseye, 8.1-py3.10-bullseye, 8-py3.10-bullseye, py3.10-bullseye
+SharedTags: 8.1.0, 8.1, 8, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.10-bullseye
+
+Tags: 8.1.0-py3.10-slim-bullseye, 8.1-py3.10-slim-bullseye, 8-py3.10-slim-bullseye, py3.10-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.10-slim-bullseye
+
+Tags: 8.1.0-py3.10-buster, 8.1-py3.10-buster, 8-py3.10-buster, py3.10-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.10-buster
+
+Tags: 8.1.0-py3.10-slim-buster, 8.1-py3.10-slim-buster, 8-py3.10-slim-buster, py3.10-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.10-slim-buster
+
+Tags: 8.1.0-py3.10-alpine3.15, 8.1-py3.10-alpine3.15, 8-py3.10-alpine3.15, py3.10-alpine3.15
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.10-alpine3.15
+
+Tags: 8.1.0-py3.10-alpine3.14, 8.1-py3.10-alpine3.14, 8-py3.10-alpine3.14, py3.10-alpine3.14
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.10-alpine3.14
+
+Tags: 8.1.0-py3.11-rc-bullseye, 8.1-py3.11-rc-bullseye, 8-py3.11-rc-bullseye, py3.11-rc-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.11-rc-bullseye
+
+Tags: 8.1.0-py3.11-rc-slim-bullseye, 8.1-py3.11-rc-slim-bullseye, 8-py3.11-rc-slim-bullseye, py3.11-rc-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.11-rc-slim-bullseye
+
+Tags: 8.1.0-py3.11-rc-buster, 8.1-py3.11-rc-buster, 8-py3.11-rc-buster, py3.11-rc-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.11-rc-buster
+
+Tags: 8.1.0-py3.11-rc-slim-buster, 8.1-py3.11-rc-slim-buster, 8-py3.11-rc-slim-buster, py3.11-rc-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.11-rc-slim-buster
+
+Tags: 8.1.0-py3.11-rc-alpine3.15, 8.1-py3.11-rc-alpine3.15, 8-py3.11-rc-alpine3.15, py3.11-rc-alpine3.15
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.11-rc-alpine3.15
+
+Tags: 8.1.0-py3.11-rc-alpine3.14, 8.1-py3.11-rc-alpine3.14, 8-py3.11-rc-alpine3.14, py3.11-rc-alpine3.14
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.11-rc-alpine3.14
+
+Tags: 8.1.0-py3.7-bullseye, 8.1-py3.7-bullseye, 8-py3.7-bullseye, py3.7-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.7-bullseye
+
+Tags: 8.1.0-py3.7-slim-bullseye, 8.1-py3.7-slim-bullseye, 8-py3.7-slim-bullseye, py3.7-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.7-slim-bullseye
+
+Tags: 8.1.0-py3.7-buster, 8.1-py3.7-buster, 8-py3.7-buster, py3.7-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.7-buster
+
+Tags: 8.1.0-py3.7-slim-buster, 8.1-py3.7-slim-buster, 8-py3.7-slim-buster, py3.7-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.7-slim-buster
+
+Tags: 8.1.0-py3.7-alpine3.15, 8.1-py3.7-alpine3.15, 8-py3.7-alpine3.15, py3.7-alpine3.15
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.7-alpine3.15
+
+Tags: 8.1.0-py3.7-alpine3.14, 8.1-py3.7-alpine3.14, 8-py3.7-alpine3.14, py3.7-alpine3.14
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.7-alpine3.14
+
+Tags: 8.1.0-py3.8-bullseye, 8.1-py3.8-bullseye, 8-py3.8-bullseye, py3.8-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.8-bullseye
+
+Tags: 8.1.0-py3.8-slim-bullseye, 8.1-py3.8-slim-bullseye, 8-py3.8-slim-bullseye, py3.8-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.8-slim-bullseye
+
+Tags: 8.1.0-py3.8-buster, 8.1-py3.8-buster, 8-py3.8-buster, py3.8-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.8-buster
+
+Tags: 8.1.0-py3.8-slim-buster, 8.1-py3.8-slim-buster, 8-py3.8-slim-buster, py3.8-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.8-slim-buster
+
+Tags: 8.1.0-py3.8-alpine3.15, 8.1-py3.8-alpine3.15, 8-py3.8-alpine3.15, py3.8-alpine3.15
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.8-alpine3.15
+
+Tags: 8.1.0-py3.8-alpine3.14, 8.1-py3.8-alpine3.14, 8-py3.8-alpine3.14, py3.8-alpine3.14
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.8-alpine3.14
+
+Tags: 8.1.0-py3.9-bullseye, 8.1-py3.9-bullseye, 8-py3.9-bullseye, py3.9-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.9-bullseye
+
+Tags: 8.1.0-py3.9-slim-bullseye, 8.1-py3.9-slim-bullseye, 8-py3.9-slim-bullseye, py3.9-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.9-slim-bullseye
+
+Tags: 8.1.0-py3.9-buster, 8.1-py3.9-buster, 8-py3.9-buster, py3.9-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.9-buster
+
+Tags: 8.1.0-py3.9-slim-buster, 8.1-py3.9-slim-buster, 8-py3.9-slim-buster, py3.9-slim-buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.9-slim-buster
+
+Tags: 8.1.0-py3.9-alpine3.15, 8.1-py3.9-alpine3.15, 8-py3.9-alpine3.15, py3.9-alpine3.15
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.9-alpine3.15
+
+Tags: 8.1.0-py3.9-alpine3.14, 8.1-py3.9-alpine3.14, 8-py3.9-alpine3.14, py3.9-alpine3.14
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
+Directory: 8.1/py3.9-alpine3.14

--- a/library/satosa
+++ b/library/satosa
@@ -4,153 +4,18 @@ Maintainers: Matthew X. Economou <economoum@niaid.nih.gov> (@niheconomoum)
 GitRepo: https://github.com/IdentityPython/satosa-docker.git
 GitFetch: refs/heads/main
 
-Tags: 8.1.0-py3.10-bullseye, 8.1-py3.10-bullseye, 8-py3.10-bullseye, py3.10-bullseye
-SharedTags: 8.1.0, 8.1, 8, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.10-bullseye
+Tags: 8.1.1-bullseye, 8.1-bullseye, 8-bullseye, bullseye
+SharedTags: 8.1.1, 8.1, 8, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: f19ecfded89178f2a90626b87c16ebc8c3ffa94f
+Directory: 8.1/bullseye
 
-Tags: 8.1.0-py3.10-slim-bullseye, 8.1-py3.10-slim-bullseye, 8-py3.10-slim-bullseye, py3.10-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.10-slim-bullseye
+Tags: 8.1.1-slim-bullseye, 8.1-slim-bullseye, 8-slim-bullseye, slim-bullseye, 8.1.1-slim, 8.1-slim, 8-slim, slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: f19ecfded89178f2a90626b87c16ebc8c3ffa94f
+Directory: 8.1/slim-bullseye
 
-Tags: 8.1.0-py3.10-buster, 8.1-py3.10-buster, 8-py3.10-buster, py3.10-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.10-buster
-
-Tags: 8.1.0-py3.10-slim-buster, 8.1-py3.10-slim-buster, 8-py3.10-slim-buster, py3.10-slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.10-slim-buster
-
-Tags: 8.1.0-py3.10-alpine3.16, 8.1-py3.10-alpine3.16, 8-py3.10-alpine3.16, py3.10-alpine3.16
+Tags: 8.1.1-alpine3.16, 8.1-alpine3.16, 8-alpine3.16, alpine3.16, 8.1.1-alpine, 8.1-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
-Directory: 8.1/py3.10-alpine3.16
-
-Tags: 8.1.0-py3.10-alpine3.15, 8.1-py3.10-alpine3.15, 8-py3.10-alpine3.15, py3.10-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.10-alpine3.15
-
-Tags: 8.1.0-py3.11-rc-bullseye, 8.1-py3.11-rc-bullseye, 8-py3.11-rc-bullseye, py3.11-rc-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.11-rc-bullseye
-
-Tags: 8.1.0-py3.11-rc-slim-bullseye, 8.1-py3.11-rc-slim-bullseye, 8-py3.11-rc-slim-bullseye, py3.11-rc-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.11-rc-slim-bullseye
-
-Tags: 8.1.0-py3.11-rc-buster, 8.1-py3.11-rc-buster, 8-py3.11-rc-buster, py3.11-rc-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.11-rc-buster
-
-Tags: 8.1.0-py3.11-rc-slim-buster, 8.1-py3.11-rc-slim-buster, 8-py3.11-rc-slim-buster, py3.11-rc-slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.11-rc-slim-buster
-
-Tags: 8.1.0-py3.11-rc-alpine3.16, 8.1-py3.11-rc-alpine3.16, 8-py3.11-rc-alpine3.16, py3.11-rc-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
-Directory: 8.1/py3.11-rc-alpine3.16
-
-Tags: 8.1.0-py3.11-rc-alpine3.15, 8.1-py3.11-rc-alpine3.15, 8-py3.11-rc-alpine3.15, py3.11-rc-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.11-rc-alpine3.15
-
-Tags: 8.1.0-py3.7-bullseye, 8.1-py3.7-bullseye, 8-py3.7-bullseye, py3.7-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.7-bullseye
-
-Tags: 8.1.0-py3.7-slim-bullseye, 8.1-py3.7-slim-bullseye, 8-py3.7-slim-bullseye, py3.7-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.7-slim-bullseye
-
-Tags: 8.1.0-py3.7-buster, 8.1-py3.7-buster, 8-py3.7-buster, py3.7-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.7-buster
-
-Tags: 8.1.0-py3.7-slim-buster, 8.1-py3.7-slim-buster, 8-py3.7-slim-buster, py3.7-slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.7-slim-buster
-
-Tags: 8.1.0-py3.7-alpine3.16, 8.1-py3.7-alpine3.16, 8-py3.7-alpine3.16, py3.7-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
-Directory: 8.1/py3.7-alpine3.16
-
-Tags: 8.1.0-py3.7-alpine3.15, 8.1-py3.7-alpine3.15, 8-py3.7-alpine3.15, py3.7-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.7-alpine3.15
-
-Tags: 8.1.0-py3.8-bullseye, 8.1-py3.8-bullseye, 8-py3.8-bullseye, py3.8-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.8-bullseye
-
-Tags: 8.1.0-py3.8-slim-bullseye, 8.1-py3.8-slim-bullseye, 8-py3.8-slim-bullseye, py3.8-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.8-slim-bullseye
-
-Tags: 8.1.0-py3.8-buster, 8.1-py3.8-buster, 8-py3.8-buster, py3.8-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.8-buster
-
-Tags: 8.1.0-py3.8-slim-buster, 8.1-py3.8-slim-buster, 8-py3.8-slim-buster, py3.8-slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.8-slim-buster
-
-Tags: 8.1.0-py3.8-alpine3.16, 8.1-py3.8-alpine3.16, 8-py3.8-alpine3.16, py3.8-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
-Directory: 8.1/py3.8-alpine3.16
-
-Tags: 8.1.0-py3.8-alpine3.15, 8.1-py3.8-alpine3.15, 8-py3.8-alpine3.15, py3.8-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.8-alpine3.15
-
-Tags: 8.1.0-py3.9-bullseye, 8.1-py3.9-bullseye, 8-py3.9-bullseye, py3.9-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.9-bullseye
-
-Tags: 8.1.0-py3.9-slim-bullseye, 8.1-py3.9-slim-bullseye, 8-py3.9-slim-bullseye, py3.9-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.9-slim-bullseye
-
-Tags: 8.1.0-py3.9-buster, 8.1-py3.9-buster, 8-py3.9-buster, py3.9-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.9-buster
-
-Tags: 8.1.0-py3.9-slim-buster, 8.1-py3.9-slim-buster, 8-py3.9-slim-buster, py3.9-slim-buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.9-slim-buster
-
-Tags: 8.1.0-py3.9-alpine3.16, 8.1-py3.9-alpine3.16, 8-py3.9-alpine3.16, py3.9-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98669c781a8a41c6882a9eee64be2de5c28b4665
-Directory: 8.1/py3.9-alpine3.16
-
-Tags: 8.1.0-py3.9-alpine3.15, 8.1-py3.9-alpine3.15, 8-py3.9-alpine3.15, py3.9-alpine3.15
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4598350aa87f5da0e63141c3737c7296b1f43d1
-Directory: 8.1/py3.9-alpine3.15
+GitCommit: f19ecfded89178f2a90626b87c16ebc8c3ffa94f
+Directory: 8.1/alpine3.16

--- a/library/satosa
+++ b/library/satosa
@@ -1,7 +1,8 @@
-# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/07ddf375d715975fec53b01f93dc6422b391701f/generate-stackbrew-library.sh
+# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/ce9ed1fe9762516c42b0315fd2c7ac7b01809f5a/generate-stackbrew-library.sh
 
 Maintainers: Matthew X. Economou <economoum@niaid.nih.gov> (@niheconomoum)
 GitRepo: https://github.com/IdentityPython/satosa-docker.git
+GitFetch: refs/heads/main
 
 Tags: 8.1.0-py3.10-bullseye, 8.1-py3.10-bullseye, 8-py3.10-bullseye, py3.10-bullseye
 SharedTags: 8.1.0, 8.1, 8, latest


### PR DESCRIPTION
SATOSA is a configurable proxy for translating between different authentication protocols such as SAML2, OpenID Connect, and OAuth2.  It implements the Access Protocol Translation layer of [the Authentication and Authorization for Research Collaborations (AARC) Blueprint Architecture](https://aarc-project.eu/architecture/), and it is the foundation of several spoke-hub-style identity federations.  Adopters include research institutions, higher education, and governments.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
    - https://github.com/IdentityPython
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)?
    - Apache 2.0, MIT, CC0
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
    - service
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
    - https://github.com/docker-library/docs/pull/2158
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)