### PR TITLE
arangodb 3.9.7

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,10 +7,10 @@ Architectures: amd64
 GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
 Directory: alpine/3.8.8
 
-Tags: 3.9, 3.9.6
+Tags: 3.9, 3.9.7
 Architectures: amd64
-GitCommit: eaced44aa34cfe94a89684292a01d18d6099465f
-Directory: alpine/3.9.6
+GitCommit: 7e84f26b857856a5350c5c636f6bedc43ee95ab0
+Directory: alpine/3.9.7
 
 Tags: 3.10, 3.10.2, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated ArangoDB 3.9 to 3.9.7.