### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -54,100 +54,100 @@ GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
 Directory: 1.19-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.18.3-bullseye, 1.18-bullseye, 1-bullseye, bullseye
-SharedTags: 1.18.3, 1.18, 1, latest
+Tags: 1.18.4-bullseye, 1.18-bullseye, 1-bullseye, bullseye
+SharedTags: 1.18.4, 1.18, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/bullseye
 
-Tags: 1.18.3-buster, 1.18-buster, 1-buster, buster
+Tags: 1.18.4-buster, 1.18-buster, 1-buster, buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/buster
 
-Tags: 1.18.3-alpine3.16, 1.18-alpine3.16, 1-alpine3.16, alpine3.16, 1.18.3-alpine, 1.18-alpine, 1-alpine, alpine
+Tags: 1.18.4-alpine3.16, 1.18-alpine3.16, 1-alpine3.16, alpine3.16, 1.18.4-alpine, 1.18-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/alpine3.16
 
-Tags: 1.18.3-alpine3.15, 1.18-alpine3.15, 1-alpine3.15, alpine3.15
+Tags: 1.18.4-alpine3.15, 1.18-alpine3.15, 1-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/alpine3.15
 
-Tags: 1.18.3-windowsservercore-ltsc2022, 1.18-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.18.3-windowsservercore, 1.18-windowsservercore, 1-windowsservercore, windowsservercore, 1.18.3, 1.18, 1, latest
+Tags: 1.18.4-windowsservercore-ltsc2022, 1.18-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.18.4-windowsservercore, 1.18-windowsservercore, 1-windowsservercore, windowsservercore, 1.18.4, 1.18, 1, latest
 Architectures: windows-amd64
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.18.3-windowsservercore-1809, 1.18-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.18.3-windowsservercore, 1.18-windowsservercore, 1-windowsservercore, windowsservercore, 1.18.3, 1.18, 1, latest
+Tags: 1.18.4-windowsservercore-1809, 1.18-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.18.4-windowsservercore, 1.18-windowsservercore, 1-windowsservercore, windowsservercore, 1.18.4, 1.18, 1, latest
 Architectures: windows-amd64
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.18.3-nanoserver-ltsc2022, 1.18-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.18.3-nanoserver, 1.18-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.18.4-nanoserver-ltsc2022, 1.18-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.18.4-nanoserver, 1.18-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.18.3-nanoserver-1809, 1.18-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.18.3-nanoserver, 1.18-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.18.4-nanoserver-1809, 1.18-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.18.4-nanoserver, 1.18-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a212f660f30646927c1a10ecdc7b579df2d28155
+GitCommit: ad25ff18a6fcb732a2998c89424d00aa1acc2d31
 Directory: 1.18/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.17.11-bullseye, 1.17-bullseye
-SharedTags: 1.17.11, 1.17
+Tags: 1.17.12-bullseye, 1.17-bullseye
+SharedTags: 1.17.12, 1.17
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/bullseye
 
-Tags: 1.17.11-buster, 1.17-buster
+Tags: 1.17.12-buster, 1.17-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/buster
 
-Tags: 1.17.11-alpine3.16, 1.17-alpine3.16, 1.17.11-alpine, 1.17-alpine
+Tags: 1.17.12-alpine3.16, 1.17-alpine3.16, 1.17.12-alpine, 1.17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/alpine3.16
 
-Tags: 1.17.11-alpine3.15, 1.17-alpine3.15
+Tags: 1.17.12-alpine3.15, 1.17-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/alpine3.15
 
-Tags: 1.17.11-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022
-SharedTags: 1.17.11-windowsservercore, 1.17-windowsservercore, 1.17.11, 1.17
+Tags: 1.17.12-windowsservercore-ltsc2022, 1.17-windowsservercore-ltsc2022
+SharedTags: 1.17.12-windowsservercore, 1.17-windowsservercore, 1.17.12, 1.17
 Architectures: windows-amd64
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.17.11-windowsservercore-1809, 1.17-windowsservercore-1809
-SharedTags: 1.17.11-windowsservercore, 1.17-windowsservercore, 1.17.11, 1.17
+Tags: 1.17.12-windowsservercore-1809, 1.17-windowsservercore-1809
+SharedTags: 1.17.12-windowsservercore, 1.17-windowsservercore, 1.17.12, 1.17
 Architectures: windows-amd64
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.17.11-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022
-SharedTags: 1.17.11-nanoserver, 1.17-nanoserver
+Tags: 1.17.12-nanoserver-ltsc2022, 1.17-nanoserver-ltsc2022
+SharedTags: 1.17.12-nanoserver, 1.17-nanoserver
 Architectures: windows-amd64
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.17.11-nanoserver-1809, 1.17-nanoserver-1809
-SharedTags: 1.17.11-nanoserver, 1.17-nanoserver
+Tags: 1.17.12-nanoserver-1809, 1.17-nanoserver-1809
+SharedTags: 1.17.12-nanoserver, 1.17-nanoserver
 Architectures: windows-amd64
-GitCommit: c9770462b0173169d0ef4ea0772da46db9a0a53d
+GitCommit: 4348478f52ef8b5072aade7eed6835fd8de6738d
 Directory: 1.17/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/ad25ff1: Update 1.18 to 1.18.4
- https://github.com/docker-library/golang/commit/4348478: Update 1.17 to 1.17.12
- https://github.com/docker-library/golang/commit/f536f59: Remove stretch-based images (now EOL)