### PR TITLE
Replace Storm openjdk base image with eclipse-temurin

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -3,9 +3,9 @@ GitRepo: https://github.com/31z4/storm-docker.git
 Architectures: amd64
 
 Tags: 1.2.4, 1.2
-GitCommit: a80831113011cf40a53e91e98790e99ad5a76280
+GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 1.2.4
 
 Tags: 2.4.0, 2.4, latest
-GitCommit: f72658afa5e9c4ee4d4d5ef5cf9b32b226d0ed19
+GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 2.4.0


### PR DESCRIPTION
Because OpenJDK is fully deprecated as per https://github.com/docker-library/docs/pull/2162.