### PR TITLE
arangodb 3.8.8, 3.9.4

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,15 +2,15 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.8, 3.8.7
+Tags: 3.8, 3.8.8
 Architectures: amd64
-GitCommit: 0e1a717e606a4fd6fa406fdb26bf5cc61486d0e5
-Directory: alpine/3.8.7
+GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
+Directory: alpine/3.8.8
 
-Tags: 3.9, 3.9.3
+Tags: 3.9, 3.9.4
 Architectures: amd64
-GitCommit: 66deb6fc6518f7d81a2e6087b2397447e240f8c4
-Directory: alpine/3.9.3
+GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
+Directory: alpine/3.9.4
 
 Tags: 3.10, 3.10.0, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated ArangoDB 3.8 to 3.8.8 and 3.9 to 3.9.4.