### PR TITLE
arangodb 3.9.8, 3.10.3

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,12 +7,12 @@ Architectures: amd64
 GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
 Directory: alpine/3.8.8
 
-Tags: 3.9, 3.9.7
+Tags: 3.9, 3.9.8
 Architectures: amd64
-GitCommit: 7e84f26b857856a5350c5c636f6bedc43ee95ab0
-Directory: alpine/3.9.7
+GitCommit: 42d86d150782ccdfdf848bd5e4dc3b51d85f4364
+Directory: alpine/3.9.8
 
-Tags: 3.10, 3.10.2, latest
+Tags: 3.10, 3.10.3, latest
 Architectures: amd64, arm64v8
-GitCommit: 71fda53ef666d8c85fbd70748a26e7c86bcf3fbf
-Directory: alpine/3.10.2
+GitCommit: 42d86d150782ccdfdf848bd5e4dc3b51d85f4364
+Directory: alpine/3.10.3


### PR DESCRIPTION
Updated ArangoDB 3.9 to 3.9.8 and 3.10 to 3.10.3.