### PR TITLE
Update Clear Linux OS to 36640

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c6800ab95be4f67b95eaf96b192ec6a491de1ea7
-GitFetch: refs/heads/base-36620
+GitCommit: ac3e041c6e6eb3bbbff3a466a91970baadd28540
+GitFetch: refs/heads/base-36640


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36640

@bryteise @djklimes @bryteise