### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.7-dev0, 2.7-dev, 2.7-dev0-bullseye, 2.7-dev-bullseye
+Tags: 2.7-dev1, 2.7-dev, 2.7-dev1-bullseye, 2.7-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e3e46b4c54b24e8c564851776e60be13e619f729
+GitCommit: fc61eb99aa22c59229b212d83a3c9096a442df2c
 Directory: 2.7
 
-Tags: 2.7-dev0-alpine, 2.7-dev-alpine, 2.7-dev0-alpine3.16, 2.7-dev-alpine3.16
+Tags: 2.7-dev1-alpine, 2.7-dev-alpine, 2.7-dev1-alpine3.16, 2.7-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e3e46b4c54b24e8c564851776e60be13e619f729
+GitCommit: fc61eb99aa22c59229b212d83a3c9096a442df2c
 Directory: 2.7/alpine
 
 Tags: 2.6.1, 2.6, lts, latest, 2.6.1-bullseye, 2.6-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fc61eb9: Update 2.7 to 2.7-dev1