### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,62 +5,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.11.7, 3.11, 3, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 951163e34b4d4fd5f033ebcd6eebeb4c46f53db9
+Tags: 3.11.8, 3.11, 3, latest
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: e08fa77bc1b1601b3bd5638ff5f25d4d2ced724d
 Directory: 3.11/ubuntu
 
-Tags: 3.11.7-management, 3.11-management, 3-management, management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Tags: 3.11.8-management, 3.11-management, 3-management, management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 65eb19295b7975c4614d6071fb3fc6a1b86282a1
 Directory: 3.11/ubuntu/management
 
-Tags: 3.11.7-alpine, 3.11-alpine, 3-alpine, alpine
+Tags: 3.11.8-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 951163e34b4d4fd5f033ebcd6eebeb4c46f53db9
+GitCommit: e08fa77bc1b1601b3bd5638ff5f25d4d2ced724d
 Directory: 3.11/alpine
 
-Tags: 3.11.7-management-alpine, 3.11-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.11.8-management-alpine, 3.11-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 65eb19295b7975c4614d6071fb3fc6a1b86282a1
 Directory: 3.11/alpine/management
 
-Tags: 3.10.14, 3.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 2667503316c08b40e10b0c43d54d71bfe5f194b8
+Tags: 3.10.17, 3.10
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: ca404c1cb4030dc2db04829df101b2063f1a8649
 Directory: 3.10/ubuntu
 
-Tags: 3.10.14-management, 3.10-management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Tags: 3.10.17-management, 3.10-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 6e226fe8e99702c8726d5e7d5c5864e69548048d
 Directory: 3.10/ubuntu/management
 
-Tags: 3.10.14-alpine, 3.10-alpine
+Tags: 3.10.17-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2667503316c08b40e10b0c43d54d71bfe5f194b8
+GitCommit: ca404c1cb4030dc2db04829df101b2063f1a8649
 Directory: 3.10/alpine
 
-Tags: 3.10.14-management-alpine, 3.10-management-alpine
+Tags: 3.10.17-management-alpine, 3.10-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6e226fe8e99702c8726d5e7d5c5864e69548048d
 Directory: 3.10/alpine/management
 
-Tags: 3.9.27, 3.9
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 83e0a9443ab2b30c3121acd2d6ae0190962d7ba5
+Tags: 3.9.28, 3.9
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 8f13e19291937c94fe0d8f12b03f8cd728903422
 Directory: 3.9/ubuntu
 
-Tags: 3.9.27-management, 3.9-management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Tags: 3.9.28-management, 3.9-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/ubuntu/management
 
-Tags: 3.9.27-alpine, 3.9-alpine
+Tags: 3.9.28-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83e0a9443ab2b30c3121acd2d6ae0190962d7ba5
+GitCommit: 8f13e19291937c94fe0d8f12b03f8cd728903422
 Directory: 3.9/alpine
 
-Tags: 3.9.27-management-alpine, 3.9-management-alpine
+Tags: 3.9.28-management-alpine, 3.9-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b07819f873e5a68b2bb54e01f0caa41c26b277f3
 Directory: 3.9/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/ca404c1: Update 3.10 to 3.10.17
- https://github.com/docker-library/rabbitmq/commit/e08fa77: Merge pull request https://github.com/docker-library/rabbitmq/pull/602 from lukebakken/lukebakken/openssl-3.0
- https://github.com/docker-library/rabbitmq/commit/cd3bef2: Update 3.11 to 3.11.8
- https://github.com/docker-library/rabbitmq/commit/8f13e19: Bump OpenSSL to 3.0
- https://github.com/docker-library/rabbitmq/commit/7f459e1: Update 3.10 to 3.10.16
- https://github.com/docker-library/rabbitmq/commit/4b492fa: Update 3.9 to 3.9.28, otp 25.2.2
- https://github.com/docker-library/rabbitmq/commit/2f098f6: Update 3.11 to otp 25.2.2
- https://github.com/docker-library/rabbitmq/commit/7579eaa: Update 3.10 to otp 25.2.2