### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.2.0
+Tags: 8.2.1
 Architectures: amd64, arm64v8
-GitCommit: c424be7c85ac270fb8cb37c858783f619af7efa6
+GitCommit: e27b925f1c8d2bc6cd0cee2eb0f005dd16dcc359
 Directory: 8
 
-Tags: 7.17.3
+Tags: 7.17.4
 Architectures: amd64, arm64v8
-GitCommit: f82097fb479c4d4b64eafcd6982fb99ef5919d5c
+GitCommit: 8869c735312681ee05f01494e2ec26b610ab94f8
 Directory: 7
 
 Tags: 6.8.23

--- a/library/kibana
+++ b/library/kibana
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.2.0
+Tags: 8.2.1
 Architectures: amd64, arm64v8
-GitCommit: bbe04d23f47f031789806a41d768eacf53e7a255
+GitCommit: f4a15fddf1c7fb3f9eedafa2d4b25ec305b5fa1d
 Directory: 8
 
-Tags: 7.17.3
+Tags: 7.17.4
 Architectures: amd64, arm64v8
-GitCommit: bab70d6340c944eb961dd3ab54da6814969e8f01
+GitCommit: ea515d33861122a505a983d26485f9c7c82d3856
 Directory: 7
 
 Tags: 6.8.23

--- a/library/logstash
+++ b/library/logstash
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.2.0
+Tags: 8.2.1
 Architectures: amd64, arm64v8
-GitCommit: dc08e4112fe8c01795dd1bac43ce82d21d280247
+GitCommit: 6a10a8ea58978373a7e43d10b14d6a0cb9784010
 Directory: 8
 
-Tags: 7.17.3
+Tags: 7.17.4
 Architectures: amd64, arm64v8
-GitCommit: 74c9384f34112e5ee37a0725b71077558bd97a1d
+GitCommit: bc8f45efe824d4cceb4d5e6cfd974b51b355ca01
 Directory: 7
 
 Tags: 6.8.23


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/8869c73: Update to 7.17.4
- https://github.com/docker-library/elasticsearch/commit/e27b925: Update to 8.2.1

logstash:
- https://github.com/docker-library/logstash/commit/bc8f45e: Update to 7.17.4
- https://github.com/docker-library/logstash/commit/6a10a8e: Update to 8.2.1

kibana:
- https://github.com/docker-library/kibana/commit/42215cb: Merge pull request https://github.com/docker-library/kibana/pull/98 from infosiftr/buildkit-history
- https://github.com/docker-library/kibana/commit/7d2a884: Update history munging to account for buildkit-isms in published 7 & 8 images
- https://github.com/docker-library/kibana/commit/ea515d3: Update to 7.17.4
- https://github.com/docker-library/kibana/commit/f4a15fd: Update to 8.2.1