### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -7,135 +7,135 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.12.0a3-bullseye, 3.12-rc-bullseye
 SharedTags: 3.12.0a3, 3.12-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/bullseye
 
 Tags: 3.12.0a3-slim-bullseye, 3.12-rc-slim-bullseye, 3.12.0a3-slim, 3.12-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/slim-bullseye
 
 Tags: 3.12.0a3-buster, 3.12-rc-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/buster
 
 Tags: 3.12.0a3-slim-buster, 3.12-rc-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/slim-buster
 
 Tags: 3.12.0a3-alpine3.17, 3.12-rc-alpine3.17, 3.12.0a3-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/alpine3.17
 
 Tags: 3.12.0a3-alpine3.16, 3.12-rc-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/alpine3.16
 
 Tags: 3.12.0a3-windowsservercore-ltsc2022, 3.12-rc-windowsservercore-ltsc2022
 SharedTags: 3.12.0a3-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a3, 3.12-rc
 Architectures: windows-amd64
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.12.0a3-windowsservercore-1809, 3.12-rc-windowsservercore-1809
 SharedTags: 3.12.0a3-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a3, 3.12-rc
 Architectures: windows-amd64
-GitCommit: c4696682db7d24c997f6a417c5ff4873e83b8d7c
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.12-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.11.1-bullseye, 3.11-bullseye, 3-bullseye, bullseye
 SharedTags: 3.11.1, 3.11, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/bullseye
 
 Tags: 3.11.1-slim-bullseye, 3.11-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.11.1-slim, 3.11-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/slim-bullseye
 
 Tags: 3.11.1-buster, 3.11-buster, 3-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/buster
 
 Tags: 3.11.1-slim-buster, 3.11-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/slim-buster
 
 Tags: 3.11.1-alpine3.17, 3.11-alpine3.17, 3-alpine3.17, alpine3.17, 3.11.1-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/alpine3.17
 
 Tags: 3.11.1-alpine3.16, 3.11-alpine3.16, 3-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/alpine3.16
 
 Tags: 3.11.1-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.11.1-windowsservercore, 3.11-windowsservercore, 3-windowsservercore, windowsservercore, 3.11.1, 3.11, 3, latest
 Architectures: windows-amd64
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.11.1-windowsservercore-1809, 3.11-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.11.1-windowsservercore, 3.11-windowsservercore, 3-windowsservercore, windowsservercore, 3.11.1, 3.11, 3, latest
 Architectures: windows-amd64
-GitCommit: 722776d3f5cbc638c5cf42e1ad61a702980e2213
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.9-bullseye, 3.10-bullseye
 SharedTags: 3.10.9, 3.10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/bullseye
 
 Tags: 3.10.9-slim-bullseye, 3.10-slim-bullseye, 3.10.9-slim, 3.10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.9-buster, 3.10-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/buster
 
 Tags: 3.10.9-slim-buster, 3.10-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/slim-buster
 
 Tags: 3.10.9-alpine3.17, 3.10-alpine3.17, 3.10.9-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/alpine3.17
 
 Tags: 3.10.9-alpine3.16, 3.10-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/alpine3.16
 
 Tags: 3.10.9-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022
 SharedTags: 3.10.9-windowsservercore, 3.10-windowsservercore, 3.10.9, 3.10
 Architectures: windows-amd64
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.10.9-windowsservercore-1809, 3.10-windowsservercore-1809
 SharedTags: 3.10.9-windowsservercore, 3.10-windowsservercore, 3.10.9, 3.10
 Architectures: windows-amd64
-GitCommit: 7a54933c66171020473b9a4f06aec4e8ffb43a45
+GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/29c5505: Merge pull request https://github.com/docker-library/python/pull/783 from infosiftr/setuptools-65.5.1
- https://github.com/docker-library/python/commit/a660dab: Ditch "tac|tac" for more reliable scraping
- https://github.com/docker-library/python/commit/046374f: Temporarily add an explicit bump from setuptools 65.5.0 to 65.5.1
- https://github.com/docker-library/python/commit/826fc07: Update 3.11
- https://github.com/docker-library/python/commit/095cb43: Update 3.11
- https://github.com/docker-library/python/commit/3fa0ae0: Update generated README