### PR TITLE
archlinux: Release 20221218.0.111778

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221211.0.109768
-GitCommit: 96fe3998602908d80dac2212c79a0a5c6ad41fb1
-GitFetch: refs/tags/v20221211.0.109768
+Tags: latest, base, base-20221218.0.111778
+GitCommit: 1875c0834970bdd23b398e99876a24c14f8262e0
+GitFetch: refs/tags/v20221218.0.111778
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221211.0.109768
-GitCommit: 96fe3998602908d80dac2212c79a0a5c6ad41fb1
-GitFetch: refs/tags/v20221211.0.109768
+Tags: base-devel, base-devel-20221218.0.111778
+GitCommit: 1875c0834970bdd23b398e99876a24c14f8262e0
+GitFetch: refs/tags/v20221218.0.111778
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks