### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,42 +44,42 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 541751988360a0ee55b6bee53c2d41acafaee35d
 Directory: 2.5/alpine
 
-Tags: 2.4.19, 2.4, 2.4.19-bullseye, 2.4-bullseye
+Tags: 2.4.20, 2.4, 2.4.20-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b07fcf19b4ee54ef37ffbf7241372961ddc97b8c
+GitCommit: 6a15b45320ff96bb7548248596ac0ee3d38d8fab
 Directory: 2.4
 
-Tags: 2.4.19-alpine, 2.4-alpine, 2.4.19-alpine3.17, 2.4-alpine3.17
+Tags: 2.4.20-alpine, 2.4-alpine, 2.4.20-alpine3.17, 2.4-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95fe4acadbc54495913fc1361daedfc65df2a3a6
+GitCommit: 6a15b45320ff96bb7548248596ac0ee3d38d8fab
 Directory: 2.4/alpine
 
-Tags: 2.2.25, 2.2, 2.2.25-bullseye, 2.2-bullseye
+Tags: 2.2.26, 2.2, 2.2.26-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 241d8833cfd3498f40cbd733c4fa7bc53d46f5c7
+GitCommit: 509852454b03fd3aeaad66d46b5f6655275646bb
 Directory: 2.2
 
-Tags: 2.2.25-alpine, 2.2-alpine, 2.2.25-alpine3.17, 2.2-alpine3.17
+Tags: 2.2.26-alpine, 2.2-alpine, 2.2.26-alpine3.17, 2.2-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95fe4acadbc54495913fc1361daedfc65df2a3a6
+GitCommit: 509852454b03fd3aeaad66d46b5f6655275646bb
 Directory: 2.2/alpine
 
-Tags: 2.0.29, 2.0, 2.0.29-buster, 2.0-buster
+Tags: 2.0.30, 2.0, 2.0.30-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dbe220ea2f7df73b4ac848b3b63af0ec7651cb26
+GitCommit: c845b04087b9d388d60f3158670c37c31e7e6fbb
 Directory: 2.0
 
-Tags: 2.0.29-alpine, 2.0-alpine, 2.0.29-alpine3.16, 2.0-alpine3.16
+Tags: 2.0.30-alpine, 2.0-alpine, 2.0.30-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: c845b04087b9d388d60f3158670c37c31e7e6fbb
 Directory: 2.0/alpine
 
-Tags: 1.8.30, 1.8, 1.8.30-buster, 1.8-buster
+Tags: 1.8.31, 1.8, 1.8.31-buster, 1.8-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 47dd63fdb9a0674dae6cc2acb3ab4484bb51674a
+GitCommit: ed3c865a0a2f63d7a35af04e1406d858da83109e
 Directory: 1.8
 
-Tags: 1.8.30-alpine, 1.8-alpine, 1.8.30-alpine3.16, 1.8-alpine3.16
+Tags: 1.8.31-alpine, 1.8-alpine, 1.8.31-alpine3.16, 1.8-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e20f82ffe32ac00b8ace027321ff8dff4ff9d2e
+GitCommit: ed3c865a0a2f63d7a35af04e1406d858da83109e
 Directory: 1.8/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c845b04: Update 2.0 to 2.0.30
- https://github.com/docker-library/haproxy/commit/ed3c865: Update 1.8 to 1.8.31
- https://github.com/docker-library/haproxy/commit/6a15b45: Update 2.4 to 2.4.20
- https://github.com/docker-library/haproxy/commit/5098524: Update 2.2 to 2.2.26