### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev11, 2.6-dev, 2.6-dev11-bullseye, 2.6-dev-bullseye
+Tags: 2.6-dev12, 2.6-dev, 2.6-dev12-bullseye, 2.6-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb64357067593584ab00b6273bd7ecb91eb0fc87
+GitCommit: 8e1062519b926bb7ba1f713e3718a02f44ff12f6
 Directory: 2.6-rc
 
-Tags: 2.6-dev11-alpine, 2.6-dev-alpine, 2.6-dev11-alpine3.16, 2.6-dev-alpine3.16
+Tags: 2.6-dev12-alpine, 2.6-dev-alpine, 2.6-dev12-alpine3.16, 2.6-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: 8e1062519b926bb7ba1f713e3718a02f44ff12f6
 Directory: 2.6-rc/alpine
 
 Tags: 2.5.7, 2.5, latest, 2.5.7-bullseye, 2.5-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8e10625: Update 2.6-rc to 2.6-dev12