### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,35 +1,20 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/891b7108294a629e6cc16c2f4bf643d9475894cc/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/9805367fb85866f8a273a0c983f274e3be98638a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.1.1-apache, 6.1-apache, 6-apache, apache, 6.1.1, 6.1, 6, latest, 6.1.1-php7.4-apache, 6.1-php7.4-apache, 6-php7.4-apache, php7.4-apache, 6.1.1-php7.4, 6.1-php7.4, 6-php7.4, php7.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
-Directory: latest/php7.4/apache
-
-Tags: 6.1.1-fpm, 6.1-fpm, 6-fpm, fpm, 6.1.1-php7.4-fpm, 6.1-php7.4-fpm, 6-php7.4-fpm, php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
-Directory: latest/php7.4/fpm
-
-Tags: 6.1.1-fpm-alpine, 6.1-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.1.1-php7.4-fpm-alpine, 6.1-php7.4-fpm-alpine, 6-php7.4-fpm-alpine, php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
-Directory: latest/php7.4/fpm-alpine
-
-Tags: 6.1.1-php8.0-apache, 6.1-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.1.1-php8.0, 6.1-php8.0, 6-php8.0, php8.0
+Tags: 6.1.1-apache, 6.1-apache, 6-apache, apache, 6.1.1, 6.1, 6, latest, 6.1.1-php8.0-apache, 6.1-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.1.1-php8.0, 6.1-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
 Directory: latest/php8.0/apache
 
-Tags: 6.1.1-php8.0-fpm, 6.1-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.1.1-fpm, 6.1-fpm, 6-fpm, fpm, 6.1.1-php8.0-fpm, 6.1-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
 Directory: latest/php8.0/fpm
 
-Tags: 6.1.1-php8.0-fpm-alpine, 6.1-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.1.1-fpm-alpine, 6.1-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.1.1-php8.0-fpm-alpine, 6.1-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
 Directory: latest/php8.0/fpm-alpine
@@ -49,12 +34,7 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
 Directory: latest/php8.1/fpm-alpine
 
-Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php7.4, cli-2.7-php7.4, cli-2-php7.4, cli-php7.4
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
-Directory: cli/php7.4/alpine
-
-Tags: cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
 Directory: cli/php8.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/69b6ba6: Merge pull request https://github.com/docker-library/wordpress/pull/775 from infosiftr/php7.4eol
- https://github.com/docker-library/wordpress/commit/9805367: Remove EOL PHP 7.4 and update default version (conservatively) to 8.0
- https://github.com/docker-library/wordpress/commit/2da4702: Use new "bashbrew" composite action