### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -16,10 +16,10 @@ Directory: 5/alpine
 
 Tags: 4.48.2, 4.48, 4
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0001cca23a061ce8799137808b9ca22c78b60eab
+GitCommit: 7b4bc3f80d2d9752a6dea43cc38013b627c3e759
 Directory: 4/debian
 
 Tags: 4.48.2-alpine, 4.48-alpine, 4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 0001cca23a061ce8799137808b9ca22c78b60eab
+GitCommit: 7b4bc3f80d2d9752a6dea43cc38013b627c3e759
 Directory: 4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/550d7e9: Merge pull request https://github.com/docker-library/ghost/pull/328 from infosiftr/no-python2
- https://github.com/docker-library/ghost/commit/7b4bc3f: Switch back to python3 since python2 is not available in alpine 3.16