### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 3bc216c99bcf44b2cf8f8873a705e95e484b0901
+GitCommit: 04ae082ff40c8d4be2d20f87041e9c71447f7af4
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.18-cli, 20.10-cli, 20-cli, cli, 20.10.18-cli-alpine3.16, 20.10.18, 20.10, 20, latest, 20.10.18-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: c13cbee1cfd9d7582f7b2e9f958cf24e39b64715
+GitCommit: eb357e73137c2e5bc0d098d760d6d0fda6d4e655
 Directory: 20.10/cli
 
 Tags: 20.10.18-dind, 20.10-dind, 20-dind, dind, 20.10.18-dind-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/04ae082: Update 22.06-rc to compose 2.11.0
- https://github.com/docker-library/docker/commit/eb357e7: Update 20.10 to compose 2.11.0