### PR TITLE
Add a file for explicitly pinning BASHBREW_BUILDKIT_SYNTAX

### DIFF
--- a/.bashbrew-buildkit-syntax
+++ b/.bashbrew-buildkit-syntax
@@ -1,0 +1,1 @@
+docker/dockerfile:1.4.3@sha256:9ba7531bd80fb0a858632727cf7a112fbfd19b17e94c4e84ced81e24ef1a0dbc


### PR DESCRIPTION
This is a continuation of docker-library/bashbrew#43 -- it's intended that the 2-3 places we invoke builds (GitHub Actions and Jenkins) set the value of `BASHBREW_BUILDKIT_SYNTAX` to the contents of this file.