### PR TITLE
Release Telegraf v1.25.1

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -1,7 +1,7 @@
 Maintainers: Josh Powers <jpowers@influxdata.com> (@powersj),
              Sven Rebhan <srebhan@influxdata.com> (@srebhan)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
-GitCommit: dbc42012042db536190ddd0686327a3a9e59a0e3
+GitCommit: 8b3e53402995a512dff1e7e3ffb5f80ca586fa6d
 
 
 Tags: 1.23, 1.23.4
@@ -18,9 +18,9 @@ Directory: telegraf/1.24
 Tags: 1.24-alpine, 1.24.4-alpine
 Directory: telegraf/1.24/alpine
 
-Tags: 1.25, 1.25.0, latest
+Tags: 1.25, 1.25.1, latest
 Architectures: amd64, arm32v7, arm64v8
 Directory: telegraf/1.25
 
-Tags: 1.25-alpine, 1.25.0-alpine, alpine
+Tags: 1.25-alpine, 1.25.1-alpine, alpine
 Directory: telegraf/1.25/alpine


### PR DESCRIPTION
New minor release + updated GPG keys. Thanks!

For background, as a part of the CircleCI fallout, we rotated our GPG keys see [this blog post](https://www.influxdata.com/blog/linux-package-signing-key-rotation/) for additional details.