### PR TITLE
archlinux: Release 20230122.0.120412

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230115.0.118859
-GitCommit: f7624de21a4eef6c4695832c8da04b7cafa29a28
-GitFetch: refs/tags/v20230115.0.118859
+Tags: latest, base, base-20230122.0.120412
+GitCommit: e338afb69df3895a2615b9f81370676e2dad45bc
+GitFetch: refs/tags/v20230122.0.120412
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230115.0.118859
-GitCommit: f7624de21a4eef6c4695832c8da04b7cafa29a28
-GitFetch: refs/tags/v20230115.0.118859
+Tags: base-devel, base-devel-20230122.0.120412
+GitCommit: e338afb69df3895a2615b9f81370676e2dad45bc
+GitFetch: refs/tags/v20230122.0.120412
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks