### PR TITLE
Update maintainers list

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -2,7 +2,8 @@ Maintainers: David Reimschussel <dreimschussel@influxdata.com> (@reimda),
              Josh Powers <jpowers@influxdata.com> (@powersj),
              Mya Longmire <mlongmire@influxdata.com> (@MyaLongmire),
              Sebastian Spaink <sspaink@influxdata.com> (@sspaink),
-             Sven Rebhan <srebhan@influxdata.com> (@srebhan)
+             Sven Rebhan <srebhan@influxdata.com> (@srebhan),
+             Alan Pope <apope@influxdata.com> (@popey)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
 GitCommit: 1cec93ead66bb9ca4a1e34a2070dfafba3b9c7a9
 


### PR DESCRIPTION
Adding myself to the maintainers' list for the official telegraf docker images, for future releases.

Tagging @reimda @powersj @MyaLongmire @sspaink @srebhan to +1  if required.