### PR TITLE
arangodb 3.10.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -12,7 +12,7 @@ Architectures: amd64
 GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
 Directory: alpine/3.9.4
 
-Tags: 3.10, 3.10.0, latest
+Tags: 3.10, 3.10.1, latest
 Architectures: amd64, arm64v8
-GitCommit: 31df6aaffd35f1e221d59cc1802eeb71db058c9d
-Directory: alpine/3.10.0
+GitCommit: 4f04df410807f42cb2be282b8143405ce5593bbc
+Directory: alpine/3.10.1


### PR DESCRIPTION
Updated ArangoDB 3.10 to 3.10.1.