### PR TITLE
Update Amazon Linux 2022 images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 46eae60b7768b53eba5fce016d3081d23fd4a670
 
-Tags: 2022.0.20220628.8, 2022, devel
+Tags: 2022.0.20220728.1, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: d83f9e2805292583b9bdf43fe6d5e959a3563de8
+amd64-GitCommit: d994363e8bd6af4292115b0f9744c077d1fb6340
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: ef9808b6dbfda586e241b5df1c4860f964dc4d35
+arm64v8-GitCommit: c63b633bea3e29c6fff5164475c446578130b6f9
 
-Tags: 2022.0.20220628.8-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220728.1-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: b123666c1e4c23edaccd8ce06083155b9ada5c79
+amd64-GitCommit: 82741b3e35ed5a2b17b36010d1f8e4896608c6d6
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 6ff44cdfc50db84d87366defe573ec97876073cc
+arm64v8-GitCommit: 46b47cd29079655f37b8f5f2a8806778ead3646f


### PR DESCRIPTION
Hello,

This change update Amazon Linux 2022 DockerHub images.
New image version is `2022.0.20220728.1`.

Thanks,
Sumit