### PR TITLE
[nats] Release v2.9.10

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,25 +4,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 5dfc1776f555b843bc5926a6ba14fc0f8b30b712
+GitCommit: 9a6d4c78ca08d401410de610c613d8a5c2265843
 
-Tags: 2.9.9-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.9-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.10-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.10-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.9/alpine3.17
+Directory: 2.9.10/alpine3.17
 
-Tags: 2.9.9-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.9-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.9, 2.9, 2, latest
+Tags: 2.9.10-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.10-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.10, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.9/scratch
+Directory: 2.9.10/scratch
 
-Tags: 2.9.9-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.9-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.10-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.10-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.9/windowsservercore-1809
+Directory: 2.9.10/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.9-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.9-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.9, 2.9, 2, latest
+Tags: 2.9.10-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.10-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.10, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.9/nanoserver-1809
+Directory: 2.9.10/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.10)

Signed-off-by: Byron Ruth <b@devel.io>