### PR TITLE
Upgrade Backdrop to latest release 1.23.1

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.23.0, 1.23, 1, 1.23.0-apache, 1.23-apache, 1-apache, apache, latest
+Tags: 1.23.1, 1.23, 1, 1.23.1-apache, 1.23-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 69bc3670f97cf6d060e9379bea26b2fcdf0ebc3f
+GitCommit: c49d5d6981533a6b9a5c86076b9b8b08bd04650a
 Directory: 1/apache
 
 Tags: 1.23.0-fpm, 1.23-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 69bc3670f97cf6d060e9379bea26b2fcdf0ebc3f
+GitCommit: c49d5d6981533a6b9a5c86076b9b8b08bd04650a
 Directory: 1/fpm


### PR DESCRIPTION
Here's the latest release in github:
https://github.com/backdrop/backdrop/releases/tag/1.23.1

Here is the link to the latest commits of the backdrop-docker repo: https://github.com/backdrop-ops/backdrop-docker/commits/master