### PR TITLE
[nats] Release v2.9.3

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -1,28 +1,28 @@
 Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
-             Waldemar Salinas <wally@synadia.com> (@wallyqs),
+             Waldemar Quevedo Salinas <wally@synadia.com> (@wallyqs),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 23e4d0984eebd247c6c96f222796e10f4c4a2a7e
+GitCommit: c16e478efa5ed6dc6039773098e3470d95ac2b26
 
-Tags: 2.9.2-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.2-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.3-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.3-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.2/alpine3.16
+Directory: 2.9.3/alpine3.16
 
-Tags: 2.9.2-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.2-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.2, 2.9, 2, latest
+Tags: 2.9.3-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.3-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.3, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.2/scratch
+Directory: 2.9.3/scratch
 
-Tags: 2.9.2-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.2-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.3-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.3-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.2/windowsservercore-1809
+Directory: 2.9.3/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.2-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.2-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.2, 2.9, 2, latest
+Tags: 2.9.3-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.3-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.3, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.2/nanoserver-1809
+Directory: 2.9.3/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.3)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>