### PR TITLE
Update CrateDB to 5.2.0 (currently testing) PLEASE DO NOT MERGE

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -8,7 +8,7 @@ Tags: 5.2.0, 5.2, latest
 Architectures: amd64, arm64v8
 GitCommit: b5a5f9b6a5e6df4a99b69dd4d007f667f704a73d
 
-Tags: 5.1.2, 5.1, latest
+Tags: 5.1.2, 5.1
 Architectures: amd64, arm64v8
 GitCommit: 88e4f9a14bef02c996c5b657633ef78e05274418
 

--- a/library/crate
+++ b/library/crate
@@ -4,6 +4,10 @@ Maintainers: Mathias Fußenegger <mathias@crate.io> (@mfussenegger),
              Andreas Motl <andreas.motl@crate.io> (@amotl)
 GitRepo: https://github.com/crate/docker-crate.git
 
+Tags: 5.2.0, 5.2, latest
+Architectures: amd64, arm64v8
+GitCommit: b5a5f9b6a5e6df4a99b69dd4d007f667f704a73d
+
 Tags: 5.1.2, 5.1, latest
 Architectures: amd64, arm64v8
 GitCommit: 88e4f9a14bef02c996c5b657633ef78e05274418


### PR DESCRIPTION
Temp PR to check changes to CrateDB docker image - **PLEASE DO NOT MERGE** as `5.2.0` is still only testing and **NOT** stable.