### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -46,7 +46,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.22, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 957fa310f884d82777a4c145e194d50abab7cd3e
+GitCommit: 62b837a84aee6b89ea2fe97ed33419f41fa6ff9c
 Directory: 3.9/ubuntu
 
 Tags: 3.9.22-management, 3.9-management
@@ -56,7 +56,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.22-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 957fa310f884d82777a4c145e194d50abab7cd3e
+GitCommit: 62b837a84aee6b89ea2fe97ed33419f41fa6ff9c
 Directory: 3.9/alpine
 
 Tags: 3.9.22-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/62b837a: Update 3.9 to otp 24.3.4.5