### PR TITLE
Add official image for OpenSearch

### DIFF
--- a/library/opensearch
+++ b/library/opensearch
@@ -1,0 +1,11 @@
+Maintainers: OpenSearch Project Team <opensearch@amazon.com> (@opensearch-project),
+             Rishabh Singh <sngri@amazon.com> (@rishabh6788),
+             Peter Zhu <zhujiaxi@amazon.com> (@peterzhuamazon),
+             Prudhvi Godithi <pgodithi@amazon.com> (@prudhvigodithi)
+GitRepo: https://github.com/opensearch-project/docker-images.git
+
+Tags: 2.3.0, 2.3, 2, latest
+Architectures: amd64, arm64v8
+GitCommit: 6c23ffde45b4c37dfde9b057ca241c9fd8357bc4
+Directory: 2.x
+


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

OpenSearch is a community-driven, Apache 2.0-licensed open source search and analytics suite that makes it easy to ingest, search, visualize, and analyze data. Developers build with OpenSearch for use cases such as application search, log analytics, data observability, data ingestion, and more.
To know more about OpenSearch please read our [documentation](https://opensearch.org/docs/latest/opensearch/index/)

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream? We own the source https://github.com/opensearch-project/OpenSearch
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)? [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution") Service
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)