### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -28,15 +28,15 @@ amd64-GitCommit: 5a5b6a174313cfcc9b257cbfb3edcae37a8dd186
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 31e8c3ce20300fda6123e190cf579315e26f843e
 
-Tags: 2018.03.0.20220609.0, 2018.03, 1
+Tags: 2018.03.0.20220705.1, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 7a44cc6ff549a6b4abc33d73bca88eae66c31ddc
+amd64-GitCommit: 1a4122f26c166f6a4fb08f9ba1a18e6298553863
 
-Tags: 2018.03.0.20220609.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20220705.1-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 46eae60b7768b53eba5fce016d3081d23fd4a670
+amd64-GitCommit: b05b63c38a83eeecd13ac105e0dd8f07bb91bbf4
 
 Tags: 2022.0.20220728.1, 2022, devel
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This container release contains security updates for the following packages.
Also noted are the specific CVEs addressed for each package.

#### openssl-1.0.2k-16.158.amzn1
- CVE-2022-1292

#### zlib-1.2.8-7.19.amzn1
- CVE-2018-25032

#### expat-2.1.0-14.31.amzn1
- CVE-2021-46143
- CVE-2022-22822
- CVE-2022-22823
- CVE-2022-22824
- CVE-2022-22825
- CVE-2022-22826
- CVE-2022-22827