### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: a4656f18f9a049b7ba91a5d2281af656ad819836
 
-Tags: 2.0.20221004.0, 2, latest
+Tags: 2.0.20221103.3, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 2b0c14110e17fef5c161926ee4961268940a9ffb
+amd64-GitCommit: 1ccbb847f49ab27a9a4f97179129e24a28de46be
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 0702a9f1271e2dcccd1dc9dd7e01b8ae1521f446
+arm64v8-GitCommit: bb281db99ac5ee6475ad35e48a0177c12a2778d4
 
-Tags: 2.0.20221004.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20221103.3-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 2931065160d74a86bc8d322fcf6d5b680da81f6e
+amd64-GitCommit: 78035f9231687da94a786f5ba1ce1928faa9a0aa
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: a505ba0c31bf9918dab8a52b399cab790608117a
+arm64v8-GitCommit: a142602d0ab754493d1be9e1178e911be4ff3794
 
 Tags: 2018.03.0.20221018.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- tzdata-2022e-1.amzn2.0.1
- glibc-2.26-62.amzn2
  - [CVE-2009-5155](https://alas.aws.amazon.com/cve/html/CVE-2009-5155.html)
  - [CVE-2015-8985](https://alas.aws.amazon.com/cve/html/CVE-2015-8985.html)
- curl-7.79.1-6.amzn2.0.1
  - [CVE-2022-32205](https://alas.aws.amazon.com/cve/html/CVE-2022-32205.html)
  - [CVE-2022-32206](https://alas.aws.amazon.com/cve/html/CVE-2022-32206.html)
  - [CVE-2022-32207](https://alas.aws.amazon.com/cve/html/CVE-2022-32207.html)
  - [CVE-2022-32208](https://alas.aws.amazon.com/cve/html/CVE-2022-32208.html)
  - [CVE-2022-35252](https://alas.aws.amazon.com/cve/html/CVE-2022-35252.html)
- expat-2.1.0-15.amzn2.0.1
  - [CVE-2022-40674](https://alas.aws.amazon.com/cve/html/CVE-2022-40674.html)
- util-linux-2.30.2-2.amzn2.0.9
  - [CVE-2018-7738](https://alas.aws.amazon.com/cve/html/CVE-2018-7738.html)