### PR TITLE
Update Clear Linux OS to 36700

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ac3e041c6e6eb3bbbff3a466a91970baadd28540
-GitFetch: refs/heads/base-36640
+GitCommit: 9dfc472e19f7d2ac4e3ad1f25eb6dd93bf70a7e3
+GitFetch: refs/heads/base-36700


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36700

@bryteise @djklimes @bryteise