### PR TITLE
Update Clear Linux OS to 37440

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 304e426bd8c622d3f8e03f7f63f988dd9da04607
-GitFetch: refs/heads/base-37420
+GitCommit: 7dd308d8427fe195366f55a2c48b670240f261d6
+GitFetch: refs/heads/base-37440


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37440

@bryteise @djklimes @bryteise