### PR TITLE
Update mongo-express for v1.0.0

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -5,10 +5,13 @@ Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
 
 
-GitCommit: f5e8e026f1f6454e4b639f66f5b241936dfd49c8
-Tags: 1.0.0, latest
+GitCommit: fbaa75000664d7d986ffe8b184a4b24c621c5ee7
+Tags: 1.0.1, latest
 Architectures: amd64, arm64v8
 
+GitCommit: f5e8e026f1f6454e4b639f66f5b241936dfd49c8
+Tags: 1.0.0
+Architectures: amd64, arm64v8
 
 GitCommit: 4b43fe8a1206434cb32a006cd155dd71462f092f
 Tags: 0.54.0, 0.54

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -3,13 +3,21 @@
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
              John Steel <john@jskw.dev> (@BlackthornYugen)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
-
-
-GitCommit: 0782917e644220ba2ddd81590a9630074a362488
-Tags: 1.0.1, latest
+GitCommit: a375909f86e1cac3ecc7ce381dc2ef4086f111a9
+Tags: 1.0.0-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
 Architectures: amd64, arm64v8
-
-GitCommit: f5e8e026f1f6454e4b639f66f5b241936dfd49c8
-Tags: 1.0.0
+GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
+Directory: 1.0/20-alpine3.18
+1.0.0-20 1.0-20 1-20 1.0.0-20-alpine3.17 1.0-20-alpine3.17 1-20-alpine3.17
+Tags: 1.0.0-20, 1.0-20, 1-20, 1.0.0-20-alpine3.17, 1.0-20-alpine3.17, 1-20-alpine3.17
 Architectures: amd64, arm64v8
-
+GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
+Directory: 1.0/20-alpine3.17
+Tags: 1.0.0-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18
+Architectures: amd64, arm64v8
+GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
+Directory: 1.0/18-alpine3.18
+Tags: 1.0.0, 1.0, 1, 1.0.0-18, 1.0-18, 1-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1-18-alpine3.17, latest
+Architectures: amd64, arm64v8
+GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
+Directory: 1.0/18-alpine3.17

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -22,6 +22,3 @@ GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
 Directory: 1.0/18-alpine3.18
 Tags: 1.0.0, 1.0, 1, 1.0.0-18, 1.0-18, 1-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1-18-alpine3.17, latest
 Architectures: amd64, arm64v8
-
-GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
-Directory: 1.0/18-alpine3.17

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -3,21 +3,25 @@
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
              John Steel <john@jskw.dev> (@BlackthornYugen)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
+
 GitCommit: a375909f86e1cac3ecc7ce381dc2ef4086f111a9
 Tags: 1.0.0-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
 Architectures: amd64, arm64v8
+
 GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
 Directory: 1.0/20-alpine3.18
-1.0.0-20 1.0-20 1-20 1.0.0-20-alpine3.17 1.0-20-alpine3.17 1-20-alpine3.17
 Tags: 1.0.0-20, 1.0-20, 1-20, 1.0.0-20-alpine3.17, 1.0-20-alpine3.17, 1-20-alpine3.17
 Architectures: amd64, arm64v8
+
 GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
 Directory: 1.0/20-alpine3.17
 Tags: 1.0.0-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18
 Architectures: amd64, arm64v8
+
 GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
 Directory: 1.0/18-alpine3.18
 Tags: 1.0.0, 1.0, 1, 1.0.0-18, 1.0-18, 1-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1-18-alpine3.17, latest
 Architectures: amd64, arm64v8
+
 GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
 Directory: 1.0/18-alpine3.17

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -5,7 +5,7 @@ Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
 
 
-GitCommit: fbaa75000664d7d986ffe8b184a4b24c621c5ee7
+GitCommit: 0782917e644220ba2ddd81590a9630074a362488
 Tags: 1.0.1, latest
 Architectures: amd64, arm64v8
 

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,11 +1,12 @@
 # this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/4b43fe8a1206434cb32a006cd155dd71462f092f/generate-stackbrew-library.sh
 
-Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers)
+Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
+             John Steel <john@jskw.dev> (@BlackthornYugen)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
 
 
-GitCommit: 26e7ea94e4d222de7d52531caee52149ac093c26
-Tags: 1.0.0-alpha.4, 1.0.0-alpha, latest
+GitCommit: 0fe77f884e873b344a61ca6184694042141c4fb6
+Tags: 1.0.0, latest
 Architectures: amd64, arm64v8
 
 

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -5,7 +5,7 @@ Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
 
 
-GitCommit: 0fe77f884e873b344a61ca6184694042141c4fb6
+GitCommit: f5e8e026f1f6454e4b639f66f5b241936dfd49c8
 Tags: 1.0.0, latest
 Architectures: amd64, arm64v8
 

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -13,6 +13,3 @@ GitCommit: f5e8e026f1f6454e4b639f66f5b241936dfd49c8
 Tags: 1.0.0
 Architectures: amd64, arm64v8
 
-GitCommit: 4b43fe8a1206434cb32a006cd155dd71462f092f
-Tags: 0.54.0, 0.54
-Architectures: amd64, arm64v8

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,26 +1,26 @@
-# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/3971af1b3b2703d9b6f5f6ca12e33ea4ca99bc97/generate-stackbrew-library.sh
+# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/0b9b935b188caa945834a27f7475a059c4e60b13/generate-stackbrew-library.sh
 
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
              John Steel <john@jskw.dev> (@BlackthornYugen)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
-GitCommit: 3971af1b3b2703d9b6f5f6ca12e33ea4ca99bc97
+GitCommit: 0b9b935b188caa945834a27f7475a059c4e60b13
 
-Tags: 1.0.0-20-alpine3.18, 1.0-20-alpine3.18, 1 latest-20-alpine3.18
+Tags: 1.0.0-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
 Architectures: amd64, arm64v8
 GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
 Directory: 1.0/20-alpine3.18
 
-Tags: 1.0.0-20, 1.0-20, 1 latest-20, 1.0.0-20-alpine3.17, 1.0-20-alpine3.17, 1 latest-20-alpine3.17
+Tags: 1.0.0-20, 1.0-20, 1-20, 1.0.0-20-alpine3.17, 1.0-20-alpine3.17, 1-20-alpine3.17
 Architectures: amd64, arm64v8
 GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
 Directory: 1.0/20-alpine3.17
 
-Tags: 1.0.0-18-alpine3.18, 1.0-18-alpine3.18, 1 latest-18-alpine3.18
+Tags: 1.0.0-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18
 Architectures: amd64, arm64v8
 GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
 Directory: 1.0/18-alpine3.18
 
-Tags: 1.0.0, 1.0, 1 latest, 1.0.0-18, 1.0-18, 1 latest-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1 latest-18-alpine3.17, latest
+Tags: 1.0.0, 1.0, 1, 1.0.0-18, 1.0-18, 1-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1-18-alpine3.17, latest
 Architectures: amd64, arm64v8
 GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
 Directory: 1.0/18-alpine3.17

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,24 +1,26 @@
-# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/4b43fe8a1206434cb32a006cd155dd71462f092f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/3971af1b3b2703d9b6f5f6ca12e33ea4ca99bc97/generate-stackbrew-library.sh
 
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
              John Steel <john@jskw.dev> (@BlackthornYugen)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
+GitCommit: 3971af1b3b2703d9b6f5f6ca12e33ea4ca99bc97
 
-GitCommit: a375909f86e1cac3ecc7ce381dc2ef4086f111a9
-Tags: 1.0.0-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
+Tags: 1.0.0-20-alpine3.18, 1.0-20-alpine3.18, 1 latest-20-alpine3.18
 Architectures: amd64, arm64v8
-
-GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
+GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
 Directory: 1.0/20-alpine3.18
-Tags: 1.0.0-20, 1.0-20, 1-20, 1.0.0-20-alpine3.17, 1.0-20-alpine3.17, 1-20-alpine3.17
-Architectures: amd64, arm64v8
 
-GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
+Tags: 1.0.0-20, 1.0-20, 1 latest-20, 1.0.0-20-alpine3.17, 1.0-20-alpine3.17, 1 latest-20-alpine3.17
+Architectures: amd64, arm64v8
+GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
 Directory: 1.0/20-alpine3.17
-Tags: 1.0.0-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18
-Architectures: amd64, arm64v8
 
-GitCommit: 2a6d82f29978e82ab5685618dc34ba6043568917
-Directory: 1.0/18-alpine3.18
-Tags: 1.0.0, 1.0, 1, 1.0.0-18, 1.0-18, 1-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1-18-alpine3.17, latest
+Tags: 1.0.0-18-alpine3.18, 1.0-18-alpine3.18, 1 latest-18-alpine3.18
 Architectures: amd64, arm64v8
+GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
+Directory: 1.0/18-alpine3.18
+
+Tags: 1.0.0, 1.0, 1 latest, 1.0.0-18, 1.0-18, 1 latest-18, 1.0.0-18-alpine3.17, 1.0-18-alpine3.17, 1 latest-18-alpine3.17, latest
+Architectures: amd64, arm64v8
+GitCommit: 5fb537b2fd181e458f58137fdb55d061a8c23da5
+Directory: 1.0/18-alpine3.17


### PR DESCRIPTION
Mostly security updates and new configuration to support breaking changes in mongo-db driver.

See related pull requests:
https://github.com/mongo-express/mongo-express/pull/920
https://github.com/mongo-express/mongo-express-docker/pull/82

Full release notes available here:
[v1.0.0 - Initial node18 support](https://github.com/mongo-express/mongo-express/releases/tag/v1.0.0)
~~[v1.0.1 - Convert to ESM](https://github.com/mongo-express/mongo-express/releases/tag/v1.0.1)~~

Edit 2023/10/02: Removed v1.0.1 from the scope of this MR. Once we get 1.0.0 working we will immediately open a new MR for 1.0.1. 