### PR TITLE
Update Clear Linux OS to 37710

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 0f20619a2d5a034fc1c733d6d5acc4f3bf2b664b
-GitFetch: refs/heads/base-37680
+GitCommit: 34a1328d36bfa76e328368bdf86966893e7914d2
+GitFetch: refs/heads/base-37710


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37710

@bryteise @djklimes @bryteise