### PR TITLE
Update Clear Linux OS to 36420

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 233f400a81916332d8aad3decfd2388ac3f22700
-GitFetch: refs/heads/base-36410
+GitCommit: 208c90d60cae187a9cf4b0c7a7e6d67bf68e5b11
+GitFetch: refs/heads/base-36420


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36420

@bryteise @djklimes @bryteise