### PR TITLE
mariadb entrypoint fix

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,40 +6,40 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.10.1-rc-jammy, 10.10-rc-jammy, 10.10.1-rc, 10.10-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.10
 
 Tags: 10.9.3-jammy, 10.9-jammy, 10-jammy, jammy, 10.9.3, 10.9, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.9
 
 Tags: 10.8.5-jammy, 10.8-jammy, 10.8.5, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.8
 
 Tags: 10.7.6-focal, 10.7-focal, 10.7.6, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.7
 
 Tags: 10.6.10-focal, 10.6-focal, 10.6.10, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.6
 
 Tags: 10.5.17-focal, 10.5-focal, 10.5.17, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.5
 
 Tags: 10.4.26-focal, 10.4-focal, 10.4.26, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.4
 
 Tags: 10.3.36-focal, 10.3-focal, 10.3.36, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 749c720c63306d1572849afc6ab1cfa02fd08338
+GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
 Directory: 10.3


### PR DESCRIPTION
I made a mistake and caused #MariaDB/mariadb-docker/issues/460

Correct fails to set password with MARIADB_ROOT_HOST=localhost,

Now includes test case.