### PR TITLE
IBM Java version updated to 1.8.0_sr7fp10 (8.0.7.10)

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -5,31 +5,31 @@ GitRepo: https://github.com/ibmruntimes/ci.docker.git
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 2df7f5dd5dff7effe2038d4dc1d35dddfd3ca277
+GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-jre-alpine, jre-alpine
 Architectures: amd64
-GitCommit: 2df7f5dd5dff7effe2038d4dc1d35dddfd3ca277
+GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/jre/alpine
 
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 2df7f5dd5dff7effe2038d4dc1d35dddfd3ca277
+GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sfj-alpine, sfj-alpine
 Architectures: amd64
-GitCommit: 2df7f5dd5dff7effe2038d4dc1d35dddfd3ca277
+GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/sfj/alpine
 
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 2df7f5dd5dff7effe2038d4dc1d35dddfd3ca277
+GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/sdk/ubuntu
 
 Tags: 8-sdk-alpine, sdk-alpine
 Architectures: amd64
-GitCommit: 2df7f5dd5dff7effe2038d4dc1d35dddfd3ca277
+GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/sdk/alpine
 

--- a/library/ibmjava
+++ b/library/ibmjava
@@ -8,28 +8,13 @@ Architectures: amd64, i386, ppc64le, s390x
 GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/jre/ubuntu
 
-Tags: 8-jre-alpine, jre-alpine
-Architectures: amd64
-GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
-Directory: ibmjava/8/jre/alpine
-
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
 GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/sfj/ubuntu
 
-Tags: 8-sfj-alpine, sfj-alpine
-Architectures: amd64
-GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
-Directory: ibmjava/8/sfj/alpine
-
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
 GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
 Directory: ibmjava/8/sdk/ubuntu
-
-Tags: 8-sdk-alpine, sdk-alpine
-Architectures: amd64
-GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
-Directory: ibmjava/8/sdk/alpine
 


### PR DESCRIPTION
IBM Java version updated to 1.8.0_sr7fp10 (8.0.7.10)