### PR TITLE
Odoo: update 13.0-15.0 to release 20221005

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 333b10955096da859c7f581935bd243bce743589
+GitCommit: 26df6d6eef8df7a9927fbdade79772455de7e8eb
 
 Tags: 15.0, 15, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks.