### PR TITLE
Almalinux auto-update - 154351

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,3 +1,4 @@
+# This file is generated using https://github.com/almalinux/docker-images/blob/bfb6735278c3e8e2a25714bcd5431a534ece5a2c/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
@@ -17,62 +18,62 @@ arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: latest, 8, 8.6, 8.6-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: latest, 8, 8.6, 8.6-20221101
+GitFetch: refs/heads/al8-20221101-amd64
+GitCommit: 03cdf71dcf08b0563a6be20b91d0d6e0ee686cda
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20221101-arm64v8
+arm64v8-GitCommit: 376f653625e4c1aa32fc0e13720d2fbb7466832b
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20221101-ppc64le
+ppc64le-GitCommit: 3652deb3f54b24a58f102b427522bd77f1620d5f
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20221101-s390x
+s390x-GitCommit: 6995ae59937816982949cf5980b43eb4df02dc4c
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20220901
-GitFetch: refs/heads/al8-20220901-amd64
-GitCommit: 1ff60edf414285a260ad40a050841f66f8cb6ad8
+Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20221101
+GitFetch: refs/heads/al8-20221101-amd64
+GitCommit: 03cdf71dcf08b0563a6be20b91d0d6e0ee686cda
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20220901-arm64v8
-arm64v8-GitCommit: 6b53409c7c9d54ffde8eb5013f9159c4eec9706a
+arm64v8-GitFetch: refs/heads/al8-20221101-arm64v8
+arm64v8-GitCommit: 376f653625e4c1aa32fc0e13720d2fbb7466832b
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20220901-ppc64le
-ppc64le-GitCommit: e70edacf650f2439b82fcbe72886d911a91c8f14
+ppc64le-GitFetch: refs/heads/al8-20221101-ppc64le
+ppc64le-GitCommit: 3652deb3f54b24a58f102b427522bd77f1620d5f
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20220901-s390x
-s390x-GitCommit: 65b999f771d43638c576c1e2baf4c5e15027abcc
+s390x-GitFetch: refs/heads/al8-20221101-s390x
+s390x-GitCommit: 6995ae59937816982949cf5980b43eb4df02dc4c
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9, 9.0, 9.0-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9, 9.0, 9.0-20221101
+GitFetch: refs/heads/al9-20221101-amd64
+GitCommit: fe29bd26cbe2002bbf41bfcdf839ed9022f8a71c
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20221101-arm64v8
+arm64v8-GitCommit: 6ee1a8fbefda4831c01c56bc7d325e791de9d053
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20221101-ppc64le
+ppc64le-GitCommit: df8cdb5e8a6a6e2d075b87735aece5945f3fc1ec
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20221101-s390x
+s390x-GitCommit: dfc50901d44b71256a7797f2c3922db2c40420ce
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20220901
-GitFetch: refs/heads/al9-20220901-amd64
-GitCommit: 824c8437333f8dda7888a0d3b745dadd75723fdc
+Tags: 9-minimal,  9.0-minimal, 9.0-minimal-20221101
+GitFetch: refs/heads/al9-20221101-amd64
+GitCommit: fe29bd26cbe2002bbf41bfcdf839ed9022f8a71c
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20220901-arm64v8
-arm64v8-GitCommit: c5eafd4dbc9500a073f9846afd8e940dc77fb73d
+arm64v8-GitFetch: refs/heads/al9-20221101-arm64v8
+arm64v8-GitCommit: 6ee1a8fbefda4831c01c56bc7d325e791de9d053
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20220901-ppc64le
-ppc64le-GitCommit: f4af629d22f7aa5dd24b7998c2e6bd63559ccff0
+ppc64le-GitFetch: refs/heads/al9-20221101-ppc64le
+ppc64le-GitCommit: df8cdb5e8a6a6e2d075b87735aece5945f3fc1ec
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20220901-s390x
-s390x-GitCommit: 7f7e861e8ac438aaa8c4ba7b7fa4c351c6d5e3c8
+s390x-GitFetch: refs/heads/al9-20221101-s390x
+s390x-GitCommit: dfc50901d44b71256a7797f2c3922db2c40420ce
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @srbala or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `expat` changed from 2.2.5-8.el8_6.2 to 2.2.5-8.el8_6.3
- `glib2` changed from 2.56.4-158.el8 to 2.56.4-158.el8_6.1
- `gnutls` changed from 3.6.16-4.el8 to 3.6.16-5.el8_6
- `libksba` changed from 1.3.5-7.el8 to 1.3.5-8.el8_6
- `libsemanage` changed from 2.9-8.el8 to 2.9-9.el8_6
- `python3-rpm` changed from 4.14.3-23.el8 to 4.14.3-24.el8_6
- `rpm` changed from 4.14.3-23.el8 to 4.14.3-24.el8_6
- `rpm-build-libs` changed from 4.14.3-23.el8 to 4.14.3-24.el8_6
- `rpm-libs` changed from 4.14.3-23.el8 to 4.14.3-24.el8_6
- `sqlite-libs` changed from 3.26.0-15.el8 to 3.26.0-16.el8_6
- `systemd` changed from 239-58.el8_6.7 to 239-58.el8_6.8
- `systemd-libs` changed from 239-58.el8_6.7 to 239-58.el8_6.8
- `systemd-pam` changed from 239-58.el8_6.7 to 239-58.el8_6.8
- `tzdata` changed from 2022c-1.el8 to 2022e-1.el8
- `zlib` changed from 1.2.11-18.el8_5 to 1.2.11-19.el8_6

### AlmaLinux 9 change log

- `expat` changed from 2.2.10-12.el9_0.2 to 2.2.10-12.el9_0.3
- `gnutls` changed from 3.7.3-9.el9 to 3.7.6-12.el9_0
- `libksba` changed from 1.5.1-4.el9 to 1.5.1-5.el9_0
- `nettle` changed from 3.7.3-2.el9 to 3.8-3.el9_0
- `tzdata` changed from 2022c-1.el9_0 to 2022e-1.el9_0

