### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 5bd36bedb320dab62684649d5efb7c4da14866a9
+GitCommit: 3bc216c99bcf44b2cf8f8873a705e95e484b0901
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.17-cli, 20.10-cli, 20-cli, cli, 20.10.17-cli-alpine3.16, 20.10.17, 20.10, 20, latest, 20.10.17-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 0fa745461cd9944d46fa8a5c98e69abf11e3fce6
+GitCommit: 46a5fa097f8b9995cdab2270f0ffa623c243c3d2
 Directory: 20.10/cli
 
 Tags: 20.10.17-dind, 20.10-dind, 20-dind, dind, 20.10.17-dind-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/3bc216c: Update 22.06-rc to compose 2.10.2
- https://github.com/docker-library/docker/commit/46a5fa0: Update 20.10 to compose 2.10.2