### PR TITLE
Haskell bumps

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -1,42 +1,32 @@
 Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.4.3-buster, 9.4-buster, 9-buster, buster, 9.4.3, 9.4, 9, latest
+Tags: 9.4.4-buster, 9.4-buster, 9-buster, buster, 9.4.4, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: b29df0224a5f76407a41c6662513201650fde976
+GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
 Directory: 9.4/buster
 
-Tags: 9.4.3-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.3-slim, 9.4-slim, 9-slim, slim
+Tags: 9.4.4-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.4-slim, 9.4-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: b29df0224a5f76407a41c6662513201650fde976
+GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
 Directory: 9.4/slim-buster
 
 Tags: 9.2.5-buster, 9.2-buster, 9.2.5, 9.2
 Architectures: amd64, arm64v8
-GitCommit: 60a070f652853c4a1801ce00fcf2b880c79ecbfc
+GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
 Directory: 9.2/buster
 
 Tags: 9.2.5-slim-buster, 9.2-slim-buster, 9.2.5-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 60a070f652853c4a1801ce00fcf2b880c79ecbfc
+GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
 Architectures: amd64, arm64v8
-GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
+GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
 Directory: 9.0/buster
 
 Tags: 9.0.2-slim-buster, 9.0-slim-buster, 9.0.2-slim, 9.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
+GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
 Directory: 9.0/slim-buster
-
-Tags: 8.10.7-buster, 8.10-buster, 8-buster, 8.10.7, 8.10, 8
-Architectures: amd64, arm64v8
-GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
-Directory: 8.10/buster
-
-Tags: 8.10.7-slim-buster, 8.10-slim-buster, 8-slim-buster, 8.10.7-slim, 8.10-slim, 8-slim
-Architectures: amd64, arm64v8
-GitCommit: 4fd05c031a306bcc0057cdd04439700c418ffaf0
-Directory: 8.10/slim-buster


### PR DESCRIPTION
- Haskell stack bump to 2.9.3
- GHC 9.4 line bumped to 9.4.4
- Remove GHC 8.10 line which is quite old at this point.