### PR TITLE
Update Backdrop to version 1.23.0

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.21.4, 1.21, 1, 1.21.4-apache, 1.21-apache, 1-apache, apache, latest
+Tags: 1.23.0, 1.23, 1, 1.23.0-apache, 1.23-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 91ac0ee1e56bbff6d2fb49218b38a9cbf9d1a356
+GitCommit: 69bc3670f97cf6d060e9379bea26b2fcdf0ebc3f
 Directory: 1/apache
 
-Tags: 1.21.4-fpm, 1.21-fpm, 1-fpm, fpm
+Tags: 1.23.0-fpm, 1.23-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 01456d360386ed664298c53a74a75647e0965795
+GitCommit: 69bc3670f97cf6d060e9379bea26b2fcdf0ebc3f
 Directory: 1/fpm


### PR DESCRIPTION
Here is the link to the latest release of Backdrop: https://github.com/backdrop/backdrop/releases/latest https://github.com/backdrop/backdrop/releases/tag/1.23.0

Here is the link to the latest commits of the backdrop-docker repo: https://github.com/backdrop-ops/backdrop-docker/commits/master