### PR TITLE
consul: 1.12.2

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,9 +1,9 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.12.1, 1.12, latest
+Tags: 1.12.2, 1.12, latest
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: f5c112dca034d78c5e6094e256ba5a699f761cbb
+GitCommit: 5793a49e7447c010cd163aeecb51ffbdf7bce0bf
 Directory: 0.X
 
 Tags: 1.11.6, 1.11


### PR DESCRIPTION
This updates Consul's latest and 1.12 tags to the latest release from today (June 3rd 2022).