### PR TITLE
archlinux: Release 20220710.0.67642

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220703.0.65849
-GitCommit: e5340d3018a082a68586f34ce22a81da995c92fb
-GitFetch: refs/tags/v20220703.0.65849
+Tags: latest, base, base-20220710.0.67642
+GitCommit: d56a6b25d0f5a32ab2d89639a8743842da7eaf5f
+GitFetch: refs/tags/v20220710.0.67642
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220703.0.65849
-GitCommit: e5340d3018a082a68586f34ce22a81da995c92fb
-GitFetch: refs/tags/v20220703.0.65849
+Tags: base-devel, base-devel-20220710.0.67642
+GitCommit: d56a6b25d0f5a32ab2d89639a8743842da7eaf5f
+GitFetch: refs/tags/v20220710.0.67642
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks