### PR TITLE
library/perl: Revert cpanm HTTPS install by default

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,7 +1,7 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: a2d458212582f2b800bb8f1af273b9baa4ac38c8
+GitCommit: 9e28e527081bb65c9c91469836d96fd1581cca5d
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 
 Tags: 5.36.0, 5.36, 5, latest, 5.36.0-bullseye, 5.36-bullseye, 5-bullseye, bullseye


### PR DESCRIPTION
- https://github.com/Perl/docker-perl/issues/116
- https://github.com/Perl/docker-perl/pull/117