### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.7-dev2, 2.7-dev, 2.7-dev2-bullseye, 2.7-dev-bullseye
+Tags: 2.7-dev3, 2.7-dev, 2.7-dev3-bullseye, 2.7-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9605d3a0f784d4787a5cdf176fd66d08cbc10cfd
+GitCommit: 84142e66e8689a39bcba2077f063385df69c7e8a
 Directory: 2.7
 
-Tags: 2.7-dev2-alpine, 2.7-dev-alpine, 2.7-dev2-alpine3.16, 2.7-dev-alpine3.16
+Tags: 2.7-dev3-alpine, 2.7-dev-alpine, 2.7-dev3-alpine3.16, 2.7-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9605d3a0f784d4787a5cdf176fd66d08cbc10cfd
+GitCommit: 84142e66e8689a39bcba2077f063385df69c7e8a
 Directory: 2.7/alpine
 
 Tags: 2.6.2, 2.6, lts, latest, 2.6.2-bullseye, 2.6-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/84142e6: Update 2.7 to 2.7-dev3