### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -34,92 +34,92 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 09ae96ae70997acb44bac52df46e015755b228e1
 Directory: 3.2-rc/alpine3.15
 
-Tags: 3.1.2-bullseye, 3.1-bullseye, 3-bullseye, bullseye, 3.1.2, 3.1, 3, latest
+Tags: 3.1.3-bullseye, 3.1-bullseye, 3-bullseye, bullseye, 3.1.3, 3.1, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6a100006eeb52ec06bfe3f318b401cdf5a52dd6b
+GitCommit: 9fd589661dd0e12b082336e9c6f731196fe39ba8
 Directory: 3.1/bullseye
 
-Tags: 3.1.2-slim-bullseye, 3.1-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.1.2-slim, 3.1-slim, 3-slim, slim
+Tags: 3.1.3-slim-bullseye, 3.1-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.1.3-slim, 3.1-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6a100006eeb52ec06bfe3f318b401cdf5a52dd6b
+GitCommit: 9fd589661dd0e12b082336e9c6f731196fe39ba8
 Directory: 3.1/slim-bullseye
 
-Tags: 3.1.2-buster, 3.1-buster, 3-buster, buster
+Tags: 3.1.3-buster, 3.1-buster, 3-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6a100006eeb52ec06bfe3f318b401cdf5a52dd6b
+GitCommit: 9fd589661dd0e12b082336e9c6f731196fe39ba8
 Directory: 3.1/buster
 
-Tags: 3.1.2-slim-buster, 3.1-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.1.3-slim-buster, 3.1-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6a100006eeb52ec06bfe3f318b401cdf5a52dd6b
+GitCommit: 9fd589661dd0e12b082336e9c6f731196fe39ba8
 Directory: 3.1/slim-buster
 
-Tags: 3.1.2-alpine3.16, 3.1-alpine3.16, 3-alpine3.16, alpine3.16, 3.1.2-alpine, 3.1-alpine, 3-alpine, alpine
+Tags: 3.1.3-alpine3.16, 3.1-alpine3.16, 3-alpine3.16, alpine3.16, 3.1.3-alpine, 3.1-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4955e524a9a01f35979d7b7984a001fd563d5cfb
+GitCommit: 9fd589661dd0e12b082336e9c6f731196fe39ba8
 Directory: 3.1/alpine3.16
 
-Tags: 3.1.2-alpine3.15, 3.1-alpine3.15, 3-alpine3.15, alpine3.15
+Tags: 3.1.3-alpine3.15, 3.1-alpine3.15, 3-alpine3.15, alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a100006eeb52ec06bfe3f318b401cdf5a52dd6b
+GitCommit: 9fd589661dd0e12b082336e9c6f731196fe39ba8
 Directory: 3.1/alpine3.15
 
-Tags: 3.0.4-bullseye, 3.0-bullseye, 3.0.4, 3.0
+Tags: 3.0.5-bullseye, 3.0-bullseye, 3.0.5, 3.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dd1b1c9650fd9470edf8399abb2a746e597a821b
+GitCommit: ece6f45d6d00b803a4e1a33cd5a55895cf928357
 Directory: 3.0/bullseye
 
-Tags: 3.0.4-slim-bullseye, 3.0-slim-bullseye, 3.0.4-slim, 3.0-slim
+Tags: 3.0.5-slim-bullseye, 3.0-slim-bullseye, 3.0.5-slim, 3.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dd1b1c9650fd9470edf8399abb2a746e597a821b
+GitCommit: ece6f45d6d00b803a4e1a33cd5a55895cf928357
 Directory: 3.0/slim-bullseye
 
-Tags: 3.0.4-buster, 3.0-buster
+Tags: 3.0.5-buster, 3.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dd1b1c9650fd9470edf8399abb2a746e597a821b
+GitCommit: ece6f45d6d00b803a4e1a33cd5a55895cf928357
 Directory: 3.0/buster
 
-Tags: 3.0.4-slim-buster, 3.0-slim-buster
+Tags: 3.0.5-slim-buster, 3.0-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dd1b1c9650fd9470edf8399abb2a746e597a821b
+GitCommit: ece6f45d6d00b803a4e1a33cd5a55895cf928357
 Directory: 3.0/slim-buster
 
-Tags: 3.0.4-alpine3.16, 3.0-alpine3.16, 3.0.4-alpine, 3.0-alpine
+Tags: 3.0.5-alpine3.16, 3.0-alpine3.16, 3.0.5-alpine, 3.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4955e524a9a01f35979d7b7984a001fd563d5cfb
+GitCommit: ece6f45d6d00b803a4e1a33cd5a55895cf928357
 Directory: 3.0/alpine3.16
 
-Tags: 3.0.4-alpine3.15, 3.0-alpine3.15
+Tags: 3.0.5-alpine3.15, 3.0-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd1b1c9650fd9470edf8399abb2a746e597a821b
+GitCommit: ece6f45d6d00b803a4e1a33cd5a55895cf928357
 Directory: 3.0/alpine3.15
 
-Tags: 2.7.6-bullseye, 2.7-bullseye, 2-bullseye, 2.7.6, 2.7, 2
+Tags: 2.7.7-bullseye, 2.7-bullseye, 2-bullseye, 2.7.7, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c3e1e09e881f8a1f24d1ddfe1d5c6117aaa62de
+GitCommit: cdac1ffbc959768a5b82014dbb8c8006fe6f7880
 Directory: 2.7/bullseye
 
-Tags: 2.7.6-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.6-slim, 2.7-slim, 2-slim
+Tags: 2.7.7-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.7-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c3e1e09e881f8a1f24d1ddfe1d5c6117aaa62de
+GitCommit: cdac1ffbc959768a5b82014dbb8c8006fe6f7880
 Directory: 2.7/slim-bullseye
 
-Tags: 2.7.6-buster, 2.7-buster, 2-buster
+Tags: 2.7.7-buster, 2.7-buster, 2-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 2c3e1e09e881f8a1f24d1ddfe1d5c6117aaa62de
+GitCommit: cdac1ffbc959768a5b82014dbb8c8006fe6f7880
 Directory: 2.7/buster
 
-Tags: 2.7.6-slim-buster, 2.7-slim-buster, 2-slim-buster
+Tags: 2.7.7-slim-buster, 2.7-slim-buster, 2-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 2c3e1e09e881f8a1f24d1ddfe1d5c6117aaa62de
+GitCommit: cdac1ffbc959768a5b82014dbb8c8006fe6f7880
 Directory: 2.7/slim-buster
 
-Tags: 2.7.6-alpine3.16, 2.7-alpine3.16, 2-alpine3.16, 2.7.6-alpine, 2.7-alpine, 2-alpine
+Tags: 2.7.7-alpine3.16, 2.7-alpine3.16, 2-alpine3.16, 2.7.7-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4955e524a9a01f35979d7b7984a001fd563d5cfb
+GitCommit: cdac1ffbc959768a5b82014dbb8c8006fe6f7880
 Directory: 2.7/alpine3.16
 
-Tags: 2.7.6-alpine3.15, 2.7-alpine3.15, 2-alpine3.15
+Tags: 2.7.7-alpine3.15, 2.7-alpine3.15, 2-alpine3.15
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2c3e1e09e881f8a1f24d1ddfe1d5c6117aaa62de
+GitCommit: cdac1ffbc959768a5b82014dbb8c8006fe6f7880
 Directory: 2.7/alpine3.15


### PR DESCRIPTION
Changes:

- docker-library/ruby@9fd5896: Update 3.1 to 3.1.3
- docker-library/ruby@ece6f45: Update 3.0 to 3.0.5
- docker-library/ruby@cdac1ff: Update 2.7 to 2.7.7