### PR TITLE
Odoo: update 13.0-15.0 to release 20220609

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 4184e82736e681bfc37021d2a0412714355b40dd
+GitCommit: 8358407bd99d7dbfdbb37fc0bb111ef36c9c5469
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest update of Odoo docker supported versions.

Thanks.