### PR TITLE
Releasing  Neo4j 5.2.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -11,15 +11,15 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 
 
-Tags: 5.1.0, 5.1.0-community, 5.1, 5, 5-community, community, latest
+Tags: 5.2.0, 5.2.0-community, 5.2, 5, 5-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 40a0188175a855bf184b0f7c62475b81ee10e028
-Directory: 5.1.0/community
+GitCommit: 51c1670004a4c2d511a342a01a7963b78cc2c5c4
+Directory: 5.2.0/community
 
-Tags: 5.1.0-enterprise, 5.1-enterprise, 5-enterprise, enterprise
+Tags: 5.2.0-enterprise, 5.2-enterprise, 5-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 40a0188175a855bf184b0f7c62475b81ee10e028
-Directory: 5.1.0/enterprise
+GitCommit: 51c1670004a4c2d511a342a01a7963b78cc2c5c4
+Directory: 5.2.0/enterprise
 
 
 Tags: 4.4.14, 4.4.14-community, 4.4, 4.4-community


### PR DESCRIPTION
This should hopefully fix the last of the Text4Shell flags.