### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/a9906cafcd373d81cd73d85c7e2d1318bd3d2c13/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/f736d86bccabf5072d84e77b72d2b3c83446a67f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -35,15 +35,15 @@ Architectures: amd64, arm64v8
 GitCommit: c53457e2b9cafcbe209be1e9adba49c9725105b4
 Directory: 19/jdk/slim-buster
 
-Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
+Tags: 19-ea-5-jdk-alpine3.16, 19-ea-5-alpine3.16, 19-ea-jdk-alpine3.16, 19-ea-alpine3.16, 19-jdk-alpine3.16, 19-alpine3.16, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
+Architectures: amd64
+GitCommit: 04d037e69a6071859c763903b20b1b39e95b4cad
+Directory: 19/jdk/alpine3.16
+
+Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15
 Architectures: amd64
 GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
 Directory: 19/jdk/alpine3.15
-
-Tags: 19-ea-5-jdk-alpine3.14, 19-ea-5-alpine3.14, 19-ea-jdk-alpine3.14, 19-ea-alpine3.14, 19-jdk-alpine3.14, 19-alpine3.14
-Architectures: amd64
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
-Directory: 19/jdk/alpine3.14
 
 Tags: 19-ea-23-jdk-windowsservercore-ltsc2022, 19-ea-23-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
 SharedTags: 19-ea-23-jdk-windowsservercore, 19-ea-23-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-23-jdk, 19-ea-23, 19-ea-jdk, 19-ea, 19-jdk, 19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/f736d86: Calculate latest "debian", "oraclelinux", and "alpine" variants automatically
- https://github.com/docker-library/openjdk/commit/a1c9c89: Update "alpine" alias to 3.16
- https://github.com/docker-library/openjdk/commit/c1b8e93: Merge pull request https://github.com/docker-library/openjdk/pull/501 from J0WI/alpine-3.16
- https://github.com/docker-library/openjdk/commit/04d037e: Alpine 3.16