### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.17, 1.6, 1, latest, 1.6.17-bullseye, 1.6-bullseye, 1-bullseye, bullseye
+Tags: 1.6.18, 1.6, 1, latest, 1.6.18-bullseye, 1.6-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1c39f318e3a5c1b06e4c9b0d4b870c9223b26428
+GitCommit: 32c314b7d14f704aa7596d748a3024043c6e9a7e
 Directory: debian
 
-Tags: 1.6.17-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.17-alpine3.17, 1.6-alpine3.17, 1-alpine3.17, alpine3.17
+Tags: 1.6.18-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.18-alpine3.17, 1.6-alpine3.17, 1-alpine3.17, alpine3.17
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e3f84629bb2ab9975235401c716c1e00563fa82
+GitCommit: 32c314b7d14f704aa7596d748a3024043c6e9a7e
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/32c314b: Update to 1.6.18
- https://github.com/docker-library/memcached/commit/cd28d91: Update generated README