### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 22.06.0-beta.0-cli, 22.06-rc-cli, rc-cli, 22.06.0-beta.0-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 17b24e681dd70d504a7f8140114a6d4baa6112c8
+GitCommit: a1332d3535f30e56c5d2e923f97549a20474059e
 Directory: 22.06-rc/cli
 
 Tags: 22.06.0-beta.0-dind, 22.06-rc-dind, rc-dind, 22.06.0-beta.0-dind-alpine3.17, 22.06.0-beta.0, 22.06-rc, rc, 22.06.0-beta.0-alpine3.17
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.21-cli, 20.10-cli, 20-cli, cli, 20.10.21-cli-alpine3.17, 20.10.21, 20.10, 20, latest, 20.10.21-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 17b24e681dd70d504a7f8140114a6d4baa6112c8
+GitCommit: d07d0bccbb31c1272ca7734a31d7ffa9e2a423aa
 Directory: 20.10/cli
 
 Tags: 20.10.21-dind, 20.10-dind, 20-dind, dind, 20.10.21-dind-alpine3.17


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/a1332d3: Update 22.06-rc to compose 2.14.0
- https://github.com/docker-library/docker/commit/d07d0bc: Update 20.10 to compose 2.14.0