### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: b05b63c38a83eeecd13ac105e0dd8f07bb91bbf4
 
-Tags: 2022.0.20220728.1, 2022, devel
+Tags: 2022.0.20220817.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: d994363e8bd6af4292115b0f9744c077d1fb6340
+amd64-GitCommit: 0b0494117a599cb5424917a6a3c13af9b60e9586
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: c63b633bea3e29c6fff5164475c446578130b6f9
+arm64v8-GitCommit: 107012dfb4e6c266b520399f69737e1c85af2122
 
-Tags: 2022.0.20220728.1-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220817.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 82741b3e35ed5a2b17b36010d1f8e4896608c6d6
+amd64-GitCommit: b96483cf1aec246d1f60b2fa151061b0304ee2c5
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 46b47cd29079655f37b8f5f2a8806778ead3646f
+arm64v8-GitCommit: ab194ce5ed08dcc56b2fe09f53b294b7e6e51f6c


### PR DESCRIPTION
Hello,

This change update Amazon Linux 2022 DockerHub images.
New image version is 2022.0.20220817.0.

Thanks,
Tanu