### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -124,6 +124,21 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
 Directory: ubuntu/kinetic
 
+Tags: lunar-curl, 23.04-curl
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 31e15bc4a2352c20998e5da6bd8aaa727fd19d06
+Directory: ubuntu/lunar/curl
+
+Tags: lunar-scm, 23.04-scm
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 31e15bc4a2352c20998e5da6bd8aaa727fd19d06
+Directory: ubuntu/lunar/scm
+
+Tags: lunar, 23.04
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 31e15bc4a2352c20998e5da6bd8aaa727fd19d06
+Directory: ubuntu/lunar
+
 Tags: xenial-curl, 16.04-curl
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/3699b0b: Merge pull request https://github.com/docker-library/buildpack-deps/pull/138 from vicamo/for-upstream/add-lunar
- https://github.com/docker-library/buildpack-deps/commit/5d79680: Update generated README
- https://github.com/docker-library/buildpack-deps/commit/31e15bc: Add Ubuntu Lunar Lobster 23.04
- https://github.com/docker-library/buildpack-deps/commit/6be0d63: Use new "bashbrew" composite action
- https://github.com/docker-library/buildpack-deps/commit/72d6d51: Merge pull request https://github.com/docker-library/buildpack-deps/pull/137 from infosiftr/ci-updates
- https://github.com/docker-library/buildpack-deps/commit/aa54a22: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3