### PR TITLE
archlinux: Release 20221120.0.103865

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221113.0.102112
-GitCommit: 33ea24edac6753137e92b7144e0b046690b0d3ce
-GitFetch: refs/tags/v20221113.0.102112
+Tags: latest, base, base-20221120.0.103865
+GitCommit: e5ae1e577872455d8a77adee6c3dfbb7ab417035
+GitFetch: refs/tags/v20221120.0.103865
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221113.0.102112
-GitCommit: 33ea24edac6753137e92b7144e0b046690b0d3ce
-GitFetch: refs/tags/v20221113.0.102112
+Tags: base-devel, base-devel-20221120.0.103865
+GitCommit: e5ae1e577872455d8a77adee6c3dfbb7ab417035
+GitFetch: refs/tags/v20221120.0.103865
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks