### PR TITLE
Fedora 20221115 Update

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -4,26 +4,26 @@ GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 Tags: 35
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/35
-GitCommit: afbf447f359d764a8eefc8f733ccea8140933b57
+GitCommit: ca74a933654e5b53048d75225ae6976bdadf64b1
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
 ppc64le-Directory: ppc64le/
 
-Tags: 36, latest
+Tags: 36
 Architectures: amd64, arm64v8, ppc64le, s390x, arm32v7
 GitFetch: refs/heads/36
-GitCommit: a69e6897a944ff76f856ddca5343e93cd0ea2600
+GitCommit: e810becd1150a8e1f05d7765cd378e5bc02e7167
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
 arm32v7-Directory: armhfp/
 ppc64le-Directory: ppc64le/
 
-Tags: 37
+Tags: 37, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/37
-GitCommit: 3e5dc45a698ccc16a544490bb54889b08f04e549
+GitCommit: 886b921b3dc7e58aea627372b0f5509a66d4dc38
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
@@ -32,7 +32,7 @@ ppc64le-Directory: ppc64le/
 Tags: 38, rawhide
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/38
-GitCommit: 5d0e9bde5bf6b61aa5f58ecde54b6c7f79dec953
+GitCommit: 4aa98d132a5424bb790601c94a4c573a58ddd4b3
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/


### PR DESCRIPTION
Fedora 37 is now the latest release.

Signed-off-by: Clement Verna <cverna@tutanota.com>