### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,17 +9,17 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: e8ee59f9fc070e87595ea3fafe528030bddb8212
 Directory: 4.1
 
-Tags: 4.0.6, 4.0, 4, latest
+Tags: 4.0.7, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5aa6b7ed7a342c18da796561252677f17d370616
+GitCommit: 08fa5553ad2dde684ca5337c7fedd173cbc41f39
 Directory: 4.0
 
-Tags: 3.11.13, 3.11, 3
+Tags: 3.11.14, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 1a9d5f3ac97204f71bba86259aa56815f8a7eee7
+GitCommit: 13e3d6ca1ff1b6c9d780e5f018887c1d28318d50
 Directory: 3.11
 
-Tags: 3.0.27, 3.0
+Tags: 3.0.28, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9315e4444c9f92b19e3e2d4fbe7c77293f2d33d7
+GitCommit: e92196fdba778656678a9bc9bcb724b8a3584149
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/08fa555: Update 4.0 to 4.0.7
- https://github.com/docker-library/cassandra/commit/13e3d6c: Update 3.11 to 3.11.14
- https://github.com/docker-library/cassandra/commit/e92196f: Update 3.0 to 3.0.28
- https://github.com/docker-library/cassandra/commit/0d15ec5: Merge pull request https://github.com/docker-library/cassandra/pull/257 from infosiftr/ci-updates
- https://github.com/docker-library/cassandra/commit/e312f6f: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3