### PR TITLE
Haskell GHC 9.4.1 + cabal-install 3.8.1.0

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,32 +1,42 @@
 Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.2.4-buster, 9.2-buster, 9-buster, buster, 9.2.4, 9.2, 9, latest
+Tags: 9.4.1-buster, 9.4-buster, 9-buster, buster, 9.4.1, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 90dbf04d35f52704c46f3ebc08e8eeef6e9b026b
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+Directory: 9.4/buster
+
+Tags: 9.4.1-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.1-slim, 9.4-slim, 9-slim, slim
+Architectures: amd64, arm64v8
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+Directory: 9.4/slim-buster
+
+Tags: 9.2.4-buster, 9.2-buster, 9.2.4, 9.2
+Architectures: amd64, arm64v8
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
 Directory: 9.2/buster
 
-Tags: 9.2.4-slim-buster, 9.2-slim-buster, 9-slim-buster, slim-buster, 9.2.4-slim, 9.2-slim, 9-slim, slim
+Tags: 9.2.4-slim-buster, 9.2-slim-buster, 9.2.4-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 90dbf04d35f52704c46f3ebc08e8eeef6e9b026b
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
 Architectures: amd64, arm64v8
-GitCommit: 573ee754783f8d5c5674888768378c6832f8d121
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
 Directory: 9.0/buster
 
 Tags: 9.0.2-slim-buster, 9.0-slim-buster, 9.0.2-slim, 9.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 573ee754783f8d5c5674888768378c6832f8d121
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
 Directory: 9.0/slim-buster
 
 Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
 Architectures: amd64, arm64v8
-GitCommit: 595046aa00340b831927be7edb2f4eaa1a83e4e1
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
 Directory: 8.10/buster
 
 Tags: 8.10.7-slim-buster, 8.10-slim-buster, 8-slim-buster, 8.10.7-slim, 8.10-slim, 8-slim
 Architectures: amd64, arm64v8
-GitCommit: 573ee754783f8d5c5674888768378c6832f8d121
+GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
 Directory: 8.10/slim-buster

--- a/test/tests/haskell-cabal/container.sh
+++ b/test/tests/haskell-cabal/container.sh
@@ -2,4 +2,4 @@
 set -e
 
 cabal update
-cabal install --lib hashable
+cabal install --lib primitive


### PR DESCRIPTION
* Update to the [newly released GHC 9.4.1](https://www.haskell.org/ghc/download_ghc_9_4_1.html)
* Update [cabal-install to 3.8.1.0](https://github.com/haskell/cabal/releases/tag/cabal-install-v3.8.1.0).
* Switch the cabal test to use `primitive` as `hashable` does not support ghc 9.4.1 (and primitive should be generally more prompt at supporting new GHC versions).
* A side note: Will be dropping GHC 8.10 images soon, just seeing if I can sneak in another stack release that looks to be in the works before doing so. GHC 8.10 is still quite popular.