### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,107 +4,107 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-7-jdk-oraclelinux8, 21-ea-7-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-7-jdk-oracle, 21-ea-7-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-7-jdk, 21-ea-7, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-8-jdk-oraclelinux8, 21-ea-8-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-8-jdk-oracle, 21-ea-8-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-8-jdk, 21-ea-8, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-7-jdk-oraclelinux7, 21-ea-7-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-8-jdk-oraclelinux7, 21-ea-8-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-7-jdk-bullseye, 21-ea-7-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-8-jdk-bullseye, 21-ea-8-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-7-jdk-slim-bullseye, 21-ea-7-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-7-jdk-slim, 21-ea-7-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-8-jdk-slim-bullseye, 21-ea-8-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-8-jdk-slim, 21-ea-8-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-7-jdk-buster, 21-ea-7-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-8-jdk-buster, 21-ea-8-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/buster
 
-Tags: 21-ea-7-jdk-slim-buster, 21-ea-7-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-8-jdk-slim-buster, 21-ea-8-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-7-jdk-windowsservercore-ltsc2022, 21-ea-7-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-7-jdk-windowsservercore, 21-ea-7-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-7-jdk, 21-ea-7, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-8-jdk-windowsservercore-ltsc2022, 21-ea-8-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-8-jdk-windowsservercore, 21-ea-8-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-8-jdk, 21-ea-8, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-7-jdk-windowsservercore-1809, 21-ea-7-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-7-jdk-windowsservercore, 21-ea-7-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-7-jdk, 21-ea-7, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-8-jdk-windowsservercore-1809, 21-ea-8-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-8-jdk-windowsservercore, 21-ea-8-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-8-jdk, 21-ea-8, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-7-jdk-nanoserver-1809, 21-ea-7-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-7-jdk-nanoserver, 21-ea-7-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-8-jdk-nanoserver-1809, 21-ea-8-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-8-jdk-nanoserver, 21-ea-8-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 88f5a13685e1f2ca14f196e48f38ed6bb9fbb098
+GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 20-ea-33-jdk-oraclelinux8, 20-ea-33-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-33-jdk-oracle, 20-ea-33-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-33-jdk, 20-ea-33, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-34-jdk-oraclelinux8, 20-ea-34-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-34-jdk-oracle, 20-ea-34-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-34-jdk, 20-ea-34, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-33-jdk-oraclelinux7, 20-ea-33-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-34-jdk-oraclelinux7, 20-ea-34-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-33-jdk-bullseye, 20-ea-33-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-34-jdk-bullseye, 20-ea-34-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-33-jdk-slim-bullseye, 20-ea-33-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-33-jdk-slim, 20-ea-33-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-34-jdk-slim-bullseye, 20-ea-34-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-34-jdk-slim, 20-ea-34-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-33-jdk-buster, 20-ea-33-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-34-jdk-buster, 20-ea-34-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/buster
 
-Tags: 20-ea-33-jdk-slim-buster, 20-ea-33-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-34-jdk-slim-buster, 20-ea-34-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-33-jdk-windowsservercore-ltsc2022, 20-ea-33-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-33-jdk-windowsservercore, 20-ea-33-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-33-jdk, 20-ea-33, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-34-jdk-windowsservercore-ltsc2022, 20-ea-34-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-34-jdk-windowsservercore, 20-ea-34-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-34-jdk, 20-ea-34, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-33-jdk-windowsservercore-1809, 20-ea-33-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-33-jdk-windowsservercore, 20-ea-33-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-33-jdk, 20-ea-33, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-34-jdk-windowsservercore-1809, 20-ea-34-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-34-jdk-windowsservercore, 20-ea-34-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-34-jdk, 20-ea-34, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-33-jdk-nanoserver-1809, 20-ea-33-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-33-jdk-nanoserver, 20-ea-33-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-34-jdk-nanoserver-1809, 20-ea-34-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-34-jdk-nanoserver, 20-ea-34-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: b3b8f97a0f02f76e9c537fa34e56eb8f6fb34d2d
+GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/83e5fb4: Update 21 to 21-ea+8
- https://github.com/docker-library/openjdk/commit/a399b8d: Update 20 to 20-ea+34