### PR TITLE
varnish: upgrade to 7.2.0

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,26 +1,26 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/eff5fed4545f3de5a64dead871d27a01e94feb90/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/314b75ac940b9d6cb3b848e1c790f1360464cbd7/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 7.1.1, 7.1, latest
+Tags: fresh, 7.2.0, 7.2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: eff5fed4545f3de5a64dead871d27a01e94feb90
+GitCommit: 314b75ac940b9d6cb3b848e1c790f1360464cbd7
 
-Tags: fresh-alpine, 7.1.1-alpine, 7.1-alpine, alpine
+Tags: fresh-alpine, 7.2.0-alpine, 7.2-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: eff5fed4545f3de5a64dead871d27a01e94feb90
+GitCommit: 314b75ac940b9d6cb3b848e1c790f1360464cbd7
 
-Tags: old, 7.0.3, 7.0
+Tags: old, 7.1.1, 7.1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: eff5fed4545f3de5a64dead871d27a01e94feb90
+GitCommit: 9544f66456655cacda18a89ee8c9a2ad2a29234d
 
-Tags: old-alpine, 7.0.3-alpine, 7.0-alpine
+Tags: old-alpine, 7.1.1-alpine, 7.1-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/alpine
-GitCommit: eff5fed4545f3de5a64dead871d27a01e94feb90
+GitCommit: 9544f66456655cacda18a89ee8c9a2ad2a29234d
 
 Tags: stable, 6.0.10, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
new version, the only two changes are that the `debian` images gets a new library (`getdns`) and we have a pair of env variables to set the default ports (which are privileged and it's apparently an issue on old `docker` versions)