### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/b8bb85f915b560d915270fc731771f66d075aac4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/3e6136537f18347eb6cfe561748990995673d590/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: b8bb85f915b560d915270fc731771f66d075aac4
+GitCommit: 3e6136537f18347eb6cfe561748990995673d590
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fa0d085f2c037b5c01aa1dbea66fa903745a62bb
+amd64-GitCommit: d3aaee8314575a45030110eb5602e6e994ee15ce
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: ae6522fad0768851e13984150971b78104328dab
+arm32v5-GitCommit: 051735a058e3cb0c66ebfbc9b487e16c4971d01a
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 440cb0726d2660e0513a9328986f302b6dee71b9
+arm32v6-GitCommit: 2d0b33eafa8409b5b5ce1c4930d10fb499880ac1
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 7b1bf927d5fec7dad75548bf3b07a7fd1188dcef
+arm32v7-GitCommit: a9b9ea1d5301af2a6fba571d3cd696df326fa7f4
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a85554077e6765c2276a344f9d19692fc002544b
+arm64v8-GitCommit: 54a1b5e921d59d8d0d5d30d2564e1ac0df238185
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 757bcedd9a49775054801af2724c73092d0f3c73
+i386-GitCommit: e6550012bb2244560143a860dc2bc26f28f0c64b
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: a37a0130e222bf121ad25cbe802abf1e1fc0ad54
+mips64le-GitCommit: 537cf4f351d8b708afe94a99d44b3c6fb66aeb1d
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: c2cfef28204a5a78bea3c9fb44837b3732983d35
+ppc64le-GitCommit: 0570c07fb4d8ed93caffb6565facb649b80d4656
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
 riscv64-GitCommit: 6781e9d0b260afe6cce7f93db93ba988a4e57cc1
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ec7f747bc6fe3681897527310704c3921c92ba52
+s390x-GitCommit: 597506988475bf2a8e4d4ce13e98c042a75c9eaa
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/3e61365: Merge pull request https://github.com/docker-library/busybox/pull/150 from infosiftr/arm64-64k-pagesize
- https://github.com/docker-library/busybox/commit/b9b923b: Set arm64 pagesize to 64k explicitly
- https://github.com/docker-library/busybox/commit/45653b6: Merge pull request https://github.com/docker-library/busybox/pull/147 from infosiftr/ci-updates
- https://github.com/docker-library/busybox/commit/c95c599: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3