### PR TITLE
Almalinux 8.6 and Almalinux 9.0 update release - July 2022

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -17,37 +17,36 @@ arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: latest, 8, 8.6, 8.6-20220512
-GitFetch: refs/heads/al-8.6.0-20220512
-GitCommit: 072c414bfc77229e49ff1677a875a0ed5caf990b
+Tags: latest, 8, 8.6, 8.6-20220706
+GitFetch: refs/heads/al-8.6.2-20220706
+GitCommit: 8eeffdde9c4f76a33b1bbedeece7f38aba1e7a18
 amd64-File: Dockerfile-x86_64-default
 arm64v8-File: Dockerfile-aarch64-default
 ppc64le-File: Dockerfile-ppc64le-default
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220512
-GitFetch: refs/heads/al-8.6.0-20220512
-GitCommit: 072c414bfc77229e49ff1677a875a0ed5caf990b
+Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220706
+GitFetch: refs/heads/al-8.6.2-20220706
+GitCommit: 8eeffdde9c4f76a33b1bbedeece7f38aba1e7a18
 amd64-File: Dockerfile-x86_64-minimal
 arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: 9, 9.0, 9.0-20220527
-GitFetch: refs/heads/al-9.0.3-20220527
-GitCommit: 4f13f811fee725c1accbfae8c837e09716c1432e
+Tags: 9, 9.0, 9.0-20220706
+GitFetch: refs/heads/al-9.0.4-20220706
+GitCommit: 3dbd31897854a6ccc598f109f5963e54e74efb83
 amd64-File: Dockerfile-x86_64-default
 arm64v8-File: Dockerfile-aarch64-default
 ppc64le-File: Dockerfile-ppc64le-default
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220527
-GitFetch: refs/heads/al-9.0.3-20220527
-GitCommit: 4f13f811fee725c1accbfae8c837e09716c1432e
+Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220706
+GitFetch: refs/heads/al-9.0.4-20220706
+GitCommit: 3dbd31897854a6ccc598f109f5963e54e74efb83
 amd64-File: Dockerfile-x86_64-minimal
 arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-


### PR DESCRIPTION
Almalinux 8.6 and Almalinux 9.0 update release

## Almalinux 8 changes

Almalinux 8.6 GA Incremental Release. Following packages update since the previous release.

- almalinux-release upgraded from 8.6-0.1.el8 to 8.6-2.el8
- curl upgraded from 7.61.1-22.el8 to 7.61.1-22.el8_6.3     
- expat upgraded from 2.2.5-8.el8 to 2.2.5-8.el8_6.2       
- glibc upgraded from 2.28-189.1.el8 to 2.28-189.5.el8_6
- glibc-common upgraded from  2.28-189.1.el8 to 2.28-189.5.el8_6
- glibc-minimal-langpack upgraded from 2.28-189.1.el8 to 2.28-189.5.el8_6
- libgcc upgraded from 8.5.0-10.el8.alma to 8.5.0-10.1.el8_6.alma
- libstdc++ upgraded from 8.5.0-10.el8.alma to 8.5.0-10.1.el8_6.alma
- libcurl-minimal upgraded from 7.61.1-22.el8 to 7.61.1-22.el8_6.3
- libcurl upgraded from 7.61.1-22.el8 to 7.61.1-22.el8_6.3
- libgcrypt upgraded from 1.8.5-6.el8 to 1.8.5-7.el8_6      
- libxml2 upgraded from 2.9.7-13.el8 to 2.9.7-13.el8_6.1  
- vim-minimal upgraded from 8.0.1763-16.el8_5.13 to 8.0.1763-19.el8_6.2
- xz upgraded from 5.2.4-3.el8 to 5.2.4-4.el8_6     
- xz-libs upgraded from 5.2.4-3.el8 to 5.2.4-4.el8_6 

## Almalinux 9 changes

Almalinux 9.0 GA Incremental Release. Following packages update since the previous release.

- almalinux-gpg-keys upgraded from 9.0-3.el9 to 9.0-4.el9
- almalinux-release upgraded from 9.0-3.el9 to  9.0-4.el9
- almalinux-repos upgraded from 9.0-3.el9 to 9.0-4.el9
- curl-minimal upgraded from 7.76.1-14.el9 to 7.76.1-1  
- expat upgraded from 2.2.10-12.el9_0 to 2.2.10-12.el9_0.2
- libarchive upgraded from 3.5.3-1.el9 to 3.5.3-2.el9_0
- libcurl-minimal upgraded from 7.76.1-14.el9 to 7.76.1-14.el9_0.4
- libgcrypt upgraded from 1.10.0-2.el9 to 10.37-5.el9_0 
- libxml2 upgraded from 2.9.13-1.el9 to 2.9.13-1.el9_0.1
- pcre2 upgraded from 10.37-3.el9.1 to 10.37-5.el9_0
- pcre2-syntax upgraded from 10.37-3.el9.1 to 10.37-5.el9_0
- vim-minimal upgraded from 8.2.2637-15.el9 8.2.2637-16.el9_0.2
- xz upgraded from 5.2.5-7.el9 to 5.2.5-8.el9_0
- xz-libs upgraded from 5.2.5-7.el9 to 5.2.5-8.el9_0