### PR TITLE
Bump Traefik to v2.6.7 and v2.7.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 980d4fad23bdcb2c57d71b8194846caf25005958
 Directory: alpine
 
-Tags: v2.6.6-windowsservercore-1809, 2.6.6-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
+Tags: v2.6.7-windowsservercore-1809, 2.6.7-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622
+GitCommit: 57821065c86f99c3d4519b41e2a10f3ed9a050e6
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.6, 2.6.6, v2.6, 2.6, rocamadour
+Tags: v2.6.7, 2.6.7, v2.6, 2.6, rocamadour
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622
+GitCommit: 57821065c86f99c3d4519b41e2a10f3ed9a050e6
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,26 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.7.0-rc2-windowsservercore-1809, 2.7.0-rc2-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809
+Tags: v2.7.0-windowsservercore-1809, 2.7.0-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 525b8f19920873224fc5546e8f8b1e360a81a93f
+GitCommit: 980d4fad23bdcb2c57d71b8194846caf25005958
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.7.0-rc2, 2.7.0-rc2, v2.7, 2.7, epoisses
+Tags: v2.7.0, 2.7.0, v2.7, 2.7, epoisses, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 525b8f19920873224fc5546e8f8b1e360a81a93f
+GitCommit: 980d4fad23bdcb2c57d71b8194846caf25005958
 Directory: alpine
 
-Tags: v2.6.6-windowsservercore-1809, 2.6.6-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809, windowsservercore-1809
+Tags: v2.6.6-windowsservercore-1809, 2.6.6-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.6.6, 2.6.6, v2.6, 2.6, rocamadour, latest
+Tags: v2.6.6, 2.6.6, v2.6, 2.6, rocamadour
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 188029556fd580a0c9c99f1bd532950c54f40622


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.6.7](https://github.com/traefik/traefik/releases/tag/v2.6.7) and [v2.7.0](https://github.com/traefik/traefik/releases/tag/v2.7.0).

/cc @ddtmachado @mpl @ldez

Cheers
