### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -3,16 +3,13 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
             Stewart Smith (@stewartsmith),
             Christopher Miller (@mysteriouspants),
             Sumit Tomer (@sktomer),
-            Sean Kelly (@cbgbt),
             Tanu Rampal (@trampal),
             Sam Thornton (@mrthornazon),
             Preston Carpenter (@timidger),
-            Richard Kelly (@rpkelly),
             Joseph Howell-Burke (@jhowell-burke),
-            Miriam Clark (@mgclark001),
-            CJ Harris (@mrcjplease)
+            Miriam Clark (@mgclark001)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: 6eb315d367fb8c9aaeba93db9c025d5d9048a1ea
+GitCommit: a4656f18f9a049b7ba91a5d2281af656ad819836
 
 Tags: 2.0.20221004.0, 2, latest
 Architectures: amd64, arm64v8
@@ -28,15 +25,15 @@ amd64-GitCommit: 2931065160d74a86bc8d322fcf6d5b680da81f6e
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: a505ba0c31bf9918dab8a52b399cab790608117a
 
-Tags: 2018.03.0.20220907.3, 2018.03, 1
+Tags: 2018.03.0.20221018.0, 2018.03, 1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: c4dd72316dd9dc4aa96885ebed72cd05149c8efe
+amd64-GitCommit: 2ebf0c4672c0935df050382182562e6613fde551
 
-Tags: 2018.03.0.20220907.3-with-sources, 2018.03-with-sources, 1-with-sources
+Tags: 2018.03.0.20221018.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: 9dcdd0990630811a8b83e6593654f03eefea4926
+amd64-GitCommit: 8a41cfcfb50f5db617c61c3ecfeae0daee0c1db9
 
 Tags: 2022.0.20221101.0, 2022, devel
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- tzdata-2022e-1.81.amzn1