### PR TITLE
Updating 9 and 9-slim for ELSA-2022-5245 ELSA-2022-5244 ELSA-2022-4582 ELSA-2022-5252 ELSA-2022-5250 ELSA-2022-5251 ELSA-2022-4795 ELSA-2022-5242 ELSA-2022-4940 ELSA-2022-4584

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e9ae3d8225e97ec9ed287175059d3b31b4786c24
+amd64-GitCommit: 311842e14d524082eba2a4b7b1754be770c96f0c
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 58b77091acdecca74748c8842b11619b952616cd
+arm64v8-GitCommit: 32a97600f20e99bdf72ce634df72503283e7e8ca
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for:
CVE-2022-22576, CVE-2022-27774, CVE-2022-27776, CVE-2022-27782, CVE-2022-25313, CVE-2022-25314, 
CVE-2022-1271, CVE-2022-26280, CVE-2022-29824, CVE-2022-1586, CVE-2022-1587, CVE-2022-24903, 
CVE-2022-0554, CVE-2022-0943, CVE-2022-1154, CVE-2022-1420, CVE-2022-1621, CVE-2022-1629,
CVE-2022-1271, CVE-2018-25032.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-5245.html
https://linux.oracle.com/errata/ELSA-2022-5244.html
https://linux.oracle.com/errata/ELSA-2022-4582.html
https://linux.oracle.com/errata/ELSA-2022-5252.html
https://linux.oracle.com/errata/ELSA-2022-5250.html
https://linux.oracle.com/errata/ELSA-2022-5251.html
https://linux.oracle.com/errata/ELSA-2022-4795.html
https://linux.oracle.com/errata/ELSA-2022-5242.html
https://linux.oracle.com/errata/ELSA-2022-4940.html
https://linux.oracle.com/errata/ELSA-2022-4584.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>