### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.10.5, 3.10, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: e913e539a9014314c68a88b4fc20fcf107e019cf
+GitCommit: bcc9931d020300b38cab6dcbe9c03c248c8774d4
 Directory: 3.10/ubuntu
 
 Tags: 3.10.5-management, 3.10-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.5-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e913e539a9014314c68a88b4fc20fcf107e019cf
+GitCommit: bcc9931d020300b38cab6dcbe9c03c248c8774d4
 Directory: 3.10/alpine
 
 Tags: 3.10.5-management-alpine, 3.10-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.20, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: e913e539a9014314c68a88b4fc20fcf107e019cf
+GitCommit: 54e1bac1b9ad7457b8cffc566783aca959d32d1d
 Directory: 3.9/ubuntu
 
 Tags: 3.9.20-management, 3.9-management
@@ -36,7 +36,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.20-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e913e539a9014314c68a88b4fc20fcf107e019cf
+GitCommit: 54e1bac1b9ad7457b8cffc566783aca959d32d1d
 Directory: 3.9/alpine
 
 Tags: 3.9.20-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/54e1bac: Update 3.9 to openssl 1.1.1p, otp 24.3.4.2
- https://github.com/docker-library/rabbitmq/commit/bcc9931: Update 3.10 to openssl 1.1.1p, otp 24.3.4.2