### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-4991

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b784a7bd222393fbf1d8cf694a318029d41b5a83
+amd64-GitCommit: a88f4536c9145e7f4df9ab2b578f6515267b09fb
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1d328340b30b22137f59e50ae0c9d3c369d9de9f
+arm64v8-GitCommit: 2d1b3c9e9a1777fdafbdaf2c31682caecab094ce
 
 Tags: 8.6, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1271.

See https://linux.oracle.com/errata/ELSA-2022-4991.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>