### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 9605d3a0f784d4787a5cdf176fd66d08cbc10cfd
 Directory: 2.7/alpine
 
-Tags: 2.6.1, 2.6, lts, latest, 2.6.1-bullseye, 2.6-bullseye, lts-bullseye, bullseye
+Tags: 2.6.2, 2.6, lts, latest, 2.6.2-bullseye, 2.6-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2fea26446051f614031302028cef768b627da26a
+GitCommit: f6499157f0b9ca49bf9416631aa069eb617b60b3
 Directory: 2.6
 
-Tags: 2.6.1-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.1-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
+Tags: 2.6.2-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.2-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2fea26446051f614031302028cef768b627da26a
+GitCommit: f6499157f0b9ca49bf9416631aa069eb617b60b3
 Directory: 2.6/alpine
 
 Tags: 2.5.7, 2.5, 2.5.7-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/f649915: Update 2.6 to 2.6.2