### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev10, 2.6-dev, 2.6-dev10-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev11, 2.6-dev, 2.6-dev11-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eef6393563cb038926e47aa06c1b4c6960cca49d
+GitCommit: bb64357067593584ab00b6273bd7ecb91eb0fc87
 Directory: 2.6-rc
 
-Tags: 2.6-dev10-alpine, 2.6-dev-alpine, 2.6-dev10-alpine3.15, 2.6-dev-alpine3.15
+Tags: 2.6-dev11-alpine, 2.6-dev-alpine, 2.6-dev11-alpine3.15, 2.6-dev-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eef6393563cb038926e47aa06c1b4c6960cca49d
+GitCommit: bb64357067593584ab00b6273bd7ecb91eb0fc87
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.7, 2.5, latest, 2.5.7-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bb64357: Update 2.6-rc to 2.6-dev11