### PR TITLE
Update "notary" to use "Builder: buildkit"

### DIFF
--- a/library/notary
+++ b/library/notary
@@ -1,7 +1,8 @@
 Maintainers: Justin Cormack (@justincormack)
 GitRepo: https://github.com/docker/notary-official-images.git
-GitCommit: 16219dbe3c1433a6fc93e016cf421b230f681a2f
+GitCommit: 77b9b7833f8dd6be07104b214193788795a320ff
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Builder: buildkit
 
 Tags: server-0.7.0, server
 Directory: notary-server


### PR DESCRIPTION
This is intended as a test of the functionality in `bashbrew` (https://github.com/docker-library/bashbrew/pull/43) to determine what else (if anything) is necessary to start enabling this in more images.

The image here includes a change to use a straightforward multi-stage build (https://github.com/docker/notary-official-images/pull/30) which should work appropriately (including cache keeping/removing).

FYI @jedevc