### PR TITLE
Update r-base to 4.2.1 released yesterday morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.2.0, latest
+Tags: 4.2.1, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f69d608f08f472438672ec34f430141ea84c509a
-Directory: r-base/4.2.0
+GitCommit: dedd29461f0952fef9b432a58e2540ad58305a42
+Directory: r-base/4.2.1
 


### PR DESCRIPTION
Standard update of r-base to the new upstream release 4.2.1 made yesterday using the updated Debian binaries

No other container changes