### PR TITLE
MariaDB update - work around for old-mode=""

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,45 +6,45 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.11.1-rc-jammy, 10.11-rc-jammy, 10.11.1-rc, 10.11-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6a881f0800e0771afd9a291cb28b5ffef4322121
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.11
 
 Tags: 10.10.2-jammy, 10.10-jammy, 10-jammy, jammy, 10.10.2, 10.10, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6a881f0800e0771afd9a291cb28b5ffef4322121
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.10
 
 Tags: 10.9.4-jammy, 10.9-jammy, 10.9.4, 10.9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.9
 
 Tags: 10.8.6-jammy, 10.8-jammy, 10.8.6, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.8
 
 Tags: 10.7.7-focal, 10.7-focal, 10.7.7, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.7
 
 Tags: 10.6.11-focal, 10.6-focal, 10.6.11, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.6
 
 Tags: 10.5.18-focal, 10.5-focal, 10.5.18, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.5
 
 Tags: 10.4.27-focal, 10.4-focal, 10.4.27, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.4
 
 Tags: 10.3.37-focal, 10.3-focal, 10.3.37, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: cefc4b4c1e72cb63ad66642438dbf8d84808515d
+GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
 Directory: 10.3


### PR DESCRIPTION
A upstream bug report https://jira.mariadb.org/browse/MDEV-30126 is causing troubles with utf8mb4 testing.