### PR TITLE
[REF] Odoo 13.0-15.0: update to release 20220915

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 4550ffdc7480f51e34138a21812c98ba16c47551
+GitCommit: 333b10955096da859c7f581935bd243bce743589
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

As usual, here are the latest Odoo updates of suported versions.

Thanks.