### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/51b5ed5f2cb833a8d4a3e346215701b872eaab5b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/84e9f7fd2111828a1ae86979e84dab1103a55610/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 51b5ed5f2cb833a8d4a3e346215701b872eaab5b
+GitCommit: 84e9f7fd2111828a1ae86979e84dab1103a55610
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c2e72d6cf3cc382f25d7d71ae70bb2013a517f1f
+amd64-GitCommit: e0c096ead17f3740c2e7e16c67ddba966f88d097
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 5ac8fe484f6f9285d9e7062fff7312557fa59f18
+arm32v5-GitCommit: e1f89e1d853214d9932d0d034ebe1b42a16b8bac
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 95d5be717f856e57055b43d4eb3bae29dd72727d
+arm32v6-GitCommit: 08c059b2f658b52a2299ca8e7faf390a721183a9
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 532fe38e7e3c370879ef703db639115fabc41dd1
+arm32v7-GitCommit: f746bbc5539c9da8f9ab438842eb91ee6fa581ea
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0771fd6785ba397564a1c418ad1e3def3c9fa21c
+arm64v8-GitCommit: 48fcaa1068ae896c8ef37b4d23a9417de6ea600b
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 03373386eaaa8a18b673c0fef25d146ea077269f
+i386-GitCommit: 0ca4168675b32353e237c8d6f32c256ab46169a2
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: f6ac2fba064b0ba2d42ea782e7c309db65a804d6
+mips64le-GitCommit: ff7e13c41eacdc68dfb0aaf0ea8f6b92e15b6386
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 6536c13bbd6bd056706da4c2cd93025907de759b
+ppc64le-GitCommit: 85026fb9e33f59f7c3eb13922c34f97de99eff00
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 1a751ad1d0640c239f85747f3ba11743f27651fc
+riscv64-GitCommit: c5505e2c28fc5765c1e9e73327722609c483dbbd
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: f4af3d4c831313e9ad64c65bb996cce569b44a0c
+s390x-GitCommit: e22d3801939fe59f2be26e37de09b2d5d5c69e08
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/84e9f7f: Merge pull request https://github.com/docker-library/busybox/pull/144 from infosiftr/buildroot-2022.05.2
- https://github.com/docker-library/busybox/commit/bc8031b: Update buildroot to 2022.05.2