### PR TITLE
Update Monica to php 8.1

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -1,4 +1,4 @@
-# This file is generated via https://github.com/monicahq/docker/blob/f86aa012bf36e0f344dd6bf7a14c29cf3e933e3e/generate-stackbrew-library.sh
+# This file is generated via https://github.com/monicahq/docker/blob/c0340b2017890e6a465d1d4ee03331d2effc0335/generate-stackbrew-library.sh
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 GitFetch: refs/heads/main
@@ -6,14 +6,14 @@ GitFetch: refs/heads/main
 Tags: 3.7.0-apache, 3.7-apache, 3-apache, apache, 3.7.0, 3.7, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: apache
-GitCommit: 6d256f443e7cc900b48c65a3e90472a6ef42c34c
-
-Tags: 3.7.0-fpm, 3.7-fpm, 3-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-Directory: fpm
-GitCommit: 6d256f443e7cc900b48c65a3e90472a6ef42c34c
+GitCommit: c0340b2017890e6a465d1d4ee03331d2effc0335
 
 Tags: 3.7.0-fpm-alpine, 3.7-fpm-alpine, 3-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fpm-alpine
-GitCommit: 6d256f443e7cc900b48c65a3e90472a6ef42c34c
+GitCommit: c0340b2017890e6a465d1d4ee03331d2effc0335
+
+Tags: 3.7.0-fpm, 3.7-fpm, 3-fpm, fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: fpm
+GitCommit: c0340b2017890e6a465d1d4ee03331d2effc0335


### PR DESCRIPTION
Update Monica [v3.7.0](https://github.com/monicahq/monica/releases/tag/v3.7.0) to php 8.1, prior to the next release.