### PR TITLE
[oraclelinux] Updating 7 for ELSA-2022-6765

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 14eb2b6d3efbca6bf1ce634dc5de34955c3e256c
+amd64-GitCommit: 477d7e95e2f10ed724ddbcdc5f63301bd400c98f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 69495c152e4d6f3b5497ff3faa730fff77aa8351
+arm64v8-GitCommit: 6190478d9e5d6292bcbb2f2b5c77603e2679d0cd
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-38177 and CVE-2022-38178.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6765.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>