### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,70 +6,70 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 2.8-dev1, 2.8-dev, 2.8-dev1-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 817555017600e0dac39d93a75ef920adac450958
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.8
 
 Tags: 2.8-dev1-alpine, 2.8-dev-alpine, 2.8-dev1-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 817555017600e0dac39d93a75ef920adac450958
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.8/alpine
 
-Tags: 2.7.1, 2.7, latest, 2.7.1-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.2, 2.7, latest, 2.7.2-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eccea371bf2c3d5744a8ad1b2f5861825161052f
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.7
 
-Tags: 2.7.1-alpine, 2.7-alpine, alpine, 2.7.1-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.2-alpine, 2.7-alpine, alpine, 2.7.2-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eccea371bf2c3d5744a8ad1b2f5861825161052f
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.7/alpine
 
 Tags: 2.6.7, 2.6, lts, 2.6.7-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ae13c91cf82c4042360a0363b4d3fa190a51341
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.6
 
 Tags: 2.6.7-alpine, 2.6-alpine, lts-alpine, 2.6.7-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9ae13c91cf82c4042360a0363b4d3fa190a51341
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.6/alpine
 
 Tags: 2.5.10, 2.5, 2.5.10-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 541751988360a0ee55b6bee53c2d41acafaee35d
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.5
 
 Tags: 2.5.10-alpine, 2.5-alpine, 2.5.10-alpine3.17, 2.5-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 541751988360a0ee55b6bee53c2d41acafaee35d
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.5/alpine
 
 Tags: 2.4.20, 2.4, 2.4.20-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6a15b45320ff96bb7548248596ac0ee3d38d8fab
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.4
 
 Tags: 2.4.20-alpine, 2.4-alpine, 2.4.20-alpine3.17, 2.4-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a15b45320ff96bb7548248596ac0ee3d38d8fab
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.4/alpine
 
 Tags: 2.2.26, 2.2, 2.2.26-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509852454b03fd3aeaad66d46b5f6655275646bb
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.2
 
 Tags: 2.2.26-alpine, 2.2-alpine, 2.2.26-alpine3.17, 2.2-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 509852454b03fd3aeaad66d46b5f6655275646bb
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.2/alpine
 
 Tags: 2.0.30, 2.0, 2.0.30-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c845b04087b9d388d60f3158670c37c31e7e6fbb
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.0
 
 Tags: 2.0.30-alpine, 2.0-alpine, 2.0.30-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c845b04087b9d388d60f3158670c37c31e7e6fbb
+GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/079f579: Specify WORKDIR /var/lib/haproxy (https://github.com/docker-library/haproxy/pull/203)
- https://github.com/docker-library/haproxy/commit/4be428c: Update 2.7 to 2.7.2