### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.10.7, 3.10, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 91390cfe47c10a52c055ca404610397b29fa7643
+GitCommit: 12f3bdce892e410cc190dc4f3a4d9a405f478b23
 Directory: 3.10/ubuntu
 
 Tags: 3.10.7-management, 3.10-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.7-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91390cfe47c10a52c055ca404610397b29fa7643
+GitCommit: 12f3bdce892e410cc190dc4f3a4d9a405f478b23
 Directory: 3.10/alpine
 
 Tags: 3.10.7-management-alpine, 3.10-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/baebd3b: Merge pull request https://github.com/docker-library/rabbitmq/pull/569 from infosiftr/erlang-25
- https://github.com/docker-library/rabbitmq/commit/12f3bdc: Bump 3.10.x to use erlang 25