### PR TITLE
Bump Traefik to v2.9.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,18 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
+Tags: v2.9.0-rc2-windowsservercore-1809, 2.9.0-rc2-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, beaufort-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 01bff12b347ebd9cc1f1dad13b01cd987fea2880
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.9.0-rc2, 2.9.0-rc2, v2.9, 2.9, beaufort
+Architectures: amd64, arm32v6, arm64v8, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 01bff12b347ebd9cc1f1dad13b01cd987fea2880
+Directory: alpine
+
 Tags: v2.8.5-windowsservercore-1809, 2.8.5-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.9.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.9.0-rc2).

/cc @ddtmachado @kevinpollet @rtribotte

Cheers
