### PR TITLE
Bump Haskell stack to 2.9.1

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -3,40 +3,40 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.4.2-buster, 9.4-buster, 9-buster, buster, 9.4.2, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 9f3a7b0038a6ff9feb668a51cfebebdd4301c9c3
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 9.4/buster
 
 Tags: 9.4.2-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.2-slim, 9.4-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 9f3a7b0038a6ff9feb668a51cfebebdd4301c9c3
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 9.4/slim-buster
 
 Tags: 9.2.4-buster, 9.2-buster, 9.2.4, 9.2
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 9.2/buster
 
 Tags: 9.2.4-slim-buster, 9.2-slim-buster, 9.2.4-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 9.0/buster
 
 Tags: 9.0.2-slim-buster, 9.0-slim-buster, 9.0.2-slim, 9.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 9.0/slim-buster
 
 Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 8.10/buster
 
 Tags: 8.10.7-slim-buster, 8.10-slim-buster, 8-slim-buster, 8.10.7-slim, 8.10-slim, 8-slim
 Architectures: amd64, arm64v8
-GitCommit: 94c169693cc6337c2cd3994da71fb5d9f0b399b0
+GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
 Directory: 8.10/slim-buster


### PR DESCRIPTION
https://github.com/commercialhaskell/stack/releases/tag/v2.9.1