### PR TITLE
Update ruby preview version to 3.2.0-preview2

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.2.0-preview1-bullseye, 3.2-rc-bullseye, 3.2.0-preview1, 3.2-rc
+Tags: 3.2.0-preview2-bullseye, 3.2-rc-bullseye, 3.2.0-preview2, 3.2-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 34ebac96fb1563b5a021176f3b8abae1be2803de
+GitCommit: 41208aad6764925f0f082a695a076f7f39af1233
 Directory: 3.2-rc/bullseye
 
-Tags: 3.2.0-preview1-slim-bullseye, 3.2-rc-slim-bullseye, 3.2.0-preview1-slim, 3.2-rc-slim
+Tags: 3.2.0-preview2-slim-bullseye, 3.2-rc-slim-bullseye, 3.2.0-preview2-slim, 3.2-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 34ebac96fb1563b5a021176f3b8abae1be2803de
+GitCommit: 41208aad6764925f0f082a695a076f7f39af1233
 Directory: 3.2-rc/slim-bullseye
 
-Tags: 3.2.0-preview1-buster, 3.2-rc-buster
+Tags: 3.2.0-preview2-buster, 3.2-rc-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 34ebac96fb1563b5a021176f3b8abae1be2803de
+GitCommit: 41208aad6764925f0f082a695a076f7f39af1233
 Directory: 3.2-rc/buster
 
-Tags: 3.2.0-preview1-slim-buster, 3.2-rc-slim-buster
+Tags: 3.2.0-preview2-slim-buster, 3.2-rc-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 34ebac96fb1563b5a021176f3b8abae1be2803de
+GitCommit: 41208aad6764925f0f082a695a076f7f39af1233
 Directory: 3.2-rc/slim-buster
 
-Tags: 3.2.0-preview1-alpine3.16, 3.2-rc-alpine3.16, 3.2.0-preview1-alpine, 3.2-rc-alpine
+Tags: 3.2.0-preview2-alpine3.16, 3.2-rc-alpine3.16, 3.2.0-preview2-alpine, 3.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4955e524a9a01f35979d7b7984a001fd563d5cfb
+GitCommit: 41208aad6764925f0f082a695a076f7f39af1233
 Directory: 3.2-rc/alpine3.16
 
-Tags: 3.2.0-preview1-alpine3.15, 3.2-rc-alpine3.15
+Tags: 3.2.0-preview2-alpine3.15, 3.2-rc-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 34ebac96fb1563b5a021176f3b8abae1be2803de
+GitCommit: 41208aad6764925f0f082a695a076f7f39af1233
 Directory: 3.2-rc/alpine3.15
 
 Tags: 3.1.2-bullseye, 3.1-bullseye, 3-bullseye, bullseye, 3.1.2, 3.1, 3, latest


### PR DESCRIPTION
This commit updated ruby recently: https://github.com/docker-library/ruby/commit/41208aad6764925f0f082a695a076f7f39af123