### PR TITLE
update registry to alpine 3.16

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -5,4 +5,4 @@ GitRepo: https://github.com/docker/distribution-library-image.git
 Tags: 2.8.1, 2.8, 2, latest
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 GitFetch: refs/heads/master
-GitCommit: a44a420db5ec0d5a679a72e9fb539f8a69fb93f9
+GitCommit: 0be0d08b29d56bb1ef0fab93c751ca92d6976a19


### PR DESCRIPTION
- Fix CVE-2022-28391 by bumping alpine from 3.15 to 3.16

full diff: https://github.com/docker/distribution-library-image/compare/a44a420db5ec0d5a679a72e9fb539f8a69fb93f9...0be0d08b29d56bb1ef0fab93c751ca92d6976a19
