### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -73,13 +73,3 @@ Tags: 2.0.30-alpine, 2.0-alpine, 2.0.30-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c845b04087b9d388d60f3158670c37c31e7e6fbb
 Directory: 2.0/alpine
-
-Tags: 1.8.31, 1.8, 1.8.31-buster, 1.8-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: ed3c865a0a2f63d7a35af04e1406d858da83109e
-Directory: 1.8
-
-Tags: 1.8.31-alpine, 1.8-alpine, 1.8.31-alpine3.16, 1.8-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ed3c865a0a2f63d7a35af04e1406d858da83109e
-Directory: 1.8/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b64451a: Merge pull request https://github.com/docker-library/haproxy/pull/201 from TimWolla/remove-1.8
- https://github.com/docker-library/haproxy/commit/0a7bd76: Remove EOL 1.8
- https://github.com/docker-library/haproxy/commit/863eb4e: Update generated README