### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2022-7329 ELSA-2022-7323 ELSA-2022-7314 ELSA-2022-7288

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 15611f5588de4e7bc49bb174b6f81370ca169313
+amd64-GitCommit: a8c60202e037f60972b602ea1f6f1480b38b1e94
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 338c6eb78ad082e76ef58c0116c2986f53700be8
+arm64v8-GitCommit: d79346424947e8aecf2a4539b70dca6140aaf8f4
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-33099, CVE-2020-10735, CVE-2022-37434, CVE-2022-3602, CVE-2022-3786.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-7329.html
https://linux.oracle.com/errata/ELSA-2022-7323.html
https://linux.oracle.com/errata/ELSA-2022-7314.html
https://linux.oracle.com/errata/ELSA-2022-7288.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
