### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.10.7, 3.10, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 12f3bdce892e410cc190dc4f3a4d9a405f478b23
+GitCommit: 96afbc0ef1edc8747504b9511181cb52f67166ad
 Directory: 3.10/ubuntu
 
 Tags: 3.10.7-management, 3.10-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.7-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 12f3bdce892e410cc190dc4f3a4d9a405f478b23
+GitCommit: 96afbc0ef1edc8747504b9511181cb52f67166ad
 Directory: 3.10/alpine
 
 Tags: 3.10.7-management-alpine, 3.10-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.22, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 2657f20be274378e689a2e690ff54de28549b29f
+GitCommit: 2850beba32fd4c4e78e29d6148a0d2f81c61d9fb
 Directory: 3.9/ubuntu
 
 Tags: 3.9.22-management, 3.9-management
@@ -36,7 +36,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.22-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2657f20be274378e689a2e690ff54de28549b29f
+GitCommit: 2850beba32fd4c4e78e29d6148a0d2f81c61d9fb
 Directory: 3.9/alpine
 
 Tags: 3.9.22-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2850beb: Update 3.9 to otp 24.3.4.3
- https://github.com/docker-library/rabbitmq/commit/96afbc0: Update 3.10 to otp 25.0.4