### PR TITLE
Odoo: update 13.0-15.0 to release 20220826

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 774bbf90ef2ff25098c4dea8f2dca5c0295b5afa
+GitCommit: 4174d74ed1383f9c366fba899763e1fb147712d8
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

you 'll find here the latest updates of Odoo Supported versions.


Thank you.