### PR TITLE
Update to bashbrew 0.1.7

### DIFF
--- a/.github/workflows/.bashbrew/action.yml
+++ b/.github/workflows/.bashbrew/action.yml
@@ -10,8 +10,8 @@ runs:
 
     # these two version numbers are intentionally as close together as I could possibly get them because no matter what I tried, GitHub will not allow me to DRY them (can't have any useful variables in `uses:` and can't even have YAML references to steal it in `env:` or something)
     - shell: 'bash -Eeuo pipefail -x {0}'
-      run:    echo BASHBREW_VERSION=v0.1.6 >> "$GITHUB_ENV"
-    - uses: docker-library/bashbrew@v0.1.6
+      run:    echo BASHBREW_VERSION=v0.1.7 >> "$GITHUB_ENV"
+    - uses: docker-library/bashbrew@v0.1.7
       if: inputs.build == 'host'
 
     - run: docker build --pull --tag oisupport/bashbrew:base "https://github.com/docker-library/bashbrew.git#$BASHBREW_VERSION"


### PR DESCRIPTION
Notably, this adds support for `Builder: oci-import`:

> - add (experimental) `Builder: oci-import` support (https://github.com/docker-library/bashbrew/pull/61)
>   - see https://github.com/docker-library/bashbrew/pull/61#issuecomment-1340118576 for an example of the intended usage  
>     `Directory:` pointing to an ["OCI Image Layout"](https://github.com/opencontainers/image-spec/blob/v1.0.2/image-layout.md) and `File:` pointing to either a single-entry ["OCI Image Index"](https://github.com/opencontainers/image-spec/blob/v1.0.2/image-index.md) or a single raw ["OCI Content Descriptor"](https://github.com/opencontainers/image-spec/blob/v1.0.2/descriptor.md) (in either case, pointing to a single per-architecture ["OCI Image Manifest"](https://github.com/opencontainers/image-spec/blob/v1.0.2/manifest.md) object within the `blobs/` directory)