### PR TITLE
Removing support for Ubuntu 22.04 release on power architecture

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -7,155 +7,155 @@ GitFetch: refs/heads/ibm
 #-----------------------------openj9 v8 images---------------------------------
 Tags: open-8u345-b01-jdk-focal, open-8-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-8u345-b01-jdk-jammy, open-8-jdk-jammy
 SharedTags: open-8u345-b01-jdk, open-8-jdk
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-8u345-b01-jdk-centos7, open-8-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 8/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-8u345-b01-jre-focal, open-8-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-8u345-b01-jre-jammy, open-8-jre-jammy
 SharedTags: open-8u345-b01-jre, open-8-jre
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-8u345-b01-jre-centos7, open-8-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 8/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
 Tags: open-11.0.16.1_1-jdk-focal, open-11-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.16.1_1-jdk-jammy, open-11-jdk-jammy
 SharedTags: open-11.0.16.1_1-jdk, open-11-jdk
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.16.1_1-jdk-centos7, open-11-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 11/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.16.1_1-jre-focal, open-11-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.16.1_1-jre-jammy, open-11-jre-jammy
 SharedTags: open-11.0.16.1_1-jre, open-11-jre
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.16.1_1-jre-centos7, open-11-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 11/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
 Tags: open-17.0.4.1_1-jdk-focal, open-17-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.4.1_1-jdk-jammy, open-17-jdk-jammy
 SharedTags: open-17.0.4.1_1-jdk, open-17-jdk
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.4.1_1-jdk-centos7, open-17-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 17/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.4.1_1-jre-focal, open-17-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.4.1_1-jre-jammy, open-17-jre-jammy
 SharedTags: open-17.0.4.1_1-jre, open-17-jre
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.4.1_1-jre-centos7, open-17-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 17/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v18 images---------------------------------
 Tags: open-18.0.2_9-jdk-focal, open-18-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 18/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-18.0.2_9-jdk-jammy, open-18-jdk-jammy
 SharedTags: open-18.0.2_9-jdk, open-18-jdk
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 18/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-18.0.2_9-jdk-centos7, open-18-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 18/jdk/centos
 File: Dockerfile.open.releases.full
 
 Tags: open-18.0.2_9-jre-focal, open-18-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 18/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-18.0.2_9-jre-jammy, open-18-jre-jammy
 SharedTags: open-18.0.2_9-jre, open-18-jre
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+Architectures: amd64, s390x, arm64v8
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 18/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-18.0.2_9-jre-centos7, open-18-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: 86525cbd05b42bceddff3b9821d7e307eaac49b0
+GitCommit: 01a6dfbafa770fdd7521f9b2517b16c73d0662cf
 Directory: 18/jre/centos
 File: Dockerfile.open.releases.full


### PR DESCRIPTION
Semeru images for Ubuntu 22.04 has issues on Power architecture, hence removing the support till the issue is fixed. Please merge this request. Thanks !! 