### PR TITLE
archlinux: Release 20220724.0.70393

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220717.0.68836
-GitCommit: b78271622b9ad71e2d7397fcac0f6bbec604f0a2
-GitFetch: refs/tags/v20220717.0.68836
+Tags: latest, base, base-20220724.0.70393
+GitCommit: c273ad434912826f26a705aad8fc68f0475d6330
+GitFetch: refs/tags/v20220724.0.70393
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220717.0.68836
-GitCommit: b78271622b9ad71e2d7397fcac0f6bbec604f0a2
-GitFetch: refs/tags/v20220717.0.68836
+Tags: base-devel, base-devel-20220724.0.70393
+GitCommit: c273ad434912826f26a705aad8fc68f0475d6330
+GitFetch: refs/tags/v20220724.0.70393
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks