### PR TITLE
caddy: v2.6.0-beta.3 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,27 +1,27 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/33a2c552e02872da506029144986205466936fb4/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/554ed46249834de957d5ae793ddb39dfe915bacb/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.5.2-alpine, 2-alpine, alpine
 SharedTags: 2.5.2, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/alpine
-GitCommit: 33a2c552e02872da506029144986205466936fb4
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.5.2-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/builder
-GitCommit: 33a2c552e02872da506029144986205466936fb4
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.5.2-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
 SharedTags: 2.5.2-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.2, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows/1809
-GitCommit: 33a2c552e02872da506029144986205466936fb4
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -29,7 +29,7 @@ Tags: 2.5.2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsser
 SharedTags: 2.5.2-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.2, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows/ltsc2022
-GitCommit: 33a2c552e02872da506029144986205466936fb4
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
@@ -37,7 +37,7 @@ Tags: 2.5.2-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, bu
 SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows-builder/1809
-GitCommit: 33a2c552e02872da506029144986205466936fb4
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -45,7 +45,53 @@ Tags: 2.5.2-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc
 SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows-builder/ltsc2022
-GitCommit: 33a2c552e02872da506029144986205466936fb4
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.6.0-beta.3-alpine
+SharedTags: 2.6.0-beta.3
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.6/alpine
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.6.0-beta.3-builder-alpine
+SharedTags: 2.6.0-beta.3-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.6/builder
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.6.0-beta.3-windowsservercore-1809
+SharedTags: 2.6.0-beta.3-windowsservercore, 2.6.0-beta.3
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.6/windows/1809
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.6.0-beta.3-windowsservercore-ltsc2022
+SharedTags: 2.6.0-beta.3-windowsservercore, 2.6.0-beta.3
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.6/windows/ltsc2022
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.6.0-beta.3-builder-windowsservercore-1809
+SharedTags: 2.6.0-beta.3-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.6/windows-builder/1809
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.6.0-beta.3-builder-windowsservercore-ltsc2022
+SharedTags: 2.6.0-beta.3-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.6/windows-builder/ltsc2022
+GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 

--- a/library/caddy
+++ b/library/caddy
@@ -37,7 +37,7 @@ Tags: 2.5.2-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, bu
 SharedTags: 2.5.2-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.5/windows-builder/1809
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: 5334174f3d85d575a7f2ab86b6969587f183396c
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 

--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/554ed46249834de957d5ae793ddb39dfe915bacb/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/f7c8c6c15e868f70498b605feb17fd347735638d/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.5.2-alpine, 2-alpine, alpine
@@ -53,7 +53,7 @@ Tags: 2.6.0-beta.3-alpine
 SharedTags: 2.6.0-beta.3
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/alpine
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: f7c8c6c15e868f70498b605feb17fd347735638d
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.6.0-beta.3-builder-alpine
@@ -67,7 +67,7 @@ Tags: 2.6.0-beta.3-windowsservercore-1809
 SharedTags: 2.6.0-beta.3-windowsservercore, 2.6.0-beta.3
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/1809
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: f7c8c6c15e868f70498b605feb17fd347735638d
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -75,7 +75,7 @@ Tags: 2.6.0-beta.3-windowsservercore-ltsc2022
 SharedTags: 2.6.0-beta.3-windowsservercore, 2.6.0-beta.3
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/ltsc2022
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: f7c8c6c15e868f70498b605feb17fd347735638d
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.6.0-beta.3

Signed-off-by: Dave Henderson <dhenderson@gmail.com>