### PR TITLE
Update CouchDB to 3.3.1

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -4,11 +4,11 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: f39f58d2870d9116f1176780f838e9e2ca8f96b6
+GitCommit: 41b7e8df5ad77c628cc6edb8419d4ade96ccba55
 
-Tags: latest, 3.3.0, 3.3, 3
+Tags: latest, 3.3.1, 3.3, 3
 Architectures: amd64, arm64v8, ppc64le
-Directory: 3.3.0
+Directory: 3.3.1
 
 Tags: 3.2.2, 3.2
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
Also restores arm64 and ppc64le platform support