### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -1,145 +1,110 @@
-# this file is generated via https://github.com/docker-library/pypy/blob/70b03f0a3fcbe12c8cdc83024cbc5e02dd867871/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/pypy/blob/abf5191569d5cb83f3047d89403085c618023bbf/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 3.9-7.3.9-bullseye, 3.9-7.3-bullseye, 3.9-7-bullseye, 3.9-bullseye
-SharedTags: 3.9-7.3.9, 3.9-7.3, 3.9-7, 3.9
+Tags: 3.9-7.3.10-bullseye, 3.9-7.3-bullseye, 3.9-7-bullseye, 3.9-bullseye, 3-7.3.10-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
+SharedTags: 3.9-7.3.10, 3.9-7.3, 3.9-7, 3.9, 3-7.3.10, 3-7.3, 3-7, 3, latest
 Architectures: amd64, arm64v8, i386
-GitCommit: e855f978c00fba9efb64cf4422eb33067552193e
+GitCommit: 32598c5d1f2c21b171c8429ade65f39d8985724f
 Directory: 3.9/bullseye
 
-Tags: 3.9-7.3.9-slim, 3.9-7.3-slim, 3.9-7-slim, 3.9-slim, 3.9-7.3.9-slim-bullseye, 3.9-7.3-slim-bullseye, 3.9-7-slim-bullseye, 3.9-slim-bullseye
+Tags: 3.9-7.3.10-slim, 3.9-7.3-slim, 3.9-7-slim, 3.9-slim, 3-7.3.10-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.9-7.3.10-slim-bullseye, 3.9-7.3-slim-bullseye, 3.9-7-slim-bullseye, 3.9-slim-bullseye, 3-7.3.10-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: e855f978c00fba9efb64cf4422eb33067552193e
+GitCommit: 32598c5d1f2c21b171c8429ade65f39d8985724f
 Directory: 3.9/slim-bullseye
 
-Tags: 3.9-7.3.9-buster, 3.9-7.3-buster, 3.9-7-buster, 3.9-buster
+Tags: 3.9-7.3.10-buster, 3.9-7.3-buster, 3.9-7-buster, 3.9-buster, 3-7.3.10-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
 Architectures: amd64, arm64v8, i386
-GitCommit: e855f978c00fba9efb64cf4422eb33067552193e
+GitCommit: 32598c5d1f2c21b171c8429ade65f39d8985724f
 Directory: 3.9/buster
 
-Tags: 3.9-7.3.9-slim-buster, 3.9-7.3-slim-buster, 3.9-7-slim-buster, 3.9-slim-buster
+Tags: 3.9-7.3.10-slim-buster, 3.9-7.3-slim-buster, 3.9-7-slim-buster, 3.9-slim-buster, 3-7.3.10-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: e855f978c00fba9efb64cf4422eb33067552193e
+GitCommit: 32598c5d1f2c21b171c8429ade65f39d8985724f
 Directory: 3.9/slim-buster
 
-Tags: 3.9-7.3.9-windowsservercore-ltsc2022, 3.9-7.3-windowsservercore-ltsc2022, 3.9-7-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
-SharedTags: 3.9-7.3.9, 3.9-7.3, 3.9-7, 3.9, 3.9-7.3.9-windowsservercore, 3.9-7.3-windowsservercore, 3.9-7-windowsservercore, 3.9-windowsservercore
+Tags: 3.9-7.3.10-windowsservercore-ltsc2022, 3.9-7.3-windowsservercore-ltsc2022, 3.9-7-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022, 3-7.3.10-windowsservercore-ltsc2022, 3-7.3-windowsservercore-ltsc2022, 3-7-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 3.9-7.3.10, 3.9-7.3, 3.9-7, 3.9, 3-7.3.10, 3-7.3, 3-7, 3, latest, 3.9-7.3.10-windowsservercore, 3.9-7.3-windowsservercore, 3.9-7-windowsservercore, 3.9-windowsservercore, 3-7.3.10-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: e855f978c00fba9efb64cf4422eb33067552193e
+GitCommit: 32598c5d1f2c21b171c8429ade65f39d8985724f
 Directory: 3.9/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.9-7.3.9-windowsservercore-1809, 3.9-7.3-windowsservercore-1809, 3.9-7-windowsservercore-1809, 3.9-windowsservercore-1809
-SharedTags: 3.9-7.3.9, 3.9-7.3, 3.9-7, 3.9, 3.9-7.3.9-windowsservercore, 3.9-7.3-windowsservercore, 3.9-7-windowsservercore, 3.9-windowsservercore
+Tags: 3.9-7.3.10-windowsservercore-1809, 3.9-7.3-windowsservercore-1809, 3.9-7-windowsservercore-1809, 3.9-windowsservercore-1809, 3-7.3.10-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.9-7.3.10, 3.9-7.3, 3.9-7, 3.9, 3-7.3.10, 3-7.3, 3-7, 3, latest, 3.9-7.3.10-windowsservercore, 3.9-7.3-windowsservercore, 3.9-7-windowsservercore, 3.9-windowsservercore, 3-7.3.10-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: e855f978c00fba9efb64cf4422eb33067552193e
+GitCommit: 32598c5d1f2c21b171c8429ade65f39d8985724f
 Directory: 3.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.8-7.3.9-bullseye, 3.8-7.3-bullseye, 3.8-7-bullseye, 3.8-bullseye, 3-7.3.9-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
-SharedTags: 3.8-7.3.9, 3.8-7.3, 3.8-7, 3.8, 3-7.3.9, 3-7.3, 3-7, 3, latest
+Tags: 3.8-7.3.10-bullseye, 3.8-7.3-bullseye, 3.8-7-bullseye, 3.8-bullseye
+SharedTags: 3.8-7.3.10, 3.8-7.3, 3.8-7, 3.8
 Architectures: amd64, arm64v8, i386
-GitCommit: fdbc2ce6545ee14e29c7eaf78f645de9b3f082d0
+GitCommit: 89f5c1ed18630a3b989b17ff1688fbfe7b8a7102
 Directory: 3.8/bullseye
 
-Tags: 3.8-7.3.9-slim, 3.8-7.3-slim, 3.8-7-slim, 3.8-slim, 3-7.3.9-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.8-7.3.9-slim-bullseye, 3.8-7.3-slim-bullseye, 3.8-7-slim-bullseye, 3.8-slim-bullseye, 3-7.3.9-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.8-7.3.10-slim, 3.8-7.3-slim, 3.8-7-slim, 3.8-slim, 3.8-7.3.10-slim-bullseye, 3.8-7.3-slim-bullseye, 3.8-7-slim-bullseye, 3.8-slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: fdbc2ce6545ee14e29c7eaf78f645de9b3f082d0
+GitCommit: 89f5c1ed18630a3b989b17ff1688fbfe7b8a7102
 Directory: 3.8/slim-bullseye
 
-Tags: 3.8-7.3.9-buster, 3.8-7.3-buster, 3.8-7-buster, 3.8-buster, 3-7.3.9-buster, 3-7.3-buster, 3-7-buster, 3-buster, buster
+Tags: 3.8-7.3.10-buster, 3.8-7.3-buster, 3.8-7-buster, 3.8-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: fdbc2ce6545ee14e29c7eaf78f645de9b3f082d0
+GitCommit: 89f5c1ed18630a3b989b17ff1688fbfe7b8a7102
 Directory: 3.8/buster
 
-Tags: 3.8-7.3.9-slim-buster, 3.8-7.3-slim-buster, 3.8-7-slim-buster, 3.8-slim-buster, 3-7.3.9-slim-buster, 3-7.3-slim-buster, 3-7-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.8-7.3.10-slim-buster, 3.8-7.3-slim-buster, 3.8-7-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: fdbc2ce6545ee14e29c7eaf78f645de9b3f082d0
+GitCommit: 89f5c1ed18630a3b989b17ff1688fbfe7b8a7102
 Directory: 3.8/slim-buster
 
-Tags: 3.8-7.3.9-windowsservercore-ltsc2022, 3.8-7.3-windowsservercore-ltsc2022, 3.8-7-windowsservercore-ltsc2022, 3.8-windowsservercore-ltsc2022, 3-7.3.9-windowsservercore-ltsc2022, 3-7.3-windowsservercore-ltsc2022, 3-7-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 3.8-7.3.9, 3.8-7.3, 3.8-7, 3.8, 3-7.3.9, 3-7.3, 3-7, 3, latest, 3.8-7.3.9-windowsservercore, 3.8-7.3-windowsservercore, 3.8-7-windowsservercore, 3.8-windowsservercore, 3-7.3.9-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.8-7.3.10-windowsservercore-ltsc2022, 3.8-7.3-windowsservercore-ltsc2022, 3.8-7-windowsservercore-ltsc2022, 3.8-windowsservercore-ltsc2022
+SharedTags: 3.8-7.3.10, 3.8-7.3, 3.8-7, 3.8, 3.8-7.3.10-windowsservercore, 3.8-7.3-windowsservercore, 3.8-7-windowsservercore, 3.8-windowsservercore
 Architectures: windows-amd64
-GitCommit: fdbc2ce6545ee14e29c7eaf78f645de9b3f082d0
+GitCommit: 89f5c1ed18630a3b989b17ff1688fbfe7b8a7102
 Directory: 3.8/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.8-7.3.9-windowsservercore-1809, 3.8-7.3-windowsservercore-1809, 3.8-7-windowsservercore-1809, 3.8-windowsservercore-1809, 3-7.3.9-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.8-7.3.9, 3.8-7.3, 3.8-7, 3.8, 3-7.3.9, 3-7.3, 3-7, 3, latest, 3.8-7.3.9-windowsservercore, 3.8-7.3-windowsservercore, 3.8-7-windowsservercore, 3.8-windowsservercore, 3-7.3.9-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.8-7.3.10-windowsservercore-1809, 3.8-7.3-windowsservercore-1809, 3.8-7-windowsservercore-1809, 3.8-windowsservercore-1809
+SharedTags: 3.8-7.3.10, 3.8-7.3, 3.8-7, 3.8, 3.8-7.3.10-windowsservercore, 3.8-7.3-windowsservercore, 3.8-7-windowsservercore, 3.8-windowsservercore
 Architectures: windows-amd64
-GitCommit: fdbc2ce6545ee14e29c7eaf78f645de9b3f082d0
+GitCommit: 89f5c1ed18630a3b989b17ff1688fbfe7b8a7102
 Directory: 3.8/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.7-7.3.9-bullseye, 3.7-7.3-bullseye, 3.7-7-bullseye, 3.7-bullseye
-SharedTags: 3.7-7.3.9, 3.7-7.3, 3.7-7, 3.7
+Tags: 2.7-7.3.10-bullseye, 2.7-7.3-bullseye, 2.7-7-bullseye, 2.7-bullseye, 2-7.3.10-bullseye, 2-7.3-bullseye, 2-7-bullseye, 2-bullseye
+SharedTags: 2.7-7.3.10, 2.7-7.3, 2.7-7, 2.7, 2-7.3.10, 2-7.3, 2-7, 2
 Architectures: amd64, arm64v8, i386
-GitCommit: 98e45c6a79a277cf6a665c3d488863bdcb4bdc9b
-Directory: 3.7/bullseye
-
-Tags: 3.7-7.3.9-slim, 3.7-7.3-slim, 3.7-7-slim, 3.7-slim, 3.7-7.3.9-slim-bullseye, 3.7-7.3-slim-bullseye, 3.7-7-slim-bullseye, 3.7-slim-bullseye
-Architectures: amd64, arm64v8, i386
-GitCommit: 98e45c6a79a277cf6a665c3d488863bdcb4bdc9b
-Directory: 3.7/slim-bullseye
-
-Tags: 3.7-7.3.9-buster, 3.7-7.3-buster, 3.7-7-buster, 3.7-buster
-Architectures: amd64, arm64v8, i386
-GitCommit: 98e45c6a79a277cf6a665c3d488863bdcb4bdc9b
-Directory: 3.7/buster
-
-Tags: 3.7-7.3.9-slim-buster, 3.7-7.3-slim-buster, 3.7-7-slim-buster, 3.7-slim-buster
-Architectures: amd64, arm64v8, i386
-GitCommit: 98e45c6a79a277cf6a665c3d488863bdcb4bdc9b
-Directory: 3.7/slim-buster
-
-Tags: 3.7-7.3.9-windowsservercore-ltsc2022, 3.7-7.3-windowsservercore-ltsc2022, 3.7-7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022
-SharedTags: 3.7-7.3.9, 3.7-7.3, 3.7-7, 3.7, 3.7-7.3.9-windowsservercore, 3.7-7.3-windowsservercore, 3.7-7-windowsservercore, 3.7-windowsservercore
-Architectures: windows-amd64
-GitCommit: 98e45c6a79a277cf6a665c3d488863bdcb4bdc9b
-Directory: 3.7/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 3.7-7.3.9-windowsservercore-1809, 3.7-7.3-windowsservercore-1809, 3.7-7-windowsservercore-1809, 3.7-windowsservercore-1809
-SharedTags: 3.7-7.3.9, 3.7-7.3, 3.7-7, 3.7, 3.7-7.3.9-windowsservercore, 3.7-7.3-windowsservercore, 3.7-7-windowsservercore, 3.7-windowsservercore
-Architectures: windows-amd64
-GitCommit: 98e45c6a79a277cf6a665c3d488863bdcb4bdc9b
-Directory: 3.7/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 2.7-7.3.9-bullseye, 2.7-7.3-bullseye, 2.7-7-bullseye, 2.7-bullseye, 2-7.3.9-bullseye, 2-7.3-bullseye, 2-7-bullseye, 2-bullseye
-SharedTags: 2.7-7.3.9, 2.7-7.3, 2.7-7, 2.7, 2-7.3.9, 2-7.3, 2-7, 2
-Architectures: amd64, arm64v8, i386
-GitCommit: 21e3f64aaf1448107a1d3642acfc2ac8c6166523
+GitCommit: cc5b53aefe4d8b07a512528365e89c01d64b3274
 Directory: 2.7/bullseye
 
-Tags: 2.7-7.3.9-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.9-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.9-slim-bullseye, 2.7-7.3-slim-bullseye, 2.7-7-slim-bullseye, 2.7-slim-bullseye, 2-7.3.9-slim-bullseye, 2-7.3-slim-bullseye, 2-7-slim-bullseye, 2-slim-bullseye
+Tags: 2.7-7.3.10-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.10-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.10-slim-bullseye, 2.7-7.3-slim-bullseye, 2.7-7-slim-bullseye, 2.7-slim-bullseye, 2-7.3.10-slim-bullseye, 2-7.3-slim-bullseye, 2-7-slim-bullseye, 2-slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: 21e3f64aaf1448107a1d3642acfc2ac8c6166523
+GitCommit: cc5b53aefe4d8b07a512528365e89c01d64b3274
 Directory: 2.7/slim-bullseye
 
-Tags: 2.7-7.3.9-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.9-buster, 2-7.3-buster, 2-7-buster, 2-buster
+Tags: 2.7-7.3.10-buster, 2.7-7.3-buster, 2.7-7-buster, 2.7-buster, 2-7.3.10-buster, 2-7.3-buster, 2-7-buster, 2-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: 21e3f64aaf1448107a1d3642acfc2ac8c6166523
+GitCommit: cc5b53aefe4d8b07a512528365e89c01d64b3274
 Directory: 2.7/buster
 
-Tags: 2.7-7.3.9-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.9-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
+Tags: 2.7-7.3.10-slim-buster, 2.7-7.3-slim-buster, 2.7-7-slim-buster, 2.7-slim-buster, 2-7.3.10-slim-buster, 2-7.3-slim-buster, 2-7-slim-buster, 2-slim-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: 21e3f64aaf1448107a1d3642acfc2ac8c6166523
+GitCommit: cc5b53aefe4d8b07a512528365e89c01d64b3274
 Directory: 2.7/slim-buster
 
-Tags: 2.7-7.3.9-windowsservercore-ltsc2022, 2.7-7.3-windowsservercore-ltsc2022, 2.7-7-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-7.3.9-windowsservercore-ltsc2022, 2-7.3-windowsservercore-ltsc2022, 2-7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
-SharedTags: 2.7-7.3.9, 2.7-7.3, 2.7-7, 2.7, 2-7.3.9, 2-7.3, 2-7, 2, 2.7-7.3.9-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.9-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
+Tags: 2.7-7.3.10-windowsservercore-ltsc2022, 2.7-7.3-windowsservercore-ltsc2022, 2.7-7-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-7.3.10-windowsservercore-ltsc2022, 2-7.3-windowsservercore-ltsc2022, 2-7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
+SharedTags: 2.7-7.3.10, 2.7-7.3, 2.7-7, 2.7, 2-7.3.10, 2-7.3, 2-7, 2, 2.7-7.3.10-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.10-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: 21e3f64aaf1448107a1d3642acfc2ac8c6166523
+GitCommit: cc5b53aefe4d8b07a512528365e89c01d64b3274
 Directory: 2.7/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.7-7.3.9-windowsservercore-1809, 2.7-7.3-windowsservercore-1809, 2.7-7-windowsservercore-1809, 2.7-windowsservercore-1809, 2-7.3.9-windowsservercore-1809, 2-7.3-windowsservercore-1809, 2-7-windowsservercore-1809, 2-windowsservercore-1809
-SharedTags: 2.7-7.3.9, 2.7-7.3, 2.7-7, 2.7, 2-7.3.9, 2-7.3, 2-7, 2, 2.7-7.3.9-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.9-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
+Tags: 2.7-7.3.10-windowsservercore-1809, 2.7-7.3-windowsservercore-1809, 2.7-7-windowsservercore-1809, 2.7-windowsservercore-1809, 2-7.3.10-windowsservercore-1809, 2-7.3-windowsservercore-1809, 2-7-windowsservercore-1809, 2-windowsservercore-1809
+SharedTags: 2.7-7.3.10, 2.7-7.3, 2.7-7, 2.7, 2-7.3.10, 2-7.3, 2-7, 2, 2.7-7.3.10-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.10-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: 21e3f64aaf1448107a1d3642acfc2ac8c6166523
+GitCommit: cc5b53aefe4d8b07a512528365e89c01d64b3274
 Directory: 2.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/abf5191: Remove the now-unsupported 3.7 implementation and update latest to point at 3.9 (now no longer beta)
- https://github.com/docker-library/pypy/commit/32598c5: Update 3.9 to 7.3.10, python 3.9.15
- https://github.com/docker-library/pypy/commit/89f5c1e: Update 3.8 to 7.3.10, python 3.8.15
- https://github.com/docker-library/pypy/commit/cc5b53a: Update 2.7 to 7.3.10
- https://github.com/docker-library/pypy/commit/31ad6a8: Use new "bashbrew" composite action
- https://github.com/docker-library/pypy/commit/5decd75: Merge pull request https://github.com/docker-library/pypy/pull/76 from infosiftr/ci-updates
- https://github.com/docker-library/pypy/commit/020406e: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3