### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -28,15 +28,15 @@ amd64-GitCommit: e66b28907f1ecaabd20c3799b295fdffbd23d9e0
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: bc8afbbf8f243bd61ad99486b7beb4ad70b75be0
 
-Tags: 2018.03.0.20220705.1, 2018.03, 1
+Tags: 2018.03.0.20220802.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 1a4122f26c166f6a4fb08f9ba1a18e6298553863
+amd64-GitCommit: b9d60bf40f52a55f30a7abeeb123817be542d6a3
 
-Tags: 2018.03.0.20220705.1-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20220802.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: b05b63c38a83eeecd13ac105e0dd8f07bb91bbf4
+amd64-GitCommit: 62f7701ded7533f125333ad6172ebe4caedf4a00
 
 Tags: 2022.0.20220817.0, 2022, devel
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This container release contains security updates for the following packages.
Also noted are the specific CVEs addressed for each package.

#### openssl-1.0.2k-16.159.amzn1
- CVE-2022-2068

Thanks,
Sam