### PR TITLE
Releasing Neo4j 5.1

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -11,47 +11,26 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 
 
-Tags: 4.4.12, 4.4.12-community, 4.4, 4.4-community, community, latest
+Tags: 5.1.0, 5.1.0-community, 5, 5-community, community, latest
+Architectures: amd64, arm64v8
+GitCommit: 40a0188175a855bf184b0f7c62475b81ee10e028
+Directory: 5.1.0/community
+
+Tags: 5.1.0-enterprise, 5-enterprise, enterprise
+Architectures: amd64, arm64v8
+GitCommit: 40a0188175a855bf184b0f7c62475b81ee10e028
+Directory: 5.1.0/enterprise
+
+
+Tags: 4.4.12, 4.4.12-community, 4.4, 4.4-community
 Architectures: amd64, arm64v8
 GitCommit: b9b3c369b2a7d34880ac81681c7d148f733ccc22
 Directory: 4.4.12/community
 
-Tags: 4.4.12-enterprise, 4.4-enterprise, enterprise
+Tags: 4.4.12-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
 GitCommit: b9b3c369b2a7d34880ac81681c7d148f733ccc22
 Directory: 4.4.12/enterprise
-
-Tags: 4.4.11, 4.4.11-community
-Architectures: amd64, arm64v8
-GitCommit: f3604fbaecc1c5ff736b9ca79889c08397668d4e
-Directory: 4.4.11/community
-
-Tags: 4.4.11-enterprise
-Architectures: amd64, arm64v8
-GitCommit: f3604fbaecc1c5ff736b9ca79889c08397668d4e
-Directory: 4.4.11/enterprise
-
-Tags: 4.4.10, 4.4.10-community
-Architectures: amd64, arm64v8
-GitCommit: 985060aa38c5b873b18cd1b2c522c69ddb25d91a
-Directory: 4.4.10/community
-
-Tags: 4.4.10-enterprise
-Architectures: amd64, arm64v8
-GitCommit: 985060aa38c5b873b18cd1b2c522c69ddb25d91a
-Directory: 4.4.10/enterprise
-
-Tags: 4.4.9, 4.4.9-community
-Architectures: amd64, arm64v8
-GitCommit: 5a48478b5804d008df3d076d473455dfe4e00581
-Directory: 4.4.9/community
-
-Tags: 4.4.9-enterprise
-Architectures: amd64, arm64v8
-GitCommit: 5a48478b5804d008df3d076d473455dfe4e00581
-Directory: 4.4.9/enterprise
-
-
 
 
 Tags: 4.3.19, 4.3.19-community, 4.3, 4.3-community
@@ -62,34 +41,3 @@ Tags: 4.3.19-enterprise, 4.3-enterprise
 GitCommit: 43be1e819ac0ce8289da79285de07722a850072f
 Directory: 4.3.19/enterprise
 
-Tags: 4.3.18, 4.3.18-community
-GitCommit: f3604fbaecc1c5ff736b9ca79889c08397668d4e
-Directory: 4.3.18/community
-
-Tags: 4.3.18-enterprise
-GitCommit: f3604fbaecc1c5ff736b9ca79889c08397668d4e
-Directory: 4.3.18/enterprise
-
-Tags: 4.3.17, 4.3.17-community
-GitCommit: 7c2af75d181fe82851a9560aea9acb6bb5af3992
-Directory: 4.3.17/community
-
-Tags: 4.3.17-enterprise
-GitCommit: 7c2af75d181fe82851a9560aea9acb6bb5af3992
-Directory: 4.3.17/enterprise
-
-Tags: 4.3.16, 4.3.16-community
-GitCommit: feef4dc3c3e3c04a169ce82e4950151f368acf7f
-Directory: 4.3.16/community
-
-Tags: 4.3.16-enterprise
-GitCommit: feef4dc3c3e3c04a169ce82e4950151f368acf7f
-Directory: 4.3.16/enterprise
-
-Tags: 4.3.15, 4.3.15-community
-GitCommit: f5856542d55fa45a096564ddb381492b7317ede4
-Directory: 4.3.15/community
-
-Tags: 4.3.15-enterprise
-GitCommit: f5856542d55fa45a096564ddb381492b7317ede4
-Directory: 4.3.15/enterprise


### PR DESCRIPTION
It's a major neo4j release day!
Also, from now on we're only going to list the latest patch versions of neo4j as being official :+1: 