### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -28,15 +28,15 @@ amd64-GitCommit: ec5f36611a2a511ac95ffd55e62dbeaba493dddc
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 3ae699d44c6e1d83f53e0fc44c6c9dcf8c78e7e3
 
-Tags: 2018.03.0.20220802.0, 2018.03, 1
+Tags: 2018.03.0.20220907.3, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: b9d60bf40f52a55f30a7abeeb123817be542d6a3
+amd64-GitCommit: c4dd72316dd9dc4aa96885ebed72cd05149c8efe
 
-Tags: 2018.03.0.20220802.0-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20220907.3-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 62f7701ded7533f125333ad6172ebe4caedf4a00
+amd64-GitCommit: 9dcdd0990630811a8b83e6593654f03eefea4926
 
 Tags: 2022.0.20221012.0, 2022, devel
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- tzdata-2022c-1.80.amzn1
- gnupg2-2.0.28-2.35.amzn1
  - [CVE-2022-34903](https://alas.aws.amazon.com/cve/html/CVE-2022-34903.html)