### PR TITLE
Odoo: update 14.0-16.0 to release 20230109

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: bd0749b2bf01fd5b854ea87becd67c053e90698b
+GitCommit: 9674beb8a5ae48981bae2266b8c373d4eb7dd5e7
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo supported versions.

Thanks and Happy new year