### PR TITLE
caddy: 2.5.2 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,51 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/ed0273975aa3f41905483e1c3fc959e773ff0bf1/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/33a2c552e02872da506029144986205466936fb4/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.5.1-alpine, 2-alpine, alpine
-SharedTags: 2.5.1, 2, latest
+Tags: 2.5.2-alpine, 2-alpine, alpine
+SharedTags: 2.5.2, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/alpine
-GitCommit: ed0273975aa3f41905483e1c3fc959e773ff0bf1
+GitCommit: 33a2c552e02872da506029144986205466936fb4
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.5.1-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.5.1-builder, 2-builder, builder
+Tags: 2.5.2-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/builder
-GitCommit: ed0273975aa3f41905483e1c3fc959e773ff0bf1
+GitCommit: 33a2c552e02872da506029144986205466936fb4
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.5.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.5.1-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.1, 2, latest
+Tags: 2.5.2-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.5.2-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.2, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows/1809
-GitCommit: ed0273975aa3f41905483e1c3fc959e773ff0bf1
+GitCommit: 33a2c552e02872da506029144986205466936fb4
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.5.1-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.5.1-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.1, 2, latest
+Tags: 2.5.2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.5.2-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.2, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows/ltsc2022
-GitCommit: ed0273975aa3f41905483e1c3fc959e773ff0bf1
+GitCommit: 33a2c552e02872da506029144986205466936fb4
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.5.1-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.5.1-builder, 2-builder, builder
+Tags: 2.5.2-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows-builder/1809
-GitCommit: ed0273975aa3f41905483e1c3fc959e773ff0bf1
+GitCommit: 33a2c552e02872da506029144986205466936fb4
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.5.1-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.5.1-builder, 2-builder, builder
+Tags: 2.5.2-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows-builder/ltsc2022
-GitCommit: ed0273975aa3f41905483e1c3fc959e773ff0bf1
+GitCommit: 33a2c552e02872da506029144986205466936fb4
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.5.2

Signed-off-by: Dave Henderson <dhenderson@gmail.com>