### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.0.3-apache, 6.0-apache, 6-apache, apache, 6.0.3, 6.0, 6, latest, 6.0.3-php7.4-apache, 6.0-php7.4-apache, 6-php7.4-apache, php7.4-apache, 6.0.3-php7.4, 6.0-php7.4, 6-php7.4, php7.4
+Tags: 6.1.0-apache, 6.1-apache, 6-apache, apache, 6.1.0, 6.1, 6, latest, 6.1.0-php7.4-apache, 6.1-php7.4-apache, 6-php7.4-apache, php7.4-apache, 6.1.0-php7.4, 6.1-php7.4, 6-php7.4, php7.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php7.4/apache
 
-Tags: 6.0.3-fpm, 6.0-fpm, 6-fpm, fpm, 6.0.3-php7.4-fpm, 6.0-php7.4-fpm, 6-php7.4-fpm, php7.4-fpm
+Tags: 6.1.0-fpm, 6.1-fpm, 6-fpm, fpm, 6.1.0-php7.4-fpm, 6.1-php7.4-fpm, 6-php7.4-fpm, php7.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php7.4/fpm
 
-Tags: 6.0.3-fpm-alpine, 6.0-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.0.3-php7.4-fpm-alpine, 6.0-php7.4-fpm-alpine, 6-php7.4-fpm-alpine, php7.4-fpm-alpine
+Tags: 6.1.0-fpm-alpine, 6.1-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.1.0-php7.4-fpm-alpine, 6.1-php7.4-fpm-alpine, 6-php7.4-fpm-alpine, php7.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php7.4/fpm-alpine
 
-Tags: 6.0.3-php8.0-apache, 6.0-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.0.3-php8.0, 6.0-php8.0, 6-php8.0, php8.0
+Tags: 6.1.0-php8.0-apache, 6.1-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.1.0-php8.0, 6.1-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php8.0/apache
 
-Tags: 6.0.3-php8.0-fpm, 6.0-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.1.0-php8.0-fpm, 6.1-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php8.0/fpm
 
-Tags: 6.0.3-php8.0-fpm-alpine, 6.0-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.1.0-php8.0-fpm-alpine, 6.1-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.0.3-php8.1-apache, 6.0-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.0.3-php8.1, 6.0-php8.1, 6-php8.1, php8.1
+Tags: 6.1.0-php8.1-apache, 6.1-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.1.0-php8.1, 6.1-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php8.1/apache
 
-Tags: 6.0.3-php8.1-fpm, 6.0-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.1.0-php8.1-fpm, 6.1-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php8.1/fpm
 
-Tags: 6.0.3-php8.1-fpm-alpine, 6.0-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.1.0-php8.1-fpm-alpine, 6.1-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: feb1e969c394893ce20927d1fa864ad6ec7517b1
+GitCommit: e665dbf6044556ace612e09ce1e01d92bb8d6a34
 Directory: latest/php8.1/fpm-alpine
 
 Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php7.4, cli-2.7-php7.4, cli-2-php7.4, cli-php7.4
@@ -63,48 +63,3 @@ Tags: cli-2.7.1-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
 Directory: cli/php8.1/alpine
-
-Tags: beta-6.1-RC6-apache, beta-6.1-apache, beta-6-apache, beta-apache, beta-6.1-RC6, beta-6.1, beta-6, beta, beta-6.1-RC6-php7.4-apache, beta-6.1-php7.4-apache, beta-6-php7.4-apache, beta-php7.4-apache, beta-6.1-RC6-php7.4, beta-6.1-php7.4, beta-6-php7.4, beta-php7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php7.4/apache
-
-Tags: beta-6.1-RC6-fpm, beta-6.1-fpm, beta-6-fpm, beta-fpm, beta-6.1-RC6-php7.4-fpm, beta-6.1-php7.4-fpm, beta-6-php7.4-fpm, beta-php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php7.4/fpm
-
-Tags: beta-6.1-RC6-fpm-alpine, beta-6.1-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.1-RC6-php7.4-fpm-alpine, beta-6.1-php7.4-fpm-alpine, beta-6-php7.4-fpm-alpine, beta-php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php7.4/fpm-alpine
-
-Tags: beta-6.1-RC6-php8.0-apache, beta-6.1-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.1-RC6-php8.0, beta-6.1-php8.0, beta-6-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php8.0/apache
-
-Tags: beta-6.1-RC6-php8.0-fpm, beta-6.1-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php8.0/fpm
-
-Tags: beta-6.1-RC6-php8.0-fpm-alpine, beta-6.1-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php8.0/fpm-alpine
-
-Tags: beta-6.1-RC6-php8.1-apache, beta-6.1-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.1-RC6-php8.1, beta-6.1-php8.1, beta-6-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php8.1/apache
-
-Tags: beta-6.1-RC6-php8.1-fpm, beta-6.1-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php8.1/fpm
-
-Tags: beta-6.1-RC6-php8.1-fpm-alpine, beta-6.1-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01e8735497e407723c236304ba897ffea908fc77
-Directory: beta/php8.1/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/e665dbf: Update latest to 6.1.0
- https://github.com/docker-library/wordpress/commit/4808255: Update beta to 6.1.0