### PR TITLE
consul: 1.12.1, 1.11.6, and 1.10.11

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,20 +1,20 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.12.0, 1.12, latest
+Tags: 1.12.1, 1.12, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 64322c2878bfa9935b742f81cf226df056f19fd6
+GitCommit: f5c112dca034d78c5e6094e256ba5a699f761cbb
 Directory: 0.X
 
-Tags: 1.11.5, 1.11
+Tags: 1.11.6, 1.11
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 596911437f600b194c3da3ca7f47caaa8184123b
+GitCommit: c38faf2c1534f5aec6064660c1e8c9bbc03a38a0 
 Directory: 0.X
 
-Tags: 1.10.10, 1.10
+Tags: 1.10.11, 1.10
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 5b32837a6a6b94599bacb3f7c963b4697383a3e3
+GitCommit: fcced549b702f08b836ddd53d09dbedbb46e3a1d
 Directory: 0.X
 


### PR DESCRIPTION
These are the latest refs from the release yesterday (May 25th, 2022).