### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 7.0.5, 7.0, 7, latest, 7.0.5-bullseye, 7.0-bullseye, 7-bullseye, bullseye
+Tags: 7.0.6, 7.0, 7, latest, 7.0.6-bullseye, 7.0-bullseye, 7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 413d7277d124de16b28f21f6ce7a54e81b942c08
+GitCommit: 91fd9c363bd0b70ffda1726f9132917a19e65a66
 Directory: 7.0
 
-Tags: 7.0.5-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.5-alpine3.17, 7.0-alpine3.17, 7-alpine3.17, alpine3.17
+Tags: 7.0.6-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.6-alpine3.17, 7.0-alpine3.17, 7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 268eb1aee47ca9c7dc8913b4e8007a2c7391f5b6
+GitCommit: 91fd9c363bd0b70ffda1726f9132917a19e65a66
 Directory: 7.0/alpine
 
-Tags: 6.2.7, 6.2, 6, 6.2.7-bullseye, 6.2-bullseye, 6-bullseye
+Tags: 6.2.8, 6.2, 6, 6.2.8-bullseye, 6.2-bullseye, 6-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0f2bb676ab5153905089537230a732a77d26e438
+GitCommit: e85942db00480a10a51be0971acd4b849223132d
 Directory: 6.2
 
-Tags: 6.2.7-alpine, 6.2-alpine, 6-alpine, 6.2.7-alpine3.17, 6.2-alpine3.17, 6-alpine3.17
+Tags: 6.2.8-alpine, 6.2-alpine, 6-alpine, 6.2.8-alpine3.17, 6.2-alpine3.17, 6-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 268eb1aee47ca9c7dc8913b4e8007a2c7391f5b6
+GitCommit: e85942db00480a10a51be0971acd4b849223132d
 Directory: 6.2/alpine
 
 Tags: 6.0.16, 6.0, 6.0.16-bullseye, 6.0-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/91fd9c3: Update to 7.0.6
- https://github.com/docker-library/redis/commit/e85942d: Update to 6.2.8