### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.1-beta1, 4.1
+Tags: 4.1-rc1, 4.1
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e8ee59f9fc070e87595ea3fafe528030bddb8212
+GitCommit: 2fd1447ba5551e25875bc10486583d312937616f
 Directory: 4.1
 
 Tags: 4.0.7, 4.0, 4, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/2fd1447: Update 4.1 to 4.1-rc1
- https://github.com/docker-library/cassandra/commit/4e7ec37: Use new "bashbrew" composite action