### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ca-certificates-2022.2.54-74

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 63d372e3f2a15412ea3fbadab37ad7345b0518ac
+amd64-GitCommit: 3ed5ad238489277a30f25ab3d546a212aa0b988f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c020d7caab48a73179e20cc8b602c2a7a1eddd3a
+arm64v8-GitCommit: a683f4d96cb4dd667388aeff75dbe8b4f6810af0
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for ca-certificates-2022.2.54-74

See the following for details:
https://linux.oracle.com/errata/ELBA-2022-6572.html

Signed-off-by: Mark Will <mark.will@oracle.com>