### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -14,19 +14,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: 6eb315d367fb8c9aaeba93db9c025d5d9048a1ea
 
-Tags: 2.0.20220912.1, 2, latest
+Tags: 2.0.20221004.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: fb082773264a2defa7c5cfc78a398304cf136589
+amd64-GitCommit: 2b0c14110e17fef5c161926ee4961268940a9ffb
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: e94ab61e9d819742d2faa646853db233f4611634
+arm64v8-GitCommit: 0702a9f1271e2dcccd1dc9dd7e01b8ae1521f446
 
-Tags: 2.0.20220912.1-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20221004.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: ec5f36611a2a511ac95ffd55e62dbeaba493dddc
+amd64-GitCommit: 2931065160d74a86bc8d322fcf6d5b680da81f6e
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 3ae699d44c6e1d83f53e0fc44c6c9dcf8c78e7e3
+arm64v8-GitCommit: a505ba0c31bf9918dab8a52b399cab790608117a
 
 Tags: 2018.03.0.20220907.3, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- libxml2-2.9.1-6.amzn2.5.6
  - [CVE-2022-29824](https://alas.aws.amazon.com/cve/html/CVE-2022-29824.html)
- zlib-1.2.7-19.amzn2.0.2
  - [CVE-2022-37434](https://alas.aws.amazon.com/cve/html/CVE-2022-37434.html)
- tzdata-2022d-1.amzn2.0.1


Thanks,
Sam