### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.29, 8.0, 8, latest, 8.0.29-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.0.30, 8.0, 8, latest, 8.0.30-oracle, 8.0-oracle, 8-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 48f07e3da4f62de1adb876e9d657e7283ed12a0e
+GitCommit: 8a1c1d3c30e71c8efef064e26064a195737e7e1d
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.29-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.30-debian, 8.0-debian, 8-debian, debian
 Architectures: amd64
-GitCommit: 6cb73371396bdfcc048a701fa4a4c9e3eee4fde4
+GitCommit: 8a1c1d3c30e71c8efef064e26064a195737e7e1d
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.38, 5.7, 5, 5.7.38-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.39, 5.7, 5, 5.7.39-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: 48f07e3da4f62de1adb876e9d657e7283ed12a0e
+GitCommit: eb9697a801186d440355c55e81512e0441a5a854
 Directory: 5.7
 File: Dockerfile.oracle
 
-Tags: 5.7.38-debian, 5.7-debian, 5-debian
+Tags: 5.7.39-debian, 5.7-debian, 5-debian
 Architectures: amd64
-GitCommit: b22945da0ed9f152485cc68ff7565204e8d37db4
+GitCommit: eb9697a801186d440355c55e81512e0441a5a854
 Directory: 5.7
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/8a1c1d3: Update 8.0 to 8.0.30, debian 8.0.30-1debian11, mysql-shell 8.0.30-1.el8, oracle 8.0.30-1.el8
- https://github.com/docker-library/mysql/commit/eb9697a: Update 5.7 to 5.7.39, debian 5.7.39-1debian10, mysql-shell 8.0.30-1.el7, oracle 5.7.39-1.el7
- https://github.com/docker-library/mysql/commit/6535072: Update jq-template for speed improvements