### PR TITLE
Odoo: update 13.0-15.0 to release 20220708

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 69194a6afafe50da6ff7cc0db0322f797b5f1386
+GitCommit: cbd79f009ae0131996c7e50c80db28196aa587ad
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the usual updates for Odoo supported versions.

Thanks.