### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.31, 8.0, 8, latest, 8.0.31-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.0.32, 8.0, 8, latest, 8.0.32-oracle, 8.0-oracle, 8-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: e0d43b2a29867c5b7d5c01a8fea30a086861df2b
+GitCommit: b3dc453ce1a149ad698e29715d818cf042605163
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.31-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.32-debian, 8.0-debian, 8-debian, debian
 Architectures: amd64
-GitCommit: e0d43b2a29867c5b7d5c01a8fea30a086861df2b
+GitCommit: b3dc453ce1a149ad698e29715d818cf042605163
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.40, 5.7, 5, 5.7.40-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.41, 5.7, 5, 5.7.41-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: e0d43b2a29867c5b7d5c01a8fea30a086861df2b
+GitCommit: 77d590d7d141caa3280ff2d838f70c6581a9d704
 Directory: 5.7
 File: Dockerfile.oracle
 
-Tags: 5.7.40-debian, 5.7-debian, 5-debian
+Tags: 5.7.41-debian, 5.7-debian, 5-debian
 Architectures: amd64
-GitCommit: e0d43b2a29867c5b7d5c01a8fea30a086861df2b
+GitCommit: 77d590d7d141caa3280ff2d838f70c6581a9d704
 Directory: 5.7
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/b3dc453: Update 8.0 to 8.0.32, debian 8.0.32-1debian11, mysql-shell 8.0.32-1.el8, oracle 8.0.32-1.el8
- https://github.com/docker-library/mysql/commit/77d590d: Update 5.7 to 5.7.41, debian 5.7.41-1debian10, mysql-shell 8.0.32-1.el7, oracle 5.7.41-1.el7
- https://github.com/docker-library/mysql/commit/1930ff7: Update generated README
- https://github.com/docker-library/mysql/commit/43450e7: Use new "bashbrew" composite action