### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.30, 8.0, 8, latest, 8.0.30-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.0.31, 8.0, 8, latest, 8.0.31-oracle, 8.0-oracle, 8-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: e03765d83c1fddcfb48fa47dda6171c50b563382
+GitCommit: 80c475648969a83e52802e8eb2ad90519f882421
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.30-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.31-debian, 8.0-debian, 8-debian, debian
 Architectures: amd64
-GitCommit: e03765d83c1fddcfb48fa47dda6171c50b563382
+GitCommit: 80c475648969a83e52802e8eb2ad90519f882421
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.39, 5.7, 5, 5.7.39-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.40, 5.7, 5, 5.7.40-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: e03765d83c1fddcfb48fa47dda6171c50b563382
+GitCommit: 167bab0210fbe9bb83bb7bc1b5553dc85146b089
 Directory: 5.7
 File: Dockerfile.oracle
 
-Tags: 5.7.39-debian, 5.7-debian, 5-debian
+Tags: 5.7.40-debian, 5.7-debian, 5-debian
 Architectures: amd64
-GitCommit: e03765d83c1fddcfb48fa47dda6171c50b563382
+GitCommit: 167bab0210fbe9bb83bb7bc1b5553dc85146b089
 Directory: 5.7
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/80c4756: Update 8.0 to 8.0.31, debian 8.0.31-1debian11, mysql-shell 8.0.31-1.el8, oracle 8.0.31-1.el8
- https://github.com/docker-library/mysql/commit/167bab0: Update 5.7 to 5.7.40, debian 5.7.40-1debian10, mysql-shell 8.0.31-1.el7, oracle 5.7.40-1.el7