### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.2.1, 5.2, 5, latest
+Tags: 5.2.2, 5.2, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 819c182bcd91512d5d84201ef01346b2b9f46b5e
+GitCommit: 132c23c29ba414434263699151a14cb11d35abf2
 Directory: 5/debian
 
-Tags: 5.2.1-alpine, 5.2-alpine, 5-alpine, alpine
+Tags: 5.2.2-alpine, 5.2-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 819c182bcd91512d5d84201ef01346b2b9f46b5e
+GitCommit: 132c23c29ba414434263699151a14cb11d35abf2
 Directory: 5/alpine
 
 Tags: 4.48.1, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/132c23c: Update to 5.2.2, ghost-cli 1.21.0