### PR TITLE
NeuroDebian: Ubuntu impish EOLed

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,6 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: c9aa5f02de44d51bfcd81af986829550b227daeb
+GitCommit: 53a254d17e6c1c21787ed44b6e848c1af46ea9be
 
 Tags: xenial, nd16.04
 Architectures: amd64, arm64v8
@@ -25,14 +25,6 @@ Directory: dockerfiles/focal
 Tags: focal-non-free, nd20.04-non-free
 Architectures: amd64, arm64v8
 Directory: dockerfiles/focal-non-free
-
-Tags: impish, nd21.10
-Architectures: amd64, arm64v8
-Directory: dockerfiles/impish
-
-Tags: impish-non-free, nd21.10-non-free
-Architectures: amd64, arm64v8
-Directory: dockerfiles/impish-non-free
 
 Tags: jammy, nd22.04
 Architectures: amd64, arm64v8


### PR DESCRIPTION
But I was actually mostly interested to see if other images would regenerate as well since we updated/released neurodebian-freeze which fixes a bug and ideally want to see it shipped in all the images. 