### PR TITLE
Rollback Zookeeper 3.5, 3.6, 3.7 and 3.8 to openjdk base image

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -3,20 +3,40 @@ GitRepo: https://github.com/31z4/zookeeper-docker.git
 
 Tags: 3.5.9, 3.5
 Architectures: amd64, arm64v8
+GitCommit: 060f64d28d1780373f90ac152bd2538abcf1924c
+Directory: 3.5.9
+
+Tags: 3.5.9-temurin, 3.5-temurin
+Architectures: amd64, arm64v8
 GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.5.9
 
 Tags: 3.6.3, 3.6
+Architectures: amd64, arm64v8
+GitCommit: 060f64d28d1780373f90ac152bd2538abcf1924c
+Directory: 3.6.3
+
+Tags: 3.6.3-temurin, 3.6-temurin
 Architectures: amd64, arm64v8
 GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.6.3
 
 Tags: 3.7.1, 3.7
 Architectures: amd64, arm64v8
+GitCommit: 060f64d28d1780373f90ac152bd2538abcf1924c
+Directory: 3.7.1
+
+Tags: 3.7.1-temurin, 3.7-temurin
+Architectures: amd64, arm64v8
 GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.7.1
 
-Tags: 3.8.0, 3.8, latest
+Tags: 3.8.0, 3.8
+Architectures: amd64, arm64v8
+GitCommit: 060f64d28d1780373f90ac152bd2538abcf1924c
+Directory: 3.8.0
+
+Tags: 3.8.0-temurin, 3.8-temurin, latest
 Architectures: amd64, arm64v8
 GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
 Directory: 3.8.0


### PR DESCRIPTION
Base image update caused several bug reports (see https://github.com/31z4/zookeeper-docker/issues/139 and https://github.com/31z4/zookeeper-docker/issues/140). I realised that it wasn't a great idea to override existing tags. Here I rollback version specific tags and add separate tags for `temurin` based images. I will also update image docs a bit later.