### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.9.4, 5.9, 5, latest
+Tags: 5.10.1, 5.10, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5de0cce1e7ae9470a7dbdbbf776c623a3f1c7170
+GitCommit: 35af16aaf0dc86c97937db9c04dce3cb2615e543
 Directory: 5/debian
 
-Tags: 5.9.4-alpine, 5.9-alpine, 5-alpine, alpine
+Tags: 5.10.1-alpine, 5.10-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 5de0cce1e7ae9470a7dbdbbf776c623a3f1c7170
+GitCommit: 35af16aaf0dc86c97937db9c04dce3cb2615e543
 Directory: 5/alpine
 
 Tags: 4.48.2, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/35af16a: Update to 5.10.1, ghost-cli 1.22.0