### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/a04e2746f8704ea7418f17af4ca8b7001e54b29e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/5afab15a83a7c20ca754855642934f35262ccab7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: a04e2746f8704ea7418f17af4ca8b7001e54b29e
+GitCommit: 5afab15a83a7c20ca754855642934f35262ccab7
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 961fac6c16aa9395ea0036f20bdc76221a62c862
+amd64-GitCommit: 9026045e285b101a277590a161e6f8fd76b3d4bd
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d273ae613f1e54089bf12610fbaec899d2c0dade
+arm32v5-GitCommit: 78f9f82bd4f69c417e6133d9bbba6a6adff43ced
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 6e0fb53a7aa2f60fa27b85041da682f62a78173c
+arm32v6-GitCommit: de8d6ba744c1f0a4fae2b49c04409cb45dceda46
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 246f6b3cbf42952e1c0d2d0cdd50a7d33f2f4238
+arm32v7-GitCommit: 0afe5639e6ffa703a0c0e3ff7dbc3796df76d0e1
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6d732824e2972189e4606f4fb7cdd4c66072ec0c
+arm64v8-GitCommit: a60a9555a872d7fdec8116d2900aef95e227ede0
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: a256fb031f1163cafa60a04df70407c81f930015
+i386-GitCommit: ece6fa890958de4dca2451a301d8cf9891fb3f0e
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 00913a1f4cddd876eaaf0d8b978d145fd1211982
+mips64le-GitCommit: 30750e15de7727c65b29025a7d6f6e6c37c636bf
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 5d9c0d3e5413be3c95d9c0d32bf8f5ac8133df10
+ppc64le-GitCommit: 938c87fd6c8d56559ff180e381542680b26fb0f3
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 7abd4f63418acdbf7fcd30f421fa4ef5d5fd9d59
+riscv64-GitCommit: 10ec8a3882065cf5ac9fee5e206aea0327940de3
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 2ae1cd299d25e6cbbb175c77f071ff2394dc93ef
+s390x-GitCommit: 83600ae34f5943d7ec89e7b2d9dceb3b51942dd9
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/5afab15: Merge pull request https://github.com/docker-library/busybox/pull/138 from infosiftr/buildroot-2022.05
- https://github.com/docker-library/busybox/commit/f5c87df: Update buildroot to 2022.05