### PR TITLE
Odoo: update 13.0-15.0 to release 20220727

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 037310071171bd8620734dd58f15e9d8d8f038b4
+GitCommit: d0da651ee7d5b52660d3601b798b770e50e2af9f 
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the usual updates of Odoo supported versions.

Thanks