### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.7-dev4, 2.7-dev, 2.7-dev4-bullseye, 2.7-dev-bullseye
+Tags: 2.7-dev5, 2.7-dev, 2.7-dev5-bullseye, 2.7-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 99d439b7734a20dea2ff263d90b85bfaf08f91a3
+GitCommit: 77ded33c252a6652730c7b1913f9d1352b310aba
 Directory: 2.7
 
-Tags: 2.7-dev4-alpine, 2.7-dev-alpine, 2.7-dev4-alpine3.16, 2.7-dev-alpine3.16
+Tags: 2.7-dev5-alpine, 2.7-dev-alpine, 2.7-dev5-alpine3.16, 2.7-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 99d439b7734a20dea2ff263d90b85bfaf08f91a3
+GitCommit: 77ded33c252a6652730c7b1913f9d1352b310aba
 Directory: 2.7/alpine
 
-Tags: 2.6.4, 2.6, lts, latest, 2.6.4-bullseye, 2.6-bullseye, lts-bullseye, bullseye
+Tags: 2.6.5, 2.6, lts, latest, 2.6.5-bullseye, 2.6-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 84167192a0aa04397f9937ff620a06a8feed7de4
+GitCommit: 039e62b8f996edea64e90cb7e0b98bfefab9cb64
 Directory: 2.6
 
-Tags: 2.6.4-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.4-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
+Tags: 2.6.5-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.5-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 84167192a0aa04397f9937ff620a06a8feed7de4
+GitCommit: 039e62b8f996edea64e90cb7e0b98bfefab9cb64
 Directory: 2.6/alpine
 
 Tags: 2.5.8, 2.5, 2.5.8-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/039e62b: Update 2.6 to 2.6.5
- https://github.com/docker-library/haproxy/commit/77ded33: Update 2.7 to 2.7-dev5