### PR TITLE
Bump Traefik to v2.8.8 and v2.9.0-rc5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 45ba9d19d7c48c6001ef39c6bc5086ba75b85d02
 Directory: alpine
 
-Tags: v2.8.7-windowsservercore-1809, 2.8.7-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.8.8-windowsservercore-1809, 2.8.8-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8653b8ce21ce737677d27ee1525e22f4572d1332
+GitCommit: 052e5840860e7679a2b185a899dd9c19797f56a7
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.8.7, 2.8.7, v2.8, 2.8, vacherin, latest
+Tags: v2.8.8, 2.8.8, v2.8, 2.8, vacherin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8653b8ce21ce737677d27ee1525e22f4572d1332
+GitCommit: 052e5840860e7679a2b185a899dd9c19797f56a7
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809

--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.9.0-rc4-windowsservercore-1809, 2.9.0-rc4-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809
+Tags: v2.9.0-rc5-windowsservercore-1809, 2.9.0-rc5-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 45ba9d19d7c48c6001ef39c6bc5086ba75b85d02
+GitCommit: 5068ee442c37a02d7b3a6f81bece4a08d84496bf
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.9.0-rc4, 2.9.0-rc4, v2.9, 2.9, banon
+Tags: v2.9.0-rc5, 2.9.0-rc5, v2.9, 2.9, banon
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 45ba9d19d7c48c6001ef39c6bc5086ba75b85d02
+GitCommit: 5068ee442c37a02d7b3a6f81bece4a08d84496bf
 Directory: alpine
 
 Tags: v2.8.8-windowsservercore-1809, 2.8.8-windowsservercore-1809, v2.8-windowsservercore-1809, 2.8-windowsservercore-1809, vacherin-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.8.8](https://github.com/traefik/traefik/releases/tag/v2.8.8) and [v2.9.0-rc5](https://github.com/traefik/traefik/releases/tag/v2.9.0-rc5)

/cc @ddtmachado @kevinpollet @rtribotte

Cheers
