### PR TITLE
[oraclelinux] Updating 7/7-slim/8/8-slim/9/9-slim for amd64/arm64v8 for multiple errata

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8e0e115e775ded55c53c70099299d3cca9d26c21
+amd64-GitCommit: f898ff642f34ca184b97bed10199756e46f9c5ea
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 247fb3c8278a1d72d52d0dc1b4fa72bd4d51a951
+arm64v8-GitCommit: 33dd6ead13af47304e245b36ff3ff48662ff9a59
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-42898, CVE-2022-42919, CVE-2022-37434 and tzdata updates.

See the following for details:

https://linux.oracle.com/errata/ELSA-2022-8640.html
https://linux.oracle.com/errata/ELSA-2022-8638.html
https://linux.oracle.com/errata/ELSA-2022-8493.html
https://linux.oracle.com/errata/ELSA-2022-8637.html
https://linux.oracle.com/errata/ELSA-2022-9987.html
https://linux.oracle.com/errata/ELBA-2022-8447.html
https://linux.oracle.com/errata/ELBA-2022-8499.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>