### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/golang/blob/a4f559a3218c80e299fb053bf884b4566c03b71e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/golang/blob/f536f595f653b5bcc9ec33917f5586c9d6d33584/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -16,19 +16,14 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
 Directory: 1.19-rc/buster
 
-Tags: 1.19rc1-stretch, 1.19-rc-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
-Directory: 1.19-rc/stretch
-
 Tags: 1.19rc1-alpine3.16, 1.19-rc-alpine3.16, 1.19rc1-alpine, 1.19-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
 Directory: 1.19-rc/alpine3.16
 
 Tags: 1.19rc1-alpine3.15, 1.19-rc-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
 Directory: 1.19-rc/alpine3.15
 
 Tags: 1.19rc1-windowsservercore-ltsc2022, 1.19-rc-windowsservercore-ltsc2022
@@ -70,19 +65,14 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
 Directory: 1.18/buster
 
-Tags: 1.18.3-stretch, 1.18-stretch, 1-stretch, stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
-Directory: 1.18/stretch
-
 Tags: 1.18.3-alpine3.16, 1.18-alpine3.16, 1-alpine3.16, alpine3.16, 1.18.3-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
 Directory: 1.18/alpine3.16
 
 Tags: 1.18.3-alpine3.15, 1.18-alpine3.15, 1-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
 Directory: 1.18/alpine3.15
 
 Tags: 1.18.3-windowsservercore-ltsc2022, 1.18-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
@@ -124,19 +114,14 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
 Directory: 1.17/buster
 
-Tags: 1.17.11-stretch, 1.17-stretch
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
-Directory: 1.17/stretch
-
 Tags: 1.17.11-alpine3.16, 1.17-alpine3.16, 1.17.11-alpine, 1.17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
 Directory: 1.17/alpine3.16
 
 Tags: 1.17.11-alpine3.15, 1.17-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
 Directory: 1.17/alpine3.15
 
 Tags: 1.17.11-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/f536f59: Remove stretch-based images (now EOL)