### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: bfdb47e3bb0de8315bf08876d7720ab3f46ccc28
 Directory: 2.6/alpine
 
-Tags: 2.5.8, 2.5, 2.5.8-bullseye, 2.5-bullseye
+Tags: 2.5.9, 2.5, 2.5.9-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4652e975be3db3a69221e68a103dae4e5891313b
+GitCommit: 18c82fca3a11dc33c652328275a13155de6b054b
 Directory: 2.5
 
-Tags: 2.5.8-alpine, 2.5-alpine, 2.5.8-alpine3.16, 2.5-alpine3.16
+Tags: 2.5.9-alpine, 2.5-alpine, 2.5.9-alpine3.16, 2.5-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4652e975be3db3a69221e68a103dae4e5891313b
+GitCommit: 18c82fca3a11dc33c652328275a13155de6b054b
 Directory: 2.5/alpine
 
 Tags: 2.4.18, 2.4, 2.4.18-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/18c82fc: Update 2.5 to 2.5.9