### PR TITLE
[security] Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 9d962f884ebf8e098b772f47938bc8486c6b6f7b
+GitCommit: 4c2ed1a0c2cf937eadae4e4b16543063124009b3
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
@@ -38,36 +38,36 @@ GitCommit: 4c1b73e7046422ca1339b76935c2e2f4251b9c20
 Directory: 22.06-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20.10.19-cli, 20.10-cli, 20-cli, cli, 20.10.19-cli-alpine3.16, 20.10.19, 20.10, 20, latest, 20.10.19-alpine3.16
+Tags: 20.10.20-cli, 20.10-cli, 20-cli, cli, 20.10.20-cli-alpine3.16, 20.10.20, 20.10, 20, latest, 20.10.20-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 5cf48189420b2efc1c597bc9a7c35a734948f7fb
+GitCommit: 266df93e022414c12609b6e15178eac664afb50f
 Directory: 20.10/cli
 
-Tags: 20.10.19-dind, 20.10-dind, 20-dind, dind, 20.10.19-dind-alpine3.16
+Tags: 20.10.20-dind, 20.10-dind, 20-dind, dind, 20.10.20-dind-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 5cf48189420b2efc1c597bc9a7c35a734948f7fb
+GitCommit: 266df93e022414c12609b6e15178eac664afb50f
 Directory: 20.10/dind
 
-Tags: 20.10.19-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
+Tags: 20.10.20-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 5cf48189420b2efc1c597bc9a7c35a734948f7fb
+GitCommit: 266df93e022414c12609b6e15178eac664afb50f
 Directory: 20.10/dind-rootless
 
-Tags: 20.10.19-git, 20.10-git, 20-git, git
+Tags: 20.10.20-git, 20.10-git, 20-git, git
 Architectures: amd64, arm64v8
 GitCommit: f23a2bea97f6d7ec563bc316302fb8edf620ec5b
 Directory: 20.10/git
 
-Tags: 20.10.19-windowsservercore-ltsc2022, 20.10-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 20.10.19-windowsservercore, 20.10-windowsservercore, 20-windowsservercore, windowsservercore
+Tags: 20.10.20-windowsservercore-ltsc2022, 20.10-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 20.10.20-windowsservercore, 20.10-windowsservercore, 20-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 5cf48189420b2efc1c597bc9a7c35a734948f7fb
+GitCommit: 266df93e022414c12609b6e15178eac664afb50f
 Directory: 20.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20.10.19-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809, windowsservercore-1809
-SharedTags: 20.10.19-windowsservercore, 20.10-windowsservercore, 20-windowsservercore, windowsservercore
+Tags: 20.10.20-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809, windowsservercore-1809
+SharedTags: 20.10.20-windowsservercore, 20.10-windowsservercore, 20-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 5cf48189420b2efc1c597bc9a7c35a734948f7fb
+GitCommit: 266df93e022414c12609b6e15178eac664afb50f
 Directory: 20.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/4c2ed1a: Update 22.06-rc to compose 2.12.0
- https://github.com/docker-library/docker/commit/266df93: Update 20.10 to 20.10.20, compose 2.12.0
- https://github.com/docker-library/docker/commit/d08340d: Merge pull request https://github.com/docker-library/docker/pull/381 from infosiftr/ci-updates
- https://github.com/docker-library/docker/commit/5a10691: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3