### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -29,18 +29,6 @@ Tags: 0.24.0-python3.9-alpine3.15, 0.24-python3.9-alpine3.15, 0-python3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.9-alpine3.15
 
-Tags: 0.24.0-python3.9-windowsservercore-ltsc2022, 0.24-python3.9-windowsservercore-ltsc2022, 0-python3.9-windowsservercore-ltsc2022, python3.9-windowsservercore-ltsc2022
-SharedTags: 0.24.0-python3.9, 0.24-python3.9, 0-python3.9, python3.9
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-File: Dockerfile.python3.9-windowsservercore-ltsc2022
-
-Tags: 0.24.0-python3.9-windowsservercore-1809, 0.24-python3.9-windowsservercore-1809, 0-python3.9-windowsservercore-1809, python3.9-windowsservercore-1809
-SharedTags: 0.24.0-python3.9, 0.24-python3.9, 0-python3.9, python3.9
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-File: Dockerfile.python3.9-windowsservercore-1809
-
 Tags: 0.24.0-python3.8-bullseye, 0.24-python3.8-bullseye, 0-python3.8-bullseye, python3.8-bullseye
 SharedTags: 0.24.0-python3.8, 0.24-python3.8, 0-python3.8, python3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
(remove Python 3.9 Windows builds)