### PR TITLE
caddy: v2.6.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,51 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/c74bdca53a1efd5195a9c35005e5515afb5feeff/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/22df506a79f96b5ffd98bcffd8fc84b658ab4861/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/7f509065562f208807c67e0fb8dd9d28788b0d33/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.6.0-alpine, 2-alpine, alpine
-SharedTags: 2.6.0, 2, latest
+Tags: 2.6.1-alpine, 2-alpine, alpine
+SharedTags: 2.6.1, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/alpine
-GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
+GitCommit: 7f509065562f208807c67e0fb8dd9d28788b0d33
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.6.0-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.6.0-builder, 2-builder, builder
+Tags: 2.6.1-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.6.1-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/builder
-GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
+GitCommit: 7f509065562f208807c67e0fb8dd9d28788b0d33
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.6.0-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.6.0-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.0, 2, latest
+Tags: 2.6.1-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.6.1-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.1, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/1809
-GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
+GitCommit: 7f509065562f208807c67e0fb8dd9d28788b0d33
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.6.0-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.6.0-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.0, 2, latest
+Tags: 2.6.1-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.6.1-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.1, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/ltsc2022
-GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
+GitCommit: 7f509065562f208807c67e0fb8dd9d28788b0d33
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.6.0-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.6.0-builder, 2-builder, builder
+Tags: 2.6.1-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.6.1-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/1809
-GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
+GitCommit: 7f509065562f208807c67e0fb8dd9d28788b0d33
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.6.0-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.6.0-builder, 2-builder, builder
+Tags: 2.6.1-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.6.1-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/ltsc2022
-GitCommit: 22df506a79f96b5ffd98bcffd8fc84b658ab4861
+GitCommit: 7f509065562f208807c67e0fb8dd9d28788b0d33
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
Hotfix for recent 2.6 release! https://github.com/caddyserver/caddy/releases/tag/v2.6.1

Signed-off-by: Dave Henderson <dhenderson@gmail.com>