### PR TITLE
Update amazoncorretto 11 to 11.0.16.9.1 and 17 to 17.0.4.9.1

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -4,7 +4,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Joshua Cao <joshcao@amazon.com> (@caojoshua)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: aaaf98eff8bb16697f973daf9f65fbf825d55ae8
+GitCommit: 85b940cab0e1ea3d5c3ba7f566b127e673b2389d
 
 Tags: 8, 8u342, 8u342-al2, 8-al2-full, 8-al2-jdk, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
See [corretto-docker#113](https://github.com/corretto/corretto-docker/pull/113)