### PR TITLE
Update Clear Linux OS to 36620

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: fce3bfafe94717fd9b7df0241028e6a9571c838a
-GitFetch: refs/heads/base-36600
+GitCommit: c6800ab95be4f67b95eaf96b192ec6a491de1ea7
+GitFetch: refs/heads/base-36620


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36620

@bryteise @djklimes @bryteise