### PR TITLE
Bump Traefik to v2.8.0-rc2 and v2.7.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: da7e7f7fc174a4c129776872262039574c09ea48
 Directory: alpine
 
-Tags: v2.7.1-windowsservercore-1809, 2.7.1-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
+Tags: v2.7.2-windowsservercore-1809, 2.7.2-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2f8d79e1a11fea6a63e2f62e6c2897ac6c5ada69
+GitCommit: 0e5deda4f5f5a03ca6c748961eb3b1f0317914de
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.7.1, 2.7.1, v2.7, 2.7, epoisses, latest
+Tags: v2.7.2, 2.7.2, v2.7, 2.7, epoisses, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2f8d79e1a11fea6a63e2f62e6c2897ac6c5ada69
+GitCommit: 0e5deda4f5f5a03ca6c748961eb3b1f0317914de
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.8.0-rc1-windowsservercore-1809, 2.8.0-rc1-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809
+Tags: v2.8.0-rc2-windowsservercore-1809, 2.8.0-rc2-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: eb81d1e7a2b1a919070d2e626801ceb70caf2576
+GitCommit: da7e7f7fc174a4c129776872262039574c09ea48
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.8.0-rc1, 2.8.0-rc1, v2.8, 2.8, vacherin
+Tags: v2.8.0-rc2, 2.8.0-rc2, v2.8, 2.8, vacherin
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: eb81d1e7a2b1a919070d2e626801ceb70caf2576
+GitCommit: da7e7f7fc174a4c129776872262039574c09ea48
 Directory: alpine
 
 Tags: v2.7.1-windowsservercore-1809, 2.7.1-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.8.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.8.0-rc2) and [v2.7.2](https://github.com/traefik/traefik/releases/tag/v2.7.2).

/cc @rtribotte @ldez @ddtmachado

Cheers
