### PR TITLE
Releasing Neo4j 4.3.21 and 4.4.14

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -22,22 +22,22 @@ GitCommit: 40a0188175a855bf184b0f7c62475b81ee10e028
 Directory: 5.1.0/enterprise
 
 
-Tags: 4.4.13, 4.4.13-community, 4.4, 4.4-community
+Tags: 4.4.14, 4.4.14-community, 4.4, 4.4-community
 Architectures: amd64, arm64v8
-GitCommit: 80069953d612dfa6feb79863d6dc0f44147096e4
-Directory: 4.4.13/community
+GitCommit: 4fa20d1e2f3df13633989e655de0834f0309f24c
+Directory: 4.4.14/community
 
-Tags: 4.4.13-enterprise, 4.4-enterprise
+Tags: 4.4.14-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
-GitCommit: 80069953d612dfa6feb79863d6dc0f44147096e4
-Directory: 4.4.13/enterprise
+GitCommit: 4fa20d1e2f3df13633989e655de0834f0309f24c
+Directory: 4.4.14/enterprise
 
 
-Tags: 4.3.20, 4.3.20-community, 4.3, 4.3-community
-GitCommit: 9ff07d9179050394847539f18bb2053ffa4e9340
-Directory: 4.3.20/community
+Tags: 4.3.21, 4.3.21-community, 4.3, 4.3-community
+GitCommit: 81af52f8bfbf341523797c437696a58ae6578af7
+Directory: 4.3.21/community
 
-Tags: 4.3.20-enterprise, 4.3-enterprise
-GitCommit: 9ff07d9179050394847539f18bb2053ffa4e9340
-Directory: 4.3.20/enterprise
+Tags: 4.3.21-enterprise, 4.3-enterprise
+GitCommit: 81af52f8bfbf341523797c437696a58ae6578af7
+Directory: 4.3.21/enterprise
 


### PR DESCRIPTION
These two should now be totally free of the Text4Shell vulnerability :crossed_fingers: 
Thanks!