### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,67 +4,37 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.2.5-php7.4-apache, 4.2-php7.4-apache, 4-php7.4-apache, php7.4-apache
+Tags: 4.2.6, 4.2, 4, latest, 4.2.6-apache, 4.2-apache, 4-apache, apache, 4.2.6-php8.0, 4.2-php8.0, 4-php8.0, php8.0, 4.2.6-php8.0-apache, 4.2-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
-Directory: 4.2/php7.4/apache
-
-Tags: 4.2.5-php7.4-fpm-alpine, 4.2-php7.4-fpm-alpine, 4-php7.4-fpm-alpine, php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
-Directory: 4.2/php7.4/fpm-alpine
-
-Tags: 4.2.5-php7.4-fpm, 4.2-php7.4-fpm, 4-php7.4-fpm, php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
-Directory: 4.2/php7.4/fpm
-
-Tags: 4.2.5, 4.2, 4, latest, 4.2.5-apache, 4.2-apache, 4-apache, apache, 4.2.5-php8.0, 4.2-php8.0, 4-php8.0, php8.0, 4.2.5-php8.0-apache, 4.2-php8.0-apache, 4-php8.0-apache, php8.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
+GitCommit: 935f419c927c2403f587565cda1576a66d52a451
 Directory: 4.2/php8.0/apache
 
-Tags: 4.2.5-php8.0-fpm-alpine, 4.2-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.2.6-php8.0-fpm-alpine, 4.2-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
+GitCommit: 935f419c927c2403f587565cda1576a66d52a451
 Directory: 4.2/php8.0/fpm-alpine
 
-Tags: 4.2.5-php8.0-fpm, 4.2-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.2.6-php8.0-fpm, 4.2-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
+GitCommit: 935f419c927c2403f587565cda1576a66d52a451
 Directory: 4.2/php8.0/fpm
 
-Tags: 4.2.5-php8.1-apache, 4.2-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.2.6-php8.1-apache, 4.2-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
+GitCommit: 935f419c927c2403f587565cda1576a66d52a451
 Directory: 4.2/php8.1/apache
 
-Tags: 4.2.5-php8.1-fpm-alpine, 4.2-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.2.6-php8.1-fpm-alpine, 4.2-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
+GitCommit: 935f419c927c2403f587565cda1576a66d52a451
 Directory: 4.2/php8.1/fpm-alpine
 
-Tags: 4.2.5-php8.1-fpm, 4.2-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.2.6-php8.1-fpm, 4.2-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04c039b54b15307cc9b9f452f423e60ffbb2f649
+GitCommit: 935f419c927c2403f587565cda1576a66d52a451
 Directory: 4.2/php8.1/fpm
 
-Tags: 3.10.11, 3.10, 3, 3.10.11-apache, 3.10-apache, 3-apache, 3.10.11-php7.4, 3.10-php7.4, 3-php7.4, 3.10.11-php7.4-apache, 3.10-php7.4-apache, 3-php7.4-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5db422d45ababc59434db274f640a152063ee514
-Directory: 3.10/php7.4/apache
-
-Tags: 3.10.11-php7.4-fpm-alpine, 3.10-php7.4-fpm-alpine, 3-php7.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5db422d45ababc59434db274f640a152063ee514
-Directory: 3.10/php7.4/fpm-alpine
-
-Tags: 3.10.11-php7.4-fpm, 3.10-php7.4-fpm, 3-php7.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5db422d45ababc59434db274f640a152063ee514
-Directory: 3.10/php7.4/fpm
-
-Tags: 3.10.11-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
+Tags: 3.10.11, 3.10, 3, 3.10.11-apache, 3.10-apache, 3-apache, 3.10.11-php8.0, 3.10-php8.0, 3-php8.0, 3.10.11-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 17df17a732daa119f17bbcc6fb7759d7bf175d0a
 Directory: 3.10/php8.0/apache


### PR DESCRIPTION
- https://github.com/joomla-docker/docker-joomla/commit/81927626ee221cd4f402337d827e6d344de18d79: Removes PHP 7.4
- https://github.com/joomla-docker/docker-joomla/commit/618883137fea57e2a23067577022ad6855ae6def: Update version of Joomla! 4.2.5 to 4.2.6
- https://github.com/joomla-docker/docker-joomla/commit/935f419c927c2403f587565cda1576a66d52a451: Update images of Joomla! 4.2.5 to 4.2.6