### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,108 +4,56 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 20-ea-14-jdk-oraclelinux8, 20-ea-14-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-14-jdk-oracle, 20-ea-14-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-14-jdk, 20-ea-14, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-15-jdk-oraclelinux8, 20-ea-15-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-15-jdk-oracle, 20-ea-15-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-15-jdk, 20-ea-15, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-14-jdk-oraclelinux7, 20-ea-14-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-15-jdk-oraclelinux7, 20-ea-15-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-14-jdk-bullseye, 20-ea-14-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-15-jdk-bullseye, 20-ea-15-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-14-jdk-slim-bullseye, 20-ea-14-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-14-jdk-slim, 20-ea-14-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-15-jdk-slim-bullseye, 20-ea-15-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-15-jdk-slim, 20-ea-15-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-14-jdk-buster, 20-ea-14-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-15-jdk-buster, 20-ea-15-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/buster
 
-Tags: 20-ea-14-jdk-slim-buster, 20-ea-14-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-15-jdk-slim-buster, 20-ea-15-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-14-jdk-windowsservercore-ltsc2022, 20-ea-14-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-14-jdk-windowsservercore, 20-ea-14-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-14-jdk, 20-ea-14, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-15-jdk-windowsservercore-ltsc2022, 20-ea-15-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-15-jdk-windowsservercore, 20-ea-15-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-15-jdk, 20-ea-15, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-14-jdk-windowsservercore-1809, 20-ea-14-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-14-jdk-windowsservercore, 20-ea-14-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-14-jdk, 20-ea-14, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-15-jdk-windowsservercore-1809, 20-ea-15-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-15-jdk-windowsservercore, 20-ea-15-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-15-jdk, 20-ea-15, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-14-jdk-nanoserver-1809, 20-ea-14-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-14-jdk-nanoserver, 20-ea-14-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-15-jdk-nanoserver-1809, 20-ea-15-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-15-jdk-nanoserver, 20-ea-15-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: 5269477fd63c130b5307011e897d67c760768648
+GitCommit: ee9e218549dacb1b0b54b8afa02df24cd2885a02
 Directory: 20/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 19-rc-jdk-oraclelinux8, 19-rc-oraclelinux8, 19-jdk-oraclelinux8, 19-oraclelinux8, 19-rc-jdk-oracle, 19-rc-oracle, 19-jdk-oracle, 19-oracle
-SharedTags: 19-rc-jdk, 19-rc, 19-jdk, 19
-Architectures: amd64, arm64v8
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/oraclelinux8
-
-Tags: 19-rc-jdk-oraclelinux7, 19-rc-oraclelinux7, 19-jdk-oraclelinux7, 19-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/oraclelinux7
-
-Tags: 19-rc-jdk-bullseye, 19-rc-bullseye, 19-jdk-bullseye, 19-bullseye
-Architectures: amd64, arm64v8
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/bullseye
-
-Tags: 19-rc-jdk-slim-bullseye, 19-rc-slim-bullseye, 19-jdk-slim-bullseye, 19-slim-bullseye, 19-rc-jdk-slim, 19-rc-slim, 19-jdk-slim, 19-slim
-Architectures: amd64, arm64v8
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/slim-bullseye
-
-Tags: 19-rc-jdk-buster, 19-rc-buster, 19-jdk-buster, 19-buster
-Architectures: amd64, arm64v8
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/buster
-
-Tags: 19-rc-jdk-slim-buster, 19-rc-slim-buster, 19-jdk-slim-buster, 19-slim-buster
-Architectures: amd64, arm64v8
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/slim-buster
-
-Tags: 19-rc-jdk-windowsservercore-ltsc2022, 19-rc-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19-rc-jdk-windowsservercore, 19-rc-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-rc-jdk, 19-rc, 19-jdk, 19
-Architectures: windows-amd64
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 19-rc-jdk-windowsservercore-1809, 19-rc-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19-rc-jdk-windowsservercore, 19-rc-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19-rc-jdk, 19-rc, 19-jdk, 19
-Architectures: windows-amd64
-GitCommit: 6e4c15afaf7cc1db5172e0b10178012cdfda32a8
-Directory: 19/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 19-rc-jdk-nanoserver-1809, 19-rc-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19-rc-jdk-nanoserver, 19-rc-nanoserver, 19-jdk-nanoserver, 19-nanoserver
-Architectures: windows-amd64
-GitCommit: afc6de3b6821a62f8d4d7b656477db3b4cd29d1a
-Directory: 19/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 18.0.2.1-jdk-oraclelinux8, 18.0.2.1-oraclelinux8, 18.0.2-jdk-oraclelinux8, 18.0.2-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.2.1-jdk-oracle, 18.0.2.1-oracle, 18.0.2-jdk-oracle, 18.0.2-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0d67210: Merge pull request https://github.com/docker-library/openjdk/pull/515 from infosiftr/remove-19
- https://github.com/docker-library/openjdk/commit/06c6f17: Remove 19 (now GA)
- https://github.com/docker-library/openjdk/commit/ee9e218: Update 20 to 20-ea+15