### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -118,55 +118,55 @@ GitCommit: e3497a96e0b6c614bdd306d7d47ba32314545a48
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18.0.1.1-jdk-oraclelinux8, 18.0.1.1-oraclelinux8, 18.0.1-jdk-oraclelinux8, 18.0.1-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.1.1-jdk-oracle, 18.0.1.1-oracle, 18.0.1-jdk-oracle, 18.0.1-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle
-SharedTags: 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
+Tags: 18.0.2-jdk-oraclelinux8, 18.0.2-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.2-jdk-oracle, 18.0.2-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle
+SharedTags: 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: amd64, arm64v8
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18.0.1.1-jdk-oraclelinux7, 18.0.1.1-oraclelinux7, 18.0.1-jdk-oraclelinux7, 18.0.1-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7, jdk-oraclelinux7, oraclelinux7
+Tags: 18.0.2-jdk-oraclelinux7, 18.0.2-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 77713ecc13f1480f3fe2b53fe03f2afb12727c74
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18.0.1.1-jdk-bullseye, 18.0.1.1-bullseye, 18.0.1-jdk-bullseye, 18.0.1-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye, jdk-bullseye, bullseye
+Tags: 18.0.2-jdk-bullseye, 18.0.2-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye, jdk-bullseye, bullseye
 Architectures: amd64, arm64v8
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/bullseye
 
-Tags: 18.0.1.1-jdk-slim-bullseye, 18.0.1.1-slim-bullseye, 18.0.1-jdk-slim-bullseye, 18.0.1-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 18.0.1.1-jdk-slim, 18.0.1.1-slim, 18.0.1-jdk-slim, 18.0.1-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim, jdk-slim, slim
+Tags: 18.0.2-jdk-slim-bullseye, 18.0.2-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 18.0.2-jdk-slim, 18.0.2-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18.0.1.1-jdk-buster, 18.0.1.1-buster, 18.0.1-jdk-buster, 18.0.1-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster, jdk-buster, buster
+Tags: 18.0.2-jdk-buster, 18.0.2-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/buster
 
-Tags: 18.0.1.1-jdk-slim-buster, 18.0.1.1-slim-buster, 18.0.1-jdk-slim-buster, 18.0.1-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster, jdk-slim-buster, slim-buster
+Tags: 18.0.2-jdk-slim-buster, 18.0.2-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster, jdk-slim-buster, slim-buster
 Architectures: amd64, arm64v8
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/slim-buster
 
-Tags: 18.0.1.1-jdk-windowsservercore-ltsc2022, 18.0.1.1-windowsservercore-ltsc2022, 18.0.1-jdk-windowsservercore-ltsc2022, 18.0.1-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022, jdk-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 18.0.1.1-jdk-windowsservercore, 18.0.1.1-windowsservercore, 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
+Tags: 18.0.2-jdk-windowsservercore-ltsc2022, 18.0.2-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022, jdk-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: windows-amd64
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18.0.1.1-jdk-windowsservercore-1809, 18.0.1.1-windowsservercore-1809, 18.0.1-jdk-windowsservercore-1809, 18.0.1-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 18.0.1.1-jdk-windowsservercore, 18.0.1.1-windowsservercore, 18.0.1-jdk-windowsservercore, 18.0.1-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.1.1-jdk, 18.0.1.1, 18.0.1-jdk, 18.0.1, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
+Tags: 18.0.2-jdk-windowsservercore-1809, 18.0.2-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: windows-amd64
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18.0.1.1-jdk-nanoserver-1809, 18.0.1.1-nanoserver-1809, 18.0.1-jdk-nanoserver-1809, 18.0.1-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 18.0.1.1-jdk-nanoserver, 18.0.1.1-nanoserver, 18.0.1-jdk-nanoserver, 18.0.1-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver, jdk-nanoserver, nanoserver
+Tags: 18.0.2-jdk-nanoserver-1809, 18.0.2-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 18.0.2-jdk-nanoserver, 18.0.2-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: dd758df145819316fbe6cf4c53a95bfa27c62ae5
+GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5b5fbdb: Update 18 to 18.0.2