### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,34 +34,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4652e975be3db3a69221e68a103dae4e5891313b
 Directory: 2.5/alpine
 
-Tags: 2.4.17, 2.4, 2.4.17-bullseye, 2.4-bullseye
+Tags: 2.4.18, 2.4, 2.4.18-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c1ad6f1a7cf6cb8bc3baca2d490ce2c30ca58652
+GitCommit: d8a314a8b07f41e256995557e348800560543c93
 Directory: 2.4
 
-Tags: 2.4.17-alpine, 2.4-alpine, 2.4.17-alpine3.16, 2.4-alpine3.16
+Tags: 2.4.18-alpine, 2.4-alpine, 2.4.18-alpine3.16, 2.4-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: d8a314a8b07f41e256995557e348800560543c93
 Directory: 2.4/alpine
 
-Tags: 2.3.20, 2.3, 2.3.20-bullseye, 2.3-bullseye
+Tags: 2.3.21, 2.3, 2.3.21-bullseye, 2.3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bf4675441b426432378072e248f2379784d60d
+GitCommit: 19765b90c04eeaa485ba7a4b4e9e4fa61ef10fd7
 Directory: 2.3
 
-Tags: 2.3.20-alpine, 2.3-alpine, 2.3.20-alpine3.16, 2.3-alpine3.16
+Tags: 2.3.21-alpine, 2.3-alpine, 2.3.21-alpine3.16, 2.3-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: 19765b90c04eeaa485ba7a4b4e9e4fa61ef10fd7
 Directory: 2.3/alpine
 
-Tags: 2.2.24, 2.2, 2.2.24-bullseye, 2.2-bullseye
+Tags: 2.2.25, 2.2, 2.2.25-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 56be0cf2562116cc7d256a9ad4687cb7611844bf
+GitCommit: 241d8833cfd3498f40cbd733c4fa7bc53d46f5c7
 Directory: 2.2
 
-Tags: 2.2.24-alpine, 2.2-alpine, 2.2.24-alpine3.16, 2.2-alpine3.16
+Tags: 2.2.25-alpine, 2.2-alpine, 2.2.25-alpine3.16, 2.2-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: 241d8833cfd3498f40cbd733c4fa7bc53d46f5c7
 Directory: 2.2/alpine
 
 Tags: 2.0.29, 2.0, 2.0.29-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/19765b9: Update 2.3 to 2.3.21
- https://github.com/docker-library/haproxy/commit/241d883: Update 2.2 to 2.2.25
- https://github.com/docker-library/haproxy/commit/d8a314a: Update 2.4 to 2.4.18