### PR TITLE
archlinux: Release 20220918.0.86346

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220904.0.80503
-GitCommit: 347b6cbac95b58b1a4fe43a1234f54a5f33d2344
-GitFetch: refs/tags/v20220904.0.80503
+Tags: latest, base, base-20220918.0.86346
+GitCommit: cd55f31c66d31fc442d244846595a4034eef1fbc
+GitFetch: refs/tags/v20220918.0.86346
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220904.0.80503
-GitCommit: 347b6cbac95b58b1a4fe43a1234f54a5f33d2344
-GitFetch: refs/tags/v20220904.0.80503
+Tags: base-devel, base-devel-20220918.0.86346
+GitCommit: cd55f31c66d31fc442d244846595a4034eef1fbc
+GitFetch: refs/tags/v20220918.0.86346
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks