### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,147 +1,131 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: a0b6bf3c36ea7084372c442c51be38f7ddcb8bb8
+GitCommit: 05ed97521c0459bd0662907dd91958869a72158a
 Directory: dockerfiles-generated
 
-Tags: 1.0a4-python3.10-bullseye, python3.10-bullseye, 1.0a4-bullseye, bullseye
-SharedTags: 1.0a4-python3.10, python3.10, 1.0a4, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 0.24.0-python3.10-bullseye, 0.24-python3.10-bullseye, 0-python3.10-bullseye, python3.10-bullseye, 0.24.0-bullseye, 0.24-bullseye, 0-bullseye, bullseye
+SharedTags: 0.24.0-python3.10, 0.24-python3.10, 0-python3.10, python3.10, 0.24.0, 0.24, 0, latest
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.10-bullseye
 
-Tags: 1.0a4-python3.10-buster, python3.10-buster, 1.0a4-buster, buster
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Tags: 0.24.0-python3.10-buster, 0.24-python3.10-buster, 0-python3.10-buster, python3.10-buster, 0.24.0-buster, 0.24-buster, 0-buster, buster
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.10-buster
 
-Tags: 1.0a4-python3.10-alpine3.15, python3.10-alpine3.15, 1.0a4-alpine3.15, alpine3.15, 1.0a4-python3.10-alpine, python3.10-alpine, 1.0a4-alpine, alpine
+Tags: 0.24.0-python3.10-alpine3.15, 0.24-python3.10-alpine3.15, 0-python3.10-alpine3.15, python3.10-alpine3.15, 0.24.0-alpine3.15, 0.24-alpine3.15, 0-alpine3.15, alpine3.15, 0.24.0-python3.10-alpine, 0.24-python3.10-alpine, 0-python3.10-alpine, python3.10-alpine, 0.24.0-alpine, 0.24-alpine, 0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-alpine3.15
 
-Tags: 1.0a4-python3.10-alpine3.14, python3.10-alpine3.14, 1.0a4-alpine3.14, alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.10-alpine3.14
-
-Tags: 1.0a4-python3.9-bullseye, python3.9-bullseye
-SharedTags: 1.0a4-python3.9, python3.9
+Tags: 0.24.0-python3.9-bullseye, 0.24-python3.9-bullseye, 0-python3.9-bullseye, python3.9-bullseye
+SharedTags: 0.24.0-python3.9, 0.24-python3.9, 0-python3.9, python3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.9-bullseye
 
-Tags: 1.0a4-python3.9-buster, python3.9-buster
+Tags: 0.24.0-python3.9-buster, 0.24-python3.9-buster, 0-python3.9-buster, python3.9-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.9-buster
 
-Tags: 1.0a4-python3.9-alpine3.15, python3.9-alpine3.15, 1.0a4-python3.9-alpine, python3.9-alpine
+Tags: 0.24.0-python3.9-alpine3.15, 0.24-python3.9-alpine3.15, 0-python3.9-alpine3.15, python3.9-alpine3.15, 0.24.0-python3.9-alpine, 0.24-python3.9-alpine, 0-python3.9-alpine, python3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.9-alpine3.15
 
-Tags: 1.0a4-python3.9-alpine3.14, python3.9-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.9-alpine3.14
-
-Tags: 1.0a4-python3.9-windowsservercore-ltsc2022, python3.9-windowsservercore-ltsc2022
-SharedTags: 1.0a4-python3.9, python3.9
+Tags: 0.24.0-python3.9-windowsservercore-ltsc2022, 0.24-python3.9-windowsservercore-ltsc2022, 0-python3.9-windowsservercore-ltsc2022, python3.9-windowsservercore-ltsc2022
+SharedTags: 0.24.0-python3.9, 0.24-python3.9, 0-python3.9, python3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 File: Dockerfile.python3.9-windowsservercore-ltsc2022
 
-Tags: 1.0a4-python3.9-windowsservercore-1809, python3.9-windowsservercore-1809
-SharedTags: 1.0a4-python3.9, python3.9
+Tags: 0.24.0-python3.9-windowsservercore-1809, 0.24-python3.9-windowsservercore-1809, 0-python3.9-windowsservercore-1809, python3.9-windowsservercore-1809
+SharedTags: 0.24.0-python3.9, 0.24-python3.9, 0-python3.9, python3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.python3.9-windowsservercore-1809
 
-Tags: 1.0a4-python3.8-bullseye, python3.8-bullseye
-SharedTags: 1.0a4-python3.8, python3.8
+Tags: 0.24.0-python3.8-bullseye, 0.24-python3.8-bullseye, 0-python3.8-bullseye, python3.8-bullseye
+SharedTags: 0.24.0-python3.8, 0.24-python3.8, 0-python3.8, python3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.8-bullseye
 
-Tags: 1.0a4-python3.8-buster, python3.8-buster
+Tags: 0.24.0-python3.8-buster, 0.24-python3.8-buster, 0-python3.8-buster, python3.8-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.8-buster
 
-Tags: 1.0a4-python3.8-alpine3.15, python3.8-alpine3.15, 1.0a4-python3.8-alpine, python3.8-alpine
+Tags: 0.24.0-python3.8-alpine3.15, 0.24-python3.8-alpine3.15, 0-python3.8-alpine3.15, python3.8-alpine3.15, 0.24.0-python3.8-alpine, 0.24-python3.8-alpine, 0-python3.8-alpine, python3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.8-alpine3.15
 
-Tags: 1.0a4-python3.8-alpine3.14, python3.8-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.8-alpine3.14
-
-Tags: 1.0a4-python3.7-bullseye, python3.7-bullseye
-SharedTags: 1.0a4-python3.7, python3.7
+Tags: 0.24.0-python3.7-bullseye, 0.24-python3.7-bullseye, 0-python3.7-bullseye, python3.7-bullseye
+SharedTags: 0.24.0-python3.7, 0.24-python3.7, 0-python3.7, python3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.7-bullseye
 
-Tags: 1.0a4-python3.7-buster, python3.7-buster
+Tags: 0.24.0-python3.7-buster, 0.24-python3.7-buster, 0-python3.7-buster, python3.7-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.7-buster
 
-Tags: 1.0a4-python3.7-alpine3.15, python3.7-alpine3.15, 1.0a4-python3.7-alpine, python3.7-alpine
+Tags: 0.24.0-python3.7-alpine3.15, 0.24-python3.7-alpine3.15, 0-python3.7-alpine3.15, python3.7-alpine3.15, 0.24.0-python3.7-alpine, 0.24-python3.7-alpine, 0-python3.7-alpine, python3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.7-alpine3.15
 
-Tags: 1.0a4-python3.7-alpine3.14, python3.7-alpine3.14
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-File: Dockerfile.python3.7-alpine3.14
-
-Tags: 1.0a4-pypy3.9-bullseye, pypy3.9-bullseye
-SharedTags: 1.0a4-pypy3.9, pypy3.9
+Tags: 0.24.0-pypy3.9-bullseye, 0.24-pypy3.9-bullseye, 0-pypy3.9-bullseye, pypy3.9-bullseye
+SharedTags: 0.24.0-pypy3.9, 0.24-pypy3.9, 0-pypy3.9, pypy3.9
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.9-bullseye
 
-Tags: 1.0a4-pypy3.9-buster, pypy3.9-buster
+Tags: 0.24.0-pypy3.9-buster, 0.24-pypy3.9-buster, 0-pypy3.9-buster, pypy3.9-buster
 Architectures: amd64, arm64v8, i386, s390x
 File: Dockerfile.pypy3.9-buster
 
-Tags: 1.0a4-pypy3.9-windowsservercore-ltsc2022, pypy3.9-windowsservercore-ltsc2022
-SharedTags: 1.0a4-pypy3.9, pypy3.9
+Tags: 0.24.0-pypy3.9-windowsservercore-ltsc2022, 0.24-pypy3.9-windowsservercore-ltsc2022, 0-pypy3.9-windowsservercore-ltsc2022, pypy3.9-windowsservercore-ltsc2022
+SharedTags: 0.24.0-pypy3.9, 0.24-pypy3.9, 0-pypy3.9, pypy3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 File: Dockerfile.pypy3.9-windowsservercore-ltsc2022
 
-Tags: 1.0a4-pypy3.9-windowsservercore-1809, pypy3.9-windowsservercore-1809
-SharedTags: 1.0a4-pypy3.9, pypy3.9
+Tags: 0.24.0-pypy3.9-windowsservercore-1809, 0.24-pypy3.9-windowsservercore-1809, 0-pypy3.9-windowsservercore-1809, pypy3.9-windowsservercore-1809
+SharedTags: 0.24.0-pypy3.9, 0.24-pypy3.9, 0-pypy3.9, pypy3.9
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.pypy3.9-windowsservercore-1809
 
-Tags: 1.0a4-pypy3.8-bullseye, pypy3.8-bullseye, 1.0a4-pypy-bullseye, pypy-bullseye
-SharedTags: 1.0a4-pypy3.8, pypy3.8, 1.0a4-pypy, pypy
+Tags: 0.24.0-pypy3.8-bullseye, 0.24-pypy3.8-bullseye, 0-pypy3.8-bullseye, pypy3.8-bullseye, 0.24.0-pypy-bullseye, 0.24-pypy-bullseye, 0-pypy-bullseye, pypy-bullseye
+SharedTags: 0.24.0-pypy3.8, 0.24-pypy3.8, 0-pypy3.8, pypy3.8, 0.24.0-pypy, 0.24-pypy, 0-pypy, pypy
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.8-bullseye
 
-Tags: 1.0a4-pypy3.8-buster, pypy3.8-buster, 1.0a4-pypy-buster, pypy-buster
+Tags: 0.24.0-pypy3.8-buster, 0.24-pypy3.8-buster, 0-pypy3.8-buster, pypy3.8-buster, 0.24.0-pypy-buster, 0.24-pypy-buster, 0-pypy-buster, pypy-buster
 Architectures: amd64, arm64v8, i386, s390x
 File: Dockerfile.pypy3.8-buster
 
-Tags: 1.0a4-pypy3.8-windowsservercore-ltsc2022, pypy3.8-windowsservercore-ltsc2022, 1.0a4-pypy-windowsservercore-ltsc2022, pypy-windowsservercore-ltsc2022
-SharedTags: 1.0a4-pypy3.8, pypy3.8, 1.0a4-pypy, pypy
+Tags: 0.24.0-pypy3.8-windowsservercore-ltsc2022, 0.24-pypy3.8-windowsservercore-ltsc2022, 0-pypy3.8-windowsservercore-ltsc2022, pypy3.8-windowsservercore-ltsc2022, 0.24.0-pypy-windowsservercore-ltsc2022, 0.24-pypy-windowsservercore-ltsc2022, 0-pypy-windowsservercore-ltsc2022, pypy-windowsservercore-ltsc2022
+SharedTags: 0.24.0-pypy3.8, 0.24-pypy3.8, 0-pypy3.8, pypy3.8, 0.24.0-pypy, 0.24-pypy, 0-pypy, pypy
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 File: Dockerfile.pypy3.8-windowsservercore-ltsc2022
 
-Tags: 1.0a4-pypy3.8-windowsservercore-1809, pypy3.8-windowsservercore-1809, 1.0a4-pypy-windowsservercore-1809, pypy-windowsservercore-1809
-SharedTags: 1.0a4-pypy3.8, pypy3.8, 1.0a4-pypy, pypy
+Tags: 0.24.0-pypy3.8-windowsservercore-1809, 0.24-pypy3.8-windowsservercore-1809, 0-pypy3.8-windowsservercore-1809, pypy3.8-windowsservercore-1809, 0.24.0-pypy-windowsservercore-1809, 0.24-pypy-windowsservercore-1809, 0-pypy-windowsservercore-1809, pypy-windowsservercore-1809
+SharedTags: 0.24.0-pypy3.8, 0.24-pypy3.8, 0-pypy3.8, pypy3.8, 0.24.0-pypy, 0.24-pypy, 0-pypy, pypy
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.pypy3.8-windowsservercore-1809
 
-Tags: 1.0a4-pypy3.7-bullseye, pypy3.7-bullseye
-SharedTags: 1.0a4-pypy3.7, pypy3.7
+Tags: 0.24.0-pypy3.7-bullseye, 0.24-pypy3.7-bullseye, 0-pypy3.7-bullseye, pypy3.7-bullseye
+SharedTags: 0.24.0-pypy3.7, 0.24-pypy3.7, 0-pypy3.7, pypy3.7
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.7-bullseye
 
-Tags: 1.0a4-pypy3.7-buster, pypy3.7-buster
+Tags: 0.24.0-pypy3.7-buster, 0.24-pypy3.7-buster, 0-pypy3.7-buster, pypy3.7-buster
 Architectures: amd64, arm64v8, i386, s390x
 File: Dockerfile.pypy3.7-buster
 
-Tags: 1.0a4-pypy3.7-windowsservercore-ltsc2022, pypy3.7-windowsservercore-ltsc2022
-SharedTags: 1.0a4-pypy3.7, pypy3.7
+Tags: 0.24.0-pypy3.7-windowsservercore-ltsc2022, 0.24-pypy3.7-windowsservercore-ltsc2022, 0-pypy3.7-windowsservercore-ltsc2022, pypy3.7-windowsservercore-ltsc2022
+SharedTags: 0.24.0-pypy3.7, 0.24-pypy3.7, 0-pypy3.7, pypy3.7
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 File: Dockerfile.pypy3.7-windowsservercore-ltsc2022
 
-Tags: 1.0a4-pypy3.7-windowsservercore-1809, pypy3.7-windowsservercore-1809
-SharedTags: 1.0a4-pypy3.7, pypy3.7
+Tags: 0.24.0-pypy3.7-windowsservercore-1809, 0.24-pypy3.7-windowsservercore-1809, 0-pypy3.7-windowsservercore-1809, pypy3.7-windowsservercore-1809
+SharedTags: 0.24.0-pypy3.7, 0.24-pypy3.7, 0-pypy3.7, pypy3.7
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 File: Dockerfile.pypy3.7-windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/64eabdb: Merge pull request https://github.com/hylang/docker-hylang/pull/5 from tianon/update
- https://github.com/hylang/docker-hylang/commit/05ed975: Update to Hy 0.24.0, Hyrule 0.2

See also https://github.com/hylang/hy/releases/tag/0.24.0, especially:

> This release is a direct successor to 1.0a4. We've returned to 0.* version numbers to work around the inflexibility of PyPI and pip regarding the default version to install. (We skipped some version numbers because this release is several major releases since 0.20.0.) Sorry for the mess.