### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -94,21 +94,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal
 
-Tags: impish-curl, 21.10-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: fae040f3db68991f178f0a9631a03ca9837f5647
-Directory: ubuntu/impish/curl
-
-Tags: impish-scm, 21.10-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: fae040f3db68991f178f0a9631a03ca9837f5647
-Directory: ubuntu/impish/scm
-
-Tags: impish, 21.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: fae040f3db68991f178f0a9631a03ca9837f5647
-Directory: ubuntu/impish
-
 Tags: jammy-curl, 22.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/05f953e: Remove EOL Impish (21.10)
- https://github.com/docker-library/buildpack-deps/commit/6b7bff0: Update jq-template for speed improvements