### PR TITLE
archlinux: Release 20221009.0.92802

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221002.0.91257
-GitCommit: 91be06d2c64296a78bdb1bb3857efb1e5da5b24a
-GitFetch: refs/tags/v20221002.0.91257
+Tags: latest, base, base-20221009.0.92802
+GitCommit: dfe56d58a12db8200192d125e8ad858a06dc4351
+GitFetch: refs/tags/v20221009.0.92802
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221002.0.91257
-GitCommit: 91be06d2c64296a78bdb1bb3857efb1e5da5b24a
-GitFetch: refs/tags/v20221002.0.91257
+Tags: base-devel, base-devel-20221009.0.92802
+GitCommit: dfe56d58a12db8200192d125e8ad858a06dc4351
+GitFetch: refs/tags/v20221009.0.92802
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks