### PR TITLE
Update Clear Linux OS to 37120

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 7dc029ff5b3547a9899c7e4751dce4437f89d256
-GitFetch: refs/heads/base-37000
+GitCommit: 6829cc72b7641dca40cc741afeb8e150c4be9fa8
+GitFetch: refs/heads/base-37120


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37120

@bryteise @djklimes @bryteise