### PR TITLE
Bump IBM Java version to 1.8.0_sr6fp11 (8.0.6.11).

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -5,16 +5,16 @@ GitRepo: https://github.com/ibmruntimes/ci.docker.git
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
+GitCommit: a53c065b96cb945de7cbb4dc06053547755c3035
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-sfj, sfj
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
+GitCommit: a53c065b96cb945de7cbb4dc06053547755c3035
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sdk, sdk
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 2fc92061c8367eb1a8b3a5350700eec06f8d8ee8
+GitCommit: a53c065b96cb945de7cbb4dc06053547755c3035
 Directory: ibmjava/8/sdk/ubuntu
 


### PR DESCRIPTION
Request to merge 1.8.0_sr6fp11  version update changes. 