### PR TITLE
archlinux: Release 20220529.0.58327

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220522.0.57327
-GitCommit: 16d4be059eac04acaafd2f11fcec0e6afb40d123
-GitFetch: refs/tags/v20220522.0.57327
+Tags: latest, base, base-20220529.0.58327
+GitCommit: 7c4a9dcb0588507fc9c23dbb07162124dad7d5ef
+GitFetch: refs/tags/v20220529.0.58327
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220522.0.57327
-GitCommit: 16d4be059eac04acaafd2f11fcec0e6afb40d123
-GitFetch: refs/tags/v20220522.0.57327
+Tags: base-devel, base-devel-20220529.0.58327
+GitCommit: 7c4a9dcb0588507fc9c23dbb07162124dad7d5ef
+GitFetch: refs/tags/v20220529.0.58327
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks