### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2022-05-06
-Tags: 12.1.0, 12.1, 12, latest, 12.1.0-bullseye, 12.1-bullseye, 12-bullseye, bullseye
+# Last Modified: 2022-08-19
+Tags: 12.2.0, 12.2, 12, latest, 12.2.0-bullseye, 12.2-bullseye, 12-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5a94a2d5c812fe57f6f28713b0f899b879145d3
+GitCommit: 523e01b2ccf43f1fd702aa9fdc2f71c827b76525
 Directory: 12
-# Docker EOL: 2023-11-06
+# Docker EOL: 2024-02-19
 
 # Last Modified: 2022-04-21
 Tags: 11.3.0, 11.3, 11, 11.3.0-bullseye, 11.3-bullseye, 11-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/523e01b: Update 12 to 12.2.0
- https://github.com/docker-library/gcc/commit/f180919: Update jq-template for speed improvements