### PR TITLE
eclipse-temurin: add Stewart Addison as a maintainer

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -1,6 +1,7 @@
 # Eclipse Temurin OpenJDK images provided by the Eclipse Foundation.
 
-Maintainers: George Adams <george.adams@microsoft.com> (@gdams)
+Maintainers: George Adams <george.adams@microsoft.com> (@gdams),
+             Stewart Addison <sxa@redhat.com> (@sxa)
 GitRepo: https://github.com/adoptium/containers.git
 GitFetch: refs/heads/main
 


### PR DESCRIPTION
@sxa has been a long-term contributor to the Eclipse Temurin project and is the defacto infra-lead