### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cfeedce7f5b0d926605b57a7ae8510f9dd8a9f11
 Directory: 2.7/alpine
 
-Tags: 2.6.5, 2.6, lts, latest, 2.6.5-bullseye, 2.6-bullseye, lts-bullseye, bullseye
+Tags: 2.6.6, 2.6, lts, latest, 2.6.6-bullseye, 2.6-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 039e62b8f996edea64e90cb7e0b98bfefab9cb64
+GitCommit: bfdb47e3bb0de8315bf08876d7720ab3f46ccc28
 Directory: 2.6
 
-Tags: 2.6.5-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.5-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
+Tags: 2.6.6-alpine, 2.6-alpine, lts-alpine, alpine, 2.6.6-alpine3.16, 2.6-alpine3.16, lts-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 039e62b8f996edea64e90cb7e0b98bfefab9cb64
+GitCommit: bfdb47e3bb0de8315bf08876d7720ab3f46ccc28
 Directory: 2.6/alpine
 
 Tags: 2.5.8, 2.5, 2.5.8-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bfdb47e: Update 2.6 to 2.6.6