### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/84e9f7fd2111828a1ae86979e84dab1103a55610/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/22c2c562514effb9e624704584f732e32c5a82da/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 84e9f7fd2111828a1ae86979e84dab1103a55610
+GitCommit: 22c2c562514effb9e624704584f732e32c5a82da
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e0c096ead17f3740c2e7e16c67ddba966f88d097
+amd64-GitCommit: 666671635bef96b5cac5b791d6366be77a437268
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: e1f89e1d853214d9932d0d034ebe1b42a16b8bac
+arm32v5-GitCommit: befccdffc23b6b11326b4619078a3d713ed1d641
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 08c059b2f658b52a2299ca8e7faf390a721183a9
+arm32v6-GitCommit: a85e7eea5b19bf80961ba49b1982477471011910
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: f746bbc5539c9da8f9ab438842eb91ee6fa581ea
+arm32v7-GitCommit: 86e040e549fffc1fd77441949b3097e13864d2b4
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 48fcaa1068ae896c8ef37b4d23a9417de6ea600b
+arm64v8-GitCommit: 028124d25921635906549cf1aaf48211f211fc4a
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 0ca4168675b32353e237c8d6f32c256ab46169a2
+i386-GitCommit: a019add518531088ba021c36ea710aa3ea754bdd
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: ff7e13c41eacdc68dfb0aaf0ea8f6b92e15b6386
+mips64le-GitCommit: 5d73b2568912b2239479942d08a632b4a362f0a1
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 85026fb9e33f59f7c3eb13922c34f97de99eff00
+ppc64le-GitCommit: 50dd33944819b7cb2c561685d87dd8e2fdc4d412
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: c5505e2c28fc5765c1e9e73327722609c483dbbd
+riscv64-GitCommit: 01332ce0352f09e04d3a065b58a489d7914f4b12
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e22d3801939fe59f2be26e37de09b2d5d5c69e08
+s390x-GitCommit: e285c93aac4c393c09b6b2e6afebfefb2306b5c5
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/22c2c56: Merge pull request https://github.com/docker-library/busybox/pull/145 from infosiftr/buildroot-2022.08
- https://github.com/docker-library/busybox/commit/b9acc3a: Update buildroot to 2022.08