### PR TITLE
Update R to 4.2.2 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.2.1, latest
+Tags: 4.2.2, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: dedd29461f0952fef9b432a58e2540ad58305a42
-Directory: r-base/4.2.1
+GitCommit: 2f92c6c8b8da7b3e61aabc44cacc0439bf267d31
+Directory: r-base/4.2.2
 


### PR DESCRIPTION
Standard update of r-base to the new upstream release 4.2.2 made this morning using the updated Debian binaries

One change of `addgroup` to `adduser` for same effect, no other changes
