### PR TITLE
Add official image for OpenSearch Dashboards

### DIFF
--- a/library/opensearch-dashboards
+++ b/library/opensearch-dashboards
@@ -1,0 +1,11 @@
+Maintainers: OpenSearch Project Team <opensearch@amazon.com> (@opensearch-project),
+             Rishabh Singh <sngri@amazon.com> (@rishabh6788),
+             Peter Zhu <zhujiaxi@amazon.com> (@peterzhuamazon),
+             Prudhvi Godithi <pgodithi@amazon.com> (@prudhvigodithi)
+GitRepo: https://github.com/opensearch-project/dashboards-docker-images.git
+
+Tags: 2.3.0, 2.3, 2, latest
+Architectures: amd64, arm64v8
+GitCommit: c8f80771985daceb6dcbe9498790b2d848159786
+Directory: 2.x
+


### PR DESCRIPTION
Signed-off-by: Rishabh Singh <sngri@amazon.com>

OpenSearch Dashboards is the default visualization tool for data in OpenSearch. It also serves as a user interface for many of the OpenSearch plugins, including security, alerting, Index State Management, SQL, and more.
To know more about OpenSearch Dashboards please read our [documentation](https://opensearch.org/docs/latest/dashboards/index/)

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream? We own the source https://github.com/opensearch-project/OpenSearch-Dashboards
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)? [Apache License 2.0](https://opensource.org/licenses/Apache-2.0)
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution") Service
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? https://github.com/docker-library/docs/pull/2197
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[x] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[x] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)