### PR TITLE
mariadb release Q4 for < 10.10

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/1f34a9d567f606f02c26267014556bec321eedbc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/88e048a3978d98d5439f84673ddd63cdb6a940f3/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart)
@@ -6,40 +6,40 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.10.1-rc-jammy, 10.10-rc-jammy, 10.10.1-rc, 10.10-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.10
 
-Tags: 10.9.3-jammy, 10.9-jammy, 10-jammy, jammy, 10.9.3, 10.9, 10, latest
+Tags: 10.9.4-jammy, 10.9-jammy, 10-jammy, jammy, 10.9.4, 10.9, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.9
 
-Tags: 10.8.5-jammy, 10.8-jammy, 10.8.5, 10.8
+Tags: 10.8.6-jammy, 10.8-jammy, 10.8.6, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.8
 
-Tags: 10.7.6-focal, 10.7-focal, 10.7.6, 10.7
+Tags: 10.7.7-focal, 10.7-focal, 10.7.7, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.7
 
-Tags: 10.6.10-focal, 10.6-focal, 10.6.10, 10.6
+Tags: 10.6.11-focal, 10.6-focal, 10.6.11, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.6
 
-Tags: 10.5.17-focal, 10.5-focal, 10.5.17, 10.5
+Tags: 10.5.18-focal, 10.5-focal, 10.5.18, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.5
 
-Tags: 10.4.26-focal, 10.4-focal, 10.4.26, 10.4
+Tags: 10.4.27-focal, 10.4-focal, 10.4.27, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.4
 
-Tags: 10.3.36-focal, 10.3-focal, 10.3.36, 10.3
+Tags: 10.3.37-focal, 10.3-focal, 10.3.37, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ee8996e7fd507cfbef594c0369af092e5cf9078a
+GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
 Directory: 10.3


### PR DESCRIPTION
10.10 and 10.11 are still coming.

For the moment 10.10 is a partially updated image.