### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.17.2, 5.17, 5, latest
+Tags: 5.18.0, 5.18, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 41e4c7c3d53684fd14f177f6cd2822ed62fef0fe
+GitCommit: fa62084cb02566522f5772d14fee14cfe439885c
 Directory: 5/debian
 
-Tags: 5.17.2-alpine, 5.17-alpine, 5-alpine, alpine
+Tags: 5.18.0-alpine, 5.18-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 41e4c7c3d53684fd14f177f6cd2822ed62fef0fe
+GitCommit: fa62084cb02566522f5772d14fee14cfe439885c
 Directory: 5/alpine
 
 Tags: 4.48.6, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/fa62084: Update to 5.18.0, ghost-cli 1.23.1