### PR TITLE
Update cirros

### DIFF
--- a/library/cirros
+++ b/library/cirros
@@ -3,12 +3,11 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-brew-cirros.git
 GitFetch: refs/heads/dist
-GitCommit: 6b155af1eeb835ab219369aeec45139b2f4ba11b
-Architectures: amd64, arm32v5, arm64v8, i386, ppc64le
+GitCommit: 00ddac1cc79093da0d08040b71b02f35e5dfe21c
+Architectures: amd64, arm32v5, arm64v8, ppc64le
 amd64-Directory: arches/amd64
 arm32v5-Directory: arches/arm32v5
 arm64v8-Directory: arches/arm64v8
-i386-Directory: arches/i386
 ppc64le-Directory: arches/ppc64le
 
-Tags: 0.5.2, 0.5, 0, latest
+Tags: 0.6.0, 0.6, 0, latest


### PR DESCRIPTION
Changes:

- https://github.com/tianon/docker-brew-cirros/commit/1f366cb: Remove i386 (unsupported upstream as of 0.6.0)
- https://github.com/tianon/docker-brew-cirros/commit/2ae8d6f: Update version-testing code for GitHub changes
- https://github.com/tianon/docker-brew-cirros/commit/d4efd05: Update README