### PR TITLE
New release of JDK18 is available

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -8,26 +8,26 @@ GitFetch: refs/heads/ibm
 Tags: open-8u332-b09-jdk-focal, open-8-jdk-focal
 SharedTags: open-8u332-b09-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 8/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-8u332-b09-jdk-centos7, open-8-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 8/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-8u332-b09-jre-focal, open-8-jre-focal
 SharedTags: open-8u332-b09-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 8/jre/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-8u332-b09-jre-centos7, open-8-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 8/jre/centos
 File: Dockerfile.open.releases.full
 
@@ -35,26 +35,26 @@ File: Dockerfile.open.releases.full
 Tags: open-11.0.15_10-jdk-focal, open-11-jdk-focal
 SharedTags: open-11.0.15_10-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 11/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.15_10-jdk-centos7, open-11-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 11/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.15_10-jre-focal, open-11-jre-focal
 SharedTags: open-11.0.15_10-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 11/jre/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.15_10-jre-centos7, open-11-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 11/jre/centos
 File: Dockerfile.open.releases.full
 
@@ -62,26 +62,26 @@ File: Dockerfile.open.releases.full
 Tags: open-16.0.2_7-jdk-focal, open-16-jdk-focal
 SharedTags: open-16.0.2_7-jdk, open-16-jdk
 Architectures: amd64, ppc64le, s390x
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 16/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-16.0.2_7-jdk-centos7, open-16-jdk-centos7
 Architectures: amd64, ppc64le
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 16/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-16.0.2_7-jre-focal, open-16-jre-focal
 SharedTags: open-16.0.2_7-jre, open-16-jre
 Architectures: amd64, ppc64le, s390x
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 16/jre/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-16.0.2_7-jre-centos7, open-16-jre-centos7
 Architectures: amd64, ppc64le
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 16/jre/centos
 File: Dockerfile.open.releases.full
 
@@ -89,52 +89,52 @@ File: Dockerfile.open.releases.full
 Tags: open-17.0.3_7-jdk-focal, open-17-jdk-focal
 SharedTags: open-17.0.3_7-jdk, open-17-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 17/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.3_7-jdk-centos7, open-17-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 17/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.3_7-jre-focal, open-17-jre-focal
 SharedTags: open-17.0.3_7-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 17/jre/ubuntu
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.3_7-jre-centos7, open-17-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 17/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v18 images---------------------------------
-Tags: open-18.0.1_10-jdk-focal, open-18-jdk-focal
-SharedTags: open-18.0.1_10-jdk, open-18-jdk
+Tags: open-18.0.1.1_2-jdk-focal, open-18-jdk-focal
+SharedTags: open-18.0.1.1_2-jdk, open-18-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 18/jdk/ubuntu
 File: Dockerfile.open.releases.full
 
-Tags: open-18.0.1_10-jdk-centos7, open-18-jdk-centos7
+Tags: open-18.0.1.1_2-jdk-centos7, open-18-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 18/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-18.0.1_10-jre-focal, open-18-jre-focal
-SharedTags: open-18.0.1_10-jre, open-18-jre
+Tags: open-18.0.1.1_2-jre-focal, open-18-jre-focal
+SharedTags: open-18.0.1.1_2-jre, open-18-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 18/jre/ubuntu
 File: Dockerfile.open.releases.full
 
-Tags: open-18.0.1_10-jre-centos7, open-18-jre-centos7
+Tags: open-18.0.1.1_2-jre-centos7, open-18-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: c732a9e86ffbbcf70be85d9f85dc05884eb24d76
+GitCommit: bf1020f89772eaf0526086663545a2e13cb0fcfb
 Directory: 18/jre/centos
 File: Dockerfile.open.releases.full


### PR DESCRIPTION
We have a new release of JDK18. Hence updating the version to refresh the container images. Thanks !!