### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.22.11, 5.22, 5, latest
+Tags: 5.23.0, 5.23, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7750beff33570fe68a6e866cea3b28ac6edc99d9
+GitCommit: b01f1e2b081132a809ed735c00cb7513f6501cfc
 Directory: 5/debian
 
-Tags: 5.22.11-alpine, 5.22-alpine, 5-alpine, alpine
+Tags: 5.23.0-alpine, 5.23-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 7750beff33570fe68a6e866cea3b28ac6edc99d9
+GitCommit: b01f1e2b081132a809ed735c00cb7513f6501cfc
 Directory: 5/alpine
 
 Tags: 4.48.8, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/b01f1e2: Update to 5.23.0, ghost-cli 1.23.1
- https://github.com/docker-library/ghost/commit/41af9db: Use new "bashbrew" composite action