### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.10.1, 5.10, 5, latest
+Tags: 5.11.0, 5.11, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 35af16aaf0dc86c97937db9c04dce3cb2615e543
+GitCommit: 0ee99f6ec473ee6c8e41c1b38beb6a5e7df1a6f6
 Directory: 5/debian
 
-Tags: 5.10.1-alpine, 5.10-alpine, 5-alpine, alpine
+Tags: 5.11.0-alpine, 5.11-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 35af16aaf0dc86c97937db9c04dce3cb2615e543
+GitCommit: 0ee99f6ec473ee6c8e41c1b38beb6a5e7df1a6f6
 Directory: 5/alpine
 
 Tags: 4.48.2, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/0ee99f6: Update to 5.11.0, ghost-cli 1.22.0