### PR TITLE
Rocky Linux updates for 9.0

### DIFF
--- a/library/rockylinux
+++ b/library/rockylinux
@@ -2,30 +2,30 @@ Maintainers: The Rocky Linux Foundation <infrastructure@rockylinux.org> (@rocky-
              Neil Hanlon <neil@resf.org> (@neilhanlon)
 GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
-Tags: latest, 8, 8.6, 8.6.20227707
+Tags: 9.0.20220712, 9, 9.0
+GitFetch: refs/heads/Rocky-9.0.20220712-Base-x86_64
+GitCommit: 4a7c10008e051c2c22eff5712ffb4cce7ed357b8
+arm64v8-GitFetch: refs/heads/Rocky-9.0.20220712-Base-aarch64
+arm64v8-GitCommit: 395fd4b32a9d2df4851a800d2830af266beca001
+Architectures: amd64, arm64v8
+
+Tags: 9.0.20220712-minimal, 9-minimal, 9.0-minimal 
+GitFetch: refs/heads/Rocky-9.0.20220712-Minimal-x86_64
+GitCommit: 478daae7943db91ad41ef244a3767b90fb1d2521
+arm64v8-GitFetch: refs/heads/Rocky-9.0.20220712-Minimal-aarch64
+arm64v8-GitCommit: f86c46c2a5e5ec7ca7c812bd60aa10f539522cf7
+Architectures: amd64, arm64v8
+
+Tags: 8.6.20227707, 8.6, 8
 GitFetch: refs/heads/Rocky-8.6.20220707-Base-x86_64
 GitCommit: 09dbe262451ff0e93fe50df95f6811b234d3d509
 arm64v8-GitFetch: refs/heads/Rocky-8.6.20220707-Base-aarch64
 arm64v8-GitCommit: 411d541689cc277f778ce5a0aa260d5a82dd83f3
 Architectures: amd64, arm64v8
 
-Tags: 8-minimal, 8.6-minimal, 8.6.20220707-minimal
+Tags: 8.6.20220707-minimal, 8-minimal, 8.6-minimal
 GitFetch: refs/heads/Rocky-8.6.20220707-Minimal-x86_64
 GitCommit: ef6b5ec9cbad530e1ba673e44dcef9d4c5d5df6a
 arm64v8-GitFetch: refs/heads/Rocky-8.6.20220707-Minimal-aarch64
 arm64v8-GitCommit: 5ba5163c86e3a4ef12601ab1ed7ad7580f9c302b
-Architectures: amd64, arm64v8
-
-Tags: 8.5.20220308
-GitFetch: refs/heads/Rocky-8.5.20220308-x86_64
-GitCommit: 82660c9c8d02077321bf6b12bd6aa512dbfce4fc 
-arm64v8-GitFetch: refs/heads/Rocky-8.5.20220308-aarch64
-arm64v8-GitCommit: a73d2de52b19977008c07227b7527c719b7db623
-Architectures: amd64, arm64v8
-
-Tags: 8.5
-GitFetch: refs/heads/Rocky-8.5-x86_64
-GitCommit: eee13752a34b9195c97d0bce92c05a838484eee8
-arm64v8-GitFetch: refs/heads/Rocky-8.5-aarch64
-arm64v8-GitCommit: df726710f2d759478bea1f06946eb168f4cff17a
 Architectures: amd64, arm64v8


### PR DESCRIPTION
* Also drop legacy 8.5.x image