### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2023-0116 ELSA-2023-0110 ELSA-2023-0103 ELSA-2023-0096 ELSA-2023-0100 ELSA-2023-0100 ELSA-2023-0173

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4205dc2e387076df43d84c44bd2617d8d0770873
+amd64-GitCommit: 0c48214d49bc1e2e1498ded618a6f898fd3af2b4
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fa5836613dda485642d5711df919701945109ae0
+arm64v8-GitCommit: 4f66b07ceef093be25fabe8530bbff8bf2371dcb
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-46848, CVE-2022-35737, CVE-2022-43680, CVE-2022-42010, CVE-2022-42011, CVE-2022-42012, CVE-2022-3821, CVE-2022-3821, CVE-2022-40303, CVE-2022-40304

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-0116.html
https://linux.oracle.com/errata/ELSA-2023-0110.html
https://linux.oracle.com/errata/ELSA-2023-0103.html
https://linux.oracle.com/errata/ELSA-2023-0096.html
https://linux.oracle.com/errata/ELSA-2023-0100.html
https://linux.oracle.com/errata/ELSA-2023-0173.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
