### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-5314 and ELSA-2022-5313

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 394d63b6fcd0d8ba95b3c030d8d36d0fb74fd4e7
+amd64-GitCommit: a6257f962838edf2bf4814d2763e66e31d5191e2
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 98e8439a11d14d20a7ca58f07311427e0ac236ed
+arm64v8-GitCommit: de9fe3fdde72f6331927d2c252cfe0690c7a7683
 
 Tags: 8.6, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-25313, CVE-2022-25314, CVE-2022-22576, CVE-2022-27774, CVE-2022-27776 and CVE-2022-27782.

See https://linux.oracle.com/errata/ELSA-2022-5314.html and https://linux.oracle.com/errata/ELSA-2022-5313.html  for details.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>