### PR TITLE
Bump Haskell GHC to 9.2.4

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,14 +1,14 @@
 Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.2.3-buster, 9.2-buster, 9-buster, buster, 9.2.3, 9.2, 9, latest
+Tags: 9.2.4-buster, 9.2-buster, 9-buster, buster, 9.2.4, 9.2, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 595046aa00340b831927be7edb2f4eaa1a83e4e1
+GitCommit: 90dbf04d35f52704c46f3ebc08e8eeef6e9b026b
 Directory: 9.2/buster
 
-Tags: 9.2.3-slim-buster, 9.2-slim-buster, 9-slim-buster, slim-buster, 9.2.3-slim, 9.2-slim, 9-slim, slim
+Tags: 9.2.4-slim-buster, 9.2-slim-buster, 9-slim-buster, slim-buster, 9.2.4-slim, 9.2-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 573ee754783f8d5c5674888768378c6832f8d121
+GitCommit: 90dbf04d35f52704c46f3ebc08e8eeef6e9b026b
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0


### PR DESCRIPTION
https://www.haskell.org/ghc/download_ghc_9_2_4.html