### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 4c1b73e7046422ca1339b76935c2e2f4251b9c20
+GitCommit: 038fb86c696159554fb1e7f9f43a7d72de872748
 Directory: 22.06-rc
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.17, 20.10, 20, latest, 20.10.17-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 034e1d03eaf2c35ce4a21c4a4b621e2d2174b62e
+GitCommit: c4bcedc4850e5f50313ec84d057b1f47fbdfbf5f
 Directory: 20.10
 
 Tags: 20.10.17-dind, 20.10-dind, 20-dind, dind, 20.10.17-dind-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/038fb86: Update 22.06-rc to compose 2.6.1
- https://github.com/docker-library/docker/commit/c4bcedc: Update 20.10 to compose 2.6.1