### PR TITLE
Update Clear Linux OS to 36820

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 144a6e3eb77d4d4d1f97ecaf144aa8e576bbb9b7
-GitFetch: refs/heads/base-36750
+GitCommit: 33f3f474b8db231876a273778406053906944727
+GitFetch: refs/heads/base-36820


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36820

@bryteise @djklimes @bryteise