### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 62f7701ded7533f125333ad6172ebe4caedf4a00
 
-Tags: 2022.0.20220817.0, 2022, devel
+Tags: 2022.0.20220824.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: 0b0494117a599cb5424917a6a3c13af9b60e9586
+amd64-GitCommit: 31b15da23a0fba96228a9fbf3f5b1e2e23499ae7
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: 107012dfb4e6c266b520399f69737e1c85af2122
+arm64v8-GitCommit: 1ece04f535c4e93ac855f05524bb1542b631afdb
 
-Tags: 2022.0.20220817.0-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220824.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: b96483cf1aec246d1f60b2fa151061b0304ee2c5
+amd64-GitCommit: 38403cf163163bcd3bad0dbcc468cb6f6f4224a7
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: ab194ce5ed08dcc56b2fe09f53b294b7e6e51f6c
+arm64v8-GitCommit: f2c50f4c045c12108dd7250ea5e9218fd88592f2


### PR DESCRIPTION
Hello,

This change update Amazon Linux 2022 DockerHub images.
New image version is 2022.0.20220824.0.

Thanks,
Preston
