### PR TITLE
Odoo: update 14.0-16.0 to release 20221216

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 7f1788b597f69ba59dcb8d7b8d92ab1693bc7ee1
+GitCommit: 4dc567d99e0fb6cdef4cab2025c0caa3b52987b7
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

Here are the latest updates for Odoo supported versions.

Thanks.