### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 18c82fca3a11dc33c652328275a13155de6b054b
 Directory: 2.5/alpine
 
-Tags: 2.4.18, 2.4, 2.4.18-bullseye, 2.4-bullseye
+Tags: 2.4.19, 2.4, 2.4.19-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d8a314a8b07f41e256995557e348800560543c93
+GitCommit: b07fcf19b4ee54ef37ffbf7241372961ddc97b8c
 Directory: 2.4
 
-Tags: 2.4.18-alpine, 2.4-alpine, 2.4.18-alpine3.16, 2.4-alpine3.16
+Tags: 2.4.19-alpine, 2.4-alpine, 2.4.19-alpine3.16, 2.4-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d8a314a8b07f41e256995557e348800560543c93
+GitCommit: b07fcf19b4ee54ef37ffbf7241372961ddc97b8c
 Directory: 2.4/alpine
 
 Tags: 2.2.25, 2.2, 2.2.25-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b07fcf1: Update 2.4 to 2.4.19