### PR TITLE
Update Clear Linux OS to 37000

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 612151b45d826f633fa48d327342b678879db8a1
-GitFetch: refs/heads/base-36930
+GitCommit: 7dc029ff5b3547a9899c7e4751dce4437f89d256
+GitFetch: refs/heads/base-37000


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37000

@bryteise @djklimes @bryteise