### PR TITLE
Updating Dockerfile for older Couchbase Server images

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -18,9 +18,9 @@ GitCommit: aec4494ab5280caf567997d72714f57572a6315b
 Directory: community/couchbase-server/7.0.2
 
 Tags: 6.6.5, enterprise-6.6.5
-GitCommit: b9ef0fefa25a0ca646bf746765f66bf33ee3fac7
+GitCommit: aad4aa9714578906c0c993121654eaeba0bd907c
 Directory: enterprise/couchbase-server/6.6.5
 
 Tags: community-6.6.0
-GitCommit: 5929be778eb5306f116f71cc9a0a23fea6d9a7aa
+GitCommit: aad4aa9714578906c0c993121654eaeba0bd907c
 Directory: community/couchbase-server/6.6.0


### PR DESCRIPTION
These have a workaround which should allow them to build on Docker's infrastructure.