### PR TITLE
Update Clear Linux OS to 36410

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: acf3760197e09e3bf18dfd990ce084611bf90fd4
-GitFetch: refs/heads/base-36360
+GitCommit: 233f400a81916332d8aad3decfd2388ac3f22700
+GitFetch: refs/heads/base-36410


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36410

@bryteise @djklimes @bryteise