### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.6.0
+Tags: 8.6.1
 Architectures: amd64, arm64v8
-GitCommit: 06dbd87db84a477d0814e343cbf970c7abf69649
+GitCommit: 8001c62c84bb3fa9f19a2725d20d4e5f404dda5e
 Directory: 8
 
 Tags: 7.17.8

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.6.0
+Tags: 8.6.1
 Architectures: amd64, arm64v8
-GitCommit: 34ba6504a0b63a5f0f9d39564c0bfd47114d94f8
+GitCommit: 99dfd6ecee59bd6e72c85c2f6b4ded17e3180c5e
 Directory: 8
 
 Tags: 7.17.8

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.6.0
+Tags: 8.6.1
 Architectures: amd64, arm64v8
-GitCommit: 4fabc6ecfad4f4d760c3f1a53cbcf9abca905543
+GitCommit: 9061b36c4de1baca7642d05c31111515873ab7cb
 Directory: 8
 
 Tags: 7.17.8


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/8001c62: Update to 8.6.1

logstash:
- https://github.com/docker-library/logstash/commit/9061b36: Update to 8.6.1

kibana:
- https://github.com/docker-library/kibana/commit/99dfd6e: Update to 8.6.1