### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 0eb3eda3afc958405489aeda90531e558eb9e475
+GitCommit: 9d962f884ebf8e098b772f47938bc8486c6b6f7b
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.18-cli, 20.10-cli, 20-cli, cli, 20.10.18-cli-alpine3.16, 20.10.18, 20.10, 20, latest, 20.10.18-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 5e3e40486df3af0f9675c115a6127e10ac4f5b95
+GitCommit: 2fc53e853187b5f5ba0c4696189ce7abc6b62a1d
 Directory: 20.10/cli
 
 Tags: 20.10.18-dind, 20.10-dind, 20-dind, dind, 20.10.18-dind-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/9d962f8: Update 22.06-rc to compose 2.11.2
- https://github.com/docker-library/docker/commit/2fc53e8: Update 20.10 to compose 2.11.2