### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -26,7 +26,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.8, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 5c12896e9bb300a38f9436fb18cba286f1b3c02b
+GitCommit: 221037ea6c661baa6f3c1ad195ef6e15f4bfcb11
 Directory: 3.10/ubuntu
 
 Tags: 3.10.8-management, 3.10-management
@@ -36,7 +36,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.8-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c12896e9bb300a38f9436fb18cba286f1b3c02b
+GitCommit: 221037ea6c661baa6f3c1ad195ef6e15f4bfcb11
 Directory: 3.10/alpine
 
 Tags: 3.10.8-management-alpine, 3.10-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/221037e: Update 3.10 to otp 25.1.1
- https://github.com/docker-library/rabbitmq/commit/fb4cf9e: Update 3.10 to otp 25.0.3