### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-6206

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 04953458ed1d7065d26a0ccac6841316dae8f874
+amd64-GitCommit: 17423e3380ded8459b0b7738106e7faff89dd745
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d5f9011d616aed5259fe640a15dcddab6ea5e091
+arm64v8-GitCommit: caa2844443f0f1629a2e0a7c36606e0ee9f6291d
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-2526.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6206.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>