### PR TITLE
Bump Traefik to v2.8.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.8.3-windowsservercore-1809, 2.8.3-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.8.4-windowsservercore-1809, 2.8.4-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1b242b751fe417c2db296d283f1d85d29f455ddd
+GitCommit: 22f4e10f57ea0e74c14590e961315e3d5130dbb1
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.8.3, 2.8.3, v2.8, 2.8, vacherin, latest
+Tags: v2.8.4, 2.8.4, v2.8, 2.8, vacherin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1b242b751fe417c2db296d283f1d85d29f455ddd
+GitCommit: 22f4e10f57ea0e74c14590e961315e3d5130dbb1
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.8.4](https://github.com/traefik/traefik/releases/tag/v2.8.4).

/cc @ddtmachado @mpl @ldez @kevinpollet

Cheers
