### PR TITLE
Update Clear Linux OS to 37640

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 099e8ec9c863fd39cc7fb242b1e8707b09ff31ae
-GitFetch: refs/heads/base-37620
+GitCommit: af04d4edf710626daee49fb2f10552bb1db0eb81
+GitFetch: refs/heads/base-37640


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37640

@bryteise @djklimes @bryteise