### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -1,27 +1,27 @@
-# this file is generated via https://github.com/docker-library/docker/blob/e129c04f3eef8d3934e455fa1f56f4407b2c88de/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/docker/blob/f23a2bea97f6d7ec563bc316302fb8edf620ec5b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
+Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 5bda34eeb02386173b6e298cb4a983783efc7e8d
-Directory: 22.06-rc
+GitCommit: fd4039323bbf96d9cf7b8f18a38c3b9b9a9e2189
+Directory: 22.06-rc/cli
 
-Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16
+Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 4c1b73e7046422ca1339b76935c2e2f4251b9c20
+GitCommit: 1f37025ef2b9b70706d8e11cc3552830e4524758
 Directory: 22.06-rc/dind
 
 Tags: 22.06.0-beta.0-dind-rootless, 22.06-rc-dind-rootless, rc-dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: b4ebf24fc840e7f223c9e7ab361a02fa2ffd2e3e
+GitCommit: 1f37025ef2b9b70706d8e11cc3552830e4524758
 Directory: 22.06-rc/dind-rootless
 
 Tags: 22.06.0-beta.0-git, 22.06-rc-git, rc-git
 Architectures: amd64, arm64v8
-GitCommit: 4c1b73e7046422ca1339b76935c2e2f4251b9c20
+GitCommit: f23a2bea97f6d7ec563bc316302fb8edf620ec5b
 Directory: 22.06-rc/git
 
 Tags: 22.06.0-beta.0-windowsservercore-ltsc2022, 22.06-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
@@ -38,24 +38,24 @@ GitCommit: 4c1b73e7046422ca1339b76935c2e2f4251b9c20
 Directory: 22.06-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20.10.17, 20.10, 20, latest, 20.10.17-alpine3.16
+Tags: 20.10.17-cli, 20.10-cli, 20-cli, cli, 20.10.17-cli-alpine3.16, 20.10.17, 20.10, 20, latest, 20.10.17-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: a9aa984f3033753674b96b9f614f69b4650ddfa9
-Directory: 20.10
+GitCommit: 8ddb44b5fbeb13cc6d0b810976460f50538fdafb
+Directory: 20.10/cli
 
 Tags: 20.10.17-dind, 20.10-dind, 20-dind, dind, 20.10.17-dind-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 0efba9e3cd4537de89ba54de2ad8acc5e3b1759f
+GitCommit: 1f37025ef2b9b70706d8e11cc3552830e4524758
 Directory: 20.10/dind
 
 Tags: 20.10.17-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: b4ebf24fc840e7f223c9e7ab361a02fa2ffd2e3e
+GitCommit: 1f37025ef2b9b70706d8e11cc3552830e4524758
 Directory: 20.10/dind-rootless
 
 Tags: 20.10.17-git, 20.10-git, 20-git, git
 Architectures: amd64, arm64v8
-GitCommit: 387e351394bfad74bceebf8303c6c8e39c3d4ed4
+GitCommit: f23a2bea97f6d7ec563bc316302fb8edf620ec5b
 Directory: 20.10/git
 
 Tags: 20.10.17-windowsservercore-ltsc2022, 20.10-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/fd40393: Update 22.06-rc to compose 2.9.0
- https://github.com/docker-library/docker/commit/8ddb44b: Update 20.10 to compose 2.9.0
- https://github.com/docker-library/docker/commit/274f65c: Update 22.06-rc to compose 2.8.0
- https://github.com/docker-library/docker/commit/fb39a14: Update 20.10 to compose 2.8.0
- https://github.com/docker-library/docker/commit/5855597: Merge pull request https://github.com/docker-library/docker/pull/369 from infosiftr/cli
- https://github.com/docker-library/docker/commit/1f37025: Only include the CLI in the CLI variants (finally, as was intended all along)
- https://github.com/docker-library/docker/commit/f23a2be: Add explicit "cli" aliases and move "latest" to "dind" in 22.06+