### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,6 +4,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
+Tags: 4.1-beta1, 4.1
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: e8ee59f9fc070e87595ea3fafe528030bddb8212
+Directory: 4.1
+
 Tags: 4.0.6, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 5aa6b7ed7a342c18da796561252677f17d370616


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/e8ee59f: Add Cassandra 4.1 (https://github.com/docker-library/cassandra/pull/256)