### PR TITLE
Releasing neo4j 4.4.15 and 4.3.22

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -22,22 +22,22 @@ GitCommit: 51c1670004a4c2d511a342a01a7963b78cc2c5c4
 Directory: 5.2.0/enterprise
 
 
-Tags: 4.4.14, 4.4.14-community, 4.4, 4.4-community
+Tags: 4.4.15, 4.4.15-community, 4.4, 4.4-community
 Architectures: amd64, arm64v8
-GitCommit: 4fa20d1e2f3df13633989e655de0834f0309f24c
-Directory: 4.4.14/community
+GitCommit: 5d8fef9875d74f1f18266f77d1acda67ba7cc608
+Directory: 4.4.15/community
 
-Tags: 4.4.14-enterprise, 4.4-enterprise
+Tags: 4.4.15-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
-GitCommit: 4fa20d1e2f3df13633989e655de0834f0309f24c
-Directory: 4.4.14/enterprise
+GitCommit: 5d8fef9875d74f1f18266f77d1acda67ba7cc608
+Directory: 4.4.15/enterprise
 
 
-Tags: 4.3.21, 4.3.21-community, 4.3, 4.3-community
-GitCommit: 81af52f8bfbf341523797c437696a58ae6578af7
-Directory: 4.3.21/community
+Tags: 4.3.22, 4.3.22-community, 4.3, 4.3-community
+GitCommit: e2b0e75e58b9266f6510ed538a76f6cae80cdc6c
+Directory: 4.3.22/community
 
-Tags: 4.3.21-enterprise, 4.3-enterprise
-GitCommit: 81af52f8bfbf341523797c437696a58ae6578af7
-Directory: 4.3.21/enterprise
+Tags: 4.3.22-enterprise, 4.3-enterprise
+GitCommit: e2b0e75e58b9266f6510ed538a76f6cae80cdc6c
+Directory: 4.3.22/enterprise
 


### PR DESCRIPTION
Now that we're only supporting 3 images, would it be possible to get the supported tags listed on https://hub.docker.com/_/neo4j?tab=description again?

Thanks.