### PR TITLE
Update Clear Linux OS to 37680

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: af04d4edf710626daee49fb2f10552bb1db0eb81
-GitFetch: refs/heads/base-37640
+GitCommit: 0f20619a2d5a034fc1c733d6d5acc4f3bf2b664b
+GitFetch: refs/heads/base-37680


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37680

@bryteise @djklimes @bryteise