### PR TITLE
arangodb 3.10.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -12,7 +12,7 @@ Architectures: amd64
 GitCommit: eaced44aa34cfe94a89684292a01d18d6099465f
 Directory: alpine/3.9.6
 
-Tags: 3.10, 3.10.1, latest
+Tags: 3.10, 3.10.2, latest
 Architectures: amd64, arm64v8
-GitCommit: 4f04df410807f42cb2be282b8143405ce5593bbc
-Directory: alpine/3.10.1
+GitCommit: 71fda53ef666d8c85fbd70748a26e7c86bcf3fbf
+Directory: alpine/3.10.2


### PR DESCRIPTION
Updated ArangoDB 3.10 to 3.10.2.