### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
 Directory: 2.7/alpine
 
-Tags: 2.6.7, 2.6, lts, 2.6.7-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.8, 2.6, lts, 2.6.8-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: 3f34d251e1eaa353070197444bf36ccfe222756f
 Directory: 2.6
 
-Tags: 2.6.7-alpine, 2.6-alpine, lts-alpine, 2.6.7-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.8-alpine, 2.6-alpine, lts-alpine, 2.6.8-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: 3f34d251e1eaa353070197444bf36ccfe222756f
 Directory: 2.6/alpine
 
-Tags: 2.5.10, 2.5, 2.5.10-bullseye, 2.5-bullseye
+Tags: 2.5.11, 2.5, 2.5.11-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: 1e16cda4e30596c084edea399d3e6b41c0b1d015
 Directory: 2.5
 
-Tags: 2.5.10-alpine, 2.5-alpine, 2.5.10-alpine3.17, 2.5-alpine3.17
+Tags: 2.5.11-alpine, 2.5-alpine, 2.5.11-alpine3.17, 2.5-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: 1e16cda4e30596c084edea399d3e6b41c0b1d015
 Directory: 2.5/alpine
 
 Tags: 2.4.20, 2.4, 2.4.20-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3f34d25: Update 2.6 to 2.6.8
- https://github.com/docker-library/haproxy/commit/1e16cda: Update 2.5 to 2.5.11