### PR TITLE
[oraclelinux] Updating 9 for ELSA-2022-5942

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0b2ed91767e74d03a31586368c1bce7cf5039f63
+amd64-GitCommit: 59ba6f733afeadd776be048c034ba71fc6668f10
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 46c5773884c8917d42acc27b6687986983dbe491
+arm64v8-GitCommit: 413b69ecdd325362a58e65ecbd38acb8b7690840
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1785, CVE-2022-1897 and CVE-2022-1927.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-5942.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>