### PR TITLE
Update to most recent upstream commit

### DIFF
--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,45 +5,45 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 23.0.11-apache, 23.0-apache, 23-apache, 23.0.11, 23.0, 23
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 23/apache
 
 Tags: 23.0.11-fpm, 23.0-fpm, 23-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 23/fpm
 
 Tags: 23.0.11-fpm-alpine, 23.0-fpm-alpine, 23-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 23/fpm-alpine
 
 Tags: 24.0.7-apache, 24.0-apache, 24-apache, stable-apache, production-apache, 24.0.7, 24.0, 24, stable, production
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 24/apache
 
 Tags: 24.0.7-fpm, 24.0-fpm, 24-fpm, stable-fpm, production-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 24/fpm
 
 Tags: 24.0.7-fpm-alpine, 24.0-fpm-alpine, 24-fpm-alpine, stable-fpm-alpine, production-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 24/fpm-alpine
 
 Tags: 25.0.1-apache, 25.0-apache, 25-apache, apache, 25.0.1, 25.0, 25, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 25/apache
 
 Tags: 25.0.1-fpm, 25.0-fpm, 25-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 25/fpm
 
 Tags: 25.0.1-fpm-alpine, 25.0-fpm-alpine, 25-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 739d6996409825bc61000f0c901ea05fbe3debf7
+GitCommit: 6103e074d81396c235fb453a88f518104cf35382
 Directory: 25/fpm-alpine


### PR DESCRIPTION
The last couple of recently built images are behind upstream. It would be great, if the missing commits could be included. This would i.a. fix https://github.com/nextcloud/docker/pull/1789.