### PR TITLE
Replace Zookeeper openjdk base image with eclipse-temurin

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -3,20 +3,20 @@ GitRepo: https://github.com/31z4/zookeeper-docker.git
 
 Tags: 3.5.9, 3.5
 Architectures: amd64, arm64v8
-GitCommit: 928f1fa35d3414f31bb542b55891c8662b14b84a
+GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.5.9
 
 Tags: 3.6.3, 3.6
 Architectures: amd64, arm64v8
-GitCommit: 928f1fa35d3414f31bb542b55891c8662b14b84a
+GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.6.3
 
 Tags: 3.7.1, 3.7
 Architectures: amd64, arm64v8
-GitCommit: 060f64d28d1780373f90ac152bd2538abcf1924c
+GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.7.1
 
 Tags: 3.8.0, 3.8, latest
 Architectures: amd64, arm64v8
-GitCommit: d91ba6412cbb31fdcafab477bbe0198930931124
+GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.8.0


### PR DESCRIPTION
Because OpenJDK is fully deprecated as per https://github.com/docker-library/docs/pull/2162.