### PR TITLE
Slightly improved "diff-pr" output, especially around build-order

### DIFF
--- a/_bashbrew-cat-sorted.sh
+++ b/_bashbrew-cat-sorted.sh
@@ -5,8 +5,7 @@ set -Eeuo pipefail
 
 images="$(
 	bashbrew list --repos --uniq "$@" \
-		| sort -uV \
-		| xargs -r bashbrew list --repos --uniq --build-order
+		| sort -uV
 )"
 set -- $images
 
@@ -34,7 +33,6 @@ for img; do
 
 	bashbrew list --uniq "$img" \
 		| sort -V \
-		| xargs -r bashbrew list --uniq --build-order \
 		| xargs -r bashbrew cat --format '
 			{{- range $e := .TagEntries -}}
 				{{- printf "\n%s\n" ($e.ClearDefaults $.Manifest.Global) -}}


### PR DESCRIPTION
This should help avoid "empty cat" output we saw recently when something failed to fetch but was otherwise valid.

The current implementation is trying to do two things with one output:

1. normalized `bashbrew cat` diff
2. visualize `--build-order` changes

This change splits those into two separate things because combining them ends up making the diff harder to read than it should be ("changed tags + changed commit" leading to a full reordering of the diff because build-order also changed).