### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,24 +44,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1e16cda4e30596c084edea399d3e6b41c0b1d015
 Directory: 2.5/alpine
 
-Tags: 2.4.20, 2.4, 2.4.20-bullseye, 2.4-bullseye
+Tags: 2.4.21, 2.4, 2.4.21-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: ba547847c5a78e92688dd52e539a2ced84b42657
 Directory: 2.4
 
-Tags: 2.4.20-alpine, 2.4-alpine, 2.4.20-alpine3.17, 2.4-alpine3.17
+Tags: 2.4.21-alpine, 2.4-alpine, 2.4.21-alpine3.17, 2.4-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: ba547847c5a78e92688dd52e539a2ced84b42657
 Directory: 2.4/alpine
 
-Tags: 2.2.26, 2.2, 2.2.26-bullseye, 2.2-bullseye
+Tags: 2.2.27, 2.2, 2.2.27-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: eef0f5eb78c5477243d51b9b1d426a1774b2e029
 Directory: 2.2
 
-Tags: 2.2.26-alpine, 2.2-alpine, 2.2.26-alpine3.17, 2.2-alpine3.17
+Tags: 2.2.27-alpine, 2.2-alpine, 2.2.27-alpine3.17, 2.2-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: eef0f5eb78c5477243d51b9b1d426a1774b2e029
 Directory: 2.2/alpine
 
 Tags: 2.0.30, 2.0, 2.0.30-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ba54784: Update 2.4 to 2.4.21
- https://github.com/docker-library/haproxy/commit/eef0f5e: Update 2.2 to 2.2.27