### PR TITLE
nginx: introduced another variant: alpine-slim and updated to 1.23.3.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,27 +1,32 @@
-# this file is generated via https://github.com/nginxinc/docker-nginx/blob/1dca42f99b3f032d862a1d35e8a5b951d629dc98/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nginxinc/docker-nginx/blob/564ae3cd9783719b91a210023f40e8a213766a3e/generate-stackbrew-library.sh
 
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.23.2, mainline, 1, 1.23, latest
+Tags: 1.23.3, mainline, 1, 1.23, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fef51235521d1cdf8b05d8cb1378a526d2abf421
+GitCommit: 5ce65c3efd395ee2d82d32670f233140e92dba99
 Directory: mainline/debian
 
-Tags: 1.23.2-perl, mainline-perl, 1-perl, 1.23-perl, perl
+Tags: 1.23.3-perl, mainline-perl, 1-perl, 1.23-perl, perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fef51235521d1cdf8b05d8cb1378a526d2abf421
+GitCommit: 5ce65c3efd395ee2d82d32670f233140e92dba99
 Directory: mainline/debian-perl
 
-Tags: 1.23.2-alpine, mainline-alpine, 1-alpine, 1.23-alpine, alpine
+Tags: 1.23.3-alpine, mainline-alpine, 1-alpine, 1.23-alpine, alpine
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: fef51235521d1cdf8b05d8cb1378a526d2abf421
+GitCommit: 5ce65c3efd395ee2d82d32670f233140e92dba99
 Directory: mainline/alpine
 
-Tags: 1.23.2-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.23-alpine-perl, alpine-perl
+Tags: 1.23.3-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.23-alpine-perl, alpine-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: fef51235521d1cdf8b05d8cb1378a526d2abf421
+GitCommit: 5ce65c3efd395ee2d82d32670f233140e92dba99
 Directory: mainline/alpine-perl
+
+Tags: 1.23.3-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.23-alpine-slim, alpine-slim
+Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
+GitCommit: 5ce65c3efd395ee2d82d32670f233140e92dba99
+Directory: mainline/alpine-slim
 
 Tags: 1.22.1, stable, 1.22
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
alpine-slim is currently only enabled for mainline images.  Will propagate to stable when there is a new release.

Refs:
 - https://github.com/nginxinc/docker-nginx/issues/681
 - https://github.com/nginxinc/docker-nginx-unprivileged/issues/63