### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -38,16 +38,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: 9dcdd0990630811a8b83e6593654f03eefea4926
 
-Tags: 2022.0.20221019.4, 2022, devel
+Tags: 2022.0.20221101.0, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: 6ca75095019b8f2716426ca8cea6e7f8b1556fa0
+amd64-GitCommit: 0c8a333d19dc78f9a1d334c00a25d2532308cdd8
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: 11989e5e3e539787d3814f10a6ff8882869ead46
+arm64v8-GitCommit: 2844844914b2258e7e0f66bd78dbc1e1b9374b12
 
-Tags: 2022.0.20221019.4-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20221101.0-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 8a0605984047c4a9dc777b8719fb0a4c7849c39b
+amd64-GitCommit: 6596f8c22703806ea9d44b8cbcdc2db1b030a407
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 2ecad3c43572dce2853874c7530fcdab85bb324c
+arm64v8-GitCommit: c738b847cd1ecf3b62392ed632478c761bcb23b4


### PR DESCRIPTION
This updates Amazon Linux 2022 to include [OpenSSL 3.0.7](https://www.openssl.org/blog/blog/2022/11/01/email-address-overflows/), which corrects a high-severity security issue.