### PR TITLE
Bump Traefik to v3.0.0-beta2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.0-beta1-windowsservercore-1809, 3.0.0-beta1-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
+Tags: v3.0.0-beta2-windowsservercore-1809, 3.0.0-beta2-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a48eeaee4f96e6998ffec9403ac5e7078b2ae7b
+GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.0-beta1, 3.0.0-beta1, v3.0, 3.0, beaufort
+Tags: v3.0.0-beta2, 3.0.0-beta2, v3.0, 3.0, beaufort
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a48eeaee4f96e6998ffec9403ac5e7078b2ae7b
+GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
 Tags: v2.9.5-windowsservercore-1809, 2.9.5-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.0.0-beta2](https://github.com/traefik/traefik/releases/tag/v3.0.0-beta2).

/cc @ldez @rtribotte @ddtmachado

Cheers
