### PR TITLE
Odoo: update 13.0-15.0 to release 20220819

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 2cfc36507ecb28d73e894b02458c12a60f3359c1
+GitCommit: 774bbf90ef2ff25098c4dea8f2dca5c0295b5afa
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks.