### PR TITLE
[oraclelinux] Updating 7/8/8-slim/9/9-slim for amd64/arm64v8 for multiple errata

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ac95ac07bbf47d43d7b86f42efbac8bbe26473d7
+amd64-GitCommit: 15611f5588de4e7bc49bb174b6f81370ca169313
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f11a06c6cfd823e6732fba3f9a8212e57b0d12b3
+arm64v8-GitCommit: 338c6eb78ad082e76ef58c0116c2986f53700be8
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2020-35525, CVE-2020-35527, CVE-2022-2509, CVE-2022-37434, CVE-2022-41974, CVE-2022-3515.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-7108.html
https://linux.oracle.com/errata/ELSA-2022-7105.html
https://linux.oracle.com/errata/ELSA-2022-7106.html
https://linux.oracle.com/errata/ELSA-2022-7192.html
https://linux.oracle.com/errata/ELSA-2022-7186.html
https://linux.oracle.com/errata/ELSA-2022-7090.html
https://linux.oracle.com/errata/ELSA-2022-7089.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
