### PR TITLE
consul: 1.13.0

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,6 +1,12 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.12.3, 1.12, latest
+Tags: 1.13.0, 1.13, latest
+Architectures: amd64, arm32v6, arm64v8, i386
+GitRepo: https://github.com/hashicorp/docker-consul.git
+GitCommit: 12d6dcd026a350da5357f289360baec5feacdb41
+Directory: 0.X
+
+Tags: 1.12.3, 1.12
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: cf3f8016a414ab2d7932da222d5644451c79ac84
@@ -11,10 +17,3 @@ Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: 89cb955b934acb8795979f29ddcbb952b1f61130
 Directory: 0.X
-
-Tags: 1.10.12, 1.10
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 02db37c133910f2e1292012da9e55738ad23d40a
-Directory: 0.X
-


### PR DESCRIPTION
Consul 1.13.0 was released yesterday (August 9, 2022). Because this is a new major release, the `1.10.x` series of Consul is now EOL which is why it has been removed here.

Signed-off-by: Evan Culver <eculver@hashicorp.com>