### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2022-6224

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 17423e3380ded8459b0b7738106e7faff89dd745
+amd64-GitCommit: 86bbab82701ba957a039e552a317d5af89afbe12
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: caa2844443f0f1629a2e0a7c36606e0ee9f6291d
+arm64v8-GitCommit: a835d068ddcf38392118cfe744003707ce11e236
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-1292, CVE-2022-1343, CVE-2022-1473, CVE-2022-2068 and CVE-2022-2097.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6224.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>