### PR TITLE
Odoo: update 14.0-16.0 to release 20221226

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 4dc567d99e0fb6cdef4cab2025c0caa3b52987b7
+GitCommit: bd0749b2bf01fd5b854ea87becd67c053e90698b
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Merry Christmas and thank you.