### PR TITLE
22.0.0.9 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: b523af8784d11d99093102e318524ca5a4469a77
+GitCommit: 096208538720a160a88fccfd27cd536f9fe4b9c0
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -107,35 +107,5 @@ File: Dockerfile.ubuntu.openjdk11
 
 Tags: 22.0.0.6-full-java17-openj9
 Directory: releases/22.0.0.6/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.3-kernel-slim-java8-openj9
-Directory: releases/22.0.0.3/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 22.0.0.3-kernel-slim-java11-openj9
-Directory: releases/22.0.0.3/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.3-kernel-slim-java17-openj9
-Directory: releases/22.0.0.3/kernel-slim
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.3-full-java8-openj9
-Directory: releases/22.0.0.3/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 22.0.0.3-full-java11-openj9
-Directory: releases/22.0.0.3/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.3-full-java17-openj9
-Directory: releases/22.0.0.3/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 016d9edc6f35cb3b9b98b8e03e084269c6d02ab4
+GitCommit: b523af8784d11d99093102e318524ca5a4469a77
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -50,33 +50,33 @@ Directory: releases/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.8-kernel-slim-java8-openj9
-Directory: releases/22.0.0.8/kernel-slim
+Tags: 22.0.0.9-kernel-slim-java8-openj9
+Directory: releases/22.0.0.9/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 22.0.0.8-kernel-slim-java11-openj9
-Directory: releases/22.0.0.8/kernel-slim
+Tags: 22.0.0.9-kernel-slim-java11-openj9
+Directory: releases/22.0.0.9/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.8-kernel-slim-java17-openj9
-Directory: releases/22.0.0.8/kernel-slim
+Tags: 22.0.0.9-kernel-slim-java17-openj9
+Directory: releases/22.0.0.9/kernel-slim
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.8-full-java8-openj9
-Directory: releases/22.0.0.8/full
+Tags: 22.0.0.9-full-java8-openj9
+Directory: releases/22.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 22.0.0.8-full-java11-openj9
-Directory: releases/22.0.0.8/full
+Tags: 22.0.0.9-full-java11-openj9
+Directory: releases/22.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.8-full-java17-openj9
-Directory: releases/22.0.0.8/full
+Tags: 22.0.0.9-full-java17-openj9
+Directory: releases/22.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: b523af8784d11d99093102e318524ca5a4469a77
+GitCommit: 83e2c20a92ec8116c8d6cc269b1fd3e7753eea4e
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
@@ -86,33 +86,5 @@ File: Dockerfile.ubuntu.openjdk11
 
 Tags: 22.0.0.6-full-java17-openj9
 Directory: ga/22.0.0.6/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.3-kernel-java8-ibmjava
-Directory: ga/22.0.0.3/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 22.0.0.3-kernel-java11-openj9
-Directory: ga/22.0.0.3/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.3-kernel-java17-openj9
-Directory: ga/22.0.0.3/kernel
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.3-full-java8-ibmjava
-Directory: ga/22.0.0.3/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 22.0.0.3-full-java11-openj9
-Directory: ga/22.0.0.3/full
-Architectures: amd64, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.3-full-java17-openj9
-Directory: ga/22.0.0.3/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: c6c6d8be148ee2cb4b9d64affa3c34dadcd1e634
+GitCommit: b523af8784d11d99093102e318524ca5a4469a77
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
@@ -33,31 +33,31 @@ Directory: ga/latest/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.8-kernel-java8-ibmjava
-Directory: ga/22.0.0.8/kernel
+Tags: 22.0.0.9-kernel-java8-ibmjava
+Directory: ga/22.0.0.9/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 22.0.0.8-kernel-java11-openj9
-Directory: ga/22.0.0.8/kernel
+Tags: 22.0.0.9-kernel-java11-openj9
+Directory: ga/22.0.0.9/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.8-kernel-java17-openj9
-Directory: ga/22.0.0.8/kernel
+Tags: 22.0.0.9-kernel-java17-openj9
+Directory: ga/22.0.0.9/kernel
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 22.0.0.8-full-java8-ibmjava
-Directory: ga/22.0.0.8/full
+Tags: 22.0.0.9-full-java8-ibmjava
+Directory: ga/22.0.0.9/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 22.0.0.8-full-java11-openj9
-Directory: ga/22.0.0.8/full
+Tags: 22.0.0.9-full-java11-openj9
+Directory: ga/22.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 22.0.0.8-full-java17-openj9
-Directory: ga/22.0.0.8/full
+Tags: 22.0.0.9-full-java17-openj9
+Directory: ga/22.0.0.9/full
 Architectures: amd64, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 


### PR DESCRIPTION
Updates to open-liberty and websphere-liberty for the release of 22.0.0.9, including removing support for 22.0.0.3.