### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 62f7701ded7533f125333ad6172ebe4caedf4a00
 
-Tags: 2022.0.20220928.0, 2022, devel
+Tags: 2022.0.20221012.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: 0cebf00af456c41dc755275095549ae20fa2f219
+amd64-GitCommit: 807322aee2b8dcfb2ff1bb8b11e1d5b36392c429
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: bf9cae027a0316733b32d2ced4b84c379eaec95c
+arm64v8-GitCommit: 039c839888728c3e08c8cc5d0b61e8f5af3060cc
 
-Tags: 2022.0.20220928.0-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20221012.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 29e827cc03ae829154e598aa8ace1282a4d6f8aa
+amd64-GitCommit: db52fa7e4736833d2e9da0dccccb5ed227b1ab70
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 91d5c184765cd99a4c7fb9bea122a5ff212904b4
+arm64v8-GitCommit: 5a4a887264197f820315ba277c8120a6a4155de2


### PR DESCRIPTION
Hello,

This updates the Amazon Linux 2022 images to version: 2022.0.20221012.0

Thanks