### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.10.7, 3.10, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 96afbc0ef1edc8747504b9511181cb52f67166ad
+GitCommit: e3e84ca4cae306b2c199d6e529c17fd303cb54f5
 Directory: 3.10/ubuntu
 
 Tags: 3.10.7-management, 3.10-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.7-alpine, 3.10-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 96afbc0ef1edc8747504b9511181cb52f67166ad
+GitCommit: e3e84ca4cae306b2c199d6e529c17fd303cb54f5
 Directory: 3.10/alpine
 
 Tags: 3.10.7-management-alpine, 3.10-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e3e84ca: Update 3.10 to otp 25.0.4
- https://github.com/docker-library/rabbitmq/commit/f669d7e: Update 3.10 to otp 25.0.2