### PR TITLE
Remove xenial for neurodebian imgs

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,14 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: 53a254d17e6c1c21787ed44b6e848c1af46ea9be
-
-Tags: xenial, nd16.04
-Architectures: amd64, arm64v8
-Directory: dockerfiles/xenial
-
-Tags: xenial-non-free, nd16.04-non-free
-Architectures: amd64, arm64v8
-Directory: dockerfiles/xenial-non-free
+GitCommit: 1da9308291ad33a33447519ec1835bb3e37acebc
 
 Tags: bionic, nd18.04
 Architectures: amd64, arm64v8


### PR DESCRIPTION
ref: https://github.com/docker-library/official-images/pull/13950