### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 04ca906f4c72c8c4ec1eeb98fe80e5ecdfe1d791
 Directory: 2.7/alpine
 
-Tags: 2.6.6, 2.6, lts, 2.6.6-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.7, 2.6, lts, 2.6.7-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bfdb47e3bb0de8315bf08876d7720ab3f46ccc28
+GitCommit: 9ae13c91cf82c4042360a0363b4d3fa190a51341
 Directory: 2.6
 
-Tags: 2.6.6-alpine, 2.6-alpine, lts-alpine, 2.6.6-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.7-alpine, 2.6-alpine, lts-alpine, 2.6.7-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95fe4acadbc54495913fc1361daedfc65df2a3a6
+GitCommit: 9ae13c91cf82c4042360a0363b4d3fa190a51341
 Directory: 2.6/alpine
 
-Tags: 2.5.9, 2.5, 2.5.9-bullseye, 2.5-bullseye
+Tags: 2.5.10, 2.5, 2.5.10-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 18c82fca3a11dc33c652328275a13155de6b054b
+GitCommit: 541751988360a0ee55b6bee53c2d41acafaee35d
 Directory: 2.5
 
-Tags: 2.5.9-alpine, 2.5-alpine, 2.5.9-alpine3.17, 2.5-alpine3.17
+Tags: 2.5.10-alpine, 2.5-alpine, 2.5.10-alpine3.17, 2.5-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95fe4acadbc54495913fc1361daedfc65df2a3a6
+GitCommit: 541751988360a0ee55b6bee53c2d41acafaee35d
 Directory: 2.5/alpine
 
 Tags: 2.4.19, 2.4, 2.4.19-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5417519: Update 2.5 to 2.5.10
- https://github.com/docker-library/haproxy/commit/9ae13c9: Update 2.6 to 2.6.7