### PR TITLE
Add ".buildkit-build-contexts.sh" …

### DIFF
--- a/.buildkit-build-contexts.sh
+++ b/.buildkit-build-contexts.sh
@@ -1,0 +1,51 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# given a list of image references, returns an appropriate list of "ref=docker-image://foo@sha256:xxx" for the current architecture
+
+dir="$(dirname "$BASH_SOURCE")"
+
+[ -n "$BASHBREW_ARCH" ]
+archNamespace=
+
+die() {
+	echo >&2 "error: $*"
+	exit 1
+}
+
+for img; do
+	lookup=
+	case "$img" in
+		*@sha256:*)
+			lookup="$img"
+			;;
+
+		*/*)
+			file="$("$dir/.external-pins/file.sh" "$img")" || die "'$img': failed to look up external pin file"
+			digest="$(< "$file")" || die "'$img': failed to read external pin file ('$file')"
+			[ -n "$digest" ] || die "'$img': empty external pin file ('$file')"
+			lookup="${img%@*}@$digest" # img should never have an @ in it here, but just in case
+			;;
+
+		*)
+			[ -n "$BASHBREW_ARCH_NAMESPACES" ] || die 'missing BASHBREW_ARCH_NAMESPACES'
+			archNamespace="${archNamespace:-$(bashbrew cat --format '{{ archNamespace arch }}' "$dir/library/hello-world")}"
+			[ -n "$archNamespace" ] || die "failed to get arch namespace for '$BASHBREW_ARCH'"
+			lookup="$archNamespace/$img"
+			;;
+	esac
+	[ -n "$lookup" ] || die "'$img': failed to determine what image to query"
+
+	json="$(bashbrew remote arches --json "$lookup" || die "'$img': failed lookup ('$lookup')")"
+	digests="$(jq <<<"$json" -r '.arches[env.BASHBREW_ARCH] // [] | map(.digest | @sh) | join(" ")')"
+	eval "digests=( $digests )"
+
+	for digest in "${digests[@]}"; do
+		echo "$img=docker-image://${lookup%@*}@$digest"
+		continue 2
+	done
+
+	digest="$(jq <<<"$json" -r '.desc.digest')"
+	arches="$(jq <<<"$json" -r '.arches | keys | join(" ")')"
+	die "'$img': no appropriate digest for '$BASHBREW_ARCH' found in '$lookup' ('$digest'; arches '$arches')"
+done


### PR DESCRIPTION
…that creates a list of suitable `--build-context` values for passing to build

Example output/usage:

```console
$ BASHBREW_ARCH=amd64 BASHBREW_ARCH_NAMESPACES='amd64 = amd64' ./.buildkit-build-contexts.sh debian:bullseye-slim redhat/ubi9-minimal:latest debian:bullseye debian:buster docker.elastic.co/elasticsearch/elasticsearch:8.5.3@sha256:c9b454f73b1e2365d43f1f46f1b9464b981e5f98c1dd46fee01dbd5a4a446973
debian:bullseye-slim=docker-image://amd64/debian:bullseye-slim@sha256:25f10b4f1ded5341a3ca0a30290ff3cd5639415f0c5a2222d5e7d5dd72952aa1
redhat/ubi9-minimal:latest=docker-image://redhat/ubi9-minimal:latest@sha256:9e99c58835d0c56d08b7e351a1cb5c08cc378efe8badd97fa7a64330a7f8fd0a
debian:bullseye=docker-image://amd64/debian:bullseye@sha256:a4b14cf13428c71a5fce6d9380eb2ac1452a7ae4253e594dc90c8a884fdf3db2
debian:buster=docker-image://amd64/debian:buster@sha256:1487e24b974ca8b859de513d40c7f30606949c1fa1e4057df81b2dc1915edc6a
docker.elastic.co/elasticsearch/elasticsearch:8.5.3@sha256:c9b454f73b1e2365d43f1f46f1b9464b981e5f98c1dd46fee01dbd5a4a446973=docker-image://docker.elastic.co/elasticsearch/elasticsearch:8.5.3@sha256:8d3fef0b747951c6e0599654b03540e751fba19482a557d9827145eaf26cb85a
```

(Explicit Bashbrew-platform resolution, external-pins resolution, etc.)