### PR TITLE
archlinux: Release 20221225.0.113672

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20221218.0.111778
-GitCommit: 1875c0834970bdd23b398e99876a24c14f8262e0
-GitFetch: refs/tags/v20221218.0.111778
+Tags: latest, base, base-20221225.0.113672
+GitCommit: fea6b35ffcd0342cb5a9730368252ffe62e14de7
+GitFetch: refs/tags/v20221225.0.113672
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20221218.0.111778
-GitCommit: 1875c0834970bdd23b398e99876a24c14f8262e0
-GitFetch: refs/tags/v20221218.0.111778
+Tags: base-devel, base-devel-20221225.0.113672
+GitCommit: fea6b35ffcd0342cb5a9730368252ffe62e14de7
+GitFetch: refs/tags/v20221225.0.113672
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks