### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.2.1
+Tags: 8.2.2
 Architectures: amd64, arm64v8
-GitCommit: e27b925f1c8d2bc6cd0cee2eb0f005dd16dcc359
+GitCommit: c9afd496f5727e62cd8150624a6e8a8fdb1a2085
 Directory: 8
 
 Tags: 7.17.4

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.2.1
+Tags: 8.2.2
 Architectures: amd64, arm64v8
-GitCommit: f4a15fddf1c7fb3f9eedafa2d4b25ec305b5fa1d
+GitCommit: 7b5776ce592c8de0183853cc212300fae614c926
 Directory: 8
 
 Tags: 7.17.4

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.2.1
+Tags: 8.2.2
 Architectures: amd64, arm64v8
-GitCommit: 6a10a8ea58978373a7e43d10b14d6a0cb9784010
+GitCommit: a96230b9c9e6b24eea684ddd720214f6250c5a26
 Directory: 8
 
 Tags: 7.17.4


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/c9afd49: Update to 8.2.2

logstash:
- https://github.com/docker-library/logstash/commit/a96230b: Update to 8.2.2

kibana:
- https://github.com/docker-library/kibana/commit/7b5776c: Update to 8.2.2