### PR TITLE
Odoo: update 14.0-16.0 to release 20221116

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 0d7a76b1e4a50ecbfdf7ab4dc7fdf91eadffa974
+GitCommit: 456817151ac2b45022d0663bfdaf8d83707e847a
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks