### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,359 +1,161 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/f736d86bccabf5072d84e77b72d2b3c83446a67f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/f67fe7f23477c1b80b1b49f2b5d80fff07a85fec/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 20-ea-9-jdk-oraclelinux8, 20-ea-9-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-9-jdk-oracle, 20-ea-9-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-9-jdk, 20-ea-9, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-11-jdk-oraclelinux8, 20-ea-11-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-11-jdk-oracle, 20-ea-11-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-11-jdk, 20-ea-11, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-9-jdk-oraclelinux7, 20-ea-9-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-11-jdk-oraclelinux7, 20-ea-11-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-9-jdk-bullseye, 20-ea-9-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-11-jdk-bullseye, 20-ea-11-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-9-jdk-slim-bullseye, 20-ea-9-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-9-jdk-slim, 20-ea-9-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-11-jdk-slim-bullseye, 20-ea-11-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-11-jdk-slim, 20-ea-11-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-9-jdk-buster, 20-ea-9-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-11-jdk-buster, 20-ea-11-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/buster
 
-Tags: 20-ea-9-jdk-slim-buster, 20-ea-9-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-11-jdk-slim-buster, 20-ea-11-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-9-jdk-windowsservercore-ltsc2022, 20-ea-9-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-9-jdk-windowsservercore, 20-ea-9-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-9-jdk, 20-ea-9, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-11-jdk-windowsservercore-ltsc2022, 20-ea-11-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-11-jdk-windowsservercore, 20-ea-11-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-11-jdk, 20-ea-11, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-9-jdk-windowsservercore-1809, 20-ea-9-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-9-jdk-windowsservercore, 20-ea-9-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-9-jdk, 20-ea-9, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-11-jdk-windowsservercore-1809, 20-ea-11-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-11-jdk-windowsservercore, 20-ea-11-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-11-jdk, 20-ea-11, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-9-jdk-nanoserver-1809, 20-ea-9-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-9-jdk-nanoserver, 20-ea-9-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-11-jdk-nanoserver-1809, 20-ea-11-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-11-jdk-nanoserver, 20-ea-11-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: 68650ae15fc5a6e810edc04e03442d163d5c3c26
+GitCommit: 045b903d0b26a024462a358d981f0884093d936b
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 19-ea-34-jdk-oraclelinux8, 19-ea-34-oraclelinux8, 19-ea-jdk-oraclelinux8, 19-ea-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-ea-34-jdk-oracle, 19-ea-34-oracle, 19-ea-jdk-oracle, 19-ea-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-ea-34-jdk, 19-ea-34, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-rc-jdk-oraclelinux8, 19-rc-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-rc-jdk-oracle, 19-rc-oracle, 19-jdk-oracle, 19-oracle
+SharedTags: 19-rc-jdk, 19-rc, 19-jdk, 19
 Architectures: amd64, arm64v8
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/oraclelinux8
 
-Tags: 19-ea-34-jdk-oraclelinux7, 19-ea-34-oraclelinux7, 19-ea-jdk-oraclelinux7, 19-ea-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
+Tags: 19-rc-jdk-oraclelinux7, 19-rc-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/oraclelinux7
 
-Tags: 19-ea-34-jdk-bullseye, 19-ea-34-bullseye, 19-ea-jdk-bullseye, 19-ea-bullseye, 19-jdk-bullseye, 19-bullseye
+Tags: 19-rc-jdk-bullseye, 19-rc-bullseye, 19-jdk-bullseye, 19-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/bullseye
 
-Tags: 19-ea-34-jdk-slim-bullseye, 19-ea-34-slim-bullseye, 19-ea-jdk-slim-bullseye, 19-ea-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-ea-34-jdk-slim, 19-ea-34-slim, 19-ea-jdk-slim, 19-ea-slim, 19-jdk-slim, 19-slim
+Tags: 19-rc-jdk-slim-bullseye, 19-rc-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-rc-jdk-slim, 19-rc-slim, 19-jdk-slim, 19-slim
 Architectures: amd64, arm64v8
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/slim-bullseye
 
-Tags: 19-ea-34-jdk-buster, 19-ea-34-buster, 19-ea-jdk-buster, 19-ea-buster, 19-jdk-buster, 19-buster
+Tags: 19-rc-jdk-buster, 19-rc-buster, 19-jdk-buster, 19-buster
 Architectures: amd64, arm64v8
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/buster
 
-Tags: 19-ea-34-jdk-slim-buster, 19-ea-34-slim-buster, 19-ea-jdk-slim-buster, 19-ea-slim-buster, 19-jdk-slim-buster, 19-slim-buster
+Tags: 19-rc-jdk-slim-buster, 19-rc-slim-buster, 19-jdk-slim-buster, 19-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/slim-buster
 
-Tags: 19-ea-5-jdk-alpine3.16, 19-ea-5-alpine3.16, 19-ea-jdk-alpine3.16, 19-ea-alpine3.16, 19-jdk-alpine3.16, 19-alpine3.16, 19-ea-5-jdk-alpine, 19-ea-5-alpine, 19-ea-jdk-alpine, 19-ea-alpine, 19-jdk-alpine, 19-alpine
-Architectures: amd64
-GitCommit: 04d037e69a6071859c763903b20b1b39e95b4cad
-Directory: 19/jdk/alpine3.16
-
-Tags: 19-ea-5-jdk-alpine3.15, 19-ea-5-alpine3.15, 19-ea-jdk-alpine3.15, 19-ea-alpine3.15, 19-jdk-alpine3.15, 19-alpine3.15
-Architectures: amd64
-GitCommit: c6190d5cbbefd5233c190561fda803f742ae8241
-Directory: 19/jdk/alpine3.15
-
-Tags: 19-ea-34-jdk-windowsservercore-ltsc2022, 19-ea-34-windowsservercore-ltsc2022, 19-ea-jdk-windowsservercore-ltsc2022, 19-ea-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-ea-34-jdk-windowsservercore, 19-ea-34-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-34-jdk, 19-ea-34, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-rc-jdk-windowsservercore-ltsc2022, 19-rc-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19-rc-jdk-windowsservercore, 19-rc-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-rc-jdk, 19-rc, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19-ea-34-jdk-windowsservercore-1809, 19-ea-34-windowsservercore-1809, 19-ea-jdk-windowsservercore-1809, 19-ea-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-ea-34-jdk-windowsservercore, 19-ea-34-windowsservercore, 19-ea-jdk-windowsservercore, 19-ea-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-ea-34-jdk, 19-ea-34, 19-ea-jdk, 19-ea, 19-jdk, 19
+Tags: 19-rc-jdk-windowsservercore-1809, 19-rc-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19-rc-jdk-windowsservercore, 19-rc-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-rc-jdk, 19-rc, 19-jdk, 19
 Architectures: windows-amd64
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
 Directory: 19/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 19-ea-34-jdk-nanoserver-1809, 19-ea-34-nanoserver-1809, 19-ea-jdk-nanoserver-1809, 19-ea-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-ea-34-jdk-nanoserver, 19-ea-34-nanoserver, 19-ea-jdk-nanoserver, 19-ea-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19-rc-jdk-nanoserver-1809, 19-rc-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19-rc-jdk-nanoserver, 19-rc-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: 3939f3b93eff36f41c10eb10d67ff95d3bc6dba3
+GitCommit: afc6de3b6821a62f8d4d7b656477db3b4cd29d1a
 Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 18.0.2-jdk-oraclelinux8, 18.0.2-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.2-jdk-oracle, 18.0.2-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle
-SharedTags: 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
+Tags: 18.0.2.1-jdk-oraclelinux8, 18.0.2.1-oraclelinux8, 18.0.2-jdk-oraclelinux8, 18.0.2-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.2.1-jdk-oracle, 18.0.2.1-oracle, 18.0.2-jdk-oracle, 18.0.2-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle
+SharedTags: 18.0.2.1-jdk, 18.0.2.1, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: amd64, arm64v8
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/oraclelinux8
 
-Tags: 18.0.2-jdk-oraclelinux7, 18.0.2-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7, jdk-oraclelinux7, oraclelinux7
+Tags: 18.0.2.1-jdk-oraclelinux7, 18.0.2.1-oraclelinux7, 18.0.2-jdk-oraclelinux7, 18.0.2-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7, jdk-oraclelinux7, oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/oraclelinux7
 
-Tags: 18.0.2-jdk-bullseye, 18.0.2-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye, jdk-bullseye, bullseye
+Tags: 18.0.2.1-jdk-bullseye, 18.0.2.1-bullseye, 18.0.2-jdk-bullseye, 18.0.2-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye, jdk-bullseye, bullseye
 Architectures: amd64, arm64v8
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/bullseye
 
-Tags: 18.0.2-jdk-slim-bullseye, 18.0.2-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 18.0.2-jdk-slim, 18.0.2-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim, jdk-slim, slim
+Tags: 18.0.2.1-jdk-slim-bullseye, 18.0.2.1-slim-bullseye, 18.0.2-jdk-slim-bullseye, 18.0.2-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 18.0.2.1-jdk-slim, 18.0.2.1-slim, 18.0.2-jdk-slim, 18.0.2-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim, jdk-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/slim-bullseye
 
-Tags: 18.0.2-jdk-buster, 18.0.2-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster, jdk-buster, buster
+Tags: 18.0.2.1-jdk-buster, 18.0.2.1-buster, 18.0.2-jdk-buster, 18.0.2-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster, jdk-buster, buster
 Architectures: amd64, arm64v8
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/buster
 
-Tags: 18.0.2-jdk-slim-buster, 18.0.2-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster, jdk-slim-buster, slim-buster
+Tags: 18.0.2.1-jdk-slim-buster, 18.0.2.1-slim-buster, 18.0.2-jdk-slim-buster, 18.0.2-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster, jdk-slim-buster, slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/slim-buster
 
-Tags: 18.0.2-jdk-windowsservercore-ltsc2022, 18.0.2-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022, jdk-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
+Tags: 18.0.2.1-jdk-windowsservercore-ltsc2022, 18.0.2.1-windowsservercore-ltsc2022, 18.0.2-jdk-windowsservercore-ltsc2022, 18.0.2-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022, jdk-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 18.0.2.1-jdk-windowsservercore, 18.0.2.1-windowsservercore, 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2.1-jdk, 18.0.2.1, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: windows-amd64
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 18.0.2-jdk-windowsservercore-1809, 18.0.2-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
+Tags: 18.0.2.1-jdk-windowsservercore-1809, 18.0.2.1-windowsservercore-1809, 18.0.2-jdk-windowsservercore-1809, 18.0.2-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
+SharedTags: 18.0.2.1-jdk-windowsservercore, 18.0.2.1-windowsservercore, 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2.1-jdk, 18.0.2.1, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
 Architectures: windows-amd64
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 18.0.2-jdk-nanoserver-1809, 18.0.2-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 18.0.2-jdk-nanoserver, 18.0.2-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver, jdk-nanoserver, nanoserver
+Tags: 18.0.2.1-jdk-nanoserver-1809, 18.0.2.1-nanoserver-1809, 18.0.2-jdk-nanoserver-1809, 18.0.2-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
+SharedTags: 18.0.2.1-jdk-nanoserver, 18.0.2.1-nanoserver, 18.0.2-jdk-nanoserver, 18.0.2-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver, jdk-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 5b5fbdbbd1d25b3969ce8f61607e746c26aa4c62
+GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
 Directory: 18/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 11.0.16-jdk-oraclelinux8, 11.0.16-oraclelinux8, 11.0-jdk-oraclelinux8, 11.0-oraclelinux8, 11-jdk-oraclelinux8, 11-oraclelinux8, 11.0.16-jdk-oracle, 11.0.16-oracle, 11.0-jdk-oracle, 11.0-oracle, 11-jdk-oracle, 11-oracle
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/oraclelinux8
-
-Tags: 11.0.16-jdk-oraclelinux7, 11.0.16-oraclelinux7, 11.0-jdk-oraclelinux7, 11.0-oraclelinux7, 11-jdk-oraclelinux7, 11-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/oraclelinux7
-
-Tags: 11.0.16-jdk-bullseye, 11.0.16-bullseye, 11.0-jdk-bullseye, 11.0-bullseye, 11-jdk-bullseye, 11-bullseye
-SharedTags: 11.0.16-jdk, 11.0.16, 11.0-jdk, 11.0, 11-jdk, 11
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/bullseye
-
-Tags: 11.0.16-jdk-slim-bullseye, 11.0.16-slim-bullseye, 11.0-jdk-slim-bullseye, 11.0-slim-bullseye, 11-jdk-slim-bullseye, 11-slim-bullseye, 11.0.16-jdk-slim, 11.0.16-slim, 11.0-jdk-slim, 11.0-slim, 11-jdk-slim, 11-slim
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/slim-bullseye
-
-Tags: 11.0.16-jdk-buster, 11.0.16-buster, 11.0-jdk-buster, 11.0-buster, 11-jdk-buster, 11-buster
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/buster
-
-Tags: 11.0.16-jdk-slim-buster, 11.0.16-slim-buster, 11.0-jdk-slim-buster, 11.0-slim-buster, 11-jdk-slim-buster, 11-slim-buster
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/slim-buster
-
-Tags: 11.0.16-jdk-windowsservercore-ltsc2022, 11.0.16-windowsservercore-ltsc2022, 11.0-jdk-windowsservercore-ltsc2022, 11.0-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.16-jdk-windowsservercore, 11.0.16-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.16-jdk, 11.0.16, 11.0-jdk, 11.0, 11-jdk, 11
-Architectures: windows-amd64
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 11.0.16-jdk-windowsservercore-1809, 11.0.16-windowsservercore-1809, 11.0-jdk-windowsservercore-1809, 11.0-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.16-jdk-windowsservercore, 11.0.16-windowsservercore, 11.0-jdk-windowsservercore, 11.0-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.16-jdk, 11.0.16, 11.0-jdk, 11.0, 11-jdk, 11
-Architectures: windows-amd64
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 11.0.16-jdk-nanoserver-1809, 11.0.16-nanoserver-1809, 11.0-jdk-nanoserver-1809, 11.0-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.16-jdk-nanoserver, 11.0.16-nanoserver, 11.0-jdk-nanoserver, 11.0-nanoserver, 11-jdk-nanoserver, 11-nanoserver
-Architectures: windows-amd64
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 11.0.16-jre-bullseye, 11.0-jre-bullseye, 11-jre-bullseye
-SharedTags: 11.0.16-jre, 11.0-jre, 11-jre
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/bullseye
-
-Tags: 11.0.16-jre-slim-bullseye, 11.0-jre-slim-bullseye, 11-jre-slim-bullseye, 11.0.16-jre-slim, 11.0-jre-slim, 11-jre-slim
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/slim-bullseye
-
-Tags: 11.0.16-jre-buster, 11.0-jre-buster, 11-jre-buster
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/buster
-
-Tags: 11.0.16-jre-slim-buster, 11.0-jre-slim-buster, 11-jre-slim-buster
-Architectures: amd64, arm64v8
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/slim-buster
-
-Tags: 11.0.16-jre-windowsservercore-ltsc2022, 11.0-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.16-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.16-jre, 11.0-jre, 11-jre
-Architectures: windows-amd64
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 11.0.16-jre-windowsservercore-1809, 11.0-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.16-jre-windowsservercore, 11.0-jre-windowsservercore, 11-jre-windowsservercore, 11.0.16-jre, 11.0-jre, 11-jre
-Architectures: windows-amd64
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 11.0.16-jre-nanoserver-1809, 11.0-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.16-jre-nanoserver, 11.0-jre-nanoserver, 11-jre-nanoserver
-Architectures: windows-amd64
-GitCommit: 8dfb0c5645098b8c330c4811c8228cae52f18388
-Directory: 11/jre/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 8u342-jdk-oraclelinux8, 8u342-oraclelinux8, 8-jdk-oraclelinux8, 8-oraclelinux8, 8u342-jdk-oracle, 8u342-oracle, 8-jdk-oracle, 8-oracle
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/oraclelinux8
-
-Tags: 8u342-jdk-oraclelinux7, 8u342-oraclelinux7, 8-jdk-oraclelinux7, 8-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/oraclelinux7
-
-Tags: 8u342-jdk-bullseye, 8u342-bullseye, 8-jdk-bullseye, 8-bullseye
-SharedTags: 8u342-jdk, 8u342, 8-jdk, 8
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/bullseye
-
-Tags: 8u342-jdk-slim-bullseye, 8u342-slim-bullseye, 8-jdk-slim-bullseye, 8-slim-bullseye, 8u342-jdk-slim, 8u342-slim, 8-jdk-slim, 8-slim
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/slim-bullseye
-
-Tags: 8u342-jdk-buster, 8u342-buster, 8-jdk-buster, 8-buster
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/buster
-
-Tags: 8u342-jdk-slim-buster, 8u342-slim-buster, 8-jdk-slim-buster, 8-slim-buster
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/slim-buster
-
-Tags: 8u342-jdk-windowsservercore-ltsc2022, 8u342-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u342-jdk-windowsservercore, 8u342-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u342-jdk, 8u342, 8-jdk, 8
-Architectures: windows-amd64
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 8u342-jdk-windowsservercore-1809, 8u342-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u342-jdk-windowsservercore, 8u342-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u342-jdk, 8u342, 8-jdk, 8
-Architectures: windows-amd64
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 8u342-jdk-nanoserver-1809, 8u342-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u342-jdk-nanoserver, 8u342-nanoserver, 8-jdk-nanoserver, 8-nanoserver
-Architectures: windows-amd64
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 8u342-jre-bullseye, 8-jre-bullseye
-SharedTags: 8u342-jre, 8-jre
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/bullseye
-
-Tags: 8u342-jre-slim-bullseye, 8-jre-slim-bullseye, 8u342-jre-slim, 8-jre-slim
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/slim-bullseye
-
-Tags: 8u342-jre-buster, 8-jre-buster
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/buster
-
-Tags: 8u342-jre-slim-buster, 8-jre-slim-buster
-Architectures: amd64, arm64v8
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/slim-buster
-
-Tags: 8u342-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u342-jre-windowsservercore, 8-jre-windowsservercore, 8u342-jre, 8-jre
-Architectures: windows-amd64
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 8u342-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u342-jre-windowsservercore, 8-jre-windowsservercore, 8u342-jre, 8-jre
-Architectures: windows-amd64
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 8u342-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u342-jre-nanoserver, 8-jre-nanoserver
-Architectures: windows-amd64
-GitCommit: a0c4da867ddd1a11408b7ec5032f12130bdc5476
-Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/307daaf: Merge pull request https://github.com/docker-library/openjdk/pull/511 from infosiftr/rc-suffix
- https://github.com/docker-library/openjdk/commit/f67fe7f: Add "-rc" suffix to only-digit version numbers
- https://github.com/docker-library/openjdk/commit/045b903: Update 20 to 20-ea+11
- https://github.com/docker-library/openjdk/commit/6e4c15a: Update 19
- https://github.com/docker-library/openjdk/commit/4b928d2: Update 18 to 18.0.2.1
- https://github.com/docker-library/openjdk/commit/241c62f: Merge pull request https://github.com/docker-library/openjdk/pull/510 from infosiftr/orphanjdk
- https://github.com/docker-library/openjdk/commit/f9cf605: Remove now-defunct 8u and 11u builds
- https://github.com/docker-library/openjdk/commit/837d7bc: Update 20 to 20-ea+10
- https://github.com/docker-library/openjdk/commit/afc6de3: Update 19 to 19