### PR TITLE
arangodb 3.9.6

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,10 +7,10 @@ Architectures: amd64
 GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
 Directory: alpine/3.8.8
 
-Tags: 3.9, 3.9.5
+Tags: 3.9, 3.9.6
 Architectures: amd64
-GitCommit: 1f70897e99b1c2de37d5763bbe4637d4fc9dfec9
-Directory: alpine/3.9.5
+GitCommit: eaced44aa34cfe94a89684292a01d18d6099465f
+Directory: alpine/3.9.6
 
 Tags: 3.10, 3.10.1, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated ArangoDB 3.9 to 3.9.6.