### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/rabbitmq.git
 
 Tags: 3.11.2, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 87a02a40002748d02ca07f82a562be145ba498d7
+GitCommit: 67c76c7669d5bf30a09e4f2083f316586ee8aec0
 Directory: 3.11/ubuntu
 
 Tags: 3.11.2-management, 3.11-management, 3-management, management
@@ -16,7 +16,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.2-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 87a02a40002748d02ca07f82a562be145ba498d7
+GitCommit: 67c76c7669d5bf30a09e4f2083f316586ee8aec0
 Directory: 3.11/alpine
 
 Tags: 3.11.2-management-alpine, 3.11-management-alpine, 3-management-alpine, management-alpine
@@ -26,7 +26,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.10, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: ef5747433497110b6ecfba5ea7fe2b96f6d9f9dc
+GitCommit: ef0119d941863cecffe09ccd493357aad42fb349
 Directory: 3.10/ubuntu
 
 Tags: 3.10.10-management, 3.10-management
@@ -36,7 +36,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.10-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef5747433497110b6ecfba5ea7fe2b96f6d9f9dc
+GitCommit: ef0119d941863cecffe09ccd493357aad42fb349
 Directory: 3.10/alpine
 
 Tags: 3.10.10-management-alpine, 3.10-management-alpine
@@ -46,7 +46,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.24, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 4b67bdeba2a3f4dc2cdd57d197d79afd59ad3a75
+GitCommit: 53cd8a9aef90196c985ec3ccad0eb375ba33d6f9
 Directory: 3.9/ubuntu
 
 Tags: 3.9.24-management, 3.9-management
@@ -56,7 +56,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.24-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b67bdeba2a3f4dc2cdd57d197d79afd59ad3a75
+GitCommit: 53cd8a9aef90196c985ec3ccad0eb375ba33d6f9
 Directory: 3.9/alpine
 
 Tags: 3.9.24-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/53cd8a9: Update 3.9 to otp 25.1.2
- https://github.com/docker-library/rabbitmq/commit/67c76c7: Update 3.11 to otp 25.1.2
- https://github.com/docker-library/rabbitmq/commit/ef0119d: Update 3.10 to otp 25.1.2