### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.25.3, 5.25, 5, latest
+Tags: 5.25.5, 5.25, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b50037646f5b65ad697eb95c87d88f95de56804e
+GitCommit: 9b268e1bbb0d52a918e0d7c1d73c5129ec51a187
 Directory: 5/debian
 
-Tags: 5.25.3-alpine, 5.25-alpine, 5-alpine, alpine
+Tags: 5.25.5-alpine, 5.25-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: b50037646f5b65ad697eb95c87d88f95de56804e
+GitCommit: 9b268e1bbb0d52a918e0d7c1d73c5129ec51a187
 Directory: 5/alpine
 
 Tags: 4.48.9, 4.48, 4


### PR DESCRIPTION
Changes:

- docker-library/ghost@9b268e1: Update to 5.25.5, ghost-cli 1.23.1
- docker-library/ghost@6108192: Update to 5.25.4, ghost-cli 1.23.1