### PR TITLE
Odoo: update 14.0-16.0 to release 20221025

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: ad549a7c3602557abc44e9c04369965a73d78fcd
+GitCommit: 7f37c5532effd79cd96b4f0ab9303a82a0f924e8
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

you will find here the latest Odoo updates of supported versions.

Thanks