### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 7.0.0, 7.0, 7, latest, 7.0.0-bullseye, 7.0-bullseye, 7-bullseye, bullseye
+Tags: 7.0.1, 7.0, 7, latest, 7.0.1-bullseye, 7.0-bullseye, 7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0f2bb676ab5153905089537230a732a77d26e438
+GitCommit: 59337ef57e3714768b2adbb7f2b1bae43560bee1
 Directory: 7.0
 
-Tags: 7.0.0-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.0-alpine3.16, 7.0-alpine3.16, 7-alpine3.16, alpine3.16
+Tags: 7.0.1-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.1-alpine3.16, 7.0-alpine3.16, 7-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d36a031654f52ab95601de1f8a841765177cf702
+GitCommit: 59337ef57e3714768b2adbb7f2b1bae43560bee1
 Directory: 7.0/alpine
 
 Tags: 6.2.7, 6.2, 6, 6.2.7-bullseye, 6.2-bullseye, 6-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/59337ef: Update to 7.0.1