### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,52 +5,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.20rc2-bullseye, 1.20-rc-bullseye
-SharedTags: 1.20rc2, 1.20-rc
+Tags: 1.20rc3-bullseye, 1.20-rc-bullseye
+SharedTags: 1.20rc3, 1.20-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/bullseye
 
-Tags: 1.20rc2-buster, 1.20-rc-buster
+Tags: 1.20rc3-buster, 1.20-rc-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/buster
 
-Tags: 1.20rc2-alpine3.17, 1.20-rc-alpine3.17, 1.20rc2-alpine, 1.20-rc-alpine
+Tags: 1.20rc3-alpine3.17, 1.20-rc-alpine3.17, 1.20rc3-alpine, 1.20-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/alpine3.17
 
-Tags: 1.20rc2-alpine3.16, 1.20-rc-alpine3.16
+Tags: 1.20rc3-alpine3.16, 1.20-rc-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/alpine3.16
 
-Tags: 1.20rc2-windowsservercore-ltsc2022, 1.20-rc-windowsservercore-ltsc2022
-SharedTags: 1.20rc2-windowsservercore, 1.20-rc-windowsservercore, 1.20rc2, 1.20-rc
+Tags: 1.20rc3-windowsservercore-ltsc2022, 1.20-rc-windowsservercore-ltsc2022
+SharedTags: 1.20rc3-windowsservercore, 1.20-rc-windowsservercore, 1.20rc3, 1.20-rc
 Architectures: windows-amd64
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.20rc2-windowsservercore-1809, 1.20-rc-windowsservercore-1809
-SharedTags: 1.20rc2-windowsservercore, 1.20-rc-windowsservercore, 1.20rc2, 1.20-rc
+Tags: 1.20rc3-windowsservercore-1809, 1.20-rc-windowsservercore-1809
+SharedTags: 1.20rc3-windowsservercore, 1.20-rc-windowsservercore, 1.20rc3, 1.20-rc
 Architectures: windows-amd64
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.20rc2-nanoserver-ltsc2022, 1.20-rc-nanoserver-ltsc2022
-SharedTags: 1.20rc2-nanoserver, 1.20-rc-nanoserver
+Tags: 1.20rc3-nanoserver-ltsc2022, 1.20-rc-nanoserver-ltsc2022
+SharedTags: 1.20rc3-nanoserver, 1.20-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.20rc2-nanoserver-1809, 1.20-rc-nanoserver-1809
-SharedTags: 1.20rc2-nanoserver, 1.20-rc-nanoserver
+Tags: 1.20rc3-nanoserver-1809, 1.20-rc-nanoserver-1809
+SharedTags: 1.20rc3-nanoserver, 1.20-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: af7579626a74bc783a4f511a4951955390ef8c95
+GitCommit: 9a135136dcd3d56a39e1f40c5b264938eac0c7ee
 Directory: 1.20-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/9a13513: Update 1.20-rc to 1.20rc3