### PR TITLE
node: bump LTS to NodeJS 18 as scheduled

### DIFF
--- a/library/node
+++ b/library/node
@@ -34,62 +34,62 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 521cc918805cfc24e31e7d4460aba80a5e5743da
 Directory: 19/buster-slim
 
-Tags: 18-alpine3.15, 18.11-alpine3.15, 18.11.0-alpine3.15
+Tags: 18-alpine3.15, 18.11-alpine3.15, 18.11.0-alpine3.15, lts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: fdc0fd95b4a15af643d17508443f80ff6ec17433
 Directory: 18/alpine3.15
 
-Tags: 18-alpine, 18-alpine3.16, 18.11-alpine, 18.11-alpine3.16, 18.11.0-alpine, 18.11.0-alpine3.16
+Tags: 18-alpine, 18-alpine3.16, 18.11-alpine, 18.11-alpine3.16, 18.11.0-alpine, 18.11.0-alpine3.16, lts-alpine, lts-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: fdc0fd95b4a15af643d17508443f80ff6ec17433
 Directory: 18/alpine3.16
 
-Tags: 18, 18-bullseye, 18.11, 18.11-bullseye, 18.11.0, 18.11.0-bullseye
+Tags: 18, 18-bullseye, 18.11, 18.11-bullseye, 18.11.0, 18.11.0-bullseye, lts, lts-bullseye
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: fdc0fd95b4a15af643d17508443f80ff6ec17433
 Directory: 18/bullseye
 
-Tags: 18-bullseye-slim, 18-slim, 18.11-bullseye-slim, 18.11-slim, 18.11.0-bullseye-slim, 18.11.0-slim
+Tags: 18-bullseye-slim, 18-slim, 18.11-bullseye-slim, 18.11-slim, 18.11.0-bullseye-slim, 18.11.0-slim, lts-bullseye-slim, lts-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: fdc0fd95b4a15af643d17508443f80ff6ec17433
 Directory: 18/bullseye-slim
 
-Tags: 18-buster, 18.11-buster, 18.11.0-buster
+Tags: 18-buster, 18.11-buster, 18.11.0-buster, lts-buster
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: fdc0fd95b4a15af643d17508443f80ff6ec17433
 Directory: 18/buster
 
-Tags: 18-buster-slim, 18.11-buster-slim, 18.11.0-buster-slim
+Tags: 18-buster-slim, 18.11-buster-slim, 18.11.0-buster-slim, lts-buster-slim
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: fdc0fd95b4a15af643d17508443f80ff6ec17433
 Directory: 18/buster-slim
 
-Tags: 16-alpine3.15, 16.18-alpine3.15, 16.18.0-alpine3.15, gallium-alpine3.15, lts-alpine3.15
+Tags: 16-alpine3.15, 16.18-alpine3.15, 16.18.0-alpine3.15, gallium-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8edd510a1b2f64330fd7b865afd12d88c3c21679
 Directory: 16/alpine3.15
 
-Tags: 16-alpine, 16-alpine3.16, 16.18-alpine, 16.18-alpine3.16, 16.18.0-alpine, 16.18.0-alpine3.16, gallium-alpine, gallium-alpine3.16, lts-alpine, lts-alpine3.16
+Tags: 16-alpine, 16-alpine3.16, 16.18-alpine, 16.18-alpine3.16, 16.18.0-alpine, 16.18.0-alpine3.16, gallium-alpine, gallium-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8edd510a1b2f64330fd7b865afd12d88c3c21679
 Directory: 16/alpine3.16
 
-Tags: 16-bullseye, 16.18-bullseye, 16.18.0-bullseye, gallium-bullseye, lts-bullseye
+Tags: 16-bullseye, 16.18-bullseye, 16.18.0-bullseye, gallium-bullseye
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8edd510a1b2f64330fd7b865afd12d88c3c21679
 Directory: 16/bullseye
 
-Tags: 16-bullseye-slim, 16.18-bullseye-slim, 16.18.0-bullseye-slim, gallium-bullseye-slim, lts-bullseye-slim
+Tags: 16-bullseye-slim, 16.18-bullseye-slim, 16.18.0-bullseye-slim, gallium-bullseye-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 8edd510a1b2f64330fd7b865afd12d88c3c21679
 Directory: 16/bullseye-slim
 
-Tags: 16, 16-buster, 16.18, 16.18-buster, 16.18.0, 16.18.0-buster, gallium, gallium-buster, lts, lts-buster, lts-gallium
+Tags: 16, 16-buster, 16.18, 16.18-buster, 16.18.0, 16.18.0-buster, gallium, gallium-buster
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 8edd510a1b2f64330fd7b865afd12d88c3c21679
 Directory: 16/buster
 
-Tags: 16-buster-slim, 16-slim, 16.18-buster-slim, 16.18-slim, 16.18.0-buster-slim, 16.18.0-slim, gallium-buster-slim, gallium-slim, lts-buster-slim, lts-slim
+Tags: 16-buster-slim, 16-slim, 16.18-buster-slim, 16.18-slim, 16.18.0-buster-slim, 16.18.0-slim, gallium-buster-slim, gallium-slim
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 8edd510a1b2f64330fd7b865afd12d88c3c21679
 Directory: 16/buster-slim


### PR DESCRIPTION
NodeJS 18 is scheduled to become LTS today
https://github.com/nodejs/release#release-schedule