### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,15 +1,25 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/50c6e6bc5e38a96f48cf1033b86223212803418f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/62e64119b4e5413e8177795be1fb5f27d8d4068c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 4.47.4, 4.47, 4, latest
+Tags: 5.0.0, 5.0, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d2168581eb77016547ea4643822626bafa03fc46
+GitCommit: 62e64119b4e5413e8177795be1fb5f27d8d4068c
+Directory: 5/debian
+
+Tags: 5.0.0-alpine, 5.0-alpine, 5-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+GitCommit: 62e64119b4e5413e8177795be1fb5f27d8d4068c
+Directory: 5/alpine
+
+Tags: 4.48.0, 4.48, 4
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 054059f2f023935959eac76bf95a49579a034010
 Directory: 4/debian
 
-Tags: 4.47.4-alpine, 4.47-alpine, 4-alpine, alpine
+Tags: 4.48.0-alpine, 4.48-alpine, 4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d2168581eb77016547ea4643822626bafa03fc46
+GitCommit: 054059f2f023935959eac76bf95a49579a034010
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/62e6411: Add Ghost 5 support (https://github.com/docker-library/ghost/pull/306)
- https://github.com/docker-library/ghost/commit/054059f: Update to 4.48.0, ghost-cli 1.21.0