### PR TITLE
archlinux: Release 20221204.0.107760

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221127.0.105785
-GitCommit: aa8f563141c27f08b425ced81a9584560b4e1bf9
-GitFetch: refs/tags/v20221127.0.105785
+Tags: latest, base, base-20221204.0.107760
+GitCommit: 25ca9ad7ab60dafe030d019b2cff1cdf00aa7a36
+GitFetch: refs/tags/v20221204.0.107760
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221127.0.105785
-GitCommit: aa8f563141c27f08b425ced81a9584560b4e1bf9
-GitFetch: refs/tags/v20221127.0.105785
+Tags: base-devel, base-devel-20221204.0.107760
+GitCommit: 25ca9ad7ab60dafe030d019b2cff1cdf00aa7a36
+GitFetch: refs/tags/v20221204.0.107760
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks