### PR TITLE
[nats] Release v2.9.9

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -1,29 +1,28 @@
 Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Waldemar Quevedo Salinas <wally@synadia.com> (@wallyqs),
              Byron Ruth <byron@synadia.com> (@bruth),
-             Phil Pennock <pdp@synadia.com> (@philpennock),
-             Ivan Kozlovic <ivan@synadia.com> (@kozlovic)
+             Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 4301229f9496c7227908745a3ebed24bb3e5c578
+GitCommit: 5dfc1776f555b843bc5926a6ba14fc0f8b30b712
 
-Tags: 2.9.8-alpine3.16, 2.9-alpine3.16, 2-alpine3.16, alpine3.16, 2.9.8-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.9-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.9-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.8/alpine3.16
+Directory: 2.9.9/alpine3.17
 
-Tags: 2.9.8-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.8-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.8, 2.9, 2, latest
+Tags: 2.9.9-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.9-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.9, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.8/scratch
+Directory: 2.9.9/scratch
 
-Tags: 2.9.8-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.8-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.9-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.9-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.8/windowsservercore-1809
+Directory: 2.9.9/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.8-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.8-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.8, 2.9, 2, latest
+Tags: 2.9.9-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.9-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.9, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.8/nanoserver-1809
+Directory: 2.9.9/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.9)

Signed-off-by: Waldemar Quevedo <wally@synadia.com>