### PR TITLE
Bump Traefik to v2.8.0 and v2.7.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 618ff8df94a75762ae97ff4d99736ba52fe5bbbe
 Directory: alpine
 
-Tags: v2.7.2-windowsservercore-1809, 2.7.2-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809
+Tags: v2.7.3-windowsservercore-1809, 2.7.3-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0e5deda4f5f5a03ca6c748961eb3b1f0317914de
+GitCommit: 08f121c70d79bdeeb04f02a36eddebe55e13c63c
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.7.2, 2.7.2, v2.7, 2.7, epoisses
+Tags: v2.7.3, 2.7.3, v2.7, 2.7, epoisses
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0e5deda4f5f5a03ca6c748961eb3b1f0317914de
+GitCommit: 08f121c70d79bdeeb04f02a36eddebe55e13c63c
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,26 +1,26 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.8.0-rc2-windowsservercore-1809, 2.8.0-rc2-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809
+Tags: v2.8.0-windowsservercore-1809, 2.8.0-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: da7e7f7fc174a4c129776872262039574c09ea48
+GitCommit: 618ff8df94a75762ae97ff4d99736ba52fe5bbbe
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.8.0-rc2, 2.8.0-rc2, v2.8, 2.8, vacherin
+Tags: v2.8.0, 2.8.0, v2.8, 2.8, vacherin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: da7e7f7fc174a4c129776872262039574c09ea48
+GitCommit: 618ff8df94a75762ae97ff4d99736ba52fe5bbbe
 Directory: alpine
 
-Tags: v2.7.2-windowsservercore-1809, 2.7.2-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809, windowsservercore-1809
+Tags: v2.7.2-windowsservercore-1809, 2.7.2-windowsservercore-1809, v2.7-windowsservercore-1809, 2.7-windowsservercore-1809, epoisses-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 0e5deda4f5f5a03ca6c748961eb3b1f0317914de
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.7.2, 2.7.2, v2.7, 2.7, epoisses, latest
+Tags: v2.7.2, 2.7.2, v2.7, 2.7, epoisses
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 0e5deda4f5f5a03ca6c748961eb3b1f0317914de


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.8.0](https://github.com/traefik/traefik/releases/tag/v2.8.0), and [v2.7.3](https://github.com/traefik/traefik/releases/tag/v2.7.3).

/cc @ldez @rtribotte @ddtmachado

Cheers
