### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/6b6182ab460eb0f3bbd03df40659c0bb45d0ff75/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/a04e2746f8704ea7418f17af4ca8b7001e54b29e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 6b6182ab460eb0f3bbd03df40659c0bb45d0ff75
+GitCommit: a04e2746f8704ea7418f17af4ca8b7001e54b29e
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 770baf6a7afdde23a022f049ec192e544d961d16
+amd64-GitCommit: 961fac6c16aa9395ea0036f20bdc76221a62c862
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 81f62a6f483bf43e41c78fb570501dbe48028db5
+arm32v5-GitCommit: d273ae613f1e54089bf12610fbaec899d2c0dade
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: c6548564da8e02dd6bdfcf5afc47c7eac63dbc86
+arm32v6-GitCommit: 6e0fb53a7aa2f60fa27b85041da682f62a78173c
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: d8a034538ce3df8843e0a18d65ee4e9887414d37
+arm32v7-GitCommit: 246f6b3cbf42952e1c0d2d0cdd50a7d33f2f4238
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 247a8e7ac3f39dc7cf10c9fe4bcb87719eb37565
+arm64v8-GitCommit: 6d732824e2972189e4606f4fb7cdd4c66072ec0c
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 541b0ef4cc21987941548ea41156b964c2891c58
+i386-GitCommit: a256fb031f1163cafa60a04df70407c81f930015
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 9a2ea953d0284e5835ff5d798aa54fe455b63f6d
+mips64le-GitCommit: 00913a1f4cddd876eaaf0d8b978d145fd1211982
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: f323d9a676732a1c185dd959e6aa879957273709
+ppc64le-GitCommit: 5d9c0d3e5413be3c95d9c0d32bf8f5ac8133df10
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 5bef1af74eea8cd20abbd35b597ed08286863693
+riscv64-GitCommit: 7abd4f63418acdbf7fcd30f421fa4ef5d5fd9d59
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 416d6664c986d85f9a0c220ec998239f0ee4e1e9
+s390x-GitCommit: 2ae1cd299d25e6cbbb175c77f071ff2394dc93ef
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/a04e274: Merge pull request https://github.com/docker-library/busybox/pull/137 from infosiftr/buildroot-2022.02.2
- https://github.com/docker-library/busybox/commit/c23dc03: Update buildroot to 2022.02.2