### PR TITLE
archlinux: Release 20221030.0.98412

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221023.0.96685
-GitCommit: 0e8bda1ff7f8e42a20b6331d07236965a3ae495c
-GitFetch: refs/tags/v20221023.0.96685
+Tags: latest, base, base-20221030.0.98412
+GitCommit: 881e4ae77215777e13ef8ff74602e2d7141dbefd
+GitFetch: refs/tags/v20221030.0.98412
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221023.0.96685
-GitCommit: 0e8bda1ff7f8e42a20b6331d07236965a3ae495c
-GitFetch: refs/tags/v20221023.0.96685
+Tags: base-devel, base-devel-20221030.0.98412
+GitCommit: 881e4ae77215777e13ef8ff74602e2d7141dbefd
+GitFetch: refs/tags/v20221030.0.98412
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks