### PR TITLE
[oraclelinux] Updating 7, 8, 8-slim, 9 and 9-slim for ELSA-2022-6157, ELSA-2022-6159, ELSA-2022-6160

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7fc110155a6722b04cfb326d93b7c03e438bbc71
+amd64-GitCommit: 04953458ed1d7065d26a0ccac6841316dae8f874
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7a720ab8479be9a5d746932384c79927a48db3c7
+arm64v8-GitCommit: d5f9011d616aed5259fe640a15dcddab6ea5e091
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-32206, CVE-2022-32207, CVE-2022-32208 and CVE-2022-2526.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6157.html
https://linux.oracle.com/errata/ELSA-2022-6159.html
https://linux.oracle.com/errata/ELSA-2022-6160.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
