### PR TITLE
[nats] Release v2.9.7

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,25 +4,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 2c259145441a4b7f55724d0c245b553d9b34a4ee
+GitCommit: d4662e6e935fee7cd8881392734fc769c702e3f1
 
-Tags: 2.9.6-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.6-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.7-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.7-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.6/alpine3.16
+Directory: 2.9.7/alpine3.16
 
-Tags: 2.9.6-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.6-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.6, 2.9, 2, latest
+Tags: 2.9.7-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.7-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.7, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.6/scratch
+Directory: 2.9.7/scratch
 
-Tags: 2.9.6-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.6-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.7-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.7-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.6/windowsservercore-1809
+Directory: 2.9.7/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.6-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.6-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.6, 2.9, 2, latest
+Tags: 2.9.7-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.7-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.7, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.6/nanoserver-1809
+Directory: 2.9.7/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.7)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>