### PR TITLE
archlinux: Release 20221002.0.91257

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20220925.0.89186
-GitCommit: 212bcc3e02f153b57b56ca9cd5b168bc8d66c981
-GitFetch: refs/tags/v20220925.0.89186
+Tags: latest, base, base-20221002.0.91257
+GitCommit: 91be06d2c64296a78bdb1bb3857efb1e5da5b24a
+GitFetch: refs/tags/v20221002.0.91257
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20220925.0.89186
-GitCommit: 212bcc3e02f153b57b56ca9cd5b168bc8d66c981
-GitFetch: refs/tags/v20220925.0.89186
+Tags: base-devel, base-devel-20221002.0.91257
+GitCommit: 91be06d2c64296a78bdb1bb3857efb1e5da5b24a
+GitFetch: refs/tags/v20221002.0.91257
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks