### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e3e46b4c54b24e8c564851776e60be13e619f729
 Directory: 2.7/alpine
 
-Tags: 2.6.0, 2.6, lts, latest, 2.6.0-bullseye, 2.6-bullseye, lts-bullseye, bullseye
+Tags: 2.6.1, 2.6, lts, latest, 2.6.1-bullseye, 2.6-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0194df549ecef362ff27d0f06601ea784183428f
+GitCommit: 2fea26446051f614031302028cef768b627da26a
 Directory: 2.6
 
-Tags: 2.6.0-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.0-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
+Tags: 2.6.1-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.1-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0194df549ecef362ff27d0f06601ea784183428f
+GitCommit: 2fea26446051f614031302028cef768b627da26a
 Directory: 2.6/alpine
 
 Tags: 2.5.7, 2.5, 2.5.7-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2fea264: Update 2.6 to 2.6.1