### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 20-ea-21-jdk-oraclelinux8, 20-ea-21-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-21-jdk-oracle, 20-ea-21-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-21-jdk, 20-ea-21, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-22-jdk-oraclelinux8, 20-ea-22-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-22-jdk-oracle, 20-ea-22-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-22-jdk, 20-ea-22, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-21-jdk-oraclelinux7, 20-ea-21-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-22-jdk-oraclelinux7, 20-ea-22-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-21-jdk-bullseye, 20-ea-21-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-22-jdk-bullseye, 20-ea-22-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-21-jdk-slim-bullseye, 20-ea-21-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-21-jdk-slim, 20-ea-21-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-22-jdk-slim-bullseye, 20-ea-22-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-22-jdk-slim, 20-ea-22-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-21-jdk-buster, 20-ea-21-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-22-jdk-buster, 20-ea-22-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/buster
 
-Tags: 20-ea-21-jdk-slim-buster, 20-ea-21-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-22-jdk-slim-buster, 20-ea-22-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-21-jdk-windowsservercore-ltsc2022, 20-ea-21-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-21-jdk-windowsservercore, 20-ea-21-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-21-jdk, 20-ea-21, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-22-jdk-windowsservercore-ltsc2022, 20-ea-22-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-22-jdk-windowsservercore, 20-ea-22-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-22-jdk, 20-ea-22, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-21-jdk-windowsservercore-1809, 20-ea-21-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-21-jdk-windowsservercore, 20-ea-21-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-21-jdk, 20-ea-21, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-22-jdk-windowsservercore-1809, 20-ea-22-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-22-jdk-windowsservercore, 20-ea-22-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-22-jdk, 20-ea-22, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-21-jdk-nanoserver-1809, 20-ea-21-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-21-jdk-nanoserver, 20-ea-21-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-22-jdk-nanoserver-1809, 20-ea-22-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-22-jdk-nanoserver, 20-ea-22-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: f52dc45c090a13e29a95739522a47a001560b770
+GitCommit: 46ccb4defef04af6e78b70aa078080ede3fdaaa2
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/46ccb4d: Update 20 to 20-ea+22