### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,52 +5,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.19rc1-bullseye, 1.19-rc-bullseye
-SharedTags: 1.19rc1, 1.19-rc
+Tags: 1.19rc2-bullseye, 1.19-rc-bullseye
+SharedTags: 1.19rc2, 1.19-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/bullseye
 
-Tags: 1.19rc1-buster, 1.19-rc-buster
+Tags: 1.19rc2-buster, 1.19-rc-buster
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/buster
 
-Tags: 1.19rc1-alpine3.16, 1.19-rc-alpine3.16, 1.19rc1-alpine, 1.19-rc-alpine
+Tags: 1.19rc2-alpine3.16, 1.19-rc-alpine3.16, 1.19rc2-alpine, 1.19-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/alpine3.16
 
-Tags: 1.19rc1-alpine3.15, 1.19-rc-alpine3.15
+Tags: 1.19rc2-alpine3.15, 1.19-rc-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f536f595f653b5bcc9ec33917f5586c9d6d33584
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/alpine3.15
 
-Tags: 1.19rc1-windowsservercore-ltsc2022, 1.19-rc-windowsservercore-ltsc2022
-SharedTags: 1.19rc1-windowsservercore, 1.19-rc-windowsservercore, 1.19rc1, 1.19-rc
+Tags: 1.19rc2-windowsservercore-ltsc2022, 1.19-rc-windowsservercore-ltsc2022
+SharedTags: 1.19rc2-windowsservercore, 1.19-rc-windowsservercore, 1.19rc2, 1.19-rc
 Architectures: windows-amd64
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.19rc1-windowsservercore-1809, 1.19-rc-windowsservercore-1809
-SharedTags: 1.19rc1-windowsservercore, 1.19-rc-windowsservercore, 1.19rc1, 1.19-rc
+Tags: 1.19rc2-windowsservercore-1809, 1.19-rc-windowsservercore-1809
+SharedTags: 1.19rc2-windowsservercore, 1.19-rc-windowsservercore, 1.19rc2, 1.19-rc
 Architectures: windows-amd64
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.19rc1-nanoserver-ltsc2022, 1.19-rc-nanoserver-ltsc2022
-SharedTags: 1.19rc1-nanoserver, 1.19-rc-nanoserver
+Tags: 1.19rc2-nanoserver-ltsc2022, 1.19-rc-nanoserver-ltsc2022
+SharedTags: 1.19rc2-nanoserver, 1.19-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.19rc1-nanoserver-1809, 1.19-rc-nanoserver-1809
-SharedTags: 1.19rc1-nanoserver, 1.19-rc-nanoserver
+Tags: 1.19rc2-nanoserver-1809, 1.19-rc-nanoserver-1809
+SharedTags: 1.19rc2-nanoserver, 1.19-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 395bc78cc45e54c78a2913426aeb247484cbfaf7
+GitCommit: 93e59e7a57a9c20a4468d16b96b007be58743b9f
 Directory: 1.19-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/93e59e7: Update 1.19-rc to 1.19rc2