### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.27.0, 5.27, 5, latest
+Tags: 5.28.0, 5.28, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 404a78a6d0661112d5399e564e0a48b13b9def16
+GitCommit: 4045ac630b28e66a5be928a97d64e51176e66927
 Directory: 5/debian
 
-Tags: 5.27.0-alpine, 5.27-alpine, 5-alpine, alpine
+Tags: 5.28.0-alpine, 5.28-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 404a78a6d0661112d5399e564e0a48b13b9def16
+GitCommit: 4045ac630b28e66a5be928a97d64e51176e66927
 Directory: 5/alpine
 
 Tags: 4.48.9, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4045ac6: Update to 5.28.0, ghost-cli 1.24.0