### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -170,190 +170,190 @@ GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
 Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.15-jdk-oraclelinux8, 11.0.15-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.15-jdk-oracle, 11.0.15-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
+Tags: 11.0.16-jdk-oraclelinux8, 11.0.16-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.16-jdk-oracle, 11.0.16-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/oraclelinux8
 
-Tags: 11.0.15-jdk-oraclelinux7, 11.0.15-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
+Tags: 11.0.16-jdk-oraclelinux7, 11.0.16-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 77713ecc13f1480f3fe2b53fe03f2afb12727c74
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/oraclelinux7
 
-Tags: 11.0.15-jdk-bullseye, 11.0.15-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
-SharedTags: 11.0.15-jdk, 11.0.15, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.16-jdk-bullseye, 11.0.16-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
+SharedTags: 11.0.16-jdk, 11.0.16, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/bullseye
 
-Tags: 11.0.15-jdk-slim-bullseye, 11.0.15-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.15-jdk-slim, 11.0.15-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
+Tags: 11.0.16-jdk-slim-bullseye, 11.0.16-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.16-jdk-slim, 11.0.16-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/slim-bullseye
 
-Tags: 11.0.15-jdk-buster, 11.0.15-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
+Tags: 11.0.16-jdk-buster, 11.0.16-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/buster
 
-Tags: 11.0.15-jdk-slim-buster, 11.0.15-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
+Tags: 11.0.16-jdk-slim-buster, 11.0.16-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/slim-buster
 
-Tags: 11.0.15-jdk-windowsservercore-ltsc2022, 11.0.15-windowsservercore-ltsc2022, 11.0-jdk-windowsservercore-ltsc2022, 11.0-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.15-jdk-windowsservercore, 11.0.15-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.15-jdk, 11.0.15, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.16-jdk-windowsservercore-ltsc2022, 11.0.16-windowsservercore-ltsc2022, 11.0-jdk-windowsservercore-ltsc2022, 11.0-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.16-jdk-windowsservercore, 11.0.16-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.16-jdk, 11.0.16, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.15-jdk-windowsservercore-1809, 11.0.15-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.15-jdk-windowsservercore, 11.0.15-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.15-jdk, 11.0.15, 11.0-jdk, 11.0, 11-jdk, 11
+Tags: 11.0.16-jdk-windowsservercore-1809, 11.0.16-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.16-jdk-windowsservercore, 11.0.16-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.16-jdk, 11.0.16, 11.0-jdk, 11.0, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.15-jdk-nanoserver-1809, 11.0.15-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.15-jdk-nanoserver, 11.0.15-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.16-jdk-nanoserver-1809, 11.0.16-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.16-jdk-nanoserver, 11.0.16-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.15-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
-SharedTags: 11.0.15-jre, 11.0-jre, 11-jre
+Tags: 11.0.16-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
+SharedTags: 11.0.16-jre, 11.0-jre, 11-jre
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/bullseye
 
-Tags: 11.0.15-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.15-jre-slim, 11.0-jre-slim, 11-jre-slim
+Tags: 11.0.16-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.16-jre-slim, 11.0-jre-slim, 11-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/slim-bullseye
 
-Tags: 11.0.15-jre-buster, 11.0-jre-buster, 11-jre-buster
+Tags: 11.0.16-jre-buster, 11.0-jre-buster, 11-jre-buster
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/buster
 
-Tags: 11.0.15-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
+Tags: 11.0.16-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/slim-buster
 
-Tags: 11.0.15-jre-windowsservercore-ltsc2022, 11.0-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.15-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.15-jre, 11.0-jre, 11-jre
+Tags: 11.0.16-jre-windowsservercore-ltsc2022, 11.0-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.16-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.16-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.15-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.15-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.15-jre, 11.0-jre, 11-jre
+Tags: 11.0.16-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.16-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.16-jre, 11.0-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.15-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.15-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.16-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.16-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 87352133c6e7e03310f992ca2827aa06df225f27
+GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u332-jdk-oraclelinux8, 8u332-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u332-jdk-oracle, 8u332-oracle, 8-jdk-oracle, 8-oracle
+Tags: 8u342-jdk-oraclelinux8, 8u342-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u342-jdk-oracle, 8u342-oracle, 8-jdk-oracle, 8-oracle
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/oraclelinux8
 
-Tags: 8u332-jdk-oraclelinux7, 8u332-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
+Tags: 8u342-jdk-oraclelinux7, 8u342-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 77713ecc13f1480f3fe2b53fe03f2afb12727c74
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/oraclelinux7
 
-Tags: 8u332-jdk-bullseye, 8u332-bullseye, 8-jdk-bullseye, 8-bullseye
-SharedTags: 8u332-jdk, 8u332, 8-jdk, 8
+Tags: 8u342-jdk-bullseye, 8u342-bullseye, 8-jdk-bullseye, 8-bullseye
+SharedTags: 8u342-jdk, 8u342, 8-jdk, 8
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/bullseye
 
-Tags: 8u332-jdk-slim-bullseye, 8u332-slim-bullseye, 8-jdk-slim-bullseye, 8-slim-bullseye, 8u332-jdk-slim, 8u332-slim, 8-jdk-slim, 8-slim
+Tags: 8u342-jdk-slim-bullseye, 8u342-slim-bullseye, 8-jdk-slim-bullseye, 8-slim-bullseye, 8u342-jdk-slim, 8u342-slim, 8-jdk-slim, 8-slim
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/slim-bullseye
 
-Tags: 8u332-jdk-buster, 8u332-buster, 8-jdk-buster, 8-buster
+Tags: 8u342-jdk-buster, 8u342-buster, 8-jdk-buster, 8-buster
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/buster
 
-Tags: 8u332-jdk-slim-buster, 8u332-slim-buster, 8-jdk-slim-buster, 8-slim-buster
+Tags: 8u342-jdk-slim-buster, 8u342-slim-buster, 8-jdk-slim-buster, 8-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/slim-buster
 
-Tags: 8u332-jdk-windowsservercore-ltsc2022, 8u332-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u332-jdk-windowsservercore, 8u332-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u332-jdk, 8u332, 8-jdk, 8
+Tags: 8u342-jdk-windowsservercore-ltsc2022, 8u342-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u342-jdk-windowsservercore, 8u342-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u342-jdk, 8u342, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u332-jdk-windowsservercore-1809, 8u332-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u332-jdk-windowsservercore, 8u332-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u332-jdk, 8u332, 8-jdk, 8
+Tags: 8u342-jdk-windowsservercore-1809, 8u342-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u342-jdk-windowsservercore, 8u342-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u342-jdk, 8u342, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u332-jdk-nanoserver-1809, 8u332-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u332-jdk-nanoserver, 8u332-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u342-jdk-nanoserver-1809, 8u342-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u342-jdk-nanoserver, 8u342-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u332-jre-bullseye, 8-jre-bullseye
-SharedTags: 8u332-jre, 8-jre
+Tags: 8u342-jre-bullseye, 8-jre-bullseye
+SharedTags: 8u342-jre, 8-jre
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/bullseye
 
-Tags: 8u332-jre-slim-bullseye, 8-jre-slim-bullseye, 8u332-jre-slim, 8-jre-slim
+Tags: 8u342-jre-slim-bullseye, 8-jre-slim-bullseye, 8u342-jre-slim, 8-jre-slim
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/slim-bullseye
 
-Tags: 8u332-jre-buster, 8-jre-buster
+Tags: 8u342-jre-buster, 8-jre-buster
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/buster
 
-Tags: 8u332-jre-slim-buster, 8-jre-slim-buster
+Tags: 8u342-jre-slim-buster, 8-jre-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/slim-buster
 
-Tags: 8u332-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u332-jre-windowsservercore, 8-jre-windowsservercore, 8u332-jre, 8-jre
+Tags: 8u342-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u342-jre-windowsservercore, 8-jre-windowsservercore, 8u342-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u332-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u332-jre-windowsservercore, 8-jre-windowsservercore, 8u332-jre, 8-jre
+Tags: 8u342-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u342-jre-windowsservercore, 8-jre-windowsservercore, 8u342-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u332-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u332-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u342-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u342-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: da594d91b0364d5f1a32e0ce6b4d3fd8a9116844
+GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8dfb0c5: Update 11 to 11.0.16
- https://github.com/docker-library/openjdk/commit/5f932db: Revert OpenJDK11U hack (no longer necessary for this final release 😂)
- https://github.com/docker-library/openjdk/commit/a0c4da8: Update 8 to 8u342