### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -13,8 +13,3 @@ Tags: 7.17.7
 Architectures: amd64, arm64v8
 GitCommit: c9d6474663e3d707c9792e793c4e67d6b773f006
 Directory: 7
-
-Tags: 6.8.23
-Architectures: amd64
-GitCommit: 00b6bd7d3432a1c7ba195060bf6d13d9a2541c11
-Directory: 6

--- a/library/kibana
+++ b/library/kibana
@@ -13,8 +13,3 @@ Tags: 7.17.7
 Architectures: amd64, arm64v8
 GitCommit: 38a693842d361744c409b655bfa2c1d4a4f90278
 Directory: 7
-
-Tags: 6.8.23
-Architectures: amd64
-GitCommit: e344361c58744dd623753d9a45dc8502a279b942
-Directory: 6

--- a/library/logstash
+++ b/library/logstash
@@ -13,8 +13,3 @@ Tags: 7.17.7
 Architectures: amd64, arm64v8
 GitCommit: 20756581f2b7799bc39b4e47d47722de4fbf3712
 Directory: 7
-
-Tags: 6.8.23
-Architectures: amd64
-GitCommit: 4c31d4c6b43c303275256545b5ac5111afa0f2e1
-Directory: 6


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/5cabf94: Merge pull request https://github.com/docker-library/elasticsearch/pull/204 from infosiftr/eol
- https://github.com/docker-library/elasticsearch/commit/3e2c989: Remove eol version 6.x

logstash:
- https://github.com/docker-library/logstash/commit/6328b07: Merge pull request https://github.com/docker-library/logstash/pull/105 from infosiftr/eol
- https://github.com/docker-library/logstash/commit/91ddac9: Remove eol version 6.x

kibana:
- https://github.com/docker-library/kibana/commit/63fae4c: Merge pull request https://github.com/docker-library/kibana/pull/99 from infosiftr/eol
- https://github.com/docker-library/kibana/commit/dc8f4b0: Remove eol version 6.x