### PR TITLE
Update rust:alpine to 3.16

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/186e4d580b5581861907c015d6b58919c809e375/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/178e152b46fd79c934c350600259a9bff4e38fc1/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
 GitRepo: https://github.com/rust-lang/docker-rust.git
@@ -23,13 +23,13 @@ Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 186e4d580b5581861907c015d6b58919c809e375
 Directory: 1.61.0/bullseye/slim
 
-Tags: 1-alpine3.14, 1.61-alpine3.14, 1.61.0-alpine3.14, alpine3.14
-Architectures: amd64, arm64v8
-GitCommit: 186e4d580b5581861907c015d6b58919c809e375
-Directory: 1.61.0/alpine3.14
-
-Tags: 1-alpine3.15, 1.61-alpine3.15, 1.61.0-alpine3.15, alpine3.15, 1-alpine, 1.61-alpine, 1.61.0-alpine, alpine
+Tags: 1-alpine3.15, 1.61-alpine3.15, 1.61.0-alpine3.15, alpine3.15
 Architectures: amd64, arm64v8
 GitCommit: 186e4d580b5581861907c015d6b58919c809e375
 Directory: 1.61.0/alpine3.15
+
+Tags: 1-alpine3.16, 1.61-alpine3.16, 1.61.0-alpine3.16, alpine3.16, 1-alpine, 1.61-alpine, 1.61.0-alpine, alpine
+Architectures: amd64, arm64v8
+GitCommit: 178e152b46fd79c934c350600259a9bff4e38fc1
+Directory: 1.61.0/alpine3.16
 


### PR DESCRIPTION
This re-generates the Rust docker tags based on the latest docker-rust
master, using the `x.py` script.