### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.0.5, 4.0, 4, latest
+Tags: 4.0.6, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b3332696b4a6a4405ebf95a4c4065543ee1a073d
+GitCommit: 5aa6b7ed7a342c18da796561252677f17d370616
 Directory: 4.0
 
 Tags: 3.11.13, 3.11, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/5aa6b7e: Update 4.0 to 4.0.6