### PR TITLE
Bump Traefik to v2.8.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.8.1-windowsservercore-1809, 2.8.1-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.8.2-windowsservercore-1809, 2.8.2-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a88952be53ca873807f0bde453fa8e687b806fb3
+GitCommit: 0303c88799ca3fac9d487f3e2dbdc413dde1bc2c
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.8.1, 2.8.1, v2.8, 2.8, vacherin, latest
+Tags: v2.8.2, 2.8.2, v2.8, 2.8, vacherin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a88952be53ca873807f0bde453fa8e687b806fb3
+GitCommit: 0303c88799ca3fac9d487f3e2dbdc413dde1bc2c
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.8.2](https://github.com/traefik/traefik/releases/tag/v2.8.2).

/cc @ddtmachado @mpl @ldez @kevinpollet

Cheers
