### PR TITLE
eclipse-temurin: add ppc64le support for temurin 19

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -361,21 +361,21 @@ Directory: 19/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 19_36-jdk-focal, 19-jdk-focal, 19-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: dcd73aeb1beb8ba4bc913a8131bccca8c951e99a
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: c25ab6851db6c7ca509dd70d60d27b48aff64024
 Directory: 19/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 19_36-jdk-jammy, 19-jdk-jammy, 19-jammy
 SharedTags: 19_36-jdk, 19-jdk, 19, latest
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: dcd73aeb1beb8ba4bc913a8131bccca8c951e99a
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: c25ab6851db6c7ca509dd70d60d27b48aff64024
 Directory: 19/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 19_36-jdk-centos7, 19-jdk-centos7, 19-centos7
-Architectures: amd64, arm64v8
-GitCommit: dcd73aeb1beb8ba4bc913a8131bccca8c951e99a
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c25ab6851db6c7ca509dd70d60d27b48aff64024
 Directory: 19/jdk/centos
 File: Dockerfile.releases.full
 
@@ -418,21 +418,21 @@ Directory: 19/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 19_36-jre-focal, 19-jre-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: dcd73aeb1beb8ba4bc913a8131bccca8c951e99a
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: c25ab6851db6c7ca509dd70d60d27b48aff64024
 Directory: 19/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 19_36-jre-jammy, 19-jre-jammy
 SharedTags: 19_36-jre, 19-jre
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: dcd73aeb1beb8ba4bc913a8131bccca8c951e99a
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: c25ab6851db6c7ca509dd70d60d27b48aff64024
 Directory: 19/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 19_36-jre-centos7, 19-jre-centos7
-Architectures: amd64, arm64v8
-GitCommit: dcd73aeb1beb8ba4bc913a8131bccca8c951e99a
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c25ab6851db6c7ca509dd70d60d27b48aff64024
 Directory: 19/jre/centos
 File: Dockerfile.releases.full
 


### PR DESCRIPTION
adds missing ppc64le images for temurin 19