### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,60 +6,105 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.1.1-apache, 6.1-apache, 6-apache, apache, 6.1.1, 6.1, 6, latest, 6.1.1-php8.0-apache, 6.1-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.1.1-php8.0, 6.1-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.0/apache
 
 Tags: 6.1.1-fpm, 6.1-fpm, 6-fpm, fpm, 6.1.1-php8.0-fpm, 6.1-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.0/fpm
 
 Tags: 6.1.1-fpm-alpine, 6.1-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.1.1-php8.0-fpm-alpine, 6.1-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.0/fpm-alpine
 
 Tags: 6.1.1-php8.1-apache, 6.1-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.1.1-php8.1, 6.1-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.1/apache
 
 Tags: 6.1.1-php8.1-fpm, 6.1-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.1/fpm
 
 Tags: 6.1.1-php8.1-fpm-alpine, 6.1-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97f75b51f909fbd9894d128ea6893120cfd23979
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.1/fpm-alpine
 
 Tags: 6.1.1-php8.2-apache, 6.1-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.1.1-php8.2, 6.1-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6569609b4db94cdf0c2eac852456049ac7eacea5
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.2/apache
 
 Tags: 6.1.1-php8.2-fpm, 6.1-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6569609b4db94cdf0c2eac852456049ac7eacea5
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.2/fpm
 
 Tags: 6.1.1-php8.2-fpm-alpine, 6.1-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6569609b4db94cdf0c2eac852456049ac7eacea5
+GitCommit: 51a939a2a5e387ce04697ce9967a07bbe3892601
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
+GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.0/alpine
 
 Tags: cli-2.7.1-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b95184001fd181d86d4a409a4ae26b23795bb0d4
+GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.1/alpine
 
 Tags: cli-2.7.1-php8.2, cli-2.7-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6569609b4db94cdf0c2eac852456049ac7eacea5
+GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.2/alpine
+
+Tags: beta-6.2-beta1-apache, beta-6.2-apache, beta-6-apache, beta-apache, beta-6.2-beta1, beta-6.2, beta-6, beta, beta-6.2-beta1-php8.0-apache, beta-6.2-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.2-beta1-php8.0, beta-6.2-php8.0, beta-6-php8.0, beta-php8.0
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.0/apache
+
+Tags: beta-6.2-beta1-fpm, beta-6.2-fpm, beta-6-fpm, beta-fpm, beta-6.2-beta1-php8.0-fpm, beta-6.2-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.0/fpm
+
+Tags: beta-6.2-beta1-fpm-alpine, beta-6.2-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.2-beta1-php8.0-fpm-alpine, beta-6.2-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.0/fpm-alpine
+
+Tags: beta-6.2-beta1-php8.1-apache, beta-6.2-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.2-beta1-php8.1, beta-6.2-php8.1, beta-6-php8.1, beta-php8.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.1/apache
+
+Tags: beta-6.2-beta1-php8.1-fpm, beta-6.2-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.1/fpm
+
+Tags: beta-6.2-beta1-php8.1-fpm-alpine, beta-6.2-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.1/fpm-alpine
+
+Tags: beta-6.2-beta1-php8.2-apache, beta-6.2-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.2-beta1-php8.2, beta-6.2-php8.2, beta-6-php8.2, beta-php8.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.2/apache
+
+Tags: beta-6.2-beta1-php8.2-fpm, beta-6.2-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.2/fpm
+
+Tags: beta-6.2-beta1-php8.2-fpm-alpine, beta-6.2-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 9732991309b06adbe332ee6fa4d4ae5a549e6673
+Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/9732991: Update beta to 6.2-beta1
- https://github.com/docker-library/wordpress/commit/e956c68: Merge pull request https://github.com/docker-library/wordpress/pull/794 from infosiftr/deprecated-opcache-option
- https://github.com/docker-library/wordpress/commit/51a939a: Drop deprecated opcache.fast_shutdown config
- https://github.com/docker-library/wordpress/commit/809519c: Update cli to 2.7.1
- https://github.com/docker-library/wordpress/commit/cafe8db: Update cli to 2.6.0
- https://github.com/docker-library/wordpress/commit/c705336: Update generated README