### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.5.0
+Tags: 8.5.1
 Architectures: amd64, arm64v8
-GitCommit: 880612c18229a15d10ee548cfc87878973bc4cbb
+GitCommit: 072bf85e5c76fe9093a69c43f45970690ef893e6
 Directory: 8
 
 Tags: 7.17.7

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.5.0
+Tags: 8.5.1
 Architectures: amd64, arm64v8
-GitCommit: 74610c8c5370a1a43369ed9ef1eed97e91bb34ad
+GitCommit: c0ce5b8c237e4faecb1a3f078467054abb2c7b95
 Directory: 8
 
 Tags: 7.17.7

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.5.0
+Tags: 8.5.1
 Architectures: amd64, arm64v8
-GitCommit: dd4d705dba69601c4fa45cefe37baebc67db8a9f
+GitCommit: 08046ac50192cf0c5d04a8bd94536d41dfb8957c
 Directory: 8
 
 Tags: 7.17.7


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/d73dffb: Remove unnecessary CentOS references
- https://github.com/docker-library/elasticsearch/commit/072bf85: Update to 8.5.1

logstash:
- https://github.com/docker-library/logstash/commit/008fdf0: Remove unnecessary CentOS references and add Kibana's timestamp-ignoring code
- https://github.com/docker-library/logstash/commit/08046ac: Update to 8.5.1

kibana:
- https://github.com/docker-library/kibana/commit/9312d5a: Remove unnecessary CentOS reference
- https://github.com/docker-library/kibana/commit/c0ce5b8: Update to 8.5.1