### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.7-dev8, 2.7-dev, 2.7-dev8-bullseye, 2.7-dev-bullseye
+Tags: 2.7-dev9, 2.7-dev, 2.7-dev9-bullseye, 2.7-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cd1c198fc46e312fccf9818c5388494eb4a70f83
+GitCommit: dc6b385d6fbfc9e038750f7ad316eb50bbc9c2bd
 Directory: 2.7
 
-Tags: 2.7-dev8-alpine, 2.7-dev-alpine, 2.7-dev8-alpine3.16, 2.7-dev-alpine3.16
+Tags: 2.7-dev9-alpine, 2.7-dev-alpine, 2.7-dev9-alpine3.16, 2.7-dev-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cd1c198fc46e312fccf9818c5388494eb4a70f83
+GitCommit: dc6b385d6fbfc9e038750f7ad316eb50bbc9c2bd
 Directory: 2.7/alpine
 
 Tags: 2.6.6, 2.6, lts, latest, 2.6.6-bullseye, 2.6-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/dc6b385: Update 2.7 to 2.7-dev9
- https://github.com/docker-library/haproxy/commit/91c88f7: Use new "bashbrew" composite action
- https://github.com/docker-library/haproxy/commit/56dfd94: Merge pull request https://github.com/docker-library/haproxy/pull/195 from infosiftr/ci-updates
- https://github.com/docker-library/haproxy/commit/42e94c3: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3