### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -51,15 +51,15 @@ Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
+GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.0/alpine
 
 Tags: cli-2.7.1-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
+GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.1/alpine
 
 Tags: cli-2.7.1-php8.2, cli-2.7-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6569609b4db94cdf0c2eac852456049ac7eacea5
+GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/809519c: Update cli to 2.7.1
- https://github.com/docker-library/wordpress/commit/cafe8db: Update cli to 2.6.0
- https://github.com/docker-library/wordpress/commit/c705336: Update generated README