### PR TITLE
Temporarily revert perl back to before cpm was added

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,7 +1,7 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 87a4b9df7a72c9874d000274ab806d00e9cfbf1a
+GitCommit: 37fe216e72bed2a80cf699478fa7b7a7fed656c2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 
 Tags: 5.36.0, 5.36, 5, latest, 5.36.0-bullseye, 5.36-bullseye, 5-bullseye, bullseye

--- a/test/config.sh
+++ b/test/config.sh
@@ -169,6 +169,7 @@ imageTests+=(
 	'
 	[perl]='
 		perl-hello-world
+		perl-cpanm
 	'
 	[php]='
 		php-ext-install

--- a/test/tests/perl-cpanm/container.sh
+++ b/test/tests/perl-cpanm/container.sh
@@ -1,0 +1,4 @@
+#!/bin/sh
+set -eux
+
+cpanm --notest Mojolicious

--- a/test/tests/perl-cpanm/run.sh
+++ b/test/tests/perl-cpanm/run.sh
@@ -1,0 +1,1 @@
+../run-sh-in-container.sh


### PR DESCRIPTION
The "cpm" additions removed "cpanm" (accidentally) -- a fix is in progress but maintainers are already into the weekend. 🙈

This is a partial revert of https://github.com/docker-library/official-images/pull/12612 while https://github.com/Perl/docker-perl/pull/121 is pending :heart: