### PR TITLE
Releasing neo4j 4.3.17 and legacy versions 3.5.35, 4.1.12 and 4.2.19

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -12,12 +12,12 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 Tags: 4.4.10, 4.4.10-community, 4.4, 4.4-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 985060aa38c5b873b18cd1b2c522c69ddb25d91a
+GitCommit: 598a291bc442f218be772f377d029689dba39ab8
 Directory: 4.4.10/community
 
 Tags: 4.4.10-enterprise, 4.4-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 985060aa38c5b873b18cd1b2c522c69ddb25d91a
+GitCommit: 598a291bc442f218be772f377d029689dba39ab8
 Directory: 4.4.10/enterprise
 
 Tags: 4.4.9, 4.4.9-community

--- a/library/neo4j
+++ b/library/neo4j
@@ -12,12 +12,12 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 Tags: 4.4.10, 4.4.10-community, 4.4, 4.4-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 598a291bc442f218be772f377d029689dba39ab8
+GitCommit: 985060aa38c5b873b18cd1b2c522c69ddb25d91a
 Directory: 4.4.10/community
 
 Tags: 4.4.10-enterprise, 4.4-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 598a291bc442f218be772f377d029689dba39ab8
+GitCommit: 985060aa38c5b873b18cd1b2c522c69ddb25d91a
 Directory: 4.4.10/enterprise
 
 Tags: 4.4.9, 4.4.9-community

--- a/library/neo4j
+++ b/library/neo4j
@@ -120,11 +120,20 @@ Architectures: amd64, arm64v8
 GitCommit: c3cd89287e0295cbac5ef85de7210ac879934243
 Directory: 4.4.0/enterprise
 
-Tags: 4.3.16, 4.3.16-community, 4.3, 4.3-community
+
+Tags: 4.3.17, 4.3.17-community, 4.3, 4.3-community
+GitCommit: 7c2af75d181fe82851a9560aea9acb6bb5af3992
+Directory: 4.3.17/community
+
+Tags: 4.3.17-enterprise, 4.3-enterprise
+GitCommit: 7c2af75d181fe82851a9560aea9acb6bb5af3992
+Directory: 4.3.17/enterprise
+
+Tags: 4.3.16, 4.3.16-community
 GitCommit: feef4dc3c3e3c04a169ce82e4950151f368acf7f
 Directory: 4.3.16/community
 
-Tags: 4.3.16-enterprise, 4.3-enterprise
+Tags: 4.3.16-enterprise
 GitCommit: feef4dc3c3e3c04a169ce82e4950151f368acf7f
 Directory: 4.3.16/enterprise
 
@@ -255,3 +264,31 @@ Directory: 4.3.0/community
 Tags: 4.3.0-enterprise
 GitCommit: 4e1de71ba0017d996c292730663fd40d14d3e983
 Directory: 4.3.0/enterprise
+
+
+
+
+
+Tags: 4.2.19, 4.2.19-community, 4.2, 4.2-community
+GitCommit: ef8675812ff5f14c12796e15429b5d51e78bb40e
+Directory: 4.2.19/community
+
+Tags: 4.2.19-enterprise, 4.2-enterprise
+GitCommit: ef8675812ff5f14c12796e15429b5d51e78bb40e
+Directory: 4.2.19/enterprise
+
+Tags: 4.1.12, 4.1.12-community, 4.1, 4.1-community
+GitCommit: 9cc37f4de8fffc770754ce6f1cc55681517eea79
+Directory: 4.1.12/community
+
+Tags: 4.1.12-enterprise, 4.1-enterprise
+GitCommit: 9cc37f4de8fffc770754ce6f1cc55681517eea79
+Directory: 4.1.12/enterprise
+
+Tags: 3.5.35, 3.5.35-community, 3.5, 3.5-community
+GitCommit: a68e29db3f0acfcdc104a2cdd545aa8e48533231
+Directory: 3.5.35/community
+
+Tags: 3.5.35-enterprise, 3.5-enterprise
+GitCommit: a68e29db3f0acfcdc104a2cdd545aa8e48533231
+Directory: 3.5.35/enterprise


### PR DESCRIPTION
We had to release bug fixes to some old, unsupported neo4j versions. So there are some images here we need publishing, but don't really mind about getting security updates on them. I don't know if you have a procedure for that? Once  those images have been accepted and published in dockerhub, should I submit another PR to delete them from this library file?