### PR TITLE
[oraclelinux] Update Oracle Linux images for tzdata-2022g-1

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f898ff642f34ca184b97bed10199756e46f9c5ea
+amd64-GitCommit: 4205dc2e387076df43d84c44bd2617d8d0770873
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 33dd6ead13af47304e245b36ff3ff48662ff9a59
+arm64v8-GitCommit: fa5836613dda485642d5711df919701945109ae0
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for rebase to tzdata-2022g-1.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>