### PR TITLE
archlinux: Release 20230129.0.122153

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230122.0.120412
-GitCommit: e338afb69df3895a2615b9f81370676e2dad45bc
-GitFetch: refs/tags/v20230122.0.120412
+Tags: latest, base, base-20230129.0.122153
+GitCommit: 75dd5eff9d3bf9fdeb3201d33baa4fae53fbc5e7
+GitFetch: refs/tags/v20230129.0.122153
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230122.0.120412
-GitCommit: e338afb69df3895a2615b9f81370676e2dad45bc
-GitFetch: refs/tags/v20230122.0.120412
+Tags: base-devel, base-devel-20230129.0.122153
+GitCommit: 75dd5eff9d3bf9fdeb3201d33baa4fae53fbc5e7
+GitFetch: refs/tags/v20230129.0.122153
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks