### PR TITLE
archlinux: Release 20221113.0.102112

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221106.0.100148
-GitCommit: 3425453aa7f47d2d03486b4d55c6010598cb225e
-GitFetch: refs/tags/v20221106.0.100148
+Tags: latest, base, base-20221113.0.102112
+GitCommit: 33ea24edac6753137e92b7144e0b046690b0d3ce
+GitFetch: refs/tags/v20221113.0.102112
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221106.0.100148
-GitCommit: 3425453aa7f47d2d03486b4d55c6010598cb225e
-GitFetch: refs/tags/v20221106.0.100148
+Tags: base-devel, base-devel-20221113.0.102112
+GitCommit: 33ea24edac6753137e92b7144e0b046690b0d3ce
+GitFetch: refs/tags/v20221113.0.102112
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks