### PR TITLE
[oraclelinux] Updating 7, 7-slim, 8, 8-slim, 9, 9-slim for ELSA-2022-6834, ELSA-2022-6778, ELSA-2022-6838 and tzdata-2022d-1

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 477d7e95e2f10ed724ddbcdc5f63301bd400c98f
+amd64-GitCommit: 42cbe0d772212a38fd6e80beb4d064c3d853a6c3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6190478d9e5d6292bcbb2f2b5c77603e2679d0cd
+arm64v8-GitCommit: 4dca2809d02b0517ea722f990be569adbb8f6736
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-40674, CVE-2022-38177, CVE-2022-38178, and tzdata-2022d-1.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6834.html
https://linux.oracle.com/errata/ELSA-2022-6778.html
https://linux.oracle.com/errata/ELSA-2022-6838.html
https://linux.oracle.com/errata/ELBA-2022-6827.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>