### PR TITLE
MediaWiki: 1.38.2 / 1.37.3 / 1.35.7 releases

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,36 +2,36 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: b89d9119c165d11eb3d6ee51d4aee76b04bfb077
+GitCommit: afad53fa36180bf0821adc49d020ec40127bcdc0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.38.1, 1.38, stable, latest
+Tags: 1.38.2, 1.38, stable, latest
 Directory: 1.38/apache
 
-Tags: 1.38.1-fpm, 1.38-fpm, stable-fpm
+Tags: 1.38.2-fpm, 1.38-fpm, stable-fpm
 Directory: 1.38/fpm
 
-Tags: 1.38.1-fpm-alpine, 1.38-fpm-alpine, stable-fpm-alpine
+Tags: 1.38.2-fpm-alpine, 1.38-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.38/fpm-alpine
 
-Tags: 1.37.2, 1.37, legacy
+Tags: 1.37.3, 1.37, legacy
 Directory: 1.37/apache
 
-Tags: 1.37.2-fpm, 1.37-fpm, legacy-fpm
+Tags: 1.37.3-fpm, 1.37-fpm, legacy-fpm
 Directory: 1.37/fpm
 
-Tags: 1.37.2-fpm-alpine, 1.37-fpm-alpine, legacy-fpm-alpine
+Tags: 1.37.3-fpm-alpine, 1.37-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.37/fpm-alpine
 
-Tags: 1.35.6, 1.35, lts, legacylts
+Tags: 1.35.7, 1.35, lts, legacylts
 Directory: 1.35/apache
 
-Tags: 1.35.6-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
+Tags: 1.35.7-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.6-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.35.7-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 


### PR DESCRIPTION
Refs <https://github.com/wikimedia/mediawiki-docker/pull/111> and https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/message/PIPYDRSHXOYW5DB7X755QDNUV5EZWPWB/.