### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2022-6463 ELSA-2022-6457 ELBA-2022-6459

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 86bbab82701ba957a039e552a317d5af89afbe12
+amd64-GitCommit: 63d372e3f2a15412ea3fbadab37ad7345b0518ac
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a835d068ddcf38392118cfe744003707ce11e236
+arm64v8-GitCommit: c020d7caab48a73179e20cc8b602c2a7a1eddd3a
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-34903, CVE-2015-20107 and CVE-2022-0391.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6463.html
https://linux.oracle.com/errata/ELSA-2022-6457.html
https://linux.oracle.com/errata/ELBA-2022-6459.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
