### PR TITLE
Update irssi

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.2.3, 1.2, 1, latest
+Tags: 1.4.1, 1.4, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2e8af6fb56f4f54058636a1ca3cf475f95afb357
+GitCommit: 10e8961c5636481bf1dc041ca2a5c12a63dcad3d
 Directory: debian
 
-Tags: 1.2.3-alpine, 1.2-alpine, 1-alpine, alpine
+Tags: 1.4.1-alpine, 1.4-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2e8af6fb56f4f54058636a1ca3cf475f95afb357
+GitCommit: 10e8961c5636481bf1dc041ca2a5c12a63dcad3d
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/jessfraz/irssi/commit/10e8961: Update to 1.4.1, Alpine 3.16, Debian Bullseye, Meson+Ninja (https://github.com/jessfraz/irssi/pull/27)