### PR TITLE
arangodb 3.9.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -10,6 +10,6 @@ Tags: 3.8, 3.8.7
 GitCommit: 0e1a717e606a4fd6fa406fdb26bf5cc61486d0e5
 Directory: alpine/3.8.7
 
-Tags: 3.9, 3.9.1, latest
-GitCommit: fbffe152059676e01c686b7fca6843cdac7769cd
-Directory: alpine/3.9.1
+Tags: 3.9, 3.9.2, latest
+GitCommit: d04f072245c99c77b3c8c8f6a40c9061603eefd5
+Directory: alpine/3.9.2


### PR DESCRIPTION
Updated ArangoDB 3.9 to 3.9.2.