### PR TITLE
caddy: v2.6.0 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,97 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/49bd8fc1ddde0133e1c5ec61e656044de0f70bae/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/22df506a79f96b5ffd98bcffd8fc84b658ab4861/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.5.2-alpine, 2-alpine, alpine
-SharedTags: 2.5.2, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.5/alpine
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.5.2-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.5.2-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.5/builder
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.5.2-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.5.2-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.2, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.5/windows/1809
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
-Tags: 2.5.2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.5.2-windowsservercore, 2-windowsservercore, windowsservercore, 2.5.2, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.5/windows/ltsc2022
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 2.5.2-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.5.2-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.5/windows-builder/1809
-GitCommit: 5334174f3d85d575a7f2ab86b6969587f183396c
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
-Tags: 2.5.2-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.5.2-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.5/windows-builder/ltsc2022
-GitCommit: 554ed46249834de957d5ae793ddb39dfe915bacb
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 2.6.0-beta.5-alpine
-SharedTags: 2.6.0-beta.5
+Tags: 2.6.0-alpine, 2-alpine, alpine
+SharedTags: 2.6.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/alpine
-GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
+GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.6.0-beta.5-builder-alpine
-SharedTags: 2.6.0-beta.5-builder
+Tags: 2.6.0-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.6.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/builder
-GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
+GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.6.0-beta.5-windowsservercore-1809
-SharedTags: 2.6.0-beta.5-windowsservercore, 2.6.0-beta.5
+Tags: 2.6.0-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.6.0-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/1809
-GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
+GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.6.0-beta.5-windowsservercore-ltsc2022
-SharedTags: 2.6.0-beta.5-windowsservercore, 2.6.0-beta.5
+Tags: 2.6.0-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.6.0-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.0, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/ltsc2022
-GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
+GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.6.0-beta.5-builder-windowsservercore-1809
-SharedTags: 2.6.0-beta.5-builder
+Tags: 2.6.0-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.6.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/1809
-GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
+GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.6.0-beta.5-builder-windowsservercore-ltsc2022
-SharedTags: 2.6.0-beta.5-builder
+Tags: 2.6.0-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.6.0-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/ltsc2022
-GitCommit: 49bd8fc1ddde0133e1c5ec61e656044de0f70bae
+GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.6.0

Signed-off-by: Dave Henderson <dhenderson@gmail.com>