### PR TITLE
Odoo: update 13.0-15.0 to release 20220812

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: d0da651ee7d5b52660d3601b798b770e50e2af9f 
+GitCommit: 2cfc36507ecb28d73e894b02458c12a60f3359c1
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

you will find here the latest updates of Odoo supported versions.

Thanks