### PR TITLE
[nats-streaming] Release v0.25.2

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -2,25 +2,25 @@ Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
 GitFetch: refs/heads/main
-GitCommit: eae0f6184db0e22634105ee143b529cd3dbfbb6d
+GitCommit: bbf86e1ee1e9ade913719d60da4069ff2470dbd7
 
-Tags: 0.24.6-alpine3.15, 0.24-alpine3.15, alpine3.15, 0.24.6-alpine, 0.24-alpine, alpine
+Tags: 0.25.2-alpine3.16, 0.25-alpine3.16, alpine3.16, 0.25.2-alpine, 0.25-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.24.6/alpine3.15
+Directory: 0.25.2/alpine3.16
 
-Tags: 0.24.6-scratch, 0.24-scratch, scratch, 0.24.6-linux, 0.24-linux, linux
-SharedTags: 0.24.6, 0.24, latest
+Tags: 0.25.2-scratch, 0.25-scratch, scratch, 0.25.2-linux, 0.25-linux, linux
+SharedTags: 0.25.2, 0.25, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.24.6/scratch
+Directory: 0.25.2/scratch
 
-Tags: 0.24.6-windowsservercore-1809, 0.24-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.24.6-windowsservercore, 0.24-windowsservercore, windowsservercore
+Tags: 0.25.2-windowsservercore-1809, 0.25-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.25.2-windowsservercore, 0.25-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.24.6/windowsservercore-1809
+Directory: 0.25.2/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 0.24.6-nanoserver-1809, 0.24-nanoserver-1809, nanoserver-1809
-SharedTags: 0.24.6-nanoserver, 0.24-nanoserver, nanoserver, 0.24.6, 0.24, latest
+Tags: 0.25.2-nanoserver-1809, 0.25-nanoserver-1809, nanoserver-1809
+SharedTags: 0.25.2-nanoserver, 0.25-nanoserver, nanoserver, 0.25.2, 0.25, latest
 Architectures: windows-amd64
-Directory: 0.24.6/nanoserver-1809
+Directory: 0.25.2/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.25.2)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>