### PR TITLE
Update Clear Linux OS to 37960

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 553d147992605c949490d35334adf2ed19027053
-GitFetch: refs/heads/base-37860
+GitCommit: f1f3bc5ed4067e796e3ca7d7d3182bff018b00a5
+GitFetch: refs/heads/base-37960


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 37960

@bryteise @djklimes @bryteise