### PR TITLE
Rollback Storm 1.2 and 2.4 to openjdk base image

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -3,9 +3,17 @@ GitRepo: https://github.com/31z4/storm-docker.git
 Architectures: amd64
 
 Tags: 1.2.4, 1.2
+GitCommit: f72658afa5e9c4ee4d4d5ef5cf9b32b226d0ed19
+Directory: 1.2.4
+
+Tags: 1.2.4-temurin, 1.2-temurin
 GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 1.2.4
 
-Tags: 2.4.0, 2.4, latest
+Tags: 2.4.0, 2.4
+GitCommit: f72658afa5e9c4ee4d4d5ef5cf9b32b226d0ed19
+Directory: 2.4.0
+
+Tags: 2.4.0-temurin, 2.4-temurin, latest
 GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 2.4.0


### PR DESCRIPTION
Similar to https://github.com/docker-library/official-images/pull/12949. This is to avoid breaking changes for the existing tags  (except for `latest`).