### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 20-ea-23-jdk-oraclelinux8, 20-ea-23-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-23-jdk-oracle, 20-ea-23-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-23-jdk, 20-ea-23, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-24-jdk-oraclelinux8, 20-ea-24-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-24-jdk-oracle, 20-ea-24-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-24-jdk, 20-ea-24, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-23-jdk-oraclelinux7, 20-ea-23-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-24-jdk-oraclelinux7, 20-ea-24-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-23-jdk-bullseye, 20-ea-23-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-24-jdk-bullseye, 20-ea-24-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-23-jdk-slim-bullseye, 20-ea-23-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-23-jdk-slim, 20-ea-23-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-24-jdk-slim-bullseye, 20-ea-24-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-24-jdk-slim, 20-ea-24-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-23-jdk-buster, 20-ea-23-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-24-jdk-buster, 20-ea-24-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/buster
 
-Tags: 20-ea-23-jdk-slim-buster, 20-ea-23-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-24-jdk-slim-buster, 20-ea-24-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-23-jdk-windowsservercore-ltsc2022, 20-ea-23-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-23-jdk-windowsservercore, 20-ea-23-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-23-jdk, 20-ea-23, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-24-jdk-windowsservercore-ltsc2022, 20-ea-24-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-24-jdk-windowsservercore, 20-ea-24-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-24-jdk, 20-ea-24, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-23-jdk-windowsservercore-1809, 20-ea-23-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-23-jdk-windowsservercore, 20-ea-23-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-23-jdk, 20-ea-23, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-24-jdk-windowsservercore-1809, 20-ea-24-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-24-jdk-windowsservercore, 20-ea-24-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-24-jdk, 20-ea-24, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-23-jdk-nanoserver-1809, 20-ea-23-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-23-jdk-nanoserver, 20-ea-23-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-24-jdk-nanoserver-1809, 20-ea-24-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-24-jdk-nanoserver, 20-ea-24-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: cd2654d251c7bab67ef341d7e594f0118dd638b0
+GitCommit: 095aa3733e7f2847a709b67d24110c92314ac11a
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/095aa37: Update 20 to 20-ea+24
- https://github.com/docker-library/openjdk/commit/759e794: Use new "bashbrew" composite action