### PR TITLE
Update Clear Linux OS to 36510

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: fad56b2967272a3d1fa1137d608b98a1d21df5d0
-GitFetch: refs/heads/base-36470
+GitCommit: 6cb2e1994577d7a178afb7a14a4213ef6e7a14bf
+GitFetch: refs/heads/base-36510


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36510

@bryteise @djklimes @bryteise