### PR TITLE
hitch: fix the version overwrite

### DIFF
--- a/library/hitch
+++ b/library/hitch
@@ -3,6 +3,10 @@ Maintainers: Thijs Feryn <thijs@varni.sh> (@thijsferyn),
              Guillaume Quintard <guillaume@varni.sh> (@gquintard)
 GitRepo: https://github.com/varnish/docker-hitch.git	
 
-Tags: 1, 1.7, 1.7.2, 1.7.2-1, latest
+Tags: 1, 1.7, 1.7.3, 1.7.3-1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3f7f06a4eeb066e03f81f5e3d170d1e13606e69e
+
+Tags: 1.7.2, 1.7.2-1
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 054c998138c8f8ec6be03c7db711b8435de41e2b


### PR DESCRIPTION
forgot to update the `populate.sh` script, so the image was updated, but not the tags. This is a hand-crafted file that should give the new image the correct tag, but also give back the `1.7.2` tags a proper image