### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,32 +6,32 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 3.2.0-bullseye, 3.2-bullseye, 3-bullseye, bullseye, 3.2.0, 3.2, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8ea8c4000c5005771efc9ce34931763d191462cb
+GitCommit: c756b06f8cc771fb54f629d51217aa1802ba6ec2
 Directory: 3.2/bullseye
 
 Tags: 3.2.0-slim-bullseye, 3.2-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.2.0-slim, 3.2-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8ea8c4000c5005771efc9ce34931763d191462cb
+GitCommit: c756b06f8cc771fb54f629d51217aa1802ba6ec2
 Directory: 3.2/slim-bullseye
 
 Tags: 3.2.0-buster, 3.2-buster, 3-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 8ea8c4000c5005771efc9ce34931763d191462cb
+GitCommit: c756b06f8cc771fb54f629d51217aa1802ba6ec2
 Directory: 3.2/buster
 
 Tags: 3.2.0-slim-buster, 3.2-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 8ea8c4000c5005771efc9ce34931763d191462cb
+GitCommit: c756b06f8cc771fb54f629d51217aa1802ba6ec2
 Directory: 3.2/slim-buster
 
 Tags: 3.2.0-alpine3.17, 3.2-alpine3.17, 3-alpine3.17, alpine3.17, 3.2.0-alpine, 3.2-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ea8c4000c5005771efc9ce34931763d191462cb
+GitCommit: c756b06f8cc771fb54f629d51217aa1802ba6ec2
 Directory: 3.2/alpine3.17
 
 Tags: 3.2.0-alpine3.16, 3.2-alpine3.16, 3-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8ea8c4000c5005771efc9ce34931763d191462cb
+GitCommit: c756b06f8cc771fb54f629d51217aa1802ba6ec2
 Directory: 3.2/alpine3.16
 
 Tags: 3.1.3-bullseye, 3.1-bullseye, 3.1.3, 3.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/d9b3dc7: Merge pull request https://github.com/docker-library/ruby/pull/400 from paihu/debian-yjit
- https://github.com/docker-library/ruby/commit/c756b06: Refactor to pull Rust version/checksum information from versions.json
- https://github.com/docker-library/ruby/commit/6db728e: Add YJIT support to debian 3.2+
- https://github.com/docker-library/ruby/commit/4edf684: Ditch "tac|tac" for more reliable scraping