### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.3.3
+Tags: 8.4.0
 Architectures: amd64, arm64v8
-GitCommit: 4b932a8cd186e4589366534e69adcaed364f5058
+GitCommit: 24b156a8bf8e48f6bb7693e38f745f9b4ede21b4
 Directory: 8
 
-Tags: 7.17.5
+Tags: 7.17.6
 Architectures: amd64, arm64v8
-GitCommit: b87c6bed656d0c9dc4a3495c601951234ebb4b62
+GitCommit: 752ea7a8ddcf0a209377f572cfcfdb220bde24ab
 Directory: 7
 
 Tags: 6.8.23

--- a/library/kibana
+++ b/library/kibana
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.3.3
+Tags: 8.4.0
 Architectures: amd64, arm64v8
-GitCommit: fd3dccf065822f61b3f519341e261f3d468ebbbb
+GitCommit: 3265f930a6f86a76dd9c464e604feb6a7bb95a30
 Directory: 8
 
-Tags: 7.17.5
+Tags: 7.17.6
 Architectures: amd64, arm64v8
-GitCommit: b9055e0ba9924a1c594d1797049a40f6f10d6cb1
+GitCommit: cde42377b65bfe5040c87c10e5defe1137a84f25
 Directory: 7
 
 Tags: 6.8.23

--- a/library/logstash
+++ b/library/logstash
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.3.3
+Tags: 8.4.0
 Architectures: amd64, arm64v8
-GitCommit: 3e058f5639adc8d721a649fcca8cc9eed25a61f9
+GitCommit: e1ad178cf08a45beb53acd882b6153cb5da12d9e
 Directory: 8
 
-Tags: 7.17.5
+Tags: 7.17.6
 Architectures: amd64, arm64v8
-GitCommit: 10c093d06d6c7d9acef52c42632a992ed1f7ff3d
+GitCommit: 9ac7affbbe2478d5292ea4992b73b26e692a1e5f
 Directory: 7
 
 Tags: 6.8.23


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/24b156a: Update to 8.4.0
- https://github.com/docker-library/elasticsearch/commit/752ea7a: Update to 7.17.6

logstash:
- https://github.com/docker-library/logstash/commit/e1ad178: Update to 8.4.0
- https://github.com/docker-library/logstash/commit/9ac7aff: Update to 7.17.6

kibana:
- https://github.com/docker-library/kibana/commit/3265f93: Update to 8.4.0
- https://github.com/docker-library/kibana/commit/cde4237: Update to 7.17.6