### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
 Directory: cli/php8.1/alpine
 
-Tags: beta-6.1-RC1-apache, beta-6.1-apache, beta-6-apache, beta-apache, beta-6.1-RC1, beta-6.1, beta-6, beta, beta-6.1-RC1-php7.4-apache, beta-6.1-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.1-RC1-php7.4, beta-6.1-php7.4, beta-6-php7.4, beta-php7.4
+Tags: beta-6.1-RC2-apache, beta-6.1-apache, beta-6-apache, beta-apache, beta-6.1-RC2, beta-6.1, beta-6, beta, beta-6.1-RC2-php7.4-apache, beta-6.1-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.1-RC2-php7.4, beta-6.1-php7.4, beta-6-php7.4, beta-php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php7.4/apache
 
-Tags: beta-6.1-RC1-fpm, beta-6.1-fpm, beta-6-fpm, beta-fpm, beta-6.1-RC1-php7.4-fpm, beta-6.1-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
+Tags: beta-6.1-RC2-fpm, beta-6.1-fpm, beta-6-fpm, beta-fpm, beta-6.1-RC2-php7.4-fpm, beta-6.1-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php7.4/fpm
 
-Tags: beta-6.1-RC1-fpm-alpine, beta-6.1-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.1-RC1-php7.4-fpm-alpine, beta-6.1-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
+Tags: beta-6.1-RC2-fpm-alpine, beta-6.1-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.1-RC2-php7.4-fpm-alpine, beta-6.1-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php7.4/fpm-alpine
 
-Tags: beta-6.1-RC1-php8.0-apache, beta-6.1-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.1-RC1-php8.0, beta-6.1-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.1-RC2-php8.0-apache, beta-6.1-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.1-RC2-php8.0, beta-6.1-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php8.0/apache
 
-Tags: beta-6.1-RC1-php8.0-fpm, beta-6.1-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.1-RC2-php8.0-fpm, beta-6.1-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.1-RC1-php8.0-fpm-alpine, beta-6.1-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.1-RC2-php8.0-fpm-alpine, beta-6.1-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.1-RC1-php8.1-apache, beta-6.1-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.1-RC1-php8.1, beta-6.1-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.1-RC2-php8.1-apache, beta-6.1-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.1-RC2-php8.1, beta-6.1-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php8.1/apache
 
-Tags: beta-6.1-RC1-php8.1-fpm, beta-6.1-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.1-RC2-php8.1-fpm, beta-6.1-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.1-RC1-php8.1-fpm-alpine, beta-6.1-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.1-RC2-php8.1-fpm-alpine, beta-6.1-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d0bb12b3b893c854c567476733bff3450a005ccd
+GitCommit: 56c14131a88a47556dfaf318781c992784581647
 Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/56c1413: Update beta to 6.1-RC2