### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 15.0, 15, latest, 15.0-bullseye, 15-bullseye, bullseye
+Tags: 15.1, 15, latest, 15.1-bullseye, 15-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 648e5c7dc31db0e34d8dc11891ccc50641ba6e42
+GitCommit: 75d0c1135e1cfd183bf7ee0970b7031986b0710d
 Directory: 15/bullseye
 
-Tags: 15.0-alpine, 15-alpine, alpine, 15.0-alpine3.16, 15-alpine3.16, alpine3.16
+Tags: 15.1-alpine, 15-alpine, alpine, 15.1-alpine3.16, 15-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 648e5c7dc31db0e34d8dc11891ccc50641ba6e42
+GitCommit: 75d0c1135e1cfd183bf7ee0970b7031986b0710d
 Directory: 15/alpine
 
-Tags: 14.5, 14, 14.5-bullseye, 14-bullseye
+Tags: 14.6, 14, 14.6-bullseye, 14-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6928f4995329cb0795d2aa2b88ad2c21685e35f3
+GitCommit: e8ba287990e5e312278fc59131f8a796953dc6c4
 Directory: 14/bullseye
 
-Tags: 14.5-alpine, 14-alpine, 14.5-alpine3.16, 14-alpine3.16
+Tags: 14.6-alpine, 14-alpine, 14.6-alpine3.16, 14-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56a1986772dd0f9488d54dccb82427c0db0b0599
+GitCommit: e8ba287990e5e312278fc59131f8a796953dc6c4
 Directory: 14/alpine
 
-Tags: 13.8, 13, 13.8-bullseye, 13-bullseye
+Tags: 13.9, 13, 13.9-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 701a1643a2718b4f90846e19e5860751bb970a3b
+GitCommit: 883b1c3f7b485153ec5d841271801ee436ec3314
 Directory: 13/bullseye
 
-Tags: 13.8-alpine, 13-alpine, 13.8-alpine3.16, 13-alpine3.16
+Tags: 13.9-alpine, 13-alpine, 13.9-alpine3.16, 13-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 701a1643a2718b4f90846e19e5860751bb970a3b
+GitCommit: 883b1c3f7b485153ec5d841271801ee436ec3314
 Directory: 13/alpine
 
-Tags: 12.12, 12, 12.12-bullseye, 12-bullseye
+Tags: 12.13, 12, 12.13-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5d3efd36f052338f294e7284812ad3f82a886257
+GitCommit: 5ca94d535d75308b16125d132048bf93172521db
 Directory: 12/bullseye
 
-Tags: 12.12-alpine, 12-alpine, 12.12-alpine3.16, 12-alpine3.16
+Tags: 12.13-alpine, 12-alpine, 12.13-alpine3.16, 12-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d3efd36f052338f294e7284812ad3f82a886257
+GitCommit: 5ca94d535d75308b16125d132048bf93172521db
 Directory: 12/alpine
 
-Tags: 11.17-bullseye, 11-bullseye
+Tags: 11.18-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bb963be60f9c7f69f011ae057782840ebd9e0988
+GitCommit: 14022440352a9e24d86cae450600ea56969d234b
 Directory: 11/bullseye
 
-Tags: 11.17-alpine, 11-alpine, 11.17-alpine3.16, 11-alpine3.16
+Tags: 11.18-alpine, 11-alpine, 11.18-alpine3.16, 11-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb963be60f9c7f69f011ae057782840ebd9e0988
+GitCommit: 14022440352a9e24d86cae450600ea56969d234b
 Directory: 11/alpine
 
-Tags: 10.22-bullseye, 10-bullseye
+Tags: 10.23-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 91cd38efaa82a8be0b1b993c11d740a668cd028e
+GitCommit: c3a0b48216491953f25344c3fef1b02ed157ff3e
 Directory: 10/bullseye
 
-Tags: 10.22-alpine, 10-alpine, 10.22-alpine3.16, 10-alpine3.16
+Tags: 10.23-alpine, 10-alpine, 10.23-alpine3.16, 10-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 91cd38efaa82a8be0b1b993c11d740a668cd028e
+GitCommit: c3a0b48216491953f25344c3fef1b02ed157ff3e
 Directory: 10/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/c3a0b48: Update 10 to 10.23, bullseye 10.23-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/75d0c11: Update 15 to 15.1, bullseye 15.1-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/e8ba287: Update 14 to 14.6, bullseye 14.6-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/883b1c3: Update 13 to 13.9, bullseye 13.9-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/5ca94d5: Update 12 to 12.13, bullseye 12.13-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/1402244: Update 11 to 11.18, bullseye 11.18-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/d940269: Merge pull request https://github.com/docker-library/postgres/pull/1006 from infosiftr/ci-updates
- https://github.com/docker-library/postgres/commit/44bad5f: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3