### PR TITLE
Update Clear Linux OS to 37860

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c73614202e5669dc4f907e707dc9c96a58a4f167
-GitFetch: refs/heads/base-37780
+GitCommit: 553d147992605c949490d35334adf2ed19027053
+GitFetch: refs/heads/base-37860


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37860

@bryteise @djklimes @bryteise