### PR TITLE
[oraclelinux] Updating 8, 8-slim, 9 and 9-slim for ELSA-2022-6854 and ELSA-2022-6878

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 42cbe0d772212a38fd6e80beb4d064c3d853a6c3
+amd64-GitCommit: 251dfc348c7a2915036e95130f79f61dd3e765d3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4dca2809d02b0517ea722f990be569adbb8f6736
+arm64v8-GitCommit: a185b96098fa93ca3635516e7086b5d433a05d5f
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-2509 and CVE-2022-40674.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-6854.html
https://linux.oracle.com/errata/ELSA-2022-6878.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>