### PR TITLE
Drop arm64 builds of kong on Ubuntu

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -11,7 +11,7 @@ Tags: 2.8.1-ubuntu, 2.8-ubuntu, ubuntu
 GitCommit: fffcd0a942daba110ccb89878570b50fcff64d97
 GitFetch: refs/tags/2.8.1
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.8.0-alpine, 2.8.0
 GitCommit: c32a80c3dd332d096d1a6461d2816ead344d43c5
@@ -23,7 +23,7 @@ Tags: 2.8.0-ubuntu
 GitCommit: c32a80c3dd332d096d1a6461d2816ead344d43c5
 GitFetch: refs/tags/2.8.0
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.7.2-alpine, 2.7.2, 2.7
 GitCommit: 84e21f29904b9a407287cbddf133dc36cc38a2c0
@@ -35,7 +35,7 @@ Tags: 2.7.2-ubuntu, 2.7-ubuntu
 GitCommit: 84e21f29904b9a407287cbddf133dc36cc38a2c0
 GitFetch: refs/tags/2.7.2
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.7.1-alpine, 2.7.1
 GitCommit: d47ddd41ea2a489f36d15d3da956709bcf62dcca
@@ -47,7 +47,7 @@ Tags: 2.7.1-ubuntu
 GitCommit: d47ddd41ea2a489f36d15d3da956709bcf62dcca
 GitFetch: refs/tags/2.7.1
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.6.1-alpine, 2.6.1, 2.6
 GitCommit: 5bdbfbdf25aad9f26d136ac9f0b17793289f10a1
@@ -59,7 +59,7 @@ Tags: 2.6.1-ubuntu, 2.6-ubuntu
 GitCommit: 5bdbfbdf25aad9f26d136ac9f0b17793289f10a1
 GitFetch: refs/tags/2.6.1
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.6.0-alpine, 2.6.0
 GitCommit: 37b2520bddf243a14d28fbf616cc3cccf9906d91
@@ -71,7 +71,7 @@ Tags: 2.6.0-ubuntu
 GitCommit: 37b2520bddf243a14d28fbf616cc3cccf9906d91
 GitFetch: refs/tags/2.6.0
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.5.1-alpine, 2.5.1, 2.5
 GitCommit: 74f3a1c189c13b8f94ae15343452fcd27ccce605
@@ -83,4 +83,4 @@ Tags: 2.5.1-ubuntu, 2.5-ubuntu
 GitCommit: 74f3a1c189c13b8f94ae15343452fcd27ccce605
 GitFetch: refs/tags/2.5.1
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64


### PR DESCRIPTION
On the arm64v8 build server:
```console
+ curl -fL https://download.konghq.com/gateway-2.x-ubuntu-focal/pool/all/k/kong/kong_2.8.1_amd64.deb -o /tmp/kong.deb
...
+ apt install --yes /tmp/kong.deb
...
The following packages have unmet dependencies:
 kong:amd64 : Depends: libpcre3:amd64 but it is not installable
              Depends: perl:amd64 but it is not installable
              Depends: zlib1g-dev:amd64 but it is not installable
```

These have been failing to build for quite a while and aren't really written for an arm-based build since they download an `amd64` deb file (see [line 21 of the Dockerfile](https://github.com/Kong/docker-kong/blob/da08808ea1ea1056f26ebc1ad592ad6935eff75f/ubuntu/Dockerfile#L21)).

The download site does not seem to have `arm64v8` debs available: https://download.konghq.com/gateway-2.x-ubuntu-focal/pool/all/k/kong/.

---

cc `kong` maintainers: @kikito @hutchic; if there are newer debs in the future for arm64v8, we are glad to add this back. Related issue https://github.com/Kong/docker-kong/issues/553.