### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: ba547847c5a78e92688dd52e539a2ced84b42657
 Directory: 2.4/alpine
 
-Tags: 2.2.27, 2.2, 2.2.27-bullseye, 2.2-bullseye
+Tags: 2.2.28, 2.2, 2.2.28-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eef0f5eb78c5477243d51b9b1d426a1774b2e029
+GitCommit: 7b38ae30f782f574772f1a4b2dafbea73a77f6a0
 Directory: 2.2
 
-Tags: 2.2.27-alpine, 2.2-alpine, 2.2.27-alpine3.17, 2.2-alpine3.17
+Tags: 2.2.28-alpine, 2.2-alpine, 2.2.28-alpine3.17, 2.2-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eef0f5eb78c5477243d51b9b1d426a1774b2e029
+GitCommit: 7b38ae30f782f574772f1a4b2dafbea73a77f6a0
 Directory: 2.2/alpine
 
 Tags: 2.0.30, 2.0, 2.0.30-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7b38ae3: Update 2.2 to 2.2.28