### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,107 +4,107 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-1-jdk-oraclelinux8, 21-ea-1-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-1-jdk-oracle, 21-ea-1-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-1-jdk, 21-ea-1, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-2-jdk-oraclelinux8, 21-ea-2-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-2-jdk-oracle, 21-ea-2-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-2-jdk, 21-ea-2, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-1-jdk-oraclelinux7, 21-ea-1-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-2-jdk-oraclelinux7, 21-ea-2-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-1-jdk-bullseye, 21-ea-1-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-2-jdk-bullseye, 21-ea-2-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-1-jdk-slim-bullseye, 21-ea-1-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-1-jdk-slim, 21-ea-1-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-2-jdk-slim-bullseye, 21-ea-2-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-2-jdk-slim, 21-ea-2-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-1-jdk-buster, 21-ea-1-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-2-jdk-buster, 21-ea-2-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/buster
 
-Tags: 21-ea-1-jdk-slim-buster, 21-ea-1-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-2-jdk-slim-buster, 21-ea-2-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-1-jdk-windowsservercore-ltsc2022, 21-ea-1-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-1-jdk-windowsservercore, 21-ea-1-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-1-jdk, 21-ea-1, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-2-jdk-windowsservercore-ltsc2022, 21-ea-2-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-2-jdk-windowsservercore, 21-ea-2-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-2-jdk, 21-ea-2, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-1-jdk-windowsservercore-1809, 21-ea-1-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-1-jdk-windowsservercore, 21-ea-1-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-1-jdk, 21-ea-1, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-2-jdk-windowsservercore-1809, 21-ea-2-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-2-jdk-windowsservercore, 21-ea-2-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-2-jdk, 21-ea-2, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-1-jdk-nanoserver-1809, 21-ea-1-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-1-jdk-nanoserver, 21-ea-1-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-2-jdk-nanoserver-1809, 21-ea-2-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-2-jdk-nanoserver, 21-ea-2-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 1265d56673ed4e5248f0e0db23ded21ea95d1ec5
+GitCommit: 9b372c693c4c79670748b9d04df19353c61cf741
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 20-ea-27-jdk-oraclelinux8, 20-ea-27-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-27-jdk-oracle, 20-ea-27-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-27-jdk, 20-ea-27, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-28-jdk-oraclelinux8, 20-ea-28-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-28-jdk-oracle, 20-ea-28-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-28-jdk, 20-ea-28, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-27-jdk-oraclelinux7, 20-ea-27-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-28-jdk-oraclelinux7, 20-ea-28-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-27-jdk-bullseye, 20-ea-27-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-28-jdk-bullseye, 20-ea-28-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-27-jdk-slim-bullseye, 20-ea-27-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-27-jdk-slim, 20-ea-27-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-28-jdk-slim-bullseye, 20-ea-28-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-28-jdk-slim, 20-ea-28-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-27-jdk-buster, 20-ea-27-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-28-jdk-buster, 20-ea-28-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/buster
 
-Tags: 20-ea-27-jdk-slim-buster, 20-ea-27-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-28-jdk-slim-buster, 20-ea-28-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-27-jdk-windowsservercore-ltsc2022, 20-ea-27-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-27-jdk-windowsservercore, 20-ea-27-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-27-jdk, 20-ea-27, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-28-jdk-windowsservercore-ltsc2022, 20-ea-28-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-28-jdk-windowsservercore, 20-ea-28-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-28-jdk, 20-ea-28, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-27-jdk-windowsservercore-1809, 20-ea-27-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-27-jdk-windowsservercore, 20-ea-27-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-27-jdk, 20-ea-27, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-28-jdk-windowsservercore-1809, 20-ea-28-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-28-jdk-windowsservercore, 20-ea-28-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-28-jdk, 20-ea-28, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-27-jdk-nanoserver-1809, 20-ea-27-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-27-jdk-nanoserver, 20-ea-27-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-28-jdk-nanoserver-1809, 20-ea-28-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-28-jdk-nanoserver, 20-ea-28-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: 997c7901743d7b524547d13ef45941696277fc62
+GitCommit: 7b874b1fe18cbc16ccc1274f295a222858226a66
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/9b372c6: Update 21 to 21-ea+2
- https://github.com/docker-library/openjdk/commit/7b874b1: Update 20 to 20-ea+28