### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 84142e66e8689a39bcba2077f063385df69c7e8a
 Directory: 2.7/alpine
 
-Tags: 2.6.2, 2.6, lts, latest, 2.6.2-bullseye, 2.6-bullseye, lts-bullseye, bullseye
+Tags: 2.6.3, 2.6, lts, latest, 2.6.3-bullseye, 2.6-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6499157f0b9ca49bf9416631aa069eb617b60b3
+GitCommit: 095580082023fcee88a058529490aa9cd71d1dbc
 Directory: 2.6
 
-Tags: 2.6.2-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.2-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
+Tags: 2.6.3-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.3-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6499157f0b9ca49bf9416631aa069eb617b60b3
+GitCommit: 095580082023fcee88a058529490aa9cd71d1dbc
 Directory: 2.6/alpine
 
 Tags: 2.5.8, 2.5, 2.5.8-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/0955800: Update 2.6 to 2.6.3