### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -64,21 +64,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv6
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/sid
 
-Tags: stretch-curl, oldoldstable-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55
-Directory: debian/stretch/curl
-
-Tags: stretch-scm, oldoldstable-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: debian/stretch/scm
-
-Tags: stretch, oldoldstable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: debian/stretch
-
 Tags: bionic-curl, 18.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/b6c9896: Remove a few leftover stretch bits
- https://github.com/docker-library/buildpack-deps/commit/83c4f7c: Remove Debian Stretch (now EOL)