### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: a4656f18f9a049b7ba91a5d2281af656ad819836
 
-Tags: 2.0.20221210.0, 2, latest
+Tags: 2.0.20230119.1, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 9025e0ce9166d150ef8c28dd0d88465a250cf79d
+amd64-GitCommit: 8cd3a1d4d2516e33d3b26247120ecfc8d9d01d07
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 84cd6d3fe2e3cd9126e98f2c809622c97c827482
+arm64v8-GitCommit: fe9ce6ed22a3ca487bf4fd0826c453bec40803ab
 
-Tags: 2.0.20221210.0-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20230119.1-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 2040b2eb2433e45f0f20ab4d8475bf122580a6f5
+amd64-GitCommit: b5c54379aea40f6d9a0d50af4677399d0defff7b
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: cdfaff090e256d7f9586c889467807634be5ebd9
+arm64v8-GitCommit: f164a83dfbb6c090bee67864e39f4cdf1f365d89
 
 Tags: 2018.03.0.20221209.1, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- libtasn1-4.10-1.amzn2.0.3
  - [CVE-2021-46848](https://alas.aws.amazon.com/cve/html/CVE-2021-46848.html)
- sqlite-3.7.17-8.amzn2.1.2
  - [CVE-2022-35737](https://alas.aws.amazon.com/cve/html/CVE-2022-35737.html)