### PR TITLE
Disable s390x support for satosa:alpine images

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -11,6 +11,6 @@ GitCommit: f62013ad3b8a785b37b3acc2c0b0ead94aae8b95
 Directory: 8.1/bullseye
 
 Tags: 8.1.1-alpine3.16, 8.1-alpine3.16, 8-alpine3.16, alpine3.16, 8.1.1-alpine, 8.1-alpine, 8-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 GitCommit: f62013ad3b8a785b37b3acc2c0b0ead94aae8b95
 Directory: 8.1/alpine3.16


### PR DESCRIPTION
A SATOSA dependency requires Rust to build, but Rust doesn't support
the s390x-unknown-linux-musl platform.

Cf. https://github.com/identityPython/satosa-docker/issues/1