### PR TITLE
MediaWiki: Add 1.38, drop 1.36

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,28 +2,28 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: bc248a718e85005b966c4f84ccebc92bdce58c4f
+GitCommit: b89d9119c165d11eb3d6ee51d4aee76b04bfb077
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.37.2, 1.37, stable, latest
+Tags: 1.38.1, 1.38, stable, latest
+Directory: 1.38/apache
+
+Tags: 1.38.1-fpm, 1.38-fpm, stable-fpm
+Directory: 1.38/fpm
+
+Tags: 1.38.1-fpm-alpine, 1.38-fpm-alpine, stable-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Directory: 1.38/fpm-alpine
+
+Tags: 1.37.2, 1.37, legacy
 Directory: 1.37/apache
 
-Tags: 1.37.2-fpm, 1.37-fpm, stable-fpm
+Tags: 1.37.2-fpm, 1.37-fpm, legacy-fpm
 Directory: 1.37/fpm
 
-Tags: 1.37.2-fpm-alpine, 1.37-fpm-alpine, stable-fpm-alpine
+Tags: 1.37.2-fpm-alpine, 1.37-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.37/fpm-alpine
-
-Tags: 1.36.4, 1.36, legacy
-Directory: 1.36/apache
-
-Tags: 1.36.4-fpm, 1.36-fpm, legacy-fpm
-Directory: 1.36/fpm
-
-Tags: 1.36.4-fpm-alpine, 1.36-fpm-alpine, legacy-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-Directory: 1.36/fpm-alpine
 
 Tags: 1.35.6, 1.35, lts, legacylts
 Directory: 1.35/apache


### PR DESCRIPTION
1.38 was just released and 1.36 went EOL at the same time.

This pulls in <https://github.com/wikimedia/mediawiki-docker/pull/110>.