### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/5afab15a83a7c20ca754855642934f35262ccab7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/51b5ed5f2cb833a8d4a3e346215701b872eaab5b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 5afab15a83a7c20ca754855642934f35262ccab7
+GitCommit: 51b5ed5f2cb833a8d4a3e346215701b872eaab5b
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9026045e285b101a277590a161e6f8fd76b3d4bd
+amd64-GitCommit: c2e72d6cf3cc382f25d7d71ae70bb2013a517f1f
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 78f9f82bd4f69c417e6133d9bbba6a6adff43ced
+arm32v5-GitCommit: 5ac8fe484f6f9285d9e7062fff7312557fa59f18
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: de8d6ba744c1f0a4fae2b49c04409cb45dceda46
+arm32v6-GitCommit: 95d5be717f856e57055b43d4eb3bae29dd72727d
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0afe5639e6ffa703a0c0e3ff7dbc3796df76d0e1
+arm32v7-GitCommit: 532fe38e7e3c370879ef703db639115fabc41dd1
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a60a9555a872d7fdec8116d2900aef95e227ede0
+arm64v8-GitCommit: 0771fd6785ba397564a1c418ad1e3def3c9fa21c
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: ece6fa890958de4dca2451a301d8cf9891fb3f0e
+i386-GitCommit: 03373386eaaa8a18b673c0fef25d146ea077269f
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 30750e15de7727c65b29025a7d6f6e6c37c636bf
+mips64le-GitCommit: f6ac2fba064b0ba2d42ea782e7c309db65a804d6
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 938c87fd6c8d56559ff180e381542680b26fb0f3
+ppc64le-GitCommit: 6536c13bbd6bd056706da4c2cd93025907de759b
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 10ec8a3882065cf5ac9fee5e206aea0327940de3
+riscv64-GitCommit: 1a751ad1d0640c239f85747f3ba11743f27651fc
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 83600ae34f5943d7ec89e7b2d9dceb3b51942dd9
+s390x-GitCommit: f4af3d4c831313e9ad64c65bb996cce569b44a0c
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/51b5ed5: Merge pull request https://github.com/docker-library/busybox/pull/140 from infosiftr/buildroot-2022.05.1
- https://github.com/docker-library/busybox/commit/d574bb6: Update buildroot to 2022.05.1
- https://github.com/docker-library/busybox/commit/2bbb62b: Update jq-template for speed improvements