### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -28,15 +28,15 @@ amd64-GitCommit: 5a5b6a174313cfcc9b257cbfb3edcae37a8dd186
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 31e8c3ce20300fda6123e190cf579315e26f843e
 
-Tags: 2018.03.0.20220503.0, 2018.03, 1
+Tags: 2018.03.0.20220609.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 61f736f29a376b3e5449cd3247d8f2e0b0f2180a
+amd64-GitCommit: 7a44cc6ff549a6b4abc33d73bca88eae66c31ddc
 
-Tags: 2018.03.0.20220503.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20220609.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 1076f30acaf2d9759d2c4466c613457af88cb61f
+amd64-GitCommit: 46eae60b7768b53eba5fce016d3081d23fd4a670
 
 Tags: 2022.0.20220504.1, 2022, devel
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This container release contains security updates for the following packages.
Also noted are the specific CVEs addressed for each package.

#### python27-2.7.18-2.142.amzn1
- CVE-2020-27619
- CVE-2021-23336
- CVE-2021-3733
- CVE-2021-3737
- CVE-2021-4189
- CVE-2022-0391

#### gzip-1.5-9.20.amzn1
- CVE-2022-1271

#### openldap-2.4.40-16.32.amzn1
- CVE-2022-29155

#### xz-5.2.2-1.14.amzn1
- CVE-2022-1271

#### expat-2.1.0-12.28.amzn1
- CVE-2021-45960