### PR TITLE
Bump Haskell GHC to 9.4.2

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,14 +1,14 @@
 Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.4.1-buster, 9.4-buster, 9-buster, buster, 9.4.1, 9.4, 9, latest
+Tags: 9.4.2-buster, 9.4-buster, 9-buster, buster, 9.4.2, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 9f3a7b0038a6ff9feb668a51cfebebdd4301c9c3
 Directory: 9.4/buster
 
-Tags: 9.4.1-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.1-slim, 9.4-slim, 9-slim, slim
+Tags: 9.4.2-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.2-slim, 9.4-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 9f3a7b0038a6ff9feb668a51cfebebdd4301c9c3
 Directory: 9.4/slim-buster
 
 Tags: 9.2.4-buster, 9.2-buster, 9.2.4, 9.2


### PR DESCRIPTION
https://www.haskell.org/ghc/download_ghc_9_4_2.html