### PR TITLE
Groovy 3.0.14 and 4.0.7

### DIFF
--- a/library/groovy
+++ b/library/groovy
@@ -32,32 +32,32 @@ Directory: jdk17-alpine
 
 # Groovy 4
 
-Tags: 4.0.6-jdk8, 4.0-jdk8, 4.0.6-jdk8-jammy, 4.0-jdk8-jammy
+Tags: 4.0.7-jdk8, 4.0-jdk8, 4.0.7-jdk8-jammy, 4.0-jdk8-jammy
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 834070ffcdc4afdb48573f0e3ec4587f7706f873
+GitCommit: 085e0eb9a0611dd84c16efdcad26f352157d6f79
 Directory: jdk8
 
-Tags: 4.0.6-jdk11, 4.0-jdk11, 4.0.6-jdk11-jammy, 4.0-jdk11-jammy
+Tags: 4.0.7-jdk11, 4.0-jdk11, 4.0.7-jdk11-jammy, 4.0-jdk11-jammy
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 834070ffcdc4afdb48573f0e3ec4587f7706f873
+GitCommit: 085e0eb9a0611dd84c16efdcad26f352157d6f79
 Directory: jdk11
 
-Tags: 4.0.6-jdk11-alpine, 4.0-jdk11-alpine
+Tags: 4.0.7-jdk11-alpine, 4.0-jdk11-alpine
 GitFetch: refs/heads/4.0
 Architectures: amd64
-GitCommit: 834070ffcdc4afdb48573f0e3ec4587f7706f873
+GitCommit: 085e0eb9a0611dd84c16efdcad26f352157d6f79
 Directory: jdk11-alpine
 
-Tags: 4.0.6-jdk17, 4.0-jdk17, 4.0.6-jdk, 4.0.6, 4.0, 4, 4.0.6-jdk17-jammy, 4.0-jdk17-jammy, 4.0.6-jdk-jammy, 4.0.6-jammy, 4.0-jammy, 4-jammy
+Tags: 4.0.7-jdk17, 4.0-jdk17, 4.0.7-jdk, 4.0.7, 4.0, 4, 4.0.7-jdk17-jammy, 4.0-jdk17-jammy, 4.0.7-jdk-jammy, 4.0.7-jammy, 4.0-jammy, 4-jammy
 GitFetch: refs/heads/4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 834070ffcdc4afdb48573f0e3ec4587f7706f873
+GitCommit: 085e0eb9a0611dd84c16efdcad26f352157d6f79
 Directory: jdk17
 
-Tags: 4.0.6-jdk17-alpine, 4.0-jdk17-alpine, 4.0.6-jdk-alpine, 4.0.6-alpine, 4.0-alpine, 4-alpine
+Tags: 4.0.7-jdk17-alpine, 4.0-jdk17-alpine, 4.0.7-jdk-alpine, 4.0.7-alpine, 4.0-alpine, 4-alpine
 GitFetch: refs/heads/4.0
 Architectures: amd64
-GitCommit: 834070ffcdc4afdb48573f0e3ec4587f7706f873
+GitCommit: 085e0eb9a0611dd84c16efdcad26f352157d6f79
 Directory: jdk17-alpine

--- a/library/groovy
+++ b/library/groovy
@@ -4,29 +4,29 @@ GitRepo: https://github.com/groovy/docker-groovy.git
 
 # Groovy 3
 
-Tags: 3.0.13-jdk8, 3.0-jdk8, jdk8, 3.0.13-jdk8-jammy, 3.0-jdk8-jammy, jdk8-jammy
+Tags: 3.0.14-jdk8, 3.0-jdk8, jdk8, 3.0.14-jdk8-jammy, 3.0-jdk8-jammy, jdk8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: e80bf014fa5b6f2d0a884be297b77748cbb7ef40
+GitCommit: bc4c3ee2a4e26f14458b121f238bb862c9de6b27
 Directory: jdk8
 
-Tags: 3.0.13-jdk11, 3.0-jdk11, jdk11, 3.0.13-jdk11-jammy, 3.0-jdk11-jammy, jdk11-jammy
+Tags: 3.0.14-jdk11, 3.0-jdk11, jdk11, 3.0.14-jdk11-jammy, 3.0-jdk11-jammy, jdk11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e80bf014fa5b6f2d0a884be297b77748cbb7ef40
+GitCommit: bc4c3ee2a4e26f14458b121f238bb862c9de6b27
 Directory: jdk11
 
-Tags: 3.0.13-jdk11-alpine, 3.0-jdk11-alpine, jdk11-alpine
+Tags: 3.0.14-jdk11-alpine, 3.0-jdk11-alpine, jdk11-alpine
 Architectures: amd64
-GitCommit: e80bf014fa5b6f2d0a884be297b77748cbb7ef40
+GitCommit: bc4c3ee2a4e26f14458b121f238bb862c9de6b27
 Directory: jdk11-alpine
 
-Tags: 3.0.13-jdk17, 3.0-jdk17, jdk17, 3.0.13-jdk, 3.0-jdk, 3.0.13, 3.0, 3, jdk, latest, 3.0.13-jdk17-jammy, 3.0-jdk17-jammy, jdk17-jammy, 3.0.13-jdk-jammy, 3.0-jdk-jammy, 3.0.13-jammy, 3.0-jammy, 3-jammy, jdk-jammy, jammy
+Tags: 3.0.14-jdk17, 3.0-jdk17, jdk17, 3.0.14-jdk, 3.0-jdk, 3.0.14, 3.0, 3, jdk, latest, 3.0.14-jdk17-jammy, 3.0-jdk17-jammy, jdk17-jammy, 3.0.14-jdk-jammy, 3.0-jdk-jammy, 3.0.14-jammy, 3.0-jammy, 3-jammy, jdk-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e80bf014fa5b6f2d0a884be297b77748cbb7ef40
+GitCommit: bc4c3ee2a4e26f14458b121f238bb862c9de6b27
 Directory: jdk17
 
-Tags: 3.0.13-jdk17-alpine, 3.0-jdk17-alpine, jdk17-alpine, 3.0.13-jdk-alpine, 3.0-jdk-alpine, 3.0.13-alpine, 3.0-alpine, 3-alpine, jdk-alpine, alpine
+Tags: 3.0.14-jdk17-alpine, 3.0-jdk17-alpine, jdk17-alpine, 3.0.14-jdk-alpine, 3.0-jdk-alpine, 3.0.14-alpine, 3.0-alpine, 3-alpine, jdk-alpine, alpine
 Architectures: amd64
-GitCommit: e80bf014fa5b6f2d0a884be297b77748cbb7ef40
+GitCommit: bc4c3ee2a4e26f14458b121f238bb862c9de6b27
 Directory: jdk17-alpine
 
 


### PR DESCRIPTION
The only notable change this update is https://github.com/groovy/docker-groovy/pull/86.