### PR TITLE
[oraclelinux] Updating 7, 7-slim, 8 and 8-slim for amd64/arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7cb8f0c4a97a96d08348fc430646d869ed5d92bf
+amd64-GitCommit: e9ae3d8225e97ec9ed287175059d3b31b4786c24
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6756e0d9fbf52028880008b9e7a3d12193dbd423
+arm64v8-GitCommit: 58b77091acdecca74748c8842b11619b952616cd
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-29824,CVE-2021-40528,CVE-2022-1621,CVE-2022-1629,CVE-2020-26116,CVE-2020-26137 and CVE-2021-3177.

See the following for details:
https://linux.oracle.com/errata/ELSA-2022-5317.html
https://linux.oracle.com/errata/ELSA-2022-5311.html
https://linux.oracle.com/errata/ELSA-2022-5319.html
https://linux.oracle.com/errata/ELSA-2022-5235.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>