### PR TITLE
Add new `.external-pins/tag.sh` script for going from a filename to image:tag

### DIFF
--- a/.external-pins/file.sh
+++ b/.external-pins/file.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 set -Eeuo pipefail
 
+# given an image (name:tag), return the appropriate filename
+
 dir="$(dirname "$BASH_SOURCE")"
 
 for img; do

--- a/.external-pins/tag.sh
+++ b/.external-pins/tag.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -Eeuo pipefail
+
+# given a filename, return the appropriate image (name:tag)
+
+origDir="$(dirname "$BASH_SOURCE")"
+dir="$(readlink -ve "$origDir")"
+
+for file; do
+	abs="$(readlink -vm "$file")"
+	rel="${abs#$dir/}"
+	rel="${rel##*.external-pins/}" # in case we weren't inside "$dir" but the path is legit
+	if [ "$rel" = "$abs" ]; then
+		echo >&2 "error: '$file' is not within '$origDir'"
+		echo >&2 "('$abs' vs '$dir')"
+		exit 1
+	fi
+
+	img="${rel/___/:}" # see ".external-pins/list.sh"
+	if [ "$img" = "$rel" ]; then
+		echo >&2 "error: '$file' does not contain ':' ('___') -- this violates our assumptions!"
+		exit 1
+	fi
+
+	echo "$img"
+done


### PR DESCRIPTION
This allows us to do things like ask Git for a list of `.external-pins/*/**` files changed and then convert that into a list of external image:tag references.

(This is part of the ongoing work I'm doing in https://github.com/docker-library/official-images/pull/13883)