### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.0.2-apache, 6.0-apache, 6-apache, apache, 6.0.2, 6.0, 6, latest, 6.0.2-php7.4-apache, 6.0-php7.4-apache, 6-php7.4-apache, php7.4-apache, 6.0.2-php7.4, 6.0-php7.4, 6-php7.4, php7.4
+Tags: 6.0.3-apache, 6.0-apache, 6-apache, apache, 6.0.3, 6.0, 6, latest, 6.0.3-php7.4-apache, 6.0-php7.4-apache, 6-php7.4-apache, php7.4-apache, 6.0.3-php7.4, 6.0-php7.4, 6-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php7.4/apache
 
-Tags: 6.0.2-fpm, 6.0-fpm, 6-fpm, fpm, 6.0.2-php7.4-fpm, 6.0-php7.4-fpm, 6-php7.4-fpm, php7.4-fpm
+Tags: 6.0.3-fpm, 6.0-fpm, 6-fpm, fpm, 6.0.3-php7.4-fpm, 6.0-php7.4-fpm, 6-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php7.4/fpm
 
-Tags: 6.0.2-fpm-alpine, 6.0-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.0.2-php7.4-fpm-alpine, 6.0-php7.4-fpm-alpine, 6-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 6.0.3-fpm-alpine, 6.0-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.0.3-php7.4-fpm-alpine, 6.0-php7.4-fpm-alpine, 6-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 6.0.2-php8.0-apache, 6.0-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.0.2-php8.0, 6.0-php8.0, 6-php8.0, php8.0
+Tags: 6.0.3-php8.0-apache, 6.0-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.0.3-php8.0, 6.0-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php8.0/apache
 
-Tags: 6.0.2-php8.0-fpm, 6.0-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.0.3-php8.0-fpm, 6.0-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php8.0/fpm
 
-Tags: 6.0.2-php8.0-fpm-alpine, 6.0-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.0.3-php8.0-fpm-alpine, 6.0-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.0.2-php8.1-apache, 6.0-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.0.2-php8.1, 6.0-php8.1, 6-php8.1, php8.1
+Tags: 6.0.3-php8.1-apache, 6.0-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.0.3-php8.1, 6.0-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php8.1/apache
 
-Tags: 6.0.2-php8.1-fpm, 6.0-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.0.3-php8.1-fpm, 6.0-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php8.1/fpm
 
-Tags: 6.0.2-php8.1-fpm-alpine, 6.0-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.0.3-php8.1-fpm-alpine, 6.0-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b9af6087524edc719249f590940b34ef107c95ca
+GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
 Directory: latest/php8.1/fpm-alpine
 
-Tags: cli-2.7.0, cli-2.7, cli-2, cli, cli-2.7.0-php7.4, cli-2.7-php7.4, cli-2-php7.4, cli-php7.4
+Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php7.4, cli-2.7-php7.4, cli-2-php7.4, cli-php7.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 815d020ca0e9206524f980f68bb3dda40326ff6b
+GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
 Directory: cli/php7.4/alpine
 
-Tags: cli-2.7.0-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 815d020ca0e9206524f980f68bb3dda40326ff6b
+GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
 Directory: cli/php8.0/alpine
 
-Tags: cli-2.7.0-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.7.1-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 815d020ca0e9206524f980f68bb3dda40326ff6b
+GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
 Directory: cli/php8.1/alpine
 
 Tags: beta-6.1-RC1-apache, beta-6.1-apache, beta-6-apache, beta-apache, beta-6.1-RC1, beta-6.1, beta-6, beta, beta-6.1-RC1-php7.4-apache, beta-6.1-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.1-RC1-php7.4, beta-6.1-php7.4, beta-6-php7.4, beta-php7.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/feb1e96: Update latest to 6.0.3
- https://github.com/docker-library/wordpress/commit/b951840: Update cli to 2.7.1
- https://github.com/docker-library/wordpress/commit/a51def5: Merge pull request https://github.com/docker-library/wordpress/pull/766 from infosiftr/ci-updates
- https://github.com/docker-library/wordpress/commit/d10af6a: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3