### PR TITLE
[nats] Release v2.9.5

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,25 +4,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: de42cc20301c675300d4d968f524289076fa0d4b
+GitCommit: 250499dac3672456e09f5c658b2adfd0da8c07e6
 
-Tags: 2.9.4-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.4-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.5-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.5-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.4/alpine3.16
+Directory: 2.9.5/alpine3.16
 
-Tags: 2.9.4-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.4-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.4, 2.9, 2, latest
+Tags: 2.9.5-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.5-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.5, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.4/scratch
+Directory: 2.9.5/scratch
 
-Tags: 2.9.4-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.4-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.5-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.5-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.4/windowsservercore-1809
+Directory: 2.9.5/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.4-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.4-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.4, 2.9, 2, latest
+Tags: 2.9.5-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.5-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.5, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.4/nanoserver-1809
+Directory: 2.9.5/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.5)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>