### PR TITLE
Update Docker image for Silverpeas version 6.3

### DIFF
--- a/library/silverpeas
+++ b/library/silverpeas
@@ -2,7 +2,10 @@
 Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
 GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
 
-Tags: 6.2.3, latest
-GitCommit: 899560a46feaddb077f0ec93b5da3e01be7abbe0
-GitFetch: refs/heads/6.2.x
+Tags: 6.3, latest
+GitCommit: cab21d1a3a25bf15d24f27a156d3df894123bb10
+GitFetch: refs/heads/6.3.x
 
+Tags: 6.2.3-b1
+GitCommit: 9714dcc94eb558508f085835a329a44f5c3cb52e
+GitFetch: refs/heads/6.2.x


### PR DESCRIPTION
Update silverpeas Docker library to take into account the release of Silverpeas 6.3