### PR TITLE
chore: update Node v14 and v16

### DIFF
--- a/library/node
+++ b/library/node
@@ -76,51 +76,51 @@ Directory: 16/alpine3.17
 
 Tags: 16-bullseye, 16.18-bullseye, 16.18.1-bullseye, gallium-bullseye
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 16/bullseye
 
 Tags: 16-bullseye-slim, 16.18-bullseye-slim, 16.18.1-bullseye-slim, gallium-bullseye-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 16/bullseye-slim
 
 Tags: 16, 16-buster, 16.18, 16.18-buster, 16.18.1, 16.18.1-buster, gallium, gallium-buster
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 16/buster
 
 Tags: 16-buster-slim, 16-slim, 16.18-buster-slim, 16.18-slim, 16.18.1-buster-slim, 16.18.1-slim, gallium-buster-slim, gallium-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 16/buster-slim
 
-Tags: 14-alpine3.16, 14.21-alpine3.16, 14.21.1-alpine3.16, fermium-alpine3.16
+Tags: 14-alpine3.16, 14.21-alpine3.16, 14.21.2-alpine3.16, fermium-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 14/alpine3.16
 
-Tags: 14-alpine, 14-alpine3.17, 14.21-alpine, 14.21-alpine3.17, 14.21.1-alpine, 14.21.1-alpine3.17, fermium-alpine, fermium-alpine3.17
+Tags: 14-alpine, 14-alpine3.17, 14.21-alpine, 14.21-alpine3.17, 14.21.2-alpine, 14.21.2-alpine3.17, fermium-alpine, fermium-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e9c9c55af1ef8c866a6fe4a191763fb4a1c7e700
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 14/alpine3.17
 
-Tags: 14-bullseye, 14.21-bullseye, 14.21.1-bullseye, fermium-bullseye
+Tags: 14-bullseye, 14.21-bullseye, 14.21.2-bullseye, fermium-bullseye
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 14/bullseye
 
-Tags: 14-bullseye-slim, 14.21-bullseye-slim, 14.21.1-bullseye-slim, fermium-bullseye-slim
+Tags: 14-bullseye-slim, 14.21-bullseye-slim, 14.21.2-bullseye-slim, fermium-bullseye-slim
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 14/bullseye-slim
 
-Tags: 14, 14-buster, 14.21, 14.21-buster, 14.21.1, 14.21.1-buster, fermium, fermium-buster
+Tags: 14, 14-buster, 14.21, 14.21-buster, 14.21.2, 14.21.2-buster, fermium, fermium-buster
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 14/buster
 
-Tags: 14-buster-slim, 14-slim, 14.21-buster-slim, 14.21-slim, 14.21.1-buster-slim, 14.21.1-slim, fermium-buster-slim, fermium-slim
+Tags: 14-buster-slim, 14-slim, 14.21-buster-slim, 14.21-slim, 14.21.2-buster-slim, 14.21.2-slim, fermium-buster-slim, fermium-slim
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 7bc9983852d4a0a8910f3865b199d78157d1440b
+GitCommit: 3f8018043408490439723ed3b71ab5578d69ea70
 Directory: 14/buster-slim
 


### PR DESCRIPTION
Not sure why https://github.com/nodejs/docker-node/pull/1822 didn't create a PR