### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,35 +1,45 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/50b6692229b0d82c35f925548c8cd24111319d18/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/e3e46b4c54b24e8c564851776e60be13e619f729/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.6-dev11, 2.6-dev, 2.6-dev11-bullseye, 2.6-dev-bullseye
+Tags: 2.7-dev0, 2.7-dev, 2.7-dev0-bullseye, 2.7-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb64357067593584ab00b6273bd7ecb91eb0fc87
-Directory: 2.6-rc
+GitCommit: e3e46b4c54b24e8c564851776e60be13e619f729
+Directory: 2.7
 
-Tags: 2.6-dev11-alpine, 2.6-dev-alpine, 2.6-dev11-alpine3.16, 2.6-dev-alpine3.16
+Tags: 2.7-dev0-alpine, 2.7-dev-alpine, 2.7-dev0-alpine3.16, 2.7-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
-Directory: 2.6-rc/alpine
+GitCommit: e3e46b4c54b24e8c564851776e60be13e619f729
+Directory: 2.7/alpine
 
-Tags: 2.5.7, 2.5, latest, 2.5.7-bullseye, 2.5-bullseye, bullseye
+Tags: 2.6.0, 2.6, lts, latest, 2.6.0-bullseye, 2.6-bullseye, lts-bullseye, bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 0194df549ecef362ff27d0f06601ea784183428f
+Directory: 2.6
+
+Tags: 2.6.0-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.0-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 0194df549ecef362ff27d0f06601ea784183428f
+Directory: 2.6/alpine
+
+Tags: 2.5.7, 2.5, 2.5.7-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 2a634b815ba26e961f0e63501996c7bb224a9617
 Directory: 2.5
 
-Tags: 2.5.7-alpine, 2.5-alpine, alpine, 2.5.7-alpine3.16, 2.5-alpine3.16, alpine3.16
+Tags: 2.5.7-alpine, 2.5-alpine, 2.5.7-alpine3.16, 2.5-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
 Directory: 2.5/alpine
 
-Tags: 2.4.17, 2.4, lts, 2.4.17-bullseye, 2.4-bullseye, lts-bullseye
+Tags: 2.4.17, 2.4, 2.4.17-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c1ad6f1a7cf6cb8bc3baca2d490ce2c30ca58652
 Directory: 2.4
 
-Tags: 2.4.17-alpine, 2.4-alpine, lts-alpine, 2.4.17-alpine3.16, 2.4-alpine3.16, lts-alpine3.16
+Tags: 2.4.17-alpine, 2.4-alpine, 2.4.17-alpine3.16, 2.4-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4f0e37c: Merge pull request https://github.com/docker-library/haproxy/pull/186 from TimWolla/version-json
- https://github.com/docker-library/haproxy/commit/e3e46b4: Use official JSON files as the source of truth in versions.sh
- https://github.com/docker-library/haproxy/commit/7191978: Merge pull request https://github.com/docker-library/haproxy/pull/185 from TimWolla/haproxy-2.7
- https://github.com/docker-library/haproxy/commit/0194df5: Add HAProxy 2.6 / 2.7-rc
- https://github.com/docker-library/haproxy/commit/8e10625: Update 2.6-rc to 2.6-dev12