### PR TITLE
Almalinux auto-update - 184041

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -2,52 +2,6 @@
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
-Tags: 8.5, 8.5-20220510
-GitFetch: refs/heads/al-8.5.4-20220510
-GitCommit: cc33e53ccd8b33288eb3fbce9fd3bc308272c162
-amd64-File: Dockerfile-x86_64-default
-arm64v8-File: Dockerfile-aarch64-default
-ppc64le-File: Dockerfile-ppc64le-default
-Architectures: amd64, arm64v8, ppc64le
-
-Tags: 8.5-minimal, 8.5-minimal-20220510
-GitFetch: refs/heads/al-8.5.4-20220510
-GitCommit: cc33e53ccd8b33288eb3fbce9fd3bc308272c162
-amd64-File: Dockerfile-x86_64-minimal
-arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-File: Dockerfile-ppc64le-minimal
-Architectures: amd64, arm64v8, ppc64le
-
-Tags: 8.6, 8.6-20221101
-GitFetch: refs/heads/al8-20221101-amd64
-GitCommit: 03cdf71dcf08b0563a6be20b91d0d6e0ee686cda
-amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20221101-arm64v8
-arm64v8-GitCommit: 376f653625e4c1aa32fc0e13720d2fbb7466832b
-arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20221101-ppc64le
-ppc64le-GitCommit: 3652deb3f54b24a58f102b427522bd77f1620d5f
-ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20221101-s390x
-s390x-GitCommit: 6995ae59937816982949cf5980b43eb4df02dc4c
-s390x-File: Dockerfile-s390x-default
-Architectures: amd64, arm64v8, ppc64le, s390x
-
-Tags: 8.6-minimal, 8.6-minimal-20221101
-GitFetch: refs/heads/al8-20221101-amd64
-GitCommit: 03cdf71dcf08b0563a6be20b91d0d6e0ee686cda
-amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20221101-arm64v8
-arm64v8-GitCommit: 376f653625e4c1aa32fc0e13720d2fbb7466832b
-arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20221101-ppc64le
-ppc64le-GitCommit: 3652deb3f54b24a58f102b427522bd77f1620d5f
-ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20221101-s390x
-s390x-GitCommit: 6995ae59937816982949cf5980b43eb4df02dc4c
-s390x-File: Dockerfile-s390x-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-
 Tags: latest, 8, 8.7, 8.7-20221110
 GitFetch: refs/heads/al8-20221110-amd64
 GitCommit: 8ab8e4aa3c25e7836bf777dae31545da8fd477f1

--- a/library/almalinux
+++ b/library/almalinux
@@ -1,4 +1,4 @@
-# This file is generated using https://github.com/almalinux/docker-images/blob/bfb6735278c3e8e2a25714bcd5431a534ece5a2c/gen_docker_official_library
+# This file is generated using https://github.com/almalinux/docker-images/blob/6e66d3da6b8311a44414dce101bc9a8c1fed7783/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
@@ -18,7 +18,7 @@ arm64v8-File: Dockerfile-aarch64-minimal
 ppc64le-File: Dockerfile-ppc64le-minimal
 Architectures: amd64, arm64v8, ppc64le
 
-Tags: latest, 8, 8.6, 8.6-20221101
+Tags: 8.6, 8.6-20221101
 GitFetch: refs/heads/al8-20221101-amd64
 GitCommit: 03cdf71dcf08b0563a6be20b91d0d6e0ee686cda
 amd64-File: Dockerfile-x86_64-default
@@ -33,7 +33,7 @@ s390x-GitCommit: 6995ae59937816982949cf5980b43eb4df02dc4c
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 8-minimal, 8.6-minimal, 8.6-minimal-20221101
+Tags: 8.6-minimal, 8.6-minimal-20221101
 GitFetch: refs/heads/al8-20221101-amd64
 GitCommit: 03cdf71dcf08b0563a6be20b91d0d6e0ee686cda
 amd64-File: Dockerfile-x86_64-minimal
@@ -45,6 +45,36 @@ ppc64le-GitCommit: 3652deb3f54b24a58f102b427522bd77f1620d5f
 ppc64le-File: Dockerfile-ppc64le-minimal
 s390x-GitFetch: refs/heads/al8-20221101-s390x
 s390x-GitCommit: 6995ae59937816982949cf5980b43eb4df02dc4c
+s390x-File: Dockerfile-s390x-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+
+Tags: latest, 8, 8.7, 8.7-20221110
+GitFetch: refs/heads/al8-20221110-amd64
+GitCommit: 8ab8e4aa3c25e7836bf777dae31545da8fd477f1
+amd64-File: Dockerfile-x86_64-default
+arm64v8-GitFetch: refs/heads/al8-20221110-arm64v8
+arm64v8-GitCommit: db37ab6e872dae196d1b9fd98c1e8ecce0f94349
+arm64v8-File: Dockerfile-aarch64-default
+ppc64le-GitFetch: refs/heads/al8-20221110-ppc64le
+ppc64le-GitCommit: b71757f2c8293cef6559d8cf5e24e0a57cdb44f0
+ppc64le-File: Dockerfile-ppc64le-default
+s390x-GitFetch: refs/heads/al8-20221110-s390x
+s390x-GitCommit: 3f46e5a6a984d5b8291ee25a95ed5f1020ac5532
+s390x-File: Dockerfile-s390x-default
+Architectures: amd64, arm64v8, ppc64le, s390x
+
+Tags: minimal, 8-minimal, 8.7-minimal, 8.7-minimal-20221110
+GitFetch: refs/heads/al8-20221110-amd64
+GitCommit: 8ab8e4aa3c25e7836bf777dae31545da8fd477f1
+amd64-File: Dockerfile-x86_64-minimal
+arm64v8-GitFetch: refs/heads/al8-20221110-arm64v8
+arm64v8-GitCommit: db37ab6e872dae196d1b9fd98c1e8ecce0f94349
+arm64v8-File: Dockerfile-aarch64-minimal
+ppc64le-GitFetch: refs/heads/al8-20221110-ppc64le
+ppc64le-GitCommit: b71757f2c8293cef6559d8cf5e24e0a57cdb44f0
+ppc64le-File: Dockerfile-ppc64le-minimal
+s390x-GitFetch: refs/heads/al8-20221110-s390x
+s390x-GitCommit: 3f46e5a6a984d5b8291ee25a95ed5f1020ac5532
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 


### PR DESCRIPTION
This is an auto-generated commit. Any concern or issues, please contact @srbala or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

Build for `AlmaLinux 8.7` release 

### AlmaLinux 8 change log

- `almalinux-release` changed from 8.6-2.el8 to 8.7-2.el8
- `audit-libs` changed from 3.0.7-2.el8.2 to 3.0.7-4.el8
- `binutils` changed from 2.30-113.el8 to 2.30-117.el8
- `coreutils-single` changed from 8.30-12.el8 to 8.30-13.el8
- `curl` changed from 7.61.1-22.el8_6.4 to 7.61.1-25.el8
- `dbus` changed from 1.12.8-18.el8_6.1 to 1.12.8-23.el8
- `dbus-common` changed from 1.12.8-18.el8_6.1 to 1.12.8-23.el8
- `dbus-daemon` changed from 1.12.8-18.el8_6.1 to 1.12.8-23.el8
- `dbus-libs` changed from 1.12.8-18.el8_6.1 to 1.12.8-23.el8
- `dbus-tools` changed from 1.12.8-18.el8_6.1 to 1.12.8-23.el8
- `device-mapper` changed from 1.02.181-3.el8_6.2 to 1.02.181-6.el8
- `device-mapper-libs` changed from 1.02.181-3.el8_6.2 to 1.02.181-6.el8
- `dnf` changed from 4.7.0-8.el8.alma to 4.7.0-11.el8.alma
- `dnf-data` changed from 4.7.0-8.el8.alma to 4.7.0-11.el8.alma
- `elfutils-default-yama-scope` changed from 0.186-1.el8 to 0.187-4.el8
- `elfutils-libelf` changed from 0.186-1.el8 to 0.187-4.el8
- `elfutils-libs` changed from 0.186-1.el8 to 0.187-4.el8
- `expat` changed from 2.2.5-8.el8_6.3 to 2.2.5-10.el8
- `file-libs` changed from 5.33-20.el8 to 5.33-21.el8
- `gdbm` changed from 1.18-1.el8 to 1.18-2.el8
- `gdbm-libs` changed from 1.18-1.el8 to 1.18-2.el8
- `glib2` changed from 2.56.4-158.el8_6.1 to 2.56.4-159.el8
- `glibc` changed from 2.28-189.5.el8_6 to 2.28-211.el8
- `glibc-common` changed from 2.28-189.5.el8_6 to 2.28-211.el8
- `glibc-minimal-langpack` changed from 2.28-189.5.el8_6 to 2.28-211.el8
- `iputils` changed from 20180629-9.el8 to 20180629-10.el8
- `krb5-libs` changed from 1.18.2-14.el8 to 1.18.2-21.el8
- `libarchive` changed from 3.3.3-3.el8_5 to 3.3.3-4.el8
- `libblkid` changed from 2.32.1-35.el8 to 2.32.1-38.el8
- `libcap` changed from 2.48-2.el8 to 2.48-4.el8
- `libcom_err` changed from 1.45.6-4.el8 to 1.45.6-5.el8
- `libcurl-minimal` changed from 7.61.1-22.el8_6.4 to 7.61.1-25.el8
- `libdnf` changed from 0.63.0-8.2.el8_6.alma to 0.63.0-11.1.el8.alma
- `libfdisk` changed from 2.32.1-35.el8 to 2.32.1-38.el8
- `libgcc` changed from 8.5.0-10.1.el8_6.alma to 8.5.0-15.el8.alma
- `libmount` changed from 2.32.1-35.el8 to 2.32.1-38.el8
- `libpwquality` changed from 1.4.4-3.el8 to 1.4.4-5.el8
- `librepo` changed from 1.14.2-1.el8 to 1.14.2-3.el8
- `libselinux` changed from 2.9-5.el8 to 2.9-6.el8
- `libsmartcols` changed from 2.32.1-35.el8 to 2.32.1-38.el8
- `libsolv` changed from 0.7.20-1.el8 to 0.7.20-3.el8
- `libstdc++` changed from 8.5.0-10.1.el8_6.alma to 8.5.0-15.el8.alma
- `libtirpc` changed from 1.1.4-6.el8 to 1.1.4-8.el8
- `libuuid` changed from 2.32.1-35.el8 to 2.32.1-38.el8
- `libverto` changed from 0.3.0-5.el8 to 0.3.2-2.el8
- `libxml2` changed from 2.9.7-13.el8_6.1 to 2.9.7-15.el8
- `pam` changed from 1.3.1-16.el8_6.1 to 1.3.1-22.el8
- `python3-dnf` changed from 4.7.0-8.el8.alma to 4.7.0-11.el8.alma
- `python3-hawkey` changed from 0.63.0-8.2.el8_6.alma to 0.63.0-11.1.el8.alma
- `python3-libdnf` changed from 0.63.0-8.2.el8_6.alma to 0.63.0-11.1.el8.alma
- `setup` changed from 2.12.2-6.el8 to 2.12.2-7.el8
- `shadow-utils` changed from 4.6-16.el8 to 4.6-17.el8
- `systemd` changed from 239-58.el8_6.8 to 239-68.el8
- `systemd-libs` changed from 239-58.el8_6.8 to 239-68.el8
- `systemd-pam` changed from 239-58.el8_6.8 to 239-68.el8
- `tar` changed from 1.30-5.el8 to 1.30-6.el8
- `tzdata` changed from 2022e-1.el8 to 2022f-1.el8
- `util-linux` changed from 2.32.1-35.el8 to 2.32.1-38.el8
- `yum` changed from 4.7.0-8.el8.alma to 4.7.0-11.el8.alma
- `zlib` changed from 1.2.11-19.el8_6 to 1.2.11-20.el8


