### PR TITLE
Bump Traefik to v2.9.5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v2.9.4-windowsservercore-1809, 2.9.4-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.9.5-windowsservercore-1809, 2.9.5-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 902a0bf463bda84f4cc2cefbcbf9b5b6f7a2cdb9
+GitCommit: 78e52c7538f1a06c05d91d18d8ed0b467e69160e
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.9.4, 2.9.4, v2.9, 2.9, banon, latest
+Tags: v2.9.5, 2.9.5, v2.9, 2.9, banon, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 902a0bf463bda84f4cc2cefbcbf9b5b6f7a2cdb9
+GitCommit: 78e52c7538f1a06c05d91d18d8ed0b467e69160e
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.9.5](https://github.com/traefik/traefik/releases/tag/v2.9.5).

/cc @ddtmachado @ldez @kevinpollet

Cheers
