### PR TITLE
caddy: v2.6.0-beta.5 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/f7c8c6c15e868f70498b605feb17fd347735638d/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/49bd8fc1ddde0133e1c5ec61e656044de0f70bae/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.5.2-alpine, 2-alpine, alpine
@@ -49,49 +49,49 @@ GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.6.0-beta.3-alpine
-SharedTags: 2.6.0-beta.3
+Tags: 2.6.0-beta.5-alpine
+SharedTags: 2.6.0-beta.5
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/alpine
-GitCommit: f7c8c6c15e868f70498b605feb17fd347735638d
+GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.6.0-beta.3-builder-alpine
-SharedTags: 2.6.0-beta.3-builder
+Tags: 2.6.0-beta.5-builder-alpine
+SharedTags: 2.6.0-beta.5-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/builder
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.6.0-beta.3-windowsservercore-1809
-SharedTags: 2.6.0-beta.3-windowsservercore, 2.6.0-beta.3
+Tags: 2.6.0-beta.5-windowsservercore-1809
+SharedTags: 2.6.0-beta.5-windowsservercore, 2.6.0-beta.5
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/1809
-GitCommit: f7c8c6c15e868f70498b605feb17fd347735638d
+GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.6.0-beta.3-windowsservercore-ltsc2022
-SharedTags: 2.6.0-beta.3-windowsservercore, 2.6.0-beta.3
+Tags: 2.6.0-beta.5-windowsservercore-ltsc2022
+SharedTags: 2.6.0-beta.5-windowsservercore, 2.6.0-beta.5
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/ltsc2022
-GitCommit: f7c8c6c15e868f70498b605feb17fd347735638d
+GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.6.0-beta.3-builder-windowsservercore-1809
-SharedTags: 2.6.0-beta.3-builder
+Tags: 2.6.0-beta.5-builder-windowsservercore-1809
+SharedTags: 2.6.0-beta.5-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/1809
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.6.0-beta.3-builder-windowsservercore-ltsc2022
-SharedTags: 2.6.0-beta.3-builder
+Tags: 2.6.0-beta.5-builder-windowsservercore-ltsc2022
+SharedTags: 2.6.0-beta.5-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/ltsc2022
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
+GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.6.0-beta.5

Signed-off-by: Dave Henderson <dhenderson@gmail.com>