### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -21,7 +21,7 @@ Directory: 8.2-rc/bullseye/fpm
 
 Tags: 8.2.0RC5-zts-bullseye, 8.2-rc-zts-bullseye, 8.2.0RC5-zts, 8.2-rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 70c36f0988b8b25d3b2029779ec97e7784e36035
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.2-rc/bullseye/zts
 
 Tags: 8.2.0RC5-cli-buster, 8.2-rc-cli-buster, 8.2.0RC5-buster, 8.2-rc-buster
@@ -41,7 +41,7 @@ Directory: 8.2-rc/buster/fpm
 
 Tags: 8.2.0RC5-zts-buster, 8.2-rc-zts-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 70c36f0988b8b25d3b2029779ec97e7784e36035
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.2-rc/buster/zts
 
 Tags: 8.2.0RC5-cli-alpine3.16, 8.2-rc-cli-alpine3.16, 8.2.0RC5-alpine3.16, 8.2-rc-alpine3.16, 8.2.0RC5-cli-alpine, 8.2-rc-cli-alpine, 8.2.0RC5-alpine, 8.2-rc-alpine
@@ -56,7 +56,7 @@ Directory: 8.2-rc/alpine3.16/fpm
 
 Tags: 8.2.0RC5-zts-alpine3.16, 8.2-rc-zts-alpine3.16, 8.2.0RC5-zts-alpine, 8.2-rc-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 70c36f0988b8b25d3b2029779ec97e7784e36035
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.2-rc/alpine3.16/zts
 
 Tags: 8.2.0RC5-cli-alpine3.15, 8.2-rc-cli-alpine3.15, 8.2.0RC5-alpine3.15, 8.2-rc-alpine3.15
@@ -71,7 +71,7 @@ Directory: 8.2-rc/alpine3.15/fpm
 
 Tags: 8.2.0RC5-zts-alpine3.15, 8.2-rc-zts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 70c36f0988b8b25d3b2029779ec97e7784e36035
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.2-rc/alpine3.15/zts
 
 Tags: 8.1.12-cli-bullseye, 8.1-cli-bullseye, 8-cli-bullseye, cli-bullseye, 8.1.12-bullseye, 8.1-bullseye, 8-bullseye, bullseye, 8.1.12-cli, 8.1-cli, 8-cli, cli, 8.1.12, 8.1, 8, latest
@@ -91,7 +91,7 @@ Directory: 8.1/bullseye/fpm
 
 Tags: 8.1.12-zts-bullseye, 8.1-zts-bullseye, 8-zts-bullseye, zts-bullseye, 8.1.12-zts, 8.1-zts, 8-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5aa62896690eb52891fad624f27804432cf0fdb4
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.1/bullseye/zts
 
 Tags: 8.1.12-cli-buster, 8.1-cli-buster, 8-cli-buster, cli-buster, 8.1.12-buster, 8.1-buster, 8-buster, buster
@@ -111,7 +111,7 @@ Directory: 8.1/buster/fpm
 
 Tags: 8.1.12-zts-buster, 8.1-zts-buster, 8-zts-buster, zts-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 5aa62896690eb52891fad624f27804432cf0fdb4
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.1/buster/zts
 
 Tags: 8.1.12-cli-alpine3.16, 8.1-cli-alpine3.16, 8-cli-alpine3.16, cli-alpine3.16, 8.1.12-alpine3.16, 8.1-alpine3.16, 8-alpine3.16, alpine3.16, 8.1.12-cli-alpine, 8.1-cli-alpine, 8-cli-alpine, cli-alpine, 8.1.12-alpine, 8.1-alpine, 8-alpine, alpine
@@ -126,7 +126,7 @@ Directory: 8.1/alpine3.16/fpm
 
 Tags: 8.1.12-zts-alpine3.16, 8.1-zts-alpine3.16, 8-zts-alpine3.16, zts-alpine3.16, 8.1.12-zts-alpine, 8.1-zts-alpine, 8-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5aa62896690eb52891fad624f27804432cf0fdb4
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.1/alpine3.16/zts
 
 Tags: 8.1.12-cli-alpine3.15, 8.1-cli-alpine3.15, 8-cli-alpine3.15, cli-alpine3.15, 8.1.12-alpine3.15, 8.1-alpine3.15, 8-alpine3.15, alpine3.15
@@ -141,7 +141,7 @@ Directory: 8.1/alpine3.15/fpm
 
 Tags: 8.1.12-zts-alpine3.15, 8.1-zts-alpine3.15, 8-zts-alpine3.15, zts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5aa62896690eb52891fad624f27804432cf0fdb4
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.1/alpine3.15/zts
 
 Tags: 8.0.25-cli-bullseye, 8.0-cli-bullseye, 8.0.25-bullseye, 8.0-bullseye, 8.0.25-cli, 8.0-cli, 8.0.25, 8.0
@@ -161,7 +161,7 @@ Directory: 8.0/bullseye/fpm
 
 Tags: 8.0.25-zts-bullseye, 8.0-zts-bullseye, 8.0.25-zts, 8.0-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e553e80b7cda86b2f2dd353fec9a801cc79e9190
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.0/bullseye/zts
 
 Tags: 8.0.25-cli-buster, 8.0-cli-buster, 8.0.25-buster, 8.0-buster
@@ -181,7 +181,7 @@ Directory: 8.0/buster/fpm
 
 Tags: 8.0.25-zts-buster, 8.0-zts-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e553e80b7cda86b2f2dd353fec9a801cc79e9190
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.0/buster/zts
 
 Tags: 8.0.25-cli-alpine3.16, 8.0-cli-alpine3.16, 8.0.25-alpine3.16, 8.0-alpine3.16, 8.0.25-cli-alpine, 8.0-cli-alpine, 8.0.25-alpine, 8.0-alpine
@@ -196,7 +196,7 @@ Directory: 8.0/alpine3.16/fpm
 
 Tags: 8.0.25-zts-alpine3.16, 8.0-zts-alpine3.16, 8.0.25-zts-alpine, 8.0-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e553e80b7cda86b2f2dd353fec9a801cc79e9190
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.0/alpine3.16/zts
 
 Tags: 8.0.25-cli-alpine3.15, 8.0-cli-alpine3.15, 8.0.25-alpine3.15, 8.0-alpine3.15
@@ -211,7 +211,7 @@ Directory: 8.0/alpine3.15/fpm
 
 Tags: 8.0.25-zts-alpine3.15, 8.0-zts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e553e80b7cda86b2f2dd353fec9a801cc79e9190
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 8.0/alpine3.15/zts
 
 Tags: 7.4.32-cli-bullseye, 7.4-cli-bullseye, 7-cli-bullseye, 7.4.32-bullseye, 7.4-bullseye, 7-bullseye, 7.4.32-cli, 7.4-cli, 7-cli, 7.4.32, 7.4, 7
@@ -231,7 +231,7 @@ Directory: 7.4/bullseye/fpm
 
 Tags: 7.4.32-zts-bullseye, 7.4-zts-bullseye, 7-zts-bullseye, 7.4.32-zts, 7.4-zts, 7-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fa38b1c3756b2d7654ed024229350ae20f57fd76
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 7.4/bullseye/zts
 
 Tags: 7.4.32-cli-buster, 7.4-cli-buster, 7-cli-buster, 7.4.32-buster, 7.4-buster, 7-buster
@@ -251,7 +251,7 @@ Directory: 7.4/buster/fpm
 
 Tags: 7.4.32-zts-buster, 7.4-zts-buster, 7-zts-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: fa38b1c3756b2d7654ed024229350ae20f57fd76
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 7.4/buster/zts
 
 Tags: 7.4.32-cli-alpine3.16, 7.4-cli-alpine3.16, 7-cli-alpine3.16, 7.4.32-alpine3.16, 7.4-alpine3.16, 7-alpine3.16, 7.4.32-cli-alpine, 7.4-cli-alpine, 7-cli-alpine, 7.4.32-alpine, 7.4-alpine, 7-alpine
@@ -266,7 +266,7 @@ Directory: 7.4/alpine3.16/fpm
 
 Tags: 7.4.32-zts-alpine3.16, 7.4-zts-alpine3.16, 7-zts-alpine3.16, 7.4.32-zts-alpine, 7.4-zts-alpine, 7-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa38b1c3756b2d7654ed024229350ae20f57fd76
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 7.4/alpine3.16/zts
 
 Tags: 7.4.32-cli-alpine3.15, 7.4-cli-alpine3.15, 7-cli-alpine3.15, 7.4.32-alpine3.15, 7.4-alpine3.15, 7-alpine3.15
@@ -281,5 +281,5 @@ Directory: 7.4/alpine3.15/fpm
 
 Tags: 7.4.32-zts-alpine3.15, 7.4-zts-alpine3.15, 7-zts-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fa38b1c3756b2d7654ed024229350ae20f57fd76
+GitCommit: 231fc4aa5035e87dbd2f31697510181ad41235fe
 Directory: 7.4/alpine3.15/zts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/231fc4a: fix: disable Zend Signals for ZTS builds (https://github.com/docker-library/php/pull/1331)