### PR TITLE
Release of XWiki 14.6

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -1,48 +1,48 @@
 Maintainers: XWiki Core Dev Team <committers@xwiki.org> (@xwiki)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
-Tags: 14, 14.5, 14.5.0, 14-mysql-tomcat, 14.5-mysql-tomcat, 14.5.0-mysql-tomcat, mysql-tomcat, stable-mysql-tomcat, stable-mysql, stable, latest
+Tags: 14, 14.6, 14.6.0, 14-mysql-tomcat, 14.6-mysql-tomcat, 14.6.0-mysql-tomcat, mysql-tomcat, stable-mysql-tomcat, stable-mysql, stable, latest
 Architectures: amd64, arm64v8
 Directory: 14/mysql-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
-Tags: 14-postgres-tomcat, 14.5-postgres-tomcat, 14.5.0-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres
+Tags: 14-postgres-tomcat, 14.6-postgres-tomcat, 14.6.0-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres
 Architectures: amd64, arm64v8
 Directory: 14/postgres-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
-Tags: 14-mariadb-tomcat, 14.5-mariadb-tomcat, 14.5.0-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb
+Tags: 14-mariadb-tomcat, 14.6-mariadb-tomcat, 14.6.0-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb
 Architectures: amd64, arm64v8
 Directory: 14/mariadb-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
 # Mid-year "LTS" (done by XWiki SAS developers and not official). To be removed when the next official LTS is released.
 Tags: 14.4, 14.4.2, 14.4-mysql-tomcat, 14.4.2-mysql-tomcat
 Architectures: amd64, arm64v8
 Directory: 14.4/mysql-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
 Tags: 14.4-postgres-tomcat, 14.4.2-postgres-tomcat
 Architectures: amd64, arm64v8
 Directory: 14.4/postgres-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
 Tags: 14.4-mariadb-tomcat, 14.4.2-mariadb-tomcat
 Architectures: amd64, arm64v8
 Directory:  14.4/mariadb-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
 Tags: 13, 13.10, 13.10.7, 13-mysql-tomcat, 13.10-mysql-tomcat, 13.10.7-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64, arm64v8
 Directory: 13/mysql-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
 Tags: 13-postgres-tomcat, 13.10-postgres-tomcat, 13.10.7-postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 13/postgres-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8
 
 Tags: 13-mariadb-tomcat, 13.10-mariadb-tomcat, 13.10.7-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
 Architectures: amd64, arm64v8
 Directory: 13/mariadb-tomcat
-GitCommit: 18342c6ad1e23ea3fa3efb4ad883007ecdbaa790
+GitCommit: da38c291b3e953a4c94cfe25a2e2c6e0ffd4c7e8


### PR DESCRIPTION
Note that this also contains changes for base image of tomcat in all versions and mariaDB connector version for all images.