### PR TITLE
Update Clear Linux OS to 36750

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 9dfc472e19f7d2ac4e3ad1f25eb6dd93bf70a7e3
-GitFetch: refs/heads/base-36700
+GitCommit: 144a6e3eb77d4d4d1f97ecaf144aa8e576bbb9b7
+GitFetch: refs/heads/base-36750


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36750

@bryteise @djklimes @bryteise