### PR TITLE
[ros] add perception variant

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -138,6 +138,11 @@ Architectures: amd64, arm64v8
 GitCommit: 20e3ba685bb353a3c00be9ba01c1b7a6823c9472
 Directory: ros/humble/ubuntu/jammy/ros-base
 
+Tags: humble-perception, humble-perception-jammy
+Architectures: amd64, arm64v8
+GitCommit: 20d40c96b426b8956dec203e236abff2ec29b188
+Directory: ros/humble/ubuntu/jammy/perception
+
 
 ################################################################################
 # Release: rolling
@@ -147,11 +152,16 @@ Directory: ros/humble/ubuntu/jammy/ros-base
 
 Tags: rolling-ros-core, rolling-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 86029c8abad4b4e52d95a33af079bdb874fa0b0c
+GitCommit: 20d40c96b426b8956dec203e236abff2ec29b188
 Directory: ros/rolling/ubuntu/jammy/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-jammy, rolling
 Architectures: amd64, arm64v8
-GitCommit: 86029c8abad4b4e52d95a33af079bdb874fa0b0c
+GitCommit: 20d40c96b426b8956dec203e236abff2ec29b188
 Directory: ros/rolling/ubuntu/jammy/ros-base
+
+Tags: rolling-perception, rolling-perception-jammy
+Architectures: amd64, arm64v8
+GitCommit: 20d40c96b426b8956dec203e236abff2ec29b188
+Directory: ros/rolling/ubuntu/jammy/perception
 


### PR DESCRIPTION
Add the perception image for humble and rolling ROS disctributions
This also bumps packages versions in ROS rolling