### PR TITLE
kong: add 2.5.2, add back arm64v8

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -1,86 +1,50 @@
-Maintainers: Kong Docker Maintainers <support@konghq.com> (@thekonginc)
+Maintainers: Kong Docker Maintainers <team-gateway@konghq.com> (@team-gateway-bot)
 GitRepo: https://github.com/Kong/docker-kong.git
 
 Tags: 2.8.1-alpine, 2.8.1, 2.8, alpine, latest
-GitCommit: fffcd0a942daba110ccb89878570b50fcff64d97
+GitCommit: 8a361ad78d4f84b67e893588fd3a6108bea67fe7
 GitFetch: refs/tags/2.8.1
 Directory: alpine
 Architectures: amd64, arm64v8
 
 Tags: 2.8.1-ubuntu, 2.8-ubuntu, ubuntu
-GitCommit: fffcd0a942daba110ccb89878570b50fcff64d97
+GitCommit: 8a361ad78d4f84b67e893588fd3a6108bea67fe7
 GitFetch: refs/tags/2.8.1
 Directory: ubuntu
-Architectures: amd64
-
-Tags: 2.8.0-alpine, 2.8.0
-GitCommit: c32a80c3dd332d096d1a6461d2816ead344d43c5
-GitFetch: refs/tags/2.8.0
-Directory: alpine
 Architectures: amd64, arm64v8
 
-Tags: 2.8.0-ubuntu
-GitCommit: c32a80c3dd332d096d1a6461d2816ead344d43c5
-GitFetch: refs/tags/2.8.0
-Directory: ubuntu
-Architectures: amd64
-
 Tags: 2.7.2-alpine, 2.7.2, 2.7
-GitCommit: 84e21f29904b9a407287cbddf133dc36cc38a2c0
+GitCommit: 456bfc908ed1f4fdbb348bafcf7385aeffdd421c
 GitFetch: refs/tags/2.7.2
 Directory: alpine
 Architectures: amd64, arm64v8
 
 Tags: 2.7.2-ubuntu, 2.7-ubuntu
-GitCommit: 84e21f29904b9a407287cbddf133dc36cc38a2c0
+GitCommit: 456bfc908ed1f4fdbb348bafcf7385aeffdd421c
 GitFetch: refs/tags/2.7.2
 Directory: ubuntu
-Architectures: amd64
-
-Tags: 2.7.1-alpine, 2.7.1
-GitCommit: d47ddd41ea2a489f36d15d3da956709bcf62dcca
-GitFetch: refs/tags/2.7.1
-Directory: alpine
 Architectures: amd64, arm64v8
 
-Tags: 2.7.1-ubuntu
-GitCommit: d47ddd41ea2a489f36d15d3da956709bcf62dcca
-GitFetch: refs/tags/2.7.1
-Directory: ubuntu
-Architectures: amd64
-
 Tags: 2.6.1-alpine, 2.6.1, 2.6
-GitCommit: 5bdbfbdf25aad9f26d136ac9f0b17793289f10a1
+GitCommit: aa4cf106f8933033f433cacc8f073fa4dbbeac21
 GitFetch: refs/tags/2.6.1
 Directory: alpine
 Architectures: amd64, arm64v8
 
 Tags: 2.6.1-ubuntu, 2.6-ubuntu
-GitCommit: 5bdbfbdf25aad9f26d136ac9f0b17793289f10a1
+GitCommit: aa4cf106f8933033f433cacc8f073fa4dbbeac21
 GitFetch: refs/tags/2.6.1
 Directory: ubuntu
-Architectures: amd64
+Architectures: amd64, arm64v8
 
-Tags: 2.6.0-alpine, 2.6.0
-GitCommit: 37b2520bddf243a14d28fbf616cc3cccf9906d91
-GitFetch: refs/tags/2.6.0
+Tags: 2.5.2-alpine, 2.5.2, 2.5
+GitCommit: e6fbd10247d55eba63db13216666f9db4c6d3363
+GitFetch: refs/tags/2.5.2
 Directory: alpine
 Architectures: amd64, arm64v8
 
-Tags: 2.6.0-ubuntu
-GitCommit: 37b2520bddf243a14d28fbf616cc3cccf9906d91
-GitFetch: refs/tags/2.6.0
+Tags: 2.5.2-ubuntu, 2.5-ubuntu
+GitCommit: e6fbd10247d55eba63db13216666f9db4c6d3363
+GitFetch: refs/tags/2.5.2
 Directory: ubuntu
-Architectures: amd64
-
-Tags: 2.5.1-alpine, 2.5.1, 2.5
-GitCommit: 74f3a1c189c13b8f94ae15343452fcd27ccce605
-GitFetch: refs/tags/2.5.1
-Directory: alpine
 Architectures: amd64, arm64v8
-
-Tags: 2.5.1-ubuntu, 2.5-ubuntu
-GitCommit: 74f3a1c189c13b8f94ae15343452fcd27ccce605
-GitFetch: refs/tags/2.5.1
-Directory: ubuntu
-Architectures: amd64


### PR DESCRIPTION
- Add Kong 2.5.2
- Add back arm64v8 to all of 2.5, 2.6, 2.7, and 2.8 series
- Change maintainers to Team Gateway aliases (@team-gateway-bot results
  in a notification being sent to the team email alias)