### PR TITLE
[nats] Release v2.9.12

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -5,25 +5,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: c17a8a1db7e3c98687bfacb1a2ba7a92753d5127
+GitCommit: 03452e5483a7f09c4e9ceb290997f5d71cadab77
 
-Tags: 2.9.11-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.11-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.12-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.12-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.11/alpine3.17
+Directory: 2.9.12/alpine3.17
 
-Tags: 2.9.11-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.11-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.11, 2.9, 2, latest
+Tags: 2.9.12-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.12-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.12, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.11/scratch
+Directory: 2.9.12/scratch
 
-Tags: 2.9.11-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.11-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.12-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.12-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.11/windowsservercore-1809
+Directory: 2.9.12/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.11-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.11-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.11, 2.9, 2, latest
+Tags: 2.9.12-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.12-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.12, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.11/nanoserver-1809
+Directory: 2.9.12/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.12)

Signed-off-by: Byron Ruth <byron@nats.io>