### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/dee264d35d3efd9aa8368742605d2e48979ec1b1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/f3414c2a8296f199b5a23b5c716cbe65d3856a1c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.1-rc1, 4.1
+Tags: 4.1.0, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2fd1447ba5551e25875bc10486583d312937616f
+GitCommit: 835052698f299c06e09ed49c972d6ab7bd2ef223
 Directory: 4.1
 
-Tags: 4.0.7, 4.0, 4, latest
+Tags: 4.0.7, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 08fa5553ad2dde684ca5337c7fedd173cbc41f39
 Directory: 4.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/f3414c2: Update "latest" to 4.1 (now GA)
- https://github.com/docker-library/cassandra/commit/8350526: Update 4.1 to 4.1.0