### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: f6499157f0b9ca49bf9416631aa069eb617b60b3
 Directory: 2.6/alpine
 
-Tags: 2.5.7, 2.5, 2.5.7-bullseye, 2.5-bullseye
+Tags: 2.5.8, 2.5, 2.5.8-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2a634b815ba26e961f0e63501996c7bb224a9617
+GitCommit: 4652e975be3db3a69221e68a103dae4e5891313b
 Directory: 2.5
 
-Tags: 2.5.7-alpine, 2.5-alpine, 2.5.7-alpine3.16, 2.5-alpine3.16
+Tags: 2.5.8-alpine, 2.5-alpine, 2.5.8-alpine3.16, 2.5-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: 4652e975be3db3a69221e68a103dae4e5891313b
 Directory: 2.5/alpine
 
 Tags: 2.4.17, 2.4, 2.4.17-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4652e97: Update 2.5 to 2.5.8