### PR TITLE
[varnish] adjust ENV variable

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,26 +1,26 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/314b75ac940b9d6cb3b848e1c790f1360464cbd7/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/07daf0b299f538c477be8dbac82b4a8e364d0b83/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 7.2.0, 7.2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: 314b75ac940b9d6cb3b848e1c790f1360464cbd7
+GitCommit: 07daf0b299f538c477be8dbac82b4a8e364d0b83
 
 Tags: fresh-alpine, 7.2.0-alpine, 7.2-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: 314b75ac940b9d6cb3b848e1c790f1360464cbd7
+GitCommit: 4d038be2a5553f08a24dbb357f226131d0339306
 
 Tags: old, 7.1.1, 7.1
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: 9544f66456655cacda18a89ee8c9a2ad2a29234d
+GitCommit: 07daf0b299f538c477be8dbac82b4a8e364d0b83
 
 Tags: old-alpine, 7.1.1-alpine, 7.1-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/alpine
-GitCommit: 9544f66456655cacda18a89ee8c9a2ad2a29234d
+GitCommit: 4d038be2a5553f08a24dbb357f226131d0339306
 
 Tags: stable, 6.0.10, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
`gcc` is already installed, so it's not needed in `VMOD_DEPS`, plus trying to uninstall the package will uninstall `varnish` too.

and `sbuild` is now gone too