### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.7-dev7, 2.7-dev, 2.7-dev7-bullseye, 2.7-dev-bullseye
+Tags: 2.7-dev8, 2.7-dev, 2.7-dev8-bullseye, 2.7-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6cf6ea8d0ead8fcef737b94664655127890499c2
+GitCommit: cd1c198fc46e312fccf9818c5388494eb4a70f83
 Directory: 2.7
 
-Tags: 2.7-dev7-alpine, 2.7-dev-alpine, 2.7-dev7-alpine3.16, 2.7-dev-alpine3.16
+Tags: 2.7-dev8-alpine, 2.7-dev-alpine, 2.7-dev8-alpine3.16, 2.7-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6cf6ea8d0ead8fcef737b94664655127890499c2
+GitCommit: cd1c198fc46e312fccf9818c5388494eb4a70f83
 Directory: 2.7/alpine
 
 Tags: 2.6.6, 2.6, lts, latest, 2.6.6-bullseye, 2.6-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/cd1c198: Update 2.7 to 2.7-dev8