### PR TITLE
Use Eclipse Temurin based base images

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -17,10 +17,10 @@ Directory: 3.12.6/postgres
 
 Tags: 4.0.6, 4.0
 Architectures: amd64, arm64v8
-GitCommit: e0383241cf893996e6738ccf987a5bb24061734c
+GitCommit: 00936dcf7dbb2399405c53aa05c670fa4bb79736
 Directory: 4.0.6
 
 Tags: 4.2.0, 4.2, 4, latest
 Architectures: amd64, arm64v8
-GitCommit: 236ddf936b2da47ff7d21017040e67aa537d23b7
+GitCommit: 00936dcf7dbb2399405c53aa05c670fa4bb79736
 Directory: 4.2.0


### PR DESCRIPTION
According to https://github.com/docker-library/official-images/pull/12851#issuecomment-1194480196 OpenJDK image will not be updated anymore.
This changes the base images used by GeoNetwork 4 to Jetty 9 using Eclipse Temurin instead of OpenJDK.
