### PR TITLE
mariadb: 2022-09-19 out of cycle release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,40 +6,40 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.10.1-rc-jammy, 10.10-rc-jammy, 10.10.1-rc, 10.10-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.10
 
-Tags: 10.9.2-jammy, 10.9-jammy, 10-jammy, jammy, 10.9.2, 10.9, 10, latest
+Tags: 10.9.3-jammy, 10.9-jammy, 10-jammy, jammy, 10.9.3, 10.9, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.9
 
-Tags: 10.8.4-jammy, 10.8-jammy, 10.8.4, 10.8
+Tags: 10.8.5-jammy, 10.8-jammy, 10.8.5, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.8
 
-Tags: 10.7.5-focal, 10.7-focal, 10.7.5, 10.7
+Tags: 10.7.6-focal, 10.7-focal, 10.7.6, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.7
 
-Tags: 10.6.9-focal, 10.6-focal, 10.6.9, 10.6
+Tags: 10.6.10-focal, 10.6-focal, 10.6.10, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.6
 
 Tags: 10.5.17-focal, 10.5-focal, 10.5.17, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.5
 
 Tags: 10.4.26-focal, 10.4-focal, 10.4.26, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.4
 
 Tags: 10.3.36-focal, 10.3-focal, 10.3.36, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 97e6715fb9f86010de510eef718f7341e3011c25
+GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
 Directory: 10.3


### PR DESCRIPTION
Fixes a few significant MDEVs on 10.6+ per
https://mariadb.com/kb/en/mariadb-10610-release-notes/.

Also adds the MARIADB_{ROOT_,}PASSWORD_HASH option thanks to @TheAlgorythm.