### PR TITLE
Add s390x arch support to 2.4.0-temurin image

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -1,19 +1,22 @@
 Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/storm-docker.git
-Architectures: amd64
 
 Tags: 1.2.4, 1.2
+Architectures: amd64
 GitCommit: f72658afa5e9c4ee4d4d5ef5cf9b32b226d0ed19
 Directory: 1.2.4
 
 Tags: 1.2.4-temurin, 1.2-temurin
+Architectures: amd64
 GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 1.2.4
 
 Tags: 2.4.0, 2.4
+Architectures: amd64
 GitCommit: f72658afa5e9c4ee4d4d5ef5cf9b32b226d0ed19
 Directory: 2.4.0
 
 Tags: 2.4.0-temurin, 2.4-temurin, latest
+Architectures: amd64, s390x
 GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 2.4.0


### PR DESCRIPTION
Apache Storm's OpenJDK base image has been switched to eclipse-temurin which have support for s390x arch present. This will add s390x support to Apache Storm's 2.4.0-temurin docker image.