### PR TITLE
Update to JRuby commit that includes make

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -3,7 +3,7 @@ Maintainers: JRuby Admin <admin@jruby.org> (@jruby),
              Thomas E Enebo <tom.enebo@gmail.com> (@enebo)
 GitRepo: https://github.com/jruby/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: e02df860e355676cfca1783cfa10f89e339f5672
+GitCommit: 500a1f58e7ad2be7d2af67f1b480b80ff6517314
 
 Tags: latest, 9, 9.4, 9.4.0, 9.4-jre, 9.4-jre8, 9.4.0-jre, 9.4.0-jre8, 9.4.0.0, 9.4.0.0-jre, 9.4.0.0-jre8
 Architectures: amd64, arm64v8

--- a/library/jruby
+++ b/library/jruby
@@ -45,27 +45,3 @@ Tags: 9.3-jdk17, 9.3.9-jdk17, 9.3.9.0-jdk17
 Architectures: amd64, arm64v8
 Directory: 9.3/jdk17
 
-Tags: 9.2, 9.2.21, 9.2-jre, 9.2-jre8, 9.2.21-jre, 9.2.21-jre8, 9.2.21.0, 9.2.21.0-jre, 9.2.21.0-jre8
-Architectures: amd64
-Directory: 9.2/jre8
-
-Tags: 9.2-jdk, 9.2-jdk8, 9.2.21-jdk, 9.2.21-jdk8, 9.2.21.0-jdk, 9.2.21.0-jdk8
-Architectures: amd64
-Directory: 9.2/jdk8
-
-Tags: 9.2-jre11, 9.2.21-jre11, 9.2.21.0-jre11
-Architectures: amd64
-Directory: 9.2/jre11
-
-Tags: 9.2-jdk11, 9.2.21-jdk11, 9.2.21.0-jdk11
-Architectures: amd64
-Directory: 9.2/jdk11
-
-Tags: 9.2-jdk17, 9.2.21-jdk17, 9.2.21.0-jdk17
-Architectures: amd64
-Directory: 9.2/jdk17
-
-Tags: 9.2-onbuild, 9.2.21-onbuild, 9.2.21.0-onbuild
-Architectures: amd64
-Directory: 9.2/onbuild-jdk8
-


### PR DESCRIPTION
make is needed for several dummy gems that do not need to build an extension but still attempt to run a Makefile.

See https://github.com/jruby/docker-jruby/issues/81