### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-5809 and ELSA-2022-5818

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 311842e14d524082eba2a4b7b1754be770c96f0c
+amd64-GitCommit: 8df3f29a3d6cf1e189d25f8e90b5e35bea869da8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 32a97600f20e99bdf72ce634df72503283e7e8ca
+arm64v8-GitCommit: 9ef076afef9261bcb1912e743c3c63845ad3a59a
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1586, CVE-2022-1292, CVE-2022-2068, CVE-2022-2097,

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-5809.html
https://linux.oracle.com/errata/ELSA-2022-5818.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>