### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -14,19 +14,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: c74188ab6dda46cf66acf81df5c8ec615fdeded8
 
-Tags: 2.0.20220719.0, 2, latest
+Tags: 2.0.20220805.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: e957a37db9824b86caf27e30c7a625e75278b1d7
+amd64-GitCommit: 26415c9039fa9d560723c416da68a95c96b25af3
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: cd83f2e4573bc20d1bb7c2766adbdec3a13d5afc
+arm64v8-GitCommit: 31437e8f307ec31577af1c2b9e1c2a0c9003c4ef
 
-Tags: 2.0.20220719.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20220805.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: e66b28907f1ecaabd20c3799b295fdffbd23d9e0
+amd64-GitCommit: f763826f20f7e26a2b3448f2a544660db2f5a530
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: bc8afbbf8f243bd61ad99486b7beb4ad70b75be0
+arm64v8-GitCommit: 43a28df7c080970989f6042b0110a30e1b665357
 
 Tags: 2018.03.0.20220802.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains updates for the following packages and any CVEs that are being addressed with these updates.

#### glibc-2.26-60.amzn2

#### openssl-1.0.2k-24.amzn2.0.4
- CVE-2022-2068


Thanks,
Sam