### PR TITLE
Add new AL2022 Docker images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -7,9 +7,10 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
             Sam Thornton (@mrthornazon),
             Preston Carpenter (@timidger),
             Joseph Howell-Burke (@jhowell-burke),
-            Miriam Clark (@mgclark001)
+            Miriam Clark (@mgclark001),
+            Ade Adetayo (@dadetayo)
 GitRepo: https://github.com/amazonlinux/container-images.git
-GitCommit: a4656f18f9a049b7ba91a5d2281af656ad819836
+GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
 Tags: 2.0.20230119.1, 2, latest
 Architectures: amd64, arm64v8
@@ -35,16 +36,16 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: f44a38a72435f94e02fa53a30d46d7f20852b619
 
-Tags: 2022.0.20221207.4, 2022, devel
+Tags: 2022.0.20230118.3, 2022, devel
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: 423528b1be8f280af50b6fe8c2cfa296b05e995f
+amd64-GitCommit: 8f394a73f3747b9f1c80e98b65d1f845b2c36e36
 arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: b68a0d87dafee8f62bbc7923734eb11d7610cbf6
+arm64v8-GitCommit: 40d063d4db18d8b62afbb080d75bd5fa6994d78e
 
-Tags: 2022.0.20221207.4-with-sources, 2022-with-sources, devel-with-sources
+Tags: 2022.0.20230118.3-with-sources, 2022-with-sources, devel-with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 8b3c53739a3853a701caa4ff99732c3b8325c5b4
+amd64-GitCommit: 87e3b7a4ed4bbdeba86d64cd68fbefe3f5d7acc2
 arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: 4513dc20bfb13210bb7b34d15a93aead75d88120
+arm64v8-GitCommit: e7dfe3b5d4058022a00cad9812d6624a136f93ce


### PR DESCRIPTION

Hello,

Please merge the latest updates to AL 2022 container images.

Thanks,
Ade
