### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 62f7701ded7533f125333ad6172ebe4caedf4a00
 
-Tags: 2022.0.20220831.1, 2022, devel
+Tags: 2022.0.20220928.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: b930e5823acf593b6931f810c5808679ed51957d
+amd64-GitCommit: 0cebf00af456c41dc755275095549ae20fa2f219
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: 9cf6477c0994dbd661ccd79562958e0df7ff063a
+arm64v8-GitCommit: bf9cae027a0316733b32d2ced4b84c379eaec95c
 
-Tags: 2022.0.20220831.1-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20220928.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 424b626658141641f77a87728997c08f3793ce51
+amd64-GitCommit: 29e827cc03ae829154e598aa8ace1282a4d6f8aa
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: dcc71cde8096d014d03f32e21381c3fb72703f12
+arm64v8-GitCommit: 91d5c184765cd99a4c7fb9bea122a5ff212904b4


### PR DESCRIPTION
Hello,

This change update Amazon Linux 2022 DockerHub images.
New image version is 2022.0.20220928.0.

Thanks,
Preston
