### PR TITLE
Fix satosa build errors due to missing Rust toolchain

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -7,10 +7,10 @@ GitFetch: refs/heads/main
 Tags: 8.1.1-bullseye, 8.1-bullseye, 8-bullseye, bullseye
 SharedTags: 8.1.1, 8.1, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ae2f317df322553b13fc07042348828969868bfa
+GitCommit: f62013ad3b8a785b37b3acc2c0b0ead94aae8b95
 Directory: 8.1/bullseye
 
 Tags: 8.1.1-alpine3.16, 8.1-alpine3.16, 8-alpine3.16, alpine3.16, 8.1.1-alpine, 8.1-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ae2f317df322553b13fc07042348828969868bfa
+GitCommit: f62013ad3b8a785b37b3acc2c0b0ead94aae8b95
 Directory: 8.1/alpine3.16


### PR DESCRIPTION
Builds on the arm32v5, arm32v6, arm32v7, i386, mips64le, ppc64le, and
s390x platforms are failing due to missing pyca/cryptography build
dependencies.  The referenced commit adds them.

This also includes a change that removes an extraneous layer from the
image.