### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.16.2, 5.16, 5, latest
+Tags: 5.17.0, 5.17, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 463b5935180624197ce2a527775af79501a10051
+GitCommit: a66caa70ed1c46ce7d715fbc9e713cb1b8cb363b
 Directory: 5/debian
 
-Tags: 5.16.2-alpine, 5.16-alpine, 5-alpine, alpine
+Tags: 5.17.0-alpine, 5.17-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 463b5935180624197ce2a527775af79501a10051
+GitCommit: a66caa70ed1c46ce7d715fbc9e713cb1b8cb363b
 Directory: 5/alpine
 
 Tags: 4.48.5, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/a66caa7: Update to 5.17.0, ghost-cli 1.23.0