### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -9,24 +9,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
             Preston Carpenter (@timidger),
             Richard Kelly (@rpkelly),
             Joseph Howell-Burke (@jhowell-burke),
-            Joe Gawrieh (@theOtherJoe),
+            Miriam Clark (@mgclark001),
             CJ Harris (@mrcjplease)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: c74188ab6dda46cf66acf81df5c8ec615fdeded8
+GitCommit: 6eb315d367fb8c9aaeba93db9c025d5d9048a1ea
 
-Tags: 2.0.20220805.0, 2, latest
+Tags: 2.0.20220912.1, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 26415c9039fa9d560723c416da68a95c96b25af3
+amd64-GitCommit: fb082773264a2defa7c5cfc78a398304cf136589
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 31437e8f307ec31577af1c2b9e1c2a0c9003c4ef
+arm64v8-GitCommit: e94ab61e9d819742d2faa646853db233f4611634
 
-Tags: 2.0.20220805.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20220912.1-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: f763826f20f7e26a2b3448f2a544660db2f5a530
+amd64-GitCommit: ec5f36611a2a511ac95ffd55e62dbeaba493dddc
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 43a28df7c080970989f6042b0110a30e1b665357
+arm64v8-GitCommit: 3ae699d44c6e1d83f53e0fc44c6c9dcf8c78e7e3
 
 Tags: 2018.03.0.20220802.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- gnupg2-2.0.22-5.amzn2.0.5
  - [CVE-2022-34903](https://alas.aws.amazon.com/cve/html/CVE-2022-34903.html)
- tzdata-2022c-1.amzn2


Sam