### PR TITLE
NeuroDebian: no more EOLed stretch, add arm64v8 architecture

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,6 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: c673678c2010811f745b3bb2638dd060b0534939
+GitCommit: c9aa5f02de44d51bfcd81af986829550b227daeb
 
 Tags: xenial, nd16.04
 Architectures: amd64, arm64v8

--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,57 +1,75 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: 97b3bc1860afafc294abbec1f95bc239ddeddd88
+GitCommit: c673678c2010811f745b3bb2638dd060b0534939
 
 Tags: xenial, nd16.04
+Architectures: amd64, arm64v8
 Directory: dockerfiles/xenial
 
 Tags: xenial-non-free, nd16.04-non-free
+Architectures: amd64, arm64v8
 Directory: dockerfiles/xenial-non-free
 
 Tags: bionic, nd18.04
+Architectures: amd64, arm64v8
 Directory: dockerfiles/bionic
 
 Tags: bionic-non-free, nd18.04-non-free
+Architectures: amd64, arm64v8
 Directory: dockerfiles/bionic-non-free
 
 Tags: focal, nd20.04
+Architectures: amd64, arm64v8
 Directory: dockerfiles/focal
 
 Tags: focal-non-free, nd20.04-non-free
+Architectures: amd64, arm64v8
 Directory: dockerfiles/focal-non-free
 
 Tags: impish, nd21.10
+Architectures: amd64, arm64v8
 Directory: dockerfiles/impish
 
 Tags: impish-non-free, nd21.10-non-free
+Architectures: amd64, arm64v8
 Directory: dockerfiles/impish-non-free
 
-Tags: stretch, nd90
-Directory: dockerfiles/stretch
+Tags: jammy, nd22.04
+Architectures: amd64, arm64v8
+Directory: dockerfiles/jammy
 
-Tags: stretch-non-free, nd90-non-free
-Directory: dockerfiles/stretch-non-free
+Tags: jammy-non-free, nd22.04-non-free
+Architectures: amd64, arm64v8
+Directory: dockerfiles/jammy-non-free
 
 Tags: buster, nd100
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/buster
 
 Tags: buster-non-free, nd100-non-free
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/buster-non-free
 
 Tags: bullseye, nd110, latest
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/bullseye
 
 Tags: bullseye-non-free, nd110-non-free, non-free
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/bullseye-non-free
 
 Tags: bookworm, nd120
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/bookworm
 
 Tags: bookworm-non-free, nd120-non-free
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/bookworm-non-free
 
 Tags: sid, nd
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/sid
 
 Tags: sid-non-free, nd-non-free
+Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/sid-non-free


### PR DESCRIPTION
ping @tianon - have I done specification of architectures correctly?  I have removed i386 from ubuntus since they no longer have it but kept it for debians.

We do have https://neuro.debian.net/debian/dists/bookworm/Contents-armel.gz populated  so hopefully that arm64 gets built. let's see 