### PR TITLE
[oraclelinux] Update 7 and 7-slim for ELSA-2022-5052

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a88f4536c9145e7f4df9ab2b578f6515267b09fb
+amd64-GitCommit: 394d63b6fcd0d8ba95b3c030d8d36d0fb74fd4e7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2d1b3c9e9a1777fdafbdaf2c31682caecab094ce
+arm64v8-GitCommit: 98e8439a11d14d20a7ca58f07311427e0ac236ed
 
 Tags: 8.6, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1271.

See https://linux.oracle.com/errata/ELSA-2022-5052.html for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>