### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 20-ea-25-jdk-oraclelinux8, 20-ea-25-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-25-jdk-oracle, 20-ea-25-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-25-jdk, 20-ea-25, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-26-jdk-oraclelinux8, 20-ea-26-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-26-jdk-oracle, 20-ea-26-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-26-jdk, 20-ea-26, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-25-jdk-oraclelinux7, 20-ea-25-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-26-jdk-oraclelinux7, 20-ea-26-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-25-jdk-bullseye, 20-ea-25-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-26-jdk-bullseye, 20-ea-26-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-25-jdk-slim-bullseye, 20-ea-25-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-25-jdk-slim, 20-ea-25-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-26-jdk-slim-bullseye, 20-ea-26-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-26-jdk-slim, 20-ea-26-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-25-jdk-buster, 20-ea-25-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-26-jdk-buster, 20-ea-26-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/buster
 
-Tags: 20-ea-25-jdk-slim-buster, 20-ea-25-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-26-jdk-slim-buster, 20-ea-26-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-25-jdk-windowsservercore-ltsc2022, 20-ea-25-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-25-jdk-windowsservercore, 20-ea-25-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-25-jdk, 20-ea-25, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-26-jdk-windowsservercore-ltsc2022, 20-ea-26-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-26-jdk-windowsservercore, 20-ea-26-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-26-jdk, 20-ea-26, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-25-jdk-windowsservercore-1809, 20-ea-25-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-25-jdk-windowsservercore, 20-ea-25-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-25-jdk, 20-ea-25, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-26-jdk-windowsservercore-1809, 20-ea-26-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-26-jdk-windowsservercore, 20-ea-26-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-26-jdk, 20-ea-26, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-25-jdk-nanoserver-1809, 20-ea-25-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-25-jdk-nanoserver, 20-ea-25-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-26-jdk-nanoserver-1809, 20-ea-26-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-26-jdk-nanoserver, 20-ea-26-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: 6e6e0b1dee85bcdf3cf222160a194b3e87a185dc
+GitCommit: c0ad2e3351d64a0cb01344b6eff945f5d68387c7
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/c0ad2e3: Update 20 to 20-ea+26
- https://github.com/docker-library/openjdk/commit/009158e: Add Alpine 3.17