### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,47 +1,47 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/32906bce8decc79bb0ea36974c05899663c7a4ce/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/722a28618574f1cb95c8913e9d603fb506e2a005/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 32906bce8decc79bb0ea36974c05899663c7a4ce
+GitCommit: 722a28618574f1cb95c8913e9d603fb506e2a005
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6304ea45c8e95574e40443c76f626c37e8af913f
+amd64-GitCommit: 4bcc936d8c90dfcf40b4c2728bb8150c2ee5cb82
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 081219704c8d5add75f02134100b5f5394fbc973
+arm32v5-GitCommit: 44350d7e6cb14808b40ef84aac7c5bdb8f93462d
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: eb1b7e0fcf35906c5ace281774f340838f79e8e9
+arm32v6-GitCommit: 497a3a967c09c327b84664445b43761384d55da0
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 749772a485c7dbfe5da09c2dcccd389311a9b231
+arm32v7-GitCommit: b5f1e9a8c6d4ff6fec6b6be528064c1d975c77cd
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2d6416693220b51b176bbd0d214ab4f104809ee7
+arm64v8-GitCommit: 740de92d37b1589809bdf8c17d94ee7be7acf255
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 989baf1ae8a35afe3cbd4c6b44193f357565ea49
+i386-GitCommit: 8ef0783a61092fc34718de7db1579cf2e694b432
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 90bc45635d07aeef1b636bca7f8242df676cc5b9
+mips64le-GitCommit: a020aef7981547a9efbd46ed4fa543076db978ec
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 22edb3d8ef2c9c644e3df08fc6ab6e5911cae999
+ppc64le-GitCommit: 509581849a07a77f52a8356b181b9d242c87b945
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: ba908cb4bf94c3ff5e259475b6426eafb8039a00
+riscv64-GitCommit: fce0e67b610ae4706e91f464210218194f1e6e8a
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 5eb4b7e578808112beb56d7d69a148eaa942d778
-
-Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64
-Directory: stable/uclibc
+s390x-GitCommit: 45d0107c21b3d79824cbff6b442290da17e37ac1
 
 Tags: 1.34.1-glibc, 1.34-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: stable/glibc
+
+Tags: 1.34.1-uclibc, 1.34-uclibc, 1-uclibc, stable-uclibc, uclibc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64
+Directory: stable/uclibc
 
 Tags: 1.34.1-musl, 1.34-musl, 1-musl, stable-musl, musl
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -49,24 +49,24 @@ Directory: stable/musl
 
 Tags: 1.34.1, 1.34, 1, stable, latest
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
-amd64-Directory: stable/uclibc
-arm32v5-Directory: stable/uclibc
+amd64-Directory: stable/glibc
+arm32v5-Directory: stable/glibc
 arm32v6-Directory: stable/musl
-arm32v7-Directory: stable/uclibc
-arm64v8-Directory: stable/uclibc
-i386-Directory: stable/uclibc
-mips64le-Directory: stable/uclibc
+arm32v7-Directory: stable/glibc
+arm64v8-Directory: stable/glibc
+i386-Directory: stable/glibc
+mips64le-Directory: stable/glibc
 ppc64le-Directory: stable/glibc
 riscv64-Directory: stable/uclibc
 s390x-Directory: stable/glibc
 
-Tags: 1.35.0-uclibc, 1.35-uclibc, unstable-uclibc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64
-Directory: unstable/uclibc
-
 Tags: 1.35.0-glibc, 1.35-glibc, unstable-glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: unstable/glibc
+
+Tags: 1.35.0-uclibc, 1.35-uclibc, unstable-uclibc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, riscv64
+Directory: unstable/uclibc
 
 Tags: 1.35.0-musl, 1.35-musl, unstable-musl
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
@@ -74,13 +74,13 @@ Directory: unstable/musl
 
 Tags: 1.35.0, 1.35, unstable
 Architectures: amd64, arm32v5, arm32v6, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
-amd64-Directory: unstable/uclibc
-arm32v5-Directory: unstable/uclibc
+amd64-Directory: unstable/glibc
+arm32v5-Directory: unstable/glibc
 arm32v6-Directory: unstable/musl
-arm32v7-Directory: unstable/uclibc
-arm64v8-Directory: unstable/uclibc
-i386-Directory: unstable/uclibc
-mips64le-Directory: unstable/uclibc
+arm32v7-Directory: unstable/glibc
+arm64v8-Directory: unstable/glibc
+i386-Directory: unstable/glibc
+mips64le-Directory: unstable/glibc
 ppc64le-Directory: unstable/glibc
 riscv64-Directory: unstable/uclibc
 s390x-Directory: unstable/glibc


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/722a286: Merge pull request https://github.com/docker-library/busybox/pull/154 from infosiftr/buildroot-2022.11
- https://github.com/docker-library/busybox/commit/4858368: Update "glibc" variants to be the default variants
- https://github.com/docker-library/busybox/commit/b98be8f: Update buildroot to 2022.11