### PR TITLE
Update Clear Linux OS to 36930

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 33f3f474b8db231876a273778406053906944727
-GitFetch: refs/heads/base-36820
+GitCommit: 612151b45d826f633fa48d327342b678879db8a1
+GitFetch: refs/heads/base-36930


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 36930

@bryteise @djklimes @bryteise