### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -49,62 +49,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b9af6087524edc719249f590940b34ef107c95ca
 Directory: latest/php8.1/fpm-alpine
 
-Tags: cli-2.6.0, cli-2.6, cli-2, cli, cli-2.6.0-php7.4, cli-2.6-php7.4, cli-2-php7.4, cli-php7.4
+Tags: cli-2.7.0, cli-2.7, cli-2, cli, cli-2.7.0-php7.4, cli-2.7-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 815d020ca0e9206524f980f68bb3dda40326ff6b
 Directory: cli/php7.4/alpine
 
-Tags: cli-2.6.0-php8.0, cli-2.6-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.7.0-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 815d020ca0e9206524f980f68bb3dda40326ff6b
 Directory: cli/php8.0/alpine
 
-Tags: cli-2.6.0-php8.1, cli-2.6-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.7.0-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 376f01affcaacac50d8416b5f7f4abb34d6b60d2
+GitCommit: 815d020ca0e9206524f980f68bb3dda40326ff6b
 Directory: cli/php8.1/alpine
 
-Tags: beta-6.1-beta3-apache, beta-6.1-apache, beta-6-apache, beta-apache, beta-6.1-beta3, beta-6.1, beta-6, beta, beta-6.1-beta3-php7.4-apache, beta-6.1-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.1-beta3-php7.4, beta-6.1-php7.4, beta-6-php7.4, beta-php7.4
+Tags: beta-6.1-RC1-apache, beta-6.1-apache, beta-6-apache, beta-apache, beta-6.1-RC1, beta-6.1, beta-6, beta, beta-6.1-RC1-php7.4-apache, beta-6.1-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.1-RC1-php7.4, beta-6.1-php7.4, beta-6-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php7.4/apache
 
-Tags: beta-6.1-beta3-fpm, beta-6.1-fpm, beta-6-fpm, beta-fpm, beta-6.1-beta3-php7.4-fpm, beta-6.1-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-6.1-RC1-fpm, beta-6.1-fpm, beta-6-fpm, beta-fpm, beta-6.1-RC1-php7.4-fpm, beta-6.1-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php7.4/fpm
 
-Tags: beta-6.1-beta3-fpm-alpine, beta-6.1-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.1-beta3-php7.4-fpm-alpine, beta-6.1-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-6.1-RC1-fpm-alpine, beta-6.1-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.1-RC1-php7.4-fpm-alpine, beta-6.1-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-6.1-beta3-php8.0-apache, beta-6.1-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.1-beta3-php8.0, beta-6.1-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.1-RC1-php8.0-apache, beta-6.1-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.1-RC1-php8.0, beta-6.1-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php8.0/apache
 
-Tags: beta-6.1-beta3-php8.0-fpm, beta-6.1-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.1-RC1-php8.0-fpm, beta-6.1-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.1-beta3-php8.0-fpm-alpine, beta-6.1-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.1-RC1-php8.0-fpm-alpine, beta-6.1-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.1-beta3-php8.1-apache, beta-6.1-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.1-beta3-php8.1, beta-6.1-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.1-RC1-php8.1-apache, beta-6.1-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.1-RC1-php8.1, beta-6.1-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php8.1/apache
 
-Tags: beta-6.1-beta3-php8.1-fpm, beta-6.1-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.1-RC1-php8.1-fpm, beta-6.1-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.1-beta3-php8.1-fpm-alpine, beta-6.1-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.1-RC1-php8.1-fpm-alpine, beta-6.1-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 67e960d91c547417cd879adddf9c1cf0f1dc7a95
+GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
 Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/815d020: Update cli to 2.7.0
- https://github.com/docker-library/wordpress/commit/d0bb12b: Update beta to 6.1-RC1