### PR TITLE
[gazebo] retire gazebo 9 images

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -2,36 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: 9
-
-########################################
-# Distro: ubuntu:xenial
-
-Tags: gzserver9-xenial
-Architectures: amd64
-GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
-Directory: gazebo/9/ubuntu/xenial/gzserver9
-
-Tags: libgazebo9-xenial
-Architectures: amd64
-GitCommit: 96c8fa210caaeebd50e067ade05d5fc9a4a60c84
-Directory: gazebo/9/ubuntu/xenial/libgazebo9
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: gzserver9, gzserver9-bionic
-Architectures: amd64
-GitCommit: 212f7553882e8f3e96af773ede6ef1848277c09e
-Directory: gazebo/9/ubuntu/bionic/gzserver9
-
-Tags: libgazebo9, libgazebo9-bionic
-Architectures: amd64
-GitCommit: 212f7553882e8f3e96af773ede6ef1848277c09e
-Directory: gazebo/9/ubuntu/bionic/libgazebo9
-
-
-################################################################################
 # Release: 11
 
 ########################################


### PR DESCRIPTION
Gazebo 9 has reached EOL: https://community.gazebosim.org/t/gazebo-classic-9-officially-end-of-life/1773
This PR retires the corresponding docker images

Also adresses https://github.com/docker-library/official-images/pull/13950#issuecomment-1412515624