### PR TITLE
Remove deprecated openjdk images & restore some old tags

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,122 +2,128 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: arm64v8, amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 4284bd783efe0c5dc8d223820e83a3a3ab822f06
+GitCommit: 414a57d20db8ba75a3909394e9d4abb795b3d986
 
 
 Tags: latest
-Directory: target/eclipse-temurin-17-jdk-focal/latest
+Directory: target/eclipse-temurin-17-jdk-jammy/latest
 
-Tags: openjdk-8-boot-2.8.3-bullseye, openjdk-8-boot-bullseye
-Directory: target/openjdk-8-bullseye/boot
+Tags: temurin-8-boot-2.8.3-alpine, temurin-8-boot-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-8-jdk-alpine/boot
 
-Tags: openjdk-8-boot-2.8.3-buster, openjdk-8-boot-buster
-Directory: target/openjdk-8-buster/boot
+Tags: temurin-8-boot-2.8.3-focal, temurin-8-boot-focal
+Directory: target/eclipse-temurin-8-jdk-focal/boot
 
-Tags: openjdk-8-boot-2.8.3, openjdk-8-boot-2.8.3-slim-bullseye, openjdk-8-boot-slim-bullseye
-Directory: target/openjdk-8-slim-bullseye/boot
+Tags: temurin-8-boot, temurin-8-boot-2.8.3, temurin-8-boot-2.8.3-jammy, temurin-8-boot-jammy
+Directory: target/eclipse-temurin-8-jdk-jammy/boot
 
-Tags: openjdk-8-boot-2.8.3-slim-buster, openjdk-8-boot-slim-buster
-Directory: target/openjdk-8-slim-buster/boot
+Tags: temurin-8-lein-2.9.8-alpine, temurin-8-lein-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-8-jdk-alpine/lein
 
-Tags: openjdk-8-lein-2.9.8-bullseye, openjdk-8-lein-bullseye
-Directory: target/openjdk-8-bullseye/lein
+Tags: temurin-8-lein-2.9.8-focal, temurin-8-lein-focal
+Directory: target/eclipse-temurin-8-jdk-focal/lein
 
-Tags: openjdk-8-lein-2.9.8-buster, openjdk-8-lein-buster
-Directory: target/openjdk-8-buster/lein
+Tags: temurin-8-lein, temurin-8-lein-2.9.8, temurin-8-lein-2.9.8-jammy, temurin-8-lein-jammy
+Directory: target/eclipse-temurin-8-jdk-jammy/lein
 
-Tags: openjdk-8-lein-2.9.8, openjdk-8-lein-2.9.8-slim-bullseye, openjdk-8-lein-slim-bullseye
-Directory: target/openjdk-8-slim-bullseye/lein
+Tags: temurin-8-alpine, temurin-8-tools-deps-1.11.1.1149-alpine, temurin-8-tools-deps-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-8-jdk-alpine/tools-deps
 
-Tags: openjdk-8-lein-2.9.8-slim-buster, openjdk-8-lein-slim-buster
-Directory: target/openjdk-8-slim-buster/lein
+Tags: temurin-8-focal, temurin-8-tools-deps-1.11.1.1149-focal, temurin-8-tools-deps-focal
+Directory: target/eclipse-temurin-8-jdk-focal/tools-deps
 
-Tags: openjdk-8-bullseye, openjdk-8-tools-deps-1.11.1.1149-bullseye, openjdk-8-tools-deps-bullseye
-Directory: target/openjdk-8-bullseye/tools-deps
+Tags: temurin-8-jammy, temurin-8-tools-deps, temurin-8-tools-deps-1.11.1.1149, temurin-8-tools-deps-1.11.1.1149-jammy, temurin-8-tools-deps-jammy
+Directory: target/eclipse-temurin-8-jdk-jammy/tools-deps
 
-Tags: openjdk-8-buster, openjdk-8-tools-deps-1.11.1.1149-buster, openjdk-8-tools-deps-buster
-Directory: target/openjdk-8-buster/tools-deps
+Tags: temurin-11-boot-2.8.3-alpine, temurin-11-boot-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-11-jdk-alpine/boot
 
-Tags: openjdk-8-slim-bullseye, openjdk-8-tools-deps-1.11.1.1149, openjdk-8-tools-deps-1.11.1.1149-slim-bullseye, openjdk-8-tools-deps-slim-bullseye
-Directory: target/openjdk-8-slim-bullseye/tools-deps
+Tags: temurin-11-boot-2.8.3-focal, temurin-11-boot-focal
+Directory: target/eclipse-temurin-11-jdk-focal/boot
 
-Tags: openjdk-8-slim-buster, openjdk-8-tools-deps-1.11.1.1149-slim-buster, openjdk-8-tools-deps-slim-buster
-Directory: target/openjdk-8-slim-buster/tools-deps
+Tags: temurin-11-boot, temurin-11-boot-2.8.3, temurin-11-boot-2.8.3-jammy, temurin-11-boot-jammy
+Directory: target/eclipse-temurin-11-jdk-jammy/boot
 
-Tags: openjdk-11-boot-2.8.3-bullseye, openjdk-11-boot-bullseye
-Directory: target/openjdk-11-bullseye/boot
+Tags: temurin-11-lein-2.9.8-alpine, temurin-11-lein-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-11-jdk-alpine/lein
 
-Tags: openjdk-11-boot-2.8.3-buster, openjdk-11-boot-buster
-Directory: target/openjdk-11-buster/boot
+Tags: temurin-11-lein-2.9.8-focal, temurin-11-lein-focal
+Directory: target/eclipse-temurin-11-jdk-focal/lein
 
-Tags: openjdk-11-boot-2.8.3, openjdk-11-boot-2.8.3-slim-bullseye, openjdk-11-boot-slim-bullseye
-Directory: target/openjdk-11-slim-bullseye/boot
+Tags: temurin-11-lein, temurin-11-lein-2.9.8, temurin-11-lein-2.9.8-jammy, temurin-11-lein-jammy
+Directory: target/eclipse-temurin-11-jdk-jammy/lein
 
-Tags: openjdk-11-boot-2.8.3-slim-buster, openjdk-11-boot-slim-buster
-Directory: target/openjdk-11-slim-buster/boot
+Tags: temurin-11-alpine, temurin-11-tools-deps-1.11.1.1149-alpine, temurin-11-tools-deps-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-11-jdk-alpine/tools-deps
 
-Tags: openjdk-11-lein-2.9.8-bullseye, openjdk-11-lein-bullseye
-Directory: target/openjdk-11-bullseye/lein
+Tags: temurin-11-focal, temurin-11-tools-deps-1.11.1.1149-focal, temurin-11-tools-deps-focal
+Directory: target/eclipse-temurin-11-jdk-focal/tools-deps
 
-Tags: openjdk-11-lein-2.9.8-buster, openjdk-11-lein-buster
-Directory: target/openjdk-11-buster/lein
+Tags: temurin-11-jammy, temurin-11-tools-deps, temurin-11-tools-deps-1.11.1.1149, temurin-11-tools-deps-1.11.1.1149-jammy, temurin-11-tools-deps-jammy
+Directory: target/eclipse-temurin-11-jdk-jammy/tools-deps
 
-Tags: openjdk-11-lein-2.9.8, openjdk-11-lein-2.9.8-slim-bullseye, openjdk-11-lein-slim-bullseye
-Directory: target/openjdk-11-slim-bullseye/lein
-
-Tags: openjdk-11-lein-2.9.8-slim-buster, openjdk-11-lein-slim-buster
-Directory: target/openjdk-11-slim-buster/lein
-
-Tags: openjdk-11-bullseye, openjdk-11-tools-deps-1.11.1.1149-bullseye, openjdk-11-tools-deps-bullseye
-Directory: target/openjdk-11-bullseye/tools-deps
-
-Tags: openjdk-11-buster, openjdk-11-tools-deps-1.11.1.1149-buster, openjdk-11-tools-deps-buster
-Directory: target/openjdk-11-buster/tools-deps
-
-Tags: openjdk-11-slim-bullseye, openjdk-11-tools-deps-1.11.1.1149, openjdk-11-tools-deps-1.11.1.1149-slim-bullseye, openjdk-11-tools-deps-slim-bullseye
-Directory: target/openjdk-11-slim-bullseye/tools-deps
-
-Tags: openjdk-11-slim-buster, openjdk-11-tools-deps-1.11.1.1149-slim-buster, openjdk-11-tools-deps-slim-buster
-Directory: target/openjdk-11-slim-buster/tools-deps
-
-Tags: boot-2.8.3-alpine, temurin-17-boot-2.8.3-alpine, temurin-17-boot-alpine
+Tags: boot-2.8.3-alpine, boot-alpine, temurin-17-boot-2.8.3-alpine, temurin-17-boot-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-17-jdk-alpine/boot
 
-Tags: boot-2.8.3, boot-2.8.3-focal, temurin-17-boot-2.8.3, temurin-17-boot-2.8.3-focal, temurin-17-boot-focal
+Tags: boot-2.8.3-focal, boot-focal, temurin-17-boot-2.8.3-focal, temurin-17-boot-focal
 Directory: target/eclipse-temurin-17-jdk-focal/boot
 
-Tags: lein-2.9.8-alpine, temurin-17-lein-2.9.8-alpine, temurin-17-lein-alpine
+Tags: boot, boot-2.8.3, boot-2.8.3-jammy, temurin-17-boot-2.8.3, temurin-17-boot-2.8.3-jammy, temurin-17-boot-jammy
+Directory: target/eclipse-temurin-17-jdk-jammy/boot
+
+Tags: lein-2.9.8-alpine, lein-alpine, temurin-17-lein-2.9.8-alpine, temurin-17-lein-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-17-jdk-alpine/lein
 
-Tags: lein-2.9.8, lein-2.9.8-focal, temurin-17-lein-2.9.8, temurin-17-lein-2.9.8-focal, temurin-17-lein-focal
+Tags: lein-2.9.8-focal, lein-focal, temurin-17-lein-2.9.8-focal, temurin-17-lein-focal
 Directory: target/eclipse-temurin-17-jdk-focal/lein
 
-Tags: temurin-17-alpine, temurin-17-tools-deps-1.11.1.1149-alpine, temurin-17-tools-deps-alpine, tools-deps-1.11.1.1149-alpine
+Tags: lein, lein-2.9.8, lein-2.9.8-jammy, temurin-17-lein-2.9.8, temurin-17-lein-2.9.8-jammy, temurin-17-lein-jammy
+Directory: target/eclipse-temurin-17-jdk-jammy/lein
+
+Tags: temurin-17-alpine, temurin-17-tools-deps-1.11.1.1149-alpine, temurin-17-tools-deps-alpine, tools-deps-1.11.1.1149-alpine, tools-deps-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-17-jdk-alpine/tools-deps
 
-Tags: temurin-17-focal, temurin-17-tools-deps-1.11.1.1149, temurin-17-tools-deps-1.11.1.1149-focal, temurin-17-tools-deps-focal, tools-deps-1.11.1.1149, tools-deps-1.11.1.1149-focal
+Tags: temurin-17-focal, temurin-17-tools-deps-1.11.1.1149-focal, temurin-17-tools-deps-focal, tools-deps-1.11.1.1149-focal, tools-deps-focal
 Directory: target/eclipse-temurin-17-jdk-focal/tools-deps
+
+Tags: temurin-17-jammy, temurin-17-tools-deps-1.11.1.1149, temurin-17-tools-deps-1.11.1.1149-jammy, temurin-17-tools-deps-jammy, tools-deps, tools-deps-1.11.1.1149, tools-deps-1.11.1.1149-jammy
+Directory: target/eclipse-temurin-17-jdk-jammy/tools-deps
 
 Tags: temurin-18-boot-2.8.3-alpine, temurin-18-boot-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-18-jdk-alpine/boot
 
-Tags: temurin-18-boot-2.8.3, temurin-18-boot-2.8.3-focal, temurin-18-boot-focal
+Tags: temurin-18-boot-2.8.3-focal, temurin-18-boot-focal
 Directory: target/eclipse-temurin-18-jdk-focal/boot
+
+Tags: temurin-18-boot, temurin-18-boot-2.8.3, temurin-18-boot-2.8.3-jammy, temurin-18-boot-jammy
+Directory: target/eclipse-temurin-18-jdk-jammy/boot
 
 Tags: temurin-18-lein-2.9.8-alpine, temurin-18-lein-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-18-jdk-alpine/lein
 
-Tags: temurin-18-lein-2.9.8, temurin-18-lein-2.9.8-focal, temurin-18-lein-focal
+Tags: temurin-18-lein-2.9.8-focal, temurin-18-lein-focal
 Directory: target/eclipse-temurin-18-jdk-focal/lein
+
+Tags: temurin-18-lein, temurin-18-lein-2.9.8, temurin-18-lein-2.9.8-jammy, temurin-18-lein-jammy
+Directory: target/eclipse-temurin-18-jdk-jammy/lein
 
 Tags: temurin-18-alpine, temurin-18-tools-deps-1.11.1.1149-alpine, temurin-18-tools-deps-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-18-jdk-alpine/tools-deps
 
-Tags: temurin-18-focal, temurin-18-tools-deps-1.11.1.1149, temurin-18-tools-deps-1.11.1.1149-focal, temurin-18-tools-deps-focal
+Tags: temurin-18-focal, temurin-18-tools-deps-1.11.1.1149-focal, temurin-18-tools-deps-focal
 Directory: target/eclipse-temurin-18-jdk-focal/tools-deps
+
+Tags: temurin-18-jammy, temurin-18-tools-deps, temurin-18-tools-deps-1.11.1.1149, temurin-18-tools-deps-1.11.1.1149-jammy, temurin-18-tools-deps-jammy
+Directory: target/eclipse-temurin-18-jdk-jammy/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: arm64v8, amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 414a57d20db8ba75a3909394e9d4abb795b3d986
+GitCommit: df0494190416457847fad16be62fd620b4d186b6
 
 
 Tags: latest


### PR DESCRIPTION
Specifically the "lein", "boot", and "tools-deps" tags, which our new manifest generation code was inadvertently omitting.