### PR TITLE
Deprecate Corretto Alpine 3.12 images

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -10,14 +10,6 @@ Tags: 8, 8u332, 8u332-al2, 8-al2-full, 8-al2-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.12, 8u332-alpine3.12, 8-alpine3.12-full, 8-alpine3.12-jdk
-Architectures: amd64
-Directory: 8/jdk/alpine/3.12
-
-Tags: 8-alpine3.12-jre, 8u332-alpine3.12-jre
-Architectures: amd64
-Directory: 8/jre/alpine/3.12
-
 Tags: 8-alpine3.13, 8u332-alpine3.13, 8-alpine3.13-full, 8-alpine3.13-jdk
 Architectures: amd64
 Directory: 8/jdk/alpine/3.13
@@ -46,10 +38,6 @@ Tags: 11, 11.0.15, 11.0.15-al2, 11-al2-full, 11-al2-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.12, 11.0.15-alpine3.12, 11-alpine3.12-full, 11-alpine3.12-jdk
-Architectures: amd64
-Directory: 11/jdk/alpine/3.12
-
 Tags: 11-alpine3.13, 11.0.15-alpine3.13, 11-alpine3.13-full, 11-alpine3.13-jdk
 Architectures: amd64
 Directory: 11/jdk/alpine/3.13
@@ -66,10 +54,6 @@ Tags: 17, 17.0.3, 17.0.3-al2, 17-al2-full, 17-al2-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.12, 17.0.3-alpine3.12, 17-alpine3.12-full, 17-alpine3.12-jdk
-Architectures: amd64
-Directory: 17/jdk/alpine/3.12
-
 Tags: 17-alpine3.13, 17.0.3-alpine3.13, 17-alpine3.13-full, 17-alpine3.13-jdk
 Architectures: amd64
 Directory: 17/jdk/alpine/3.13
@@ -85,10 +69,6 @@ Directory: 17/jdk/alpine/3.15
 Tags: 18, 18.0.1, 18.0.1-al2, 18-al2-full, 18-al2-jdk
 Architectures: amd64, arm64v8
 Directory: 18/jdk/al2
-
-Tags: 18-alpine3.12, 18.0.1-alpine3.12, 18-alpine3.12-full, 18-alpine3.12-jdk
-Architectures: amd64
-Directory: 18/jdk/alpine/3.12
 
 Tags: 18-alpine3.13, 18.0.1-alpine3.13, 18-alpine3.13-full, 18-alpine3.13-jdk
 Architectures: amd64


### PR DESCRIPTION
Alpine 3.12 is EOL. Deprecating Corretto Alpine 3.12 images.