### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: a5a94a2d5c812fe57f6f28713b0f899b879145d3
 Directory: 10
 # Docker EOL: 2022-10-08
 
-# Last Modified: 2021-06-01
-Tags: 9.4.0, 9.4, 9, 9.4.0-buster, 9.4-buster, 9-buster
+# Last Modified: 2022-05-27
+Tags: 9.5.0, 9.5, 9, 9.5.0-buster, 9.5-buster, 9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5a94a2d5c812fe57f6f28713b0f899b879145d3
+GitCommit: 6c40a41a202b2996b26b52e94762fe9aa8830766
 Directory: 9
-# Docker EOL: 2022-12-01
+# Docker EOL: 2023-11-27


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/6c40a41: Update 9 to 9.5.0