### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 4c2ed1a0c2cf937eadae4e4b16543063124009b3
+GitCommit: 932221bc0570ff70b6ca56cafbf2fb5b5dd00eba
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.20-cli, 20.10-cli, 20-cli, cli, 20.10.20-cli-alpine3.16, 20.10.20, 20.10, 20, latest, 20.10.20-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 266df93e022414c12609b6e15178eac664afb50f
+GitCommit: c959f0b0277ca297ef53af8d070e8a73012fe3df
 Directory: 20.10/cli
 
 Tags: 20.10.20-dind, 20.10-dind, 20-dind, dind, 20.10.20-dind-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/932221b: Update 22.06-rc to compose 2.12.2
- https://github.com/docker-library/docker/commit/c959f0b: Update 20.10 to compose 2.12.2
- https://github.com/docker-library/docker/commit/0d84709: Update 22.06-rc to compose 2.12.1
- https://github.com/docker-library/docker/commit/542075a: Update 20.10 to compose 2.12.1