### PR TITLE
mariadb: q3-2022 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -4,42 +4,42 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 10.9.1-rc-jammy, 10.9-rc-jammy, 10.9.1-rc, 10.9-rc
+Tags: 10.10.1-rc-jammy, 10.10-rc-jammy, 10.10.1-rc, 10.10-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+Directory: 10.10
+
+Tags: 10.9.2-jammy, 10.9-jammy, 10-jammy, jammy, 10.9.2, 10.9, 10, latest
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.9
 
-Tags: 10.8.3-jammy, 10.8-jammy, 10-jammy, jammy, 10.8.3, 10.8, 10, latest
+Tags: 10.8.4-jammy, 10.8-jammy, 10.8.4, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.8
 
-Tags: 10.7.4-focal, 10.7-focal, 10.7.4, 10.7
+Tags: 10.7.5-focal, 10.7-focal, 10.7.5, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c6d3396be642bbc73cd14b93e62c615e242f5a0d
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.7
 
-Tags: 10.6.8-focal, 10.6-focal, 10.6.8, 10.6
+Tags: 10.6.9-focal, 10.6-focal, 10.6.9, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.6
 
-Tags: 10.5.16-focal, 10.5-focal, 10.5.16, 10.5
+Tags: 10.5.17-focal, 10.5-focal, 10.5.17, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.5
 
-Tags: 10.4.25-focal, 10.4-focal, 10.4.25, 10.4
+Tags: 10.4.26-focal, 10.4-focal, 10.4.26, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.4
 
-Tags: 10.3.35-focal, 10.3-focal, 10.3.35, 10.3
+Tags: 10.3.36-focal, 10.3-focal, 10.3.36, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
+GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
 Directory: 10.3
-
-Tags: 10.2.44-bionic, 10.2-bionic, 10.2.44, 10.2
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: c0d07be9ad5eb3bc212c6805cc8031308c56e9b6
-Directory: 10.2


### PR DESCRIPTION
10.9 is now GA and 10.10 in RC.

10.2 is EOL.