### PR TITLE
archlinux: Release 20221016.0.94779

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221009.0.92802
-GitCommit: dfe56d58a12db8200192d125e8ad858a06dc4351
-GitFetch: refs/tags/v20221009.0.92802
+Tags: latest, base, base-20221016.0.94779
+GitCommit: c8f18eae60851c81f4a92f0a7047a5a1cce84a67
+GitFetch: refs/tags/v20221016.0.94779
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221009.0.92802
-GitCommit: dfe56d58a12db8200192d125e8ad858a06dc4351
-GitFetch: refs/tags/v20221009.0.92802
+Tags: base-devel, base-devel-20221016.0.94779
+GitCommit: c8f18eae60851c81f4a92f0a7047a5a1cce84a67
+GitFetch: refs/tags/v20221016.0.94779
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks