### PR TITLE
Odoo: Add Odoo 16.0

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 26df6d6eef8df7a9927fbdade79772455de7e8eb
+GitCommit: ad549a7c3602557abc44e9c04369965a73d78fcd
 
-Tags: 15.0, 15, latest
+Tags: 16.0, 16, latest
+Architectures: amd64
+Directory: 16.0
+
+Tags: 15.0, 15
 Architectures: amd64
 Directory: 15.0
 
 Tags: 14.0, 14
 Architectures: amd64
 Directory: 14.0
-
-Tags: 13.0, 13
-Architectures: amd64
-Directory: 13.0
 


### PR DESCRIPTION
Hello,

This PR 

* Adds Odoo 16.0
* Updates Odoo 14.0-15.0 to release 20221012
* Removes Deprecated Odoo 13.0

Thanks a lot