### PR TITLE
[ros] retire galactic images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -101,28 +101,6 @@ Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 
 ################################################################################
-# Release: galactic
-
-########################################
-# Distro: ubuntu:focal
-
-Tags: galactic-ros-core, galactic-ros-core-focal
-Architectures: amd64, arm64v8
-GitCommit: 5985ea8e2e88e25a839f0f1629fe7d32f28a39d8
-Directory: ros/galactic/ubuntu/focal/ros-core
-
-Tags: galactic-ros-base, galactic-ros-base-focal, galactic
-Architectures: amd64, arm64v8
-GitCommit: 6511d8fc0754616550b7f5ea31a40084c2462938
-Directory: ros/galactic/ubuntu/focal/ros-base
-
-Tags: galactic-ros1-bridge, galactic-ros1-bridge-focal
-Architectures: amd64, arm64v8
-GitCommit: 6e373ee0469ae61723bb5ed863a38af76e179c81
-Directory: ros/galactic/ubuntu/focal/ros1-bridge
-
-
-################################################################################
 # Release: humble
 
 ########################################


### PR DESCRIPTION
follow-up of https://github.com/docker-library/official-images/pull/13881

Stop buildin ROS Galactic images that is now EOL and final images have been built