### PR TITLE
Odoo: update 14.0-16.0 to release 20221202

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 456817151ac2b45022d0663bfdaf8d83707e847a
+GitCommit: 7f1788b597f69ba59dcb8d7b8d92ab1693bc7ee1
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks