### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 932221bc0570ff70b6ca56cafbf2fb5b5dd00eba
+GitCommit: 6028daf0c4c6f93606e961346ca1cf8226745312
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.16, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 1f37025ef2b9b70706d8e11cc3552830e4524758
+GitCommit: fbd3c1d965c8587efde1bef2d31459e54c28372e
 Directory: 22.06-rc/dind
 
 Tags: 22.06.0-beta.0-dind-rootless, 22.06-rc-dind-rootless, rc-dind-rootless
@@ -40,12 +40,12 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.21-cli, 20.10-cli, 20-cli, cli, 20.10.21-cli-alpine3.16, 20.10.21, 20.10, 20, latest, 20.10.21-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 1231bb8e025bdc715b8a8ca122ad20b5cf7ee469
+GitCommit: 6028daf0c4c6f93606e961346ca1cf8226745312
 Directory: 20.10/cli
 
 Tags: 20.10.21-dind, 20.10-dind, 20-dind, dind, 20.10.21-dind-alpine3.16
 Architectures: amd64, arm64v8
-GitCommit: 1231bb8e025bdc715b8a8ca122ad20b5cf7ee469
+GitCommit: 75036d19c3d68de7d20277d707763f32ddd487aa
 Directory: 20.10/dind
 
 Tags: 20.10.21-dind-rootless, 20.10-dind-rootless, 20-dind-rootless, dind-rootless


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/75036d1: Update 20.10
- https://github.com/docker-library/docker/commit/cef34f1: Merge pull request https://github.com/docker-library/docker/pull/384 from infosiftr/nsswitch
- https://github.com/docker-library/docker/commit/6028daf: Swap netgo prep to check instead of create
- https://github.com/docker-library/docker/commit/fbd3c1d: Update 22.06-rc