### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/22c2c562514effb9e624704584f732e32c5a82da/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/b8bb85f915b560d915270fc731771f66d075aac4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 22c2c562514effb9e624704584f732e32c5a82da
+GitCommit: b8bb85f915b560d915270fc731771f66d075aac4
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 666671635bef96b5cac5b791d6366be77a437268
+amd64-GitCommit: fa0d085f2c037b5c01aa1dbea66fa903745a62bb
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: befccdffc23b6b11326b4619078a3d713ed1d641
+arm32v5-GitCommit: ae6522fad0768851e13984150971b78104328dab
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: a85e7eea5b19bf80961ba49b1982477471011910
+arm32v6-GitCommit: 440cb0726d2660e0513a9328986f302b6dee71b9
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 86e040e549fffc1fd77441949b3097e13864d2b4
+arm32v7-GitCommit: 7b1bf927d5fec7dad75548bf3b07a7fd1188dcef
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 028124d25921635906549cf1aaf48211f211fc4a
+arm64v8-GitCommit: a85554077e6765c2276a344f9d19692fc002544b
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: a019add518531088ba021c36ea710aa3ea754bdd
+i386-GitCommit: 757bcedd9a49775054801af2724c73092d0f3c73
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 5d73b2568912b2239479942d08a632b4a362f0a1
+mips64le-GitCommit: a37a0130e222bf121ad25cbe802abf1e1fc0ad54
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 50dd33944819b7cb2c561685d87dd8e2fdc4d412
+ppc64le-GitCommit: c2cfef28204a5a78bea3c9fb44837b3732983d35
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 01332ce0352f09e04d3a065b58a489d7914f4b12
+riscv64-GitCommit: 6781e9d0b260afe6cce7f93db93ba988a4e57cc1
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e285c93aac4c393c09b6b2e6afebfefb2306b5c5
+s390x-GitCommit: ec7f747bc6fe3681897527310704c3921c92ba52
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/b8bb85f: Merge pull request https://github.com/docker-library/busybox/pull/146 from infosiftr/buildroot-2022.08.1
- https://github.com/docker-library/busybox/commit/b7a7954: Update buildroot to 2022.08.1