### PR TITLE
[nats] Release v2.8.3

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -5,25 +5,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: b89ba6e8efd296d0558f44e33a507116d1f803cf
+GitCommit: d48e482e30326889e83c243beafdb78993aea834
 
-Tags: 2.8.2-alpine3.15, 2.8-alpine3.15, 2-alpine3.15, alpine3.15, 2.8.2-alpine, 2.8-alpine, 2-alpine, alpine
+Tags: 2.8.3-alpine3.15, 2.8-alpine3.15, 2-alpine3.15, alpine3.15, 2.8.3-alpine, 2.8-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.8.2/alpine3.15
+Directory: 2.8.3/alpine3.15
 
-Tags: 2.8.2-scratch, 2.8-scratch, 2-scratch, scratch, 2.8.2-linux, 2.8-linux, 2-linux, linux
-SharedTags: 2.8.2, 2.8, 2, latest
+Tags: 2.8.3-scratch, 2.8-scratch, 2-scratch, scratch, 2.8.3-linux, 2.8-linux, 2-linux, linux
+SharedTags: 2.8.3, 2.8, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.8.2/scratch
+Directory: 2.8.3/scratch
 
-Tags: 2.8.2-windowsservercore-1809, 2.8-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.8.2-windowsservercore, 2.8-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.8.3-windowsservercore-1809, 2.8-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.8.3-windowsservercore, 2.8-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.8.2/windowsservercore-1809
+Directory: 2.8.3/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.8.2-nanoserver-1809, 2.8-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.8.2-nanoserver, 2.8-nanoserver, 2-nanoserver, nanoserver, 2.8.2, 2.8, 2, latest
+Tags: 2.8.3-nanoserver-1809, 2.8-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.8.3-nanoserver, 2.8-nanoserver, 2-nanoserver, nanoserver, 2.8.3, 2.8, 2, latest
 Architectures: windows-amd64
-Directory: 2.8.2/nanoserver-1809
+Directory: 2.8.3/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.8.3)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>