### PR TITLE
Fix ghost test to not request "//" to prevent current unending curl connection

### DIFF
--- a/test/tests/ghost-basics/run.sh
+++ b/test/tests/ghost-basics/run.sh
@@ -57,7 +57,7 @@ _request() {
 	docker run --rm \
 		--link "$cid":ghost \
 		"$clientImage" \
-		curl -fs -X"$method" "$@" "http://ghost:2368/$url"
+		curl -fs --max-time 15 -X"$method" "$@" "http://ghost:2368/${url#/}"
 }
 
 # Make sure that Ghost is listening and ready


### PR DESCRIPTION
Also prevent curl from having an unending connection by setting a `max-time`.

Fixes https://github.com/docker-library/ghost/issues/335

```console
$ ./test/run.sh ghost:5.16.2
testing ghost:5.16.2
	'utc' [1/4]...passed
	'no-hard-coded-passwords' [2/4]...passed
	'override-cmd' [3/4]...passed
	'ghost-basics' [4/4]...............passed
```