### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -9,7 +9,7 @@ Architectures: amd64, arm64v8
 GitCommit: 75c6c47f14bbb4c598aacfa7210fcbb8c9a566e3
 Directory: 8
 
-Tags: 7.17.7
+Tags: 7.17.8
 Architectures: amd64, arm64v8
-GitCommit: c9d6474663e3d707c9792e793c4e67d6b773f006
+GitCommit: 4ae79746e02c947ff9dae92f7011399f9c809f18
 Directory: 7

--- a/library/kibana
+++ b/library/kibana
@@ -9,7 +9,7 @@ Architectures: amd64, arm64v8
 GitCommit: e69ce229e1dc0e8363781e22f51aa2adb1dc8772
 Directory: 8
 
-Tags: 7.17.7
+Tags: 7.17.8
 Architectures: amd64, arm64v8
-GitCommit: 38a693842d361744c409b655bfa2c1d4a4f90278
+GitCommit: c98bb27941c6b2dafd6d963aab2b0cc9f0876315
 Directory: 7

--- a/library/logstash
+++ b/library/logstash
@@ -9,7 +9,7 @@ Architectures: amd64, arm64v8
 GitCommit: 47f532082b090b099d8df1d7ca07a773581d81fc
 Directory: 8
 
-Tags: 7.17.7
+Tags: 7.17.8
 Architectures: amd64, arm64v8
-GitCommit: 20756581f2b7799bc39b4e47d47722de4fbf3712
+GitCommit: e0450c99e0d55edb3a548a10466153bb42f6eb91
 Directory: 7


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/4ae7974: Update to 7.17.8

logstash:
- https://github.com/docker-library/logstash/commit/e0450c9: Update to 7.17.8

kibana:
- https://github.com/docker-library/kibana/commit/c98bb27: Update to 7.17.8