### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.9.0-alpha1-bullseye, 1.9-rc-bullseye, rc-bullseye
-SharedTags: 1.9.0-alpha1, 1.9-rc, rc
+Tags: 1.9.0-beta2-bullseye, 1.9-rc-bullseye, rc-bullseye
+SharedTags: 1.9.0-beta2, 1.9-rc, rc
 Architectures: amd64, arm64v8, i386
-GitCommit: 3dad07cd2d2bac9a098b5a2051af4d1f28a9d33d
+GitCommit: a60827b1feb946f2701759eb0dceb33c44c24ed3
 Directory: 1.9-rc/bullseye
 
-Tags: 1.9.0-alpha1-buster, 1.9-rc-buster, rc-buster
+Tags: 1.9.0-beta2-buster, 1.9-rc-buster, rc-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: 3dad07cd2d2bac9a098b5a2051af4d1f28a9d33d
+GitCommit: a60827b1feb946f2701759eb0dceb33c44c24ed3
 Directory: 1.9-rc/buster
 
-Tags: 1.9.0-alpha1-alpine3.17, 1.9-rc-alpine3.17, rc-alpine3.17, 1.9.0-alpha1-alpine, 1.9-rc-alpine, rc-alpine
+Tags: 1.9.0-beta2-alpine3.17, 1.9-rc-alpine3.17, rc-alpine3.17, 1.9.0-beta2-alpine, 1.9-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 1d8e89b70dd373eceea2879c87e03cc20cafec1a
+GitCommit: a60827b1feb946f2701759eb0dceb33c44c24ed3
 Directory: 1.9-rc/alpine3.17
 
-Tags: 1.9.0-alpha1-alpine3.16, 1.9-rc-alpine3.16, rc-alpine3.16
+Tags: 1.9.0-beta2-alpine3.16, 1.9-rc-alpine3.16, rc-alpine3.16
 Architectures: amd64
-GitCommit: 3dad07cd2d2bac9a098b5a2051af4d1f28a9d33d
+GitCommit: a60827b1feb946f2701759eb0dceb33c44c24ed3
 Directory: 1.9-rc/alpine3.16
 
-Tags: 1.9.0-alpha1-windowsservercore-ltsc2022, 1.9-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 1.9.0-alpha1, 1.9-rc, rc, 1.9.0-alpha1-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
+Tags: 1.9.0-beta2-windowsservercore-ltsc2022, 1.9-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 1.9.0-beta2, 1.9-rc, rc, 1.9.0-beta2-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3dad07cd2d2bac9a098b5a2051af4d1f28a9d33d
+GitCommit: a60827b1feb946f2701759eb0dceb33c44c24ed3
 Directory: 1.9-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.9.0-alpha1-windowsservercore-1809, 1.9-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.9.0-alpha1, 1.9-rc, rc, 1.9.0-alpha1-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
+Tags: 1.9.0-beta2-windowsservercore-1809, 1.9-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.9.0-beta2, 1.9-rc, rc, 1.9.0-beta2-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 3dad07cd2d2bac9a098b5a2051af4d1f28a9d33d
+GitCommit: a60827b1feb946f2701759eb0dceb33c44c24ed3
 Directory: 1.9-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/a60827b: Update 1.9-rc to 1.9.0-beta2