### PR TITLE
Release Plone 5.2.9 and 5.2.8

### DIFF
--- a/library/plone
+++ b/library/plone
@@ -4,7 +4,12 @@ Maintainers: Alin Voinea <alin.voinea@gmail.com> (@avoinea),
              Antonio De Marinis <Antonio.DeMarinis@eea.europa.eu> (@demarant)
 GitRepo: https://github.com/plone/plone.docker.git
 
-Tags: 5.2.7-python38, 5.2-python38, 5-python38, python38, 5.2.7, 5.2, 5, latest
-Architectures: amd64
-GitCommit: d17783d696042a3e9c2214c289306493e75f5ddc
-Directory: 5.2/5.2.7/debian
+Tags: 5.2.9-python38, 5.2-python38, 5-python38, python38, 5.2.9, 5.2, 5, latest
+Architectures: amd64, arm64v8
+GitCommit: dfb126db2d9c956d84ff381e7b1ee9f642edf716
+Directory: 5.2/5.2.9/debian
+
+Tags: 5.2.8-python38, 5.2.8
+Architectures: amd64, arm64v8
+GitCommit: dfb126db2d9c956d84ff381e7b1ee9f642edf716
+Directory: 5.2/5.2.8/debian


### PR DESCRIPTION
- Also trying to bring back arm64v8 - See https://github.com/plone/plone.docker/issues/170