### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 2518da5eda5a13e5ada0a4560223eae96c10aaed
+GitCommit: 5bd36bedb320dab62684649d5efb7c4da14866a9
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.17-cli, 20.10-cli, 20-cli, cli, 20.10.17-cli-alpine3.16, 20.10.17, 20.10, 20, latest, 20.10.17-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 863bb07a8db66fdd02e1fe61135466dd6813b0b6
+GitCommit: 0fa745461cd9944d46fa8a5c98e69abf11e3fce6
 Directory: 20.10/cli
 
 Tags: 20.10.17-dind, 20.10-dind, 20-dind, dind, 20.10.17-dind-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/5bd36be: Update 22.06-rc to compose 2.10.1
- https://github.com/docker-library/docker/commit/0fa7454: Update 20.10 to compose 2.10.1
- https://github.com/docker-library/docker/commit/bd567a0: Fix compose/buildx version sorting