### PR TITLE
Add back Haskell GHC docs

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -3,30 +3,30 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.4.4-buster, 9.4-buster, 9-buster, buster, 9.4.4, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
+GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.4/buster
 
 Tags: 9.4.4-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.4-slim, 9.4-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
+GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.4/slim-buster
 
 Tags: 9.2.5-buster, 9.2-buster, 9.2.5, 9.2
 Architectures: amd64, arm64v8
-GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
+GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.2/buster
 
 Tags: 9.2.5-slim-buster, 9.2-slim-buster, 9.2.5-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
+GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
 Architectures: amd64, arm64v8
-GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
+GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.0/buster
 
 Tags: 9.0.2-slim-buster, 9.0-slim-buster, 9.0.2-slim, 9.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 88cd0b3843c049d2e97d558e3218c1de0e7b9f97
+GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.0/slim-buster


### PR DESCRIPTION
They were removed from the image as they were thought to only be for human consumption. However, in certain cases they can be used to build documentation.

https://github.com/haskell/docker-haskell/issues/97