### PR TITLE
Bump Haskell GHC 9.2 to 9.2.5

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -11,14 +11,14 @@ Architectures: amd64, arm64v8
 GitCommit: b29df0224a5f76407a41c6662513201650fde976
 Directory: 9.4/slim-buster
 
-Tags: 9.2.4-buster, 9.2-buster, 9.2.4, 9.2
+Tags: 9.2.5-buster, 9.2-buster, 9.2.5, 9.2
 Architectures: amd64, arm64v8
-GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
+GitCommit: 60a070f652853c4a1801ce00fcf2b880c79ecbfc
 Directory: 9.2/buster
 
-Tags: 9.2.4-slim-buster, 9.2-slim-buster, 9.2.4-slim, 9.2-slim
+Tags: 9.2.5-slim-buster, 9.2-slim-buster, 9.2.5-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
+GitCommit: 60a070f652853c4a1801ce00fcf2b880c79ecbfc
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0


### PR DESCRIPTION
https://www.haskell.org/ghc/blog/20221107-ghc-9.2.5-released.html

Thanks