### PR TITLE
archlinux: Release 20220612.0.61195

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220529.0.58327
-GitCommit: 7c4a9dcb0588507fc9c23dbb07162124dad7d5ef
-GitFetch: refs/tags/v20220529.0.58327
+Tags: latest, base, base-20220612.0.61195
+GitCommit: 2aaaf4762884d44f71ce2845305e236212f3920b
+GitFetch: refs/tags/v20220612.0.61195
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220529.0.58327
-GitCommit: 7c4a9dcb0588507fc9c23dbb07162124dad7d5ef
-GitFetch: refs/tags/v20220529.0.58327
+Tags: base-devel, base-devel-20220612.0.61195
+GitCommit: 2aaaf4762884d44f71ce2845305e236212f3920b
+GitFetch: refs/tags/v20220612.0.61195
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks