### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.5.1
+Tags: 8.5.2
 Architectures: amd64, arm64v8
-GitCommit: 072bf85e5c76fe9093a69c43f45970690ef893e6
+GitCommit: 75c6c47f14bbb4c598aacfa7210fcbb8c9a566e3
 Directory: 8
 
 Tags: 7.17.7

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.5.1
+Tags: 8.5.2
 Architectures: amd64, arm64v8
-GitCommit: c0ce5b8c237e4faecb1a3f078467054abb2c7b95
+GitCommit: e69ce229e1dc0e8363781e22f51aa2adb1dc8772
 Directory: 8
 
 Tags: 7.17.7

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.5.1
+Tags: 8.5.2
 Architectures: amd64, arm64v8
-GitCommit: 08046ac50192cf0c5d04a8bd94536d41dfb8957c
+GitCommit: 47f532082b090b099d8df1d7ca07a773581d81fc
 Directory: 8
 
 Tags: 7.17.7


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/75c6c47: Update to 8.5.2
- https://github.com/docker-library/elasticsearch/commit/8e2e886: Use new "bashbrew" composite action

logstash:
- https://github.com/docker-library/logstash/commit/47f5320: Update to 8.5.2
- https://github.com/docker-library/logstash/commit/f798f9f: Use new "bashbrew" composite action

kibana:
- https://github.com/docker-library/kibana/commit/e69ce22: Update to 8.5.2
- https://github.com/docker-library/kibana/commit/aa11bff: Use new "bashbrew" composite action