### PR TITLE
archlinux: Release 20220821.0.76637

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220814.0.74430
-GitCommit: 2225520d2851995e1268f5b259f7eac2d7783103
-GitFetch: refs/tags/v20220814.0.74430
+Tags: latest, base, base-20220821.0.76637
+GitCommit: ef2478d7d0c5fc0752c94a996d21a9f5a9528b38
+GitFetch: refs/tags/v20220821.0.76637
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220814.0.74430
-GitCommit: 2225520d2851995e1268f5b259f7eac2d7783103
-GitFetch: refs/tags/v20220814.0.74430
+Tags: base-devel, base-devel-20220821.0.76637
+GitCommit: ef2478d7d0c5fc0752c94a996d21a9f5a9528b38
+GitFetch: refs/tags/v20220821.0.76637
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks