### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.14.1, 5.14, 5, latest
+Tags: 5.14.2, 5.14, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 61a3f9096316b22fadfc53ed3e5e58b18107ce6d
+GitCommit: c13e701715cfa0feea436163eb3b531fc1149896
 Directory: 5/debian
 
-Tags: 5.14.1-alpine, 5.14-alpine, 5-alpine, alpine
+Tags: 5.14.2-alpine, 5.14-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 61a3f9096316b22fadfc53ed3e5e58b18107ce6d
+GitCommit: c13e701715cfa0feea436163eb3b531fc1149896
 Directory: 5/alpine
 
 Tags: 4.48.4, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/c13e701: Update to 5.14.2, ghost-cli 1.23.0