### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev0, 2.8-dev, 2.8-dev0-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev1, 2.8-dev, 2.8-dev1-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 461eb7b587fa81a1ae88ef374d66f90f876b4fd8
+GitCommit: 817555017600e0dac39d93a75ef920adac450958
 Directory: 2.8
 
-Tags: 2.8-dev0-alpine, 2.8-dev-alpine, 2.8-dev0-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev1-alpine, 2.8-dev-alpine, 2.8-dev1-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 461eb7b587fa81a1ae88ef374d66f90f876b4fd8
+GitCommit: 817555017600e0dac39d93a75ef920adac450958
 Directory: 2.8/alpine
 
 Tags: 2.7.1, 2.7, latest, 2.7.1-bullseye, 2.7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8175550: Update 2.8 to 2.8-dev1