### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,62 +4,62 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.1.4-php7.4-apache, 4.1-php7.4-apache, 4-php7.4-apache, php7.4-apache
+Tags: 4.1.5-php7.4-apache, 4.1-php7.4-apache, 4-php7.4-apache, php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php7.4/apache
 
-Tags: 4.1.4-php7.4-fpm-alpine, 4.1-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 4.1.5-php7.4-fpm-alpine, 4.1-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php7.4/fpm-alpine
 
-Tags: 4.1.4-php7.4-fpm, 4.1-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
+Tags: 4.1.5-php7.4-fpm, 4.1-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php7.4/fpm
 
-Tags: 4.1.4, 4.1, 4, latest, 4.1.4-apache, 4.1-apache, 4-apache, apache, 4.1.4-php8.0, 4.1-php8.0, 4-php8.0, php8.0, 4.1.4-php8.0-apache, 4.1-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.1.5, 4.1, 4, latest, 4.1.5-apache, 4.1-apache, 4-apache, apache, 4.1.5-php8.0, 4.1-php8.0, 4-php8.0, php8.0, 4.1.5-php8.0-apache, 4.1-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php8.0/apache
 
-Tags: 4.1.4-php8.0-fpm-alpine, 4.1-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.1.5-php8.0-fpm-alpine, 4.1-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php8.0/fpm-alpine
 
-Tags: 4.1.4-php8.0-fpm, 4.1-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.1.5-php8.0-fpm, 4.1-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php8.0/fpm
 
-Tags: 4.1.4-php8.1-apache, 4.1-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.1.5-php8.1-apache, 4.1-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php8.1/apache
 
-Tags: 4.1.4-php8.1-fpm-alpine, 4.1-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.1.5-php8.1-fpm-alpine, 4.1-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php8.1/fpm-alpine
 
-Tags: 4.1.4-php8.1-fpm, 4.1-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.1.5-php8.1-fpm, 4.1-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3dff823ef94d5edddf5c3c880b144f82e75e4678
+GitCommit: 62dba686c098b97ecec6b017049bf46c8c14ba9e
 Directory: 4.1/php8.1/fpm
 
-Tags: 3.10.9, 3.10, 3, 3.10.9-apache, 3.10-apache, 3-apache, 3.10.9-php7.4, 3.10-php7.4, 3-php7.4, 3.10.9-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
+Tags: 3.10.10, 3.10, 3, 3.10.10-apache, 3.10-apache, 3-apache, 3.10.10-php7.4, 3.10-php7.4, 3-php7.4, 3.10.10-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4549508c7be302e9c2afa8fe8050f2ea74598075
+GitCommit: bb9b5cdaf8e4870496ee634f0fe7925d7940aad2
 Directory: 3.10/php7.4/apache
 
-Tags: 3.10.9-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
+Tags: 3.10.10-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4549508c7be302e9c2afa8fe8050f2ea74598075
+GitCommit: bb9b5cdaf8e4870496ee634f0fe7925d7940aad2
 Directory: 3.10/php7.4/fpm-alpine
 
-Tags: 3.10.9-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
+Tags: 3.10.10-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4549508c7be302e9c2afa8fe8050f2ea74598075
+GitCommit: bb9b5cdaf8e4870496ee634f0fe7925d7940aad2
 Directory: 3.10/php7.4/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@62dba68 Update images of Joomla! 4.1.4 to 4.1.5
- joomla-docker/docker-joomla@7a3b0ff Update version of Joomla! 4.1.4 to 4.1.5
- joomla-docker/docker-joomla@bb9b5cd Update images of Joomla! 3.10.9 to 3.10.10
- joomla-docker/docker-joomla@95eebaa Update version of Joomla! 3.10.9 to 3.10.10
- joomla-docker/docker-joomla@db49b92 Adds opcache-recommended.ini & error-logging.ini & remoteip.conf also adding ghostscript and gd with freetype and webp to all docker images.
- joomla-docker/docker-joomla@4fab42e Improve the way the package URL is added to the images, so we can add beta image to the official images if we wanted to. Adds opcache-recommended.ini & error-logging.ini & remoteip.conf also adding ghostscript and gd with freetype and webp to global dockerfile template.