### PR TITLE
Bump Traefik to v2.7.1 and v2.8.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,29 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.7.0-windowsservercore-1809, 2.7.0-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
+Tags: v2.7.1-windowsservercore-1809, 2.7.1-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 980d4fad23bdcb2c57d71b8194846caf25005958
+GitCommit: 2f8d79e1a11fea6a63e2f62e6c2897ac6c5ada69
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.7.0, 2.7.0, v2.7, 2.7, epoisses, latest
+Tags: v2.7.1, 2.7.1, v2.7, 2.7, epoisses, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 980d4fad23bdcb2c57d71b8194846caf25005958
-Directory: alpine
-
-Tags: v2.6.7-windowsservercore-1809, 2.6.7-windowsservercore-1809, v2.6-windowsservercore-1809, 2.6-windowsservercore-1809, rocamadour-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 57821065c86f99c3d4519b41e2a10f3ed9a050e6
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.6.7, 2.6.7, v2.6, 2.6, rocamadour
-Architectures: amd64, arm32v6, arm64v8, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 57821065c86f99c3d4519b41e2a10f3ed9a050e6
+GitCommit: 2f8d79e1a11fea6a63e2f62e6c2897ac6c5ada69
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,18 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
+Tags: v2.8.0-rc1-windowsservercore-1809, 2.8.0-rc1-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: eb81d1e7a2b1a919070d2e626801ceb70caf2576
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.8.0-rc1, 2.8.0-rc1, v2.8, 2.8, vacherin
+Architectures: amd64, arm32v6, arm64v8, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: eb81d1e7a2b1a919070d2e626801ceb70caf2576
+Directory: alpine
+
 Tags: v2.7.1-windowsservercore-1809, 2.7.1-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.7.1](https://github.com/traefik/traefik/releases/tag/v2.7.1) and [v2.8.0-rc1](https://github.com/traefik/traefik/releases/tag/v2.8.0-rc1).

/cc @rtribotte @ldez @ddtmachado

Cheers
