### PR TITLE
Add Apache Spark Docker Official Image

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -1,22 +1,22 @@
 Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 3.4.0-scala2.12-java11-python3-ubuntu, 3.4.0-python3, python3, 3.4.0, latest
+Tags: 3.4.1-scala2.12-java11-python3-ubuntu, 3.4.1-python3, python3, 3.4.1, latest
 Architectures: amd64,arm64v8
-GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
-Directory: ./3.4.0/scala2.12-java11-python3-ubuntu
+GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
+Directory: ./3.4.1/scala2.12-java11-python3-ubuntu
 
-Tags: 3.4.0-scala2.12-java11-r-ubuntu, 3.4.0-r, r
+Tags: 3.4.1-scala2.12-java11-r-ubuntu, 3.4.1-r, r
 Architectures: amd64,arm64v8
-GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
-Directory: ./3.4.0/scala2.12-java11-r-ubuntu
+GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
+Directory: ./3.4.1/scala2.12-java11-r-ubuntu
 
-Tags: 3.4.0-scala2.12-java11-ubuntu, 3.4.0-scala, scala
+Tags: 3.4.1-scala2.12-java11-ubuntu, 3.4.1-scala, scala
 Architectures: amd64,arm64v8
-GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
-Directory: ./3.4.0/scala2.12-java11-ubuntu
+GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
+Directory: ./3.4.1/scala2.12-java11-ubuntu
 
-Tags: 3.4.0-scala2.12-java11-python3-r-ubuntu
+Tags: 3.4.1-scala2.12-java11-python3-r-ubuntu
 Architectures: amd64,arm64v8
-GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
-Directory: ./3.4.0/scala2.12-java11-python3-r-ubuntu
+GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
+Directory: ./3.4.1/scala2.12-java11-python3-r-ubuntu

--- a/library/spark
+++ b/library/spark
@@ -1,0 +1,22 @@
+Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
+GitRepo: https://github.com/apache/spark-docker.git
+
+Tags: 3.4.0-scala2.12-java11-python3-ubuntu, 3.4.0-python3, python3, 3.4.0, latest
+Architectures: amd64,arm64v8
+GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
+Directory: ./3.4.0/scala2.12-java11-python3-ubuntu
+
+Tags: 3.4.0-scala2.12-java11-r-ubuntu, 3.4.0-r, r
+Architectures: amd64,arm64v8
+GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
+Directory: ./3.4.0/scala2.12-java11-r-ubuntu
+
+Tags: 3.4.0-scala2.12-java11-ubuntu, 3.4.0-scala, scala
+Architectures: amd64,arm64v8
+GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
+Directory: ./3.4.0/scala2.12-java11-ubuntu
+
+Tags: 3.4.0-scala2.12-java11-python3-r-ubuntu
+Architectures: amd64,arm64v8
+GitCommit: 7f9b414de48639d69c64acfd81e6792517b86f61
+Directory: ./3.4.0/scala2.12-java11-python3-r-ubuntu


### PR DESCRIPTION
This patch is adding Apache Spark Docker Official Image.

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream? [VOTE](https://lists.apache.org/thread/ro6olodm1jzdffwjx4oc7ol7oh6kshbl): [passed](https://lists.apache.org/thread/zgj1db8wht6o10prx49j5fbh092z934q) in Apache Spark Community
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)? [Apache License  2.0](https://github.com/apache/spark-docker/blob/master/LICENSE)
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution") service
-	[x] is it reasonably popular, or does it solve a particular use case well? https://spark.apache.org/ https://hub.docker.com/r/apache/spark
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long) https://github.com/docker-library/docs/pull/2200
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[x] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?) `eclipse-temurin`
-	~[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test) Extra [integration test](https://github.com/apache/spark-docker/blob/master/.github/workflows/main.yml#L171) in repo
