### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -80,7 +80,7 @@ GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/bionic
 
 Tags: focal-curl, 20.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal/curl
 
@@ -95,61 +95,46 @@ GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: ubuntu/focal
 
 Tags: jammy-curl, 22.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
 Directory: ubuntu/jammy/curl
 
 Tags: jammy-scm, 22.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
 Directory: ubuntu/jammy/scm
 
 Tags: jammy, 22.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
 Directory: ubuntu/jammy
 
 Tags: kinetic-curl, 22.10-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
 Directory: ubuntu/kinetic/curl
 
 Tags: kinetic-scm, 22.10-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
 Directory: ubuntu/kinetic/scm
 
 Tags: kinetic, 22.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
 Directory: ubuntu/kinetic
 
 Tags: lunar-curl, 23.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 31e15bc4a2352c20998e5da6bd8aaa727fd19d06
 Directory: ubuntu/lunar/curl
 
 Tags: lunar-scm, 23.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 31e15bc4a2352c20998e5da6bd8aaa727fd19d06
 Directory: ubuntu/lunar/scm
 
 Tags: lunar, 23.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 31e15bc4a2352c20998e5da6bd8aaa727fd19d06
 Directory: ubuntu/lunar
-
-Tags: xenial-curl, 16.04-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d2a6f64abe6787b7dd25c7d5322af1fa2e3f55
-Directory: ubuntu/xenial/curl
-
-Tags: xenial-scm, 16.04-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: ubuntu/xenial/scm
-
-Tags: xenial, 16.04
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/xenial


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/598c0e2: Remove xenial (now EOL)