### PR TITLE
mediawiki: Add 1.39, drop 1.37, switch to PHP 8

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,36 +2,36 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 5d098737ac1b1eb8a30a5b8277cd7f3f93a467ea
+GitCommit: fb212193436a531e326bf456cfb3c50b789478fa
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.38.4, 1.38, stable, latest
+Tags: 1.39.0, 1.39, stable, lts, latest
+Directory: 1.39/apache
+
+Tags: 1.39.0-fpm, 1.39-fpm, stable-fpm, lts-fpm
+Directory: 1.39/fpm
+
+Tags: 1.39.0-fpm-alpine, 1.39-fpm-alpine, stable-fpm-alpine, lts-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Directory: 1.39/fpm-alpine
+
+Tags: 1.38.4, 1.38, legacy
 Directory: 1.38/apache
 
-Tags: 1.38.4-fpm, 1.38-fpm, stable-fpm
+Tags: 1.38.4-fpm, 1.38-fpm, legacy-fpm
 Directory: 1.38/fpm
 
-Tags: 1.38.4-fpm-alpine, 1.38-fpm-alpine, stable-fpm-alpine
+Tags: 1.38.4-fpm-alpine, 1.38-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.38/fpm-alpine
 
-Tags: 1.37.6, 1.37, legacy
-Directory: 1.37/apache
-
-Tags: 1.37.6-fpm, 1.37-fpm, legacy-fpm
-Directory: 1.37/fpm
-
-Tags: 1.37.6-fpm-alpine, 1.37-fpm-alpine, legacy-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-Directory: 1.37/fpm-alpine
-
-Tags: 1.35.8, 1.35, lts, legacylts
+Tags: 1.35.8, 1.35, legacylts
 Directory: 1.35/apache
 
-Tags: 1.35.8-fpm, 1.35-fpm, lts-fpm, legacylts-fpm
+Tags: 1.35.8-fpm, 1.35-fpm, legacylts-fpm
 Directory: 1.35/fpm
 
-Tags: 1.35.8-fpm-alpine, 1.35-fpm-alpine, lts-fpm-alpine, legacylts-fpm-alpine
+Tags: 1.35.8-fpm-alpine, 1.35-fpm-alpine, legacylts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.35/fpm-alpine
 


### PR DESCRIPTION
* 1.39.0 is now the new "stable" and "lts" using PHP 8.1
* 1.38 is now "legacy"
* 1.37 is EOL and removed
* The remaining images are now based on PHP 8.0

See:
* https://github.com/wikimedia/mediawiki-docker/pull/116
* https://github.com/wikimedia/mediawiki-docker/pull/117