### PR TITLE
eclipse-temurin: second round of January PSU updates

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -388,130 +388,129 @@ Directory: 17/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-
 #------------------------------v19 images---------------------------------
-Tags: 19.0.1_10-jdk-alpine, 19-jdk-alpine, 19-alpine
+Tags: 19.0.2_7-jdk-alpine, 19-jdk-alpine, 19-alpine
 Architectures: amd64
-GitCommit: 3bab86587b3f3af5f67f9a6e5d33c50fdaecd4db
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jdk-focal, 19-jdk-focal, 19-focal
+Tags: 19.0.2_7-jdk-focal, 19-jdk-focal, 19-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jdk-jammy, 19-jdk-jammy, 19-jammy
-SharedTags: 19.0.1_10-jdk, 19-jdk, 19, latest
+Tags: 19.0.2_7-jdk-jammy, 19-jdk-jammy, 19-jammy
+SharedTags: 19.0.2_7-jdk, 19-jdk, 19, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jdk-centos7, 19-jdk-centos7, 19-centos7
+Tags: 19.0.2_7-jdk-centos7, 19-jdk-centos7, 19-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jdk-ubi9-minimal, 19-jdk-ubi9-minimal, 19-ubi9-minimal
+Tags: 19.0.2_7-jdk-ubi9-minimal, 19-jdk-ubi9-minimal, 19-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 910222e9f290871048016f4e0afd0c203d4a80d5
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jdk-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19.0.1_10-jdk-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19.0.1_10-jdk, 19-jdk, 19, latest
+Tags: 19.0.2_7-jdk-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
+SharedTags: 19.0.2_7-jdk-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19.0.2_7-jdk, 19-jdk, 19, latest
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19.0.1_10-jdk-nanoserver-ltsc2022, 19-jdk-nanoserver-ltsc2022, 19-nanoserver-ltsc2022
-SharedTags: 19.0.1_10-jdk-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19.0.2_7-jdk-nanoserver-ltsc2022, 19-jdk-nanoserver-ltsc2022, 19-nanoserver-ltsc2022
+SharedTags: 19.0.2_7-jdk-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 19.0.1_10-jdk-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19.0.1_10-jdk-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19.0.1_10-jdk, 19-jdk, 19, latest
+Tags: 19.0.2_7-jdk-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
+SharedTags: 19.0.2_7-jdk-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19.0.2_7-jdk, 19-jdk, 19, latest
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 19.0.1_10-jdk-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19.0.1_10-jdk-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 19.0.2_7-jdk-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
+SharedTags: 19.0.2_7-jdk-nanoserver, 19-jdk-nanoserver, 19-nanoserver
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 19.0.1_10-jre-alpine, 19-jre-alpine
+Tags: 19.0.2_7-jre-alpine, 19-jre-alpine
 Architectures: amd64
-GitCommit: 3bab86587b3f3af5f67f9a6e5d33c50fdaecd4db
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jre-focal, 19-jre-focal
+Tags: 19.0.2_7-jre-focal, 19-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jre-jammy, 19-jre-jammy
-SharedTags: 19.0.1_10-jre, 19-jre
+Tags: 19.0.2_7-jre-jammy, 19-jre-jammy
+SharedTags: 19.0.2_7-jre, 19-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jre-centos7, 19-jre-centos7
+Tags: 19.0.2_7-jre-centos7, 19-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jre-ubi9-minimal, 19-jre-ubi9-minimal
+Tags: 19.0.2_7-jre-ubi9-minimal, 19-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 910222e9f290871048016f4e0afd0c203d4a80d5
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 19.0.1_10-jre-windowsservercore-ltsc2022, 19-jre-windowsservercore-ltsc2022
-SharedTags: 19.0.1_10-jre-windowsservercore, 19-jre-windowsservercore, 19.0.1_10-jre, 19-jre
+Tags: 19.0.2_7-jre-windowsservercore-ltsc2022, 19-jre-windowsservercore-ltsc2022
+SharedTags: 19.0.2_7-jre-windowsservercore, 19-jre-windowsservercore, 19.0.2_7-jre, 19-jre
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19.0.1_10-jre-nanoserver-ltsc2022, 19-jre-nanoserver-ltsc2022
-SharedTags: 19.0.1_10-jre-nanoserver, 19-jre-nanoserver
+Tags: 19.0.2_7-jre-nanoserver-ltsc2022, 19-jre-nanoserver-ltsc2022
+SharedTags: 19.0.2_7-jre-nanoserver, 19-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 19.0.1_10-jre-windowsservercore-1809, 19-jre-windowsservercore-1809
-SharedTags: 19.0.1_10-jre-windowsservercore, 19-jre-windowsservercore, 19.0.1_10-jre, 19-jre
+Tags: 19.0.2_7-jre-windowsservercore-1809, 19-jre-windowsservercore-1809
+SharedTags: 19.0.2_7-jre-windowsservercore, 19-jre-windowsservercore, 19.0.2_7-jre, 19-jre
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 19.0.1_10-jre-nanoserver-1809, 19-jre-nanoserver-1809
-SharedTags: 19.0.1_10-jre-nanoserver, 19-jre-nanoserver
+Tags: 19.0.2_7-jre-nanoserver-1809, 19-jre-nanoserver-1809
+SharedTags: 19.0.2_7-jre-nanoserver, 19-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: e37c219c8f2aef0c0028a627b1e372a046138dea
+GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
 Directory: 19/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -6,128 +6,128 @@ GitRepo: https://github.com/adoptium/containers.git
 GitFetch: refs/heads/main
 
 #------------------------------v8 images---------------------------------
-Tags: 8u352-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u362-b09-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 3bab86587b3f3af5f67f9a6e5d33c50fdaecd4db
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jdk-focal, 8-jdk-focal, 8-focal
+Tags: 8u362-b09-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
-SharedTags: 8u352-b08-jdk, 8-jdk, 8
+Tags: 8u362-b09-jdk-jammy, 8-jdk-jammy, 8-jammy
+SharedTags: 8u362-b09-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
+Tags: 8u362-b09-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Tags: 8u362-b09-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 910222e9f290871048016f4e0afd0c203d4a80d5
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u352-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u352-b08-jdk, 8-jdk, 8
+Tags: 8u362-b09-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u362-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u362-b09-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u352-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
-SharedTags: 8u352-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u362-b09-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
+SharedTags: 8u362-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u352-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u352-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u352-b08-jdk, 8-jdk, 8
+Tags: 8u362-b09-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u362-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u362-b09-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u352-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u352-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u362-b09-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u362-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u352-b08-jre-alpine, 8-jre-alpine
+Tags: 8u362-b09-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 3bab86587b3f3af5f67f9a6e5d33c50fdaecd4db
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jre-focal, 8-jre-focal
+Tags: 8u362-b09-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jre-jammy, 8-jre-jammy
-SharedTags: 8u352-b08-jre, 8-jre
+Tags: 8u362-b09-jre-jammy, 8-jre-jammy
+SharedTags: 8u362-b09-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jre-centos7, 8-jre-centos7
+Tags: 8u362-b09-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Tags: 8u362-b09-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 910222e9f290871048016f4e0afd0c203d4a80d5
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 8u352-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u352-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u352-b08-jre, 8-jre
+Tags: 8u362-b09-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u362-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u362-b09-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u352-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
-SharedTags: 8u352-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u362-b09-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
+SharedTags: 8u362-b09-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u352-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u352-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u352-b08-jre, 8-jre
+Tags: 8u362-b09-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u362-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u362-b09-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u352-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u352-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u362-b09-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u362-b09-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: fa65b46d19f4db0e1c8736c3d7b2a8392dd58b1b
+GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
 Directory: 8/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Adds the remaining release versions