### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -14,19 +14,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: c74188ab6dda46cf66acf81df5c8ec615fdeded8
 
-Tags: 2.0.20220606.1, 2, latest
+Tags: 2.0.20220719.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: c40d99df881e3ffdf7e4afc75f63c5d7e9e9cdff
+amd64-GitCommit: e957a37db9824b86caf27e30c7a625e75278b1d7
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: dfa668c553b7a55b45e1ac0563d2e1fd3065208b
+arm64v8-GitCommit: cd83f2e4573bc20d1bb7c2766adbdec3a13d5afc
 
-Tags: 2.0.20220606.1-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20220719.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 5a5b6a174313cfcc9b257cbfb3edcae37a8dd186
+amd64-GitCommit: e66b28907f1ecaabd20c3799b295fdffbd23d9e0
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 31e8c3ce20300fda6123e190cf579315e26f843e
+arm64v8-GitCommit: bc8afbbf8f243bd61ad99486b7beb4ad70b75be0
 
 Tags: 2018.03.0.20220705.1, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains security updates for the following packages.
Also noted are the specific CVEs addressed for each package.

#### libxml2-2.9.1-6.amzn2.5.5
- CVE-2022-23308

#### curl-7.79.1-4.amzn2.0.1
- CVE-2022-27782

#### expat-2.1.0-14.amzn2.0.1
- CVE-2021-46143
- CVE-2022-22822
- CVE-2022-22823
- CVE-2022-22824
- CVE-2022-22825
- CVE-2022-22826
- CVE-2022-22827