### PR TITLE
[oraclelinux] Updating 7,7-slim,8,8-slim,9 and 9-slim for multiple errata

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0c48214d49bc1e2e1498ded618a6f898fd3af2b4
+amd64-GitCommit: ad17dede93fdaec2315c283a64ed47621e1d4a6d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4f66b07ceef093be25fabe8530bbff8bf2371dcb
+arm64v8-GitCommit: 409967fa7cd110ee8f2a248c5f345154ea933b07
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fix for the following CVEs:
CVE-2021-25220, CVE-2022-2795, CVE-2022-3715, CVE-2021-46848, CVE-2022-3821, CVE-2022-35737, CVE-2022-42010, CVE-2022-42011, CVE-2022-42012, CVE-2022-40303, CVE-2022-40304, CVE-2022-43680, CVE-2022-32221.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-0402.html
https://linux.oracle.com/errata/ELSA-2023-0343.html
https://linux.oracle.com/errata/ELSA-2023-0336.html
https://linux.oracle.com/errata/ELSA-2023-0340.html
https://linux.oracle.com/errata/ELSA-2023-0339.html
https://linux.oracle.com/errata/ELSA-2023-0335.html
https://linux.oracle.com/errata/ELSA-2023-0338.html
https://linux.oracle.com/errata/ELSA-2023-0337.html
https://linux.oracle.com/errata/ELSA-2023-0333.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>