### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3e6136537f18347eb6cfe561748990995673d590/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/f216ce377aa5896c37e24626636733af859545bc/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3e6136537f18347eb6cfe561748990995673d590
+GitCommit: f216ce377aa5896c37e24626636733af859545bc
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d3aaee8314575a45030110eb5602e6e994ee15ce
+amd64-GitCommit: 81113f6bf4dec665d1f634be785f98105026a96f
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 051735a058e3cb0c66ebfbc9b487e16c4971d01a
+arm32v5-GitCommit: 34ad376c7c4114207a17455ac1e8ac5a054c9f9f
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 2d0b33eafa8409b5b5ce1c4930d10fb499880ac1
+arm32v6-GitCommit: 3347fb4b0dc36e93a01c466f301e2d65e7d47b4a
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: a9b9ea1d5301af2a6fba571d3cd696df326fa7f4
+arm32v7-GitCommit: e1bdbe15a1f1b5611b1f7f7440f80a07f72f41e3
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 54a1b5e921d59d8d0d5d30d2564e1ac0df238185
+arm64v8-GitCommit: 685751edf358c77700bb6fc053ff97c89b14ff68
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: e6550012bb2244560143a860dc2bc26f28f0c64b
+i386-GitCommit: 315ebb6a72f47604bcd79d0e5776968d1da771ac
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 537cf4f351d8b708afe94a99d44b3c6fb66aeb1d
+mips64le-GitCommit: a37907b90283c322b1234d136f75b8c1ba2ded4d
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 0570c07fb4d8ed93caffb6565facb649b80d4656
+ppc64le-GitCommit: 8c217893d1df304d7ffdd4c3dccd09deadbc9550
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 6781e9d0b260afe6cce7f93db93ba988a4e57cc1
+riscv64-GitCommit: 6a2e43e8293fdcaf430a4cc12f97fd6fe880a3ce
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 597506988475bf2a8e4d4ce13e98c042a75c9eaa
+s390x-GitCommit: 040bc64876deb8533b175de0ad40a44e4bc093ad
 
 Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/f216ce3: Merge pull request https://github.com/docker-library/busybox/pull/152 from infosiftr/buildroot-2022.08.2
- https://github.com/docker-library/busybox/commit/ec69eda: Update buildroot to 2022.08.2
- https://github.com/docker-library/busybox/commit/0539d09: Use new "bashbrew" composite action