### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,33 +1,32 @@
 Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
-             Frédérick Lefebvre (@fred-lefebvre),
-             Stewart Smith (@stewartsmith),
-             Christopher Miller (@mysteriouspants),
-             Sumit Tomer (@sktomer),
-             Sean Kelly (@cbgbt),
-             Tanu Rampal (@trampal),
-             Kyle Gosselin-Harris (@kgharris),
-             Sam Thornton (@mrthornazon),
-             Preston Carpenter (@timidger),
-             Richard Kelly (@rpkelly),
-             Joseph Howell-Burke (@jhowell-burke),
-	     Joe Gawrieh (@theOtherJoe),
-	     CJ Harris (@mrcjplease)
+            Frédérick Lefebvre (@fred-lefebvre),
+            Stewart Smith (@stewartsmith),
+            Christopher Miller (@mysteriouspants),
+            Sumit Tomer (@sktomer),
+            Sean Kelly (@cbgbt),
+            Tanu Rampal (@trampal),
+            Sam Thornton (@mrthornazon),
+            Preston Carpenter (@timidger),
+            Richard Kelly (@rpkelly),
+            Joseph Howell-Burke (@jhowell-burke),
+            Joe Gawrieh (@theOtherJoe),
+            CJ Harris (@mrcjplease)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 0ce5724417d1fea4ad681d8683bea4237ce980c6
+GitCommit: 10e497f0474cc252f95cfd390c435645041bface
 
-Tags: 2.0.20220426.0, 2, latest
+Tags: 2.0.20220606.1, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 7f5bc7447a2d475aea0383912f6abce963e04223
+amd64-GitCommit: c40d99df881e3ffdf7e4afc75f63c5d7e9e9cdff
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: dce821d6adae5aef9952036e36ad84c95dcc92b3
+arm64v8-GitCommit: dfa668c553b7a55b45e1ac0563d2e1fd3065208b
 
-Tags: 2.0.20220426.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20220606.1-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 9e7db79f3c6d8599246d8432508337b3e9acf555
+amd64-GitCommit: 5a5b6a174313cfcc9b257cbfb3edcae37a8dd186
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 13791a82b9dbe5092626d1278096302491f9095f
+arm64v8-GitCommit: 31e8c3ce20300fda6123e190cf579315e26f843e
 
 Tags: 2018.03.0.20220503.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains security updates for the following packages.
Also noted are the specific CVEs addressed for each package.

'openssl-1.0.2k-24.amzn2.0.3'
    CVE-2022-1292
'python-2.7.18-1.amzn2.0.5'
    CVE-2020-27619
    CVE-2021-23336
    CVE-2021-3733
    CVE-2021-3737
    CVE-2021-4189
    CVE-2022-0391
'curl-7.79.1-2.amzn2.0.1'
    CVE-2022-22576
    CVE-2022-27774
    CVE-2022-27775
    CVE-2022-27776
'openldap-2.4.44-23.amzn2.0.4'
    CVE-2022-29155