### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redis.git
 
 Tags: 7.0.8, 7.0, 7, latest, 7.0.8-bullseye, 7.0-bullseye, 7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 787f47c4bda6943e29d85fa45e080bd55b2c08fa
+GitCommit: d5c6f471fe4c0db5c614b568f11d4102a0cc685b
 Directory: 7.0
 
 Tags: 7.0.8-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.8-alpine3.17, 7.0-alpine3.17, 7-alpine3.17, alpine3.17
@@ -16,7 +16,7 @@ Directory: 7.0/alpine
 
 Tags: 6.2.10, 6.2, 6, 6.2.10-bullseye, 6.2-bullseye, 6-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b463859e24cfeea54e7a323e530f254e74075f6
+GitCommit: d5c6f471fe4c0db5c614b568f11d4102a0cc685b
 Directory: 6.2
 
 Tags: 6.2.10-alpine, 6.2-alpine, 6-alpine, 6.2.10-alpine3.17, 6.2-alpine3.17, 6-alpine3.17
@@ -26,7 +26,7 @@ Directory: 6.2/alpine
 
 Tags: 6.0.17, 6.0, 6.0.17-bullseye, 6.0-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e608c4a20201d43672d6f045d4fc4c523e0473ad
+GitCommit: d5c6f471fe4c0db5c614b568f11d4102a0cc685b
 Directory: 6.0
 
 Tags: 6.0.17-alpine, 6.0-alpine, 6.0.17-alpine3.17, 6.0-alpine3.17


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/66ae35c: Merge pull request https://github.com/docker-library/redis/pull/341 from jmthomas/bump_gosu
- https://github.com/docker-library/redis/commit/d5c6f47: Bump gosu to 1.16