### PR TITLE
archlinux: Release 20220619.0.62803

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220612.0.61195
-GitCommit: 2aaaf4762884d44f71ce2845305e236212f3920b
-GitFetch: refs/tags/v20220612.0.61195
+Tags: latest, base, base-20220619.0.62803
+GitCommit: 7bf5e9bc410c1fcee420bed68b14b9fd6d03e585
+GitFetch: refs/tags/v20220619.0.62803
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220612.0.61195
-GitCommit: 2aaaf4762884d44f71ce2845305e236212f3920b
-GitFetch: refs/tags/v20220612.0.61195
+Tags: base-devel, base-devel-20220619.0.62803
+GitCommit: 7bf5e9bc410c1fcee420bed68b14b9fd6d03e585
+GitFetch: refs/tags/v20220619.0.62803
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks