### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.22, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 2850beba32fd4c4e78e29d6148a0d2f81c61d9fb
+GitCommit: 0762ce30bd49cebfcc11ea596f0f5d5a0cfbaf36
 Directory: 3.9/ubuntu
 
 Tags: 3.9.22-management, 3.9-management
@@ -36,7 +36,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.22-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2850beba32fd4c4e78e29d6148a0d2f81c61d9fb
+GitCommit: 0762ce30bd49cebfcc11ea596f0f5d5a0cfbaf36
 Directory: 3.9/alpine
 
 Tags: 3.9.22-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/0762ce3: Update 3.9 to otp 24.3.4.4