### PR TITLE
Aerospike 6.2.0.0

### DIFF
--- a/library/aerospike
+++ b/library/aerospike
@@ -1,13 +1,14 @@
 Maintainers: Lucien Volmar <lucien@aerospike.com> (@volmarl),
              Michael Coberly <mcoberly@aerospike.com> (@mcoberly2),
              Phuc Vinh <pvinh@aerospike.com> (@pvinh-spike)
+             Kevin Porter <kporter@aerospike.com (@kportertx)
 
-Tags: ee-6.1.0.3
-Architectures: amd64
-GitRepo: https://github.com/aerospike/aerospike-server-enterprise.docker.git
-GitCommit: 01871453aad7390a02a51dee11efe8e6a55f95cf
-
-Tags: ce-6.1.0.3
-Architectures: amd64
+Tags: ee-6.2.0.0
+Architectures: amd64 & arm64
 GitRepo: https://github.com/aerospike/aerospike-server.docker.git
-GitCommit: 4557452ca88bcad1929e91bd303b522a1c242b12
+GitCommit: d255671e0e0bd9616661b937bb454ea916789041
+
+Tags: ce-6.2.0.0
+Architectures: amd64 & arm64
+GitRepo: https://github.com/aerospike/aerospike-server.docker.git
+GitCommit: d255671e0e0bd9616661b937bb454ea916789041

--- a/library/aerospike
+++ b/library/aerospike
@@ -1,6 +1,6 @@
 Maintainers: Lucien Volmar <lucien@aerospike.com> (@volmarl),
              Michael Coberly <mcoberly@aerospike.com> (@mcoberly2),
-             Phuc Vinh <pvinh@aerospike.com> (@pvinh-spike)
+             Phuc Vinh <pvinh@aerospike.com> (@pvinh-spike),
              Kevin Porter <kporter@aerospike.com> (@kportertx)
 
 Tags: ee-6.2.0.0

--- a/library/aerospike
+++ b/library/aerospike
@@ -7,8 +7,10 @@ Tags: ee-6.2.0.0
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/aerospike/aerospike-server.docker.git
 GitCommit: d255671e0e0bd9616661b937bb454ea916789041
+Directory: enterprise/debian11 
 
 Tags: ce-6.2.0.0
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/aerospike/aerospike-server.docker.git
 GitCommit: d255671e0e0bd9616661b937bb454ea916789041
+Directory: community/debian11 

--- a/library/aerospike
+++ b/library/aerospike
@@ -1,7 +1,7 @@
 Maintainers: Lucien Volmar <lucien@aerospike.com> (@volmarl),
              Michael Coberly <mcoberly@aerospike.com> (@mcoberly2),
              Phuc Vinh <pvinh@aerospike.com> (@pvinh-spike)
-             Kevin Porter <kporter@aerospike.com (@kportertx)
+             Kevin Porter <kporter@aerospike.com> (@kportertx)
 
 Tags: ee-6.2.0.0
 Architectures: amd64 & arm64

--- a/library/aerospike
+++ b/library/aerospike
@@ -4,11 +4,11 @@ Maintainers: Lucien Volmar <lucien@aerospike.com> (@volmarl),
              Kevin Porter <kporter@aerospike.com> (@kportertx)
 
 Tags: ee-6.2.0.0
-Architectures: amd64 & arm64
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/aerospike/aerospike-server.docker.git
 GitCommit: d255671e0e0bd9616661b937bb454ea916789041
 
 Tags: ce-6.2.0.0
-Architectures: amd64 & arm64
+Architectures: amd64, arm64v8
 GitRepo: https://github.com/aerospike/aerospike-server.docker.git
 GitCommit: d255671e0e0bd9616661b937bb454ea916789041


### PR DESCRIPTION
https://download.aerospike.com/download/server/notes.html#6.2.0.0

Would you please also delete the "latest" build from the tag listing.