### PR TITLE
Update Clear Linux OS to 36470

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 208c90d60cae187a9cf4b0c7a7e6d67bf68e5b11
-GitFetch: refs/heads/base-36420
+GitCommit: fad56b2967272a3d1fa1137d608b98a1d21df5d0
+GitFetch: refs/heads/base-36470


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36470

@bryteise @djklimes @bryteise