### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,107 +4,107 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-4-jdk-oraclelinux8, 21-ea-4-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-4-jdk-oracle, 21-ea-4-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-4-jdk, 21-ea-4, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-5-jdk-oraclelinux8, 21-ea-5-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-5-jdk-oracle, 21-ea-5-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-5-jdk, 21-ea-5, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-4-jdk-oraclelinux7, 21-ea-4-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-5-jdk-oraclelinux7, 21-ea-5-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-4-jdk-bullseye, 21-ea-4-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-5-jdk-bullseye, 21-ea-5-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-4-jdk-slim-bullseye, 21-ea-4-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-4-jdk-slim, 21-ea-4-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-5-jdk-slim-bullseye, 21-ea-5-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-5-jdk-slim, 21-ea-5-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-4-jdk-buster, 21-ea-4-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-5-jdk-buster, 21-ea-5-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/buster
 
-Tags: 21-ea-4-jdk-slim-buster, 21-ea-4-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-5-jdk-slim-buster, 21-ea-5-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-4-jdk-windowsservercore-ltsc2022, 21-ea-4-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-4-jdk-windowsservercore, 21-ea-4-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-4-jdk, 21-ea-4, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-5-jdk-windowsservercore-ltsc2022, 21-ea-5-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-5-jdk-windowsservercore, 21-ea-5-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-5-jdk, 21-ea-5, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-4-jdk-windowsservercore-1809, 21-ea-4-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-4-jdk-windowsservercore, 21-ea-4-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-4-jdk, 21-ea-4, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-5-jdk-windowsservercore-1809, 21-ea-5-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-5-jdk-windowsservercore, 21-ea-5-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-5-jdk, 21-ea-5, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-4-jdk-nanoserver-1809, 21-ea-4-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-4-jdk-nanoserver, 21-ea-4-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-5-jdk-nanoserver-1809, 21-ea-5-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-5-jdk-nanoserver, 21-ea-5-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 4310f07d73b56b8fe43afac20ce9bc42ee03f11f
+GitCommit: bd86423db3e426763148dff5994388bfae7b98c6
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 20-ea-30-jdk-oraclelinux8, 20-ea-30-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-30-jdk-oracle, 20-ea-30-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-30-jdk, 20-ea-30, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-31-jdk-oraclelinux8, 20-ea-31-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-31-jdk-oracle, 20-ea-31-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-31-jdk, 20-ea-31, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-30-jdk-oraclelinux7, 20-ea-30-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-31-jdk-oraclelinux7, 20-ea-31-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-30-jdk-bullseye, 20-ea-30-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-31-jdk-bullseye, 20-ea-31-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-30-jdk-slim-bullseye, 20-ea-30-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-30-jdk-slim, 20-ea-30-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-31-jdk-slim-bullseye, 20-ea-31-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-31-jdk-slim, 20-ea-31-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-30-jdk-buster, 20-ea-30-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-31-jdk-buster, 20-ea-31-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/buster
 
-Tags: 20-ea-30-jdk-slim-buster, 20-ea-30-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-31-jdk-slim-buster, 20-ea-31-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-30-jdk-windowsservercore-ltsc2022, 20-ea-30-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-30-jdk-windowsservercore, 20-ea-30-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-30-jdk, 20-ea-30, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-31-jdk-windowsservercore-ltsc2022, 20-ea-31-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-31-jdk-windowsservercore, 20-ea-31-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-31-jdk, 20-ea-31, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-30-jdk-windowsservercore-1809, 20-ea-30-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-30-jdk-windowsservercore, 20-ea-30-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-30-jdk, 20-ea-30, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-31-jdk-windowsservercore-1809, 20-ea-31-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-31-jdk-windowsservercore, 20-ea-31-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-31-jdk, 20-ea-31, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-30-jdk-nanoserver-1809, 20-ea-30-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-30-jdk-nanoserver, 20-ea-30-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-31-jdk-nanoserver-1809, 20-ea-31-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-31-jdk-nanoserver, 20-ea-31-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: a01d45bbf6de1dcf5c73184ae11af4f7a2a1af37
+GitCommit: 144d02bdeaa6b86a548d156e40638445a1836164
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/bd86423: Update 21 to 21-ea+5
- https://github.com/docker-library/openjdk/commit/144d02b: Update 20 to 20-ea+31