### PR TITLE
chore(kapacitor): docker images for 1.6.5

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -2,7 +2,7 @@ Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
              j. Emrys Landivar <landivar@gmail.com> (@docmerlin),
              Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: b782b96764a95f3e1c5a259a405a9848e4d4e1fd
+GitCommit: 410d53519af0edd30a985eacc3bb060258a2705d
 
 Tags: 1.5, 1.5.9
 Architectures: amd64, arm32v7, arm64v8
@@ -11,9 +11,9 @@ Directory: kapacitor/1.5
 Tags: 1.5-alpine, 1.5.9-alpine
 Directory: kapacitor/1.5/alpine
 
-Tags: 1.6, 1.6.4, latest
+Tags: 1.6, 1.6.5, latest
 Architectures: amd64, arm64v8
 Directory: kapacitor/1.6
 
-Tags: 1.6-alpine, 1.6.4-alpine, alpine
+Tags: 1.6-alpine, 1.6.5-alpine, alpine
 Directory: kapacitor/1.6/alpine


### PR DESCRIPTION
1.6.5 docker release for kapacitor