### PR TITLE
[security] Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 5.0.3, 5.0, 5, latest, 5.0.3-bullseye, 5.0-bullseye, 5-bullseye, bullseye
+Tags: 5.0.4, 5.0, 5, latest, 5.0.4-bullseye, 5.0-bullseye, 5-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cae991b96a33dbf0771dc73c5e145c9badc4c6c8
+GitCommit: 8749011cf59188062efd880e64cd69e800e1d447
 Directory: 5.0
 
-Tags: 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.3-alpine3.15, 5.0-alpine3.15, 5-alpine3.15, alpine3.15
+Tags: 5.0.4-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.4-alpine3.16, 5.0-alpine3.16, 5-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cae991b96a33dbf0771dc73c5e145c9badc4c6c8
+GitCommit: 8749011cf59188062efd880e64cd69e800e1d447
 Directory: 5.0/alpine
 
-Tags: 4.2.8, 4.2, 4, 4.2.8-bullseye, 4.2-bullseye, 4-bullseye
+Tags: 4.2.9, 4.2, 4, 4.2.9-bullseye, 4.2-bullseye, 4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cae991b96a33dbf0771dc73c5e145c9badc4c6c8
+GitCommit: 6ba68a3fdcc615faab7fa8e32e7b3bf8247a5fb8
 Directory: 4.2
 
-Tags: 4.2.8-passenger, 4.2-passenger, 4-passenger
+Tags: 4.2.9-passenger, 4.2-passenger, 4-passenger
 Architectures: amd64
 GitCommit: 160a6433d3c392e0f332b5b62317117a2d7de943
 Directory: 4.2/passenger
 
-Tags: 4.2.8-alpine, 4.2-alpine, 4-alpine, 4.2.8-alpine3.15, 4.2-alpine3.15, 4-alpine3.15
+Tags: 4.2.9-alpine, 4.2-alpine, 4-alpine, 4.2.9-alpine3.16, 4.2-alpine3.16, 4-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cae991b96a33dbf0771dc73c5e145c9badc4c6c8
+GitCommit: 6ba68a3fdcc615faab7fa8e32e7b3bf8247a5fb8
 Directory: 4.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/8749011: Update to 5.0.4
- https://github.com/docker-library/redmine/commit/6ba68a3: Update to 4.2.9
- https://github.com/docker-library/redmine/commit/ca94318: Merge pull request https://github.com/docker-library/redmine/pull/280 from J0WI/alpine-3.16
- https://github.com/docker-library/redmine/commit/0bd1b10: Alpine 3.16
- https://github.com/docker-library/redmine/commit/9ba27b7: Use new "bashbrew" composite action