### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 461eb7b587fa81a1ae88ef374d66f90f876b4fd8
 Directory: 2.8/alpine
 
-Tags: 2.7.0, 2.7, latest, 2.7.0-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.1, 2.7, latest, 2.7.1-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04ca906f4c72c8c4ec1eeb98fe80e5ecdfe1d791
+GitCommit: eccea371bf2c3d5744a8ad1b2f5861825161052f
 Directory: 2.7
 
-Tags: 2.7.0-alpine, 2.7-alpine, alpine, 2.7.0-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.1-alpine, 2.7-alpine, alpine, 2.7.1-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04ca906f4c72c8c4ec1eeb98fe80e5ecdfe1d791
+GitCommit: eccea371bf2c3d5744a8ad1b2f5861825161052f
 Directory: 2.7/alpine
 
 Tags: 2.6.7, 2.6, lts, 2.6.7-bullseye, 2.6-bullseye, lts-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/eccea37: Update 2.7 to 2.7.1