### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.5.2
+Tags: 8.5.3
 Architectures: amd64, arm64v8
-GitCommit: 75c6c47f14bbb4c598aacfa7210fcbb8c9a566e3
+GitCommit: 8d73f43bffbde72cf3d06bbacd3185c33e9b01bc
 Directory: 8
 
 Tags: 7.17.8

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.5.2
+Tags: 8.5.3
 Architectures: amd64, arm64v8
-GitCommit: e69ce229e1dc0e8363781e22f51aa2adb1dc8772
+GitCommit: 5c03f6a2f9b1f552e5faa2664653c15b0b4c874b
 Directory: 8
 
 Tags: 7.17.8

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.5.2
+Tags: 8.5.3
 Architectures: amd64, arm64v8
-GitCommit: 47f532082b090b099d8df1d7ca07a773581d81fc
+GitCommit: 4aca8dc2999361c7634fb50a4a5bb48bd221e789
 Directory: 8
 
 Tags: 7.17.8


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/8d73f43: Update to 8.5.3

logstash:
- https://github.com/docker-library/logstash/commit/4aca8dc: Update to 8.5.3

kibana:
- https://github.com/docker-library/kibana/commit/5c03f6a: Update to 8.5.3