### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -7,227 +7,227 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.12.0a4-bullseye, 3.12-rc-bullseye
 SharedTags: 3.12.0a4, 3.12-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.12-rc/bullseye
 
 Tags: 3.12.0a4-slim-bullseye, 3.12-rc-slim-bullseye, 3.12.0a4-slim, 3.12-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.12-rc/slim-bullseye
 
 Tags: 3.12.0a4-buster, 3.12-rc-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.12-rc/buster
 
 Tags: 3.12.0a4-slim-buster, 3.12-rc-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.12-rc/slim-buster
 
 Tags: 3.12.0a4-alpine3.17, 3.12-rc-alpine3.17, 3.12.0a4-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.12-rc/alpine3.17
 
 Tags: 3.12.0a4-alpine3.16, 3.12-rc-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.12-rc/alpine3.16
 
 Tags: 3.12.0a4-windowsservercore-ltsc2022, 3.12-rc-windowsservercore-ltsc2022
 SharedTags: 3.12.0a4-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a4, 3.12-rc
 Architectures: windows-amd64
-GitCommit: bff32fbfdbd737838c16c6b01ac910fb889e0767
+GitCommit: b871ae197773dc798f3c2ba9eb380f1e592ae57f
 Directory: 3.12-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.12.0a4-windowsservercore-1809, 3.12-rc-windowsservercore-1809
 SharedTags: 3.12.0a4-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a4, 3.12-rc
 Architectures: windows-amd64
-GitCommit: bff32fbfdbd737838c16c6b01ac910fb889e0767
+GitCommit: b871ae197773dc798f3c2ba9eb380f1e592ae57f
 Directory: 3.12-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.11.1-bullseye, 3.11-bullseye, 3-bullseye, bullseye
 SharedTags: 3.11.1, 3.11, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.11/bullseye
 
 Tags: 3.11.1-slim-bullseye, 3.11-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.11.1-slim, 3.11-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.11/slim-bullseye
 
 Tags: 3.11.1-buster, 3.11-buster, 3-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.11/buster
 
 Tags: 3.11.1-slim-buster, 3.11-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.11/slim-buster
 
 Tags: 3.11.1-alpine3.17, 3.11-alpine3.17, 3-alpine3.17, alpine3.17, 3.11.1-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.11/alpine3.17
 
 Tags: 3.11.1-alpine3.16, 3.11-alpine3.16, 3-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.11/alpine3.16
 
 Tags: 3.11.1-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.11.1-windowsservercore, 3.11-windowsservercore, 3-windowsservercore, windowsservercore, 3.11.1, 3.11, 3, latest
 Architectures: windows-amd64
-GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
+GitCommit: adfcf639f0debfc3d091371e0ecc58699738df2a
 Directory: 3.11/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.11.1-windowsservercore-1809, 3.11-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.11.1-windowsservercore, 3.11-windowsservercore, 3-windowsservercore, windowsservercore, 3.11.1, 3.11, 3, latest
 Architectures: windows-amd64
-GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
+GitCommit: adfcf639f0debfc3d091371e0ecc58699738df2a
 Directory: 3.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.9-bullseye, 3.10-bullseye
 SharedTags: 3.10.9, 3.10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.10/bullseye
 
 Tags: 3.10.9-slim-bullseye, 3.10-slim-bullseye, 3.10.9-slim, 3.10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.9-buster, 3.10-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.10/buster
 
 Tags: 3.10.9-slim-buster, 3.10-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.10/slim-buster
 
 Tags: 3.10.9-alpine3.17, 3.10-alpine3.17, 3.10.9-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.10/alpine3.17
 
 Tags: 3.10.9-alpine3.16, 3.10-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.10/alpine3.16
 
 Tags: 3.10.9-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022
 SharedTags: 3.10.9-windowsservercore, 3.10-windowsservercore, 3.10.9, 3.10
 Architectures: windows-amd64
-GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
+GitCommit: 48f998b400941776398896c05e10b4e79ee74d9b
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.10.9-windowsservercore-1809, 3.10-windowsservercore-1809
 SharedTags: 3.10.9-windowsservercore, 3.10-windowsservercore, 3.10.9, 3.10
 Architectures: windows-amd64
-GitCommit: 046374fd6a8186a58ef8099e8b5f43946487f5fa
+GitCommit: 48f998b400941776398896c05e10b4e79ee74d9b
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.9.16-bullseye, 3.9-bullseye
 SharedTags: 3.9.16, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.9/bullseye
 
 Tags: 3.9.16-slim-bullseye, 3.9-slim-bullseye, 3.9.16-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.9/slim-bullseye
 
 Tags: 3.9.16-buster, 3.9-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.9/buster
 
 Tags: 3.9.16-slim-buster, 3.9-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.9/slim-buster
 
 Tags: 3.9.16-alpine3.17, 3.9-alpine3.17, 3.9.16-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.9/alpine3.17
 
 Tags: 3.9.16-alpine3.16, 3.9-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.9/alpine3.16
 
 Tags: 3.8.16-bullseye, 3.8-bullseye
 SharedTags: 3.8.16, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.8/bullseye
 
 Tags: 3.8.16-slim-bullseye, 3.8-slim-bullseye, 3.8.16-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.8/slim-bullseye
 
 Tags: 3.8.16-buster, 3.8-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.8/buster
 
 Tags: 3.8.16-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.8/slim-buster
 
 Tags: 3.8.16-alpine3.17, 3.8-alpine3.17, 3.8.16-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.8/alpine3.17
 
 Tags: 3.8.16-alpine3.16, 3.8-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.8/alpine3.16
 
 Tags: 3.7.16-bullseye, 3.7-bullseye
 SharedTags: 3.7.16, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.7/bullseye
 
 Tags: 3.7.16-slim-bullseye, 3.7-slim-bullseye, 3.7.16-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.7/slim-bullseye
 
 Tags: 3.7.16-buster, 3.7-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.7/buster
 
 Tags: 3.7.16-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.7/slim-buster
 
 Tags: 3.7.16-alpine3.17, 3.7-alpine3.17, 3.7.16-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.7/alpine3.17
 
 Tags: 3.7.16-alpine3.16, 3.7-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1af335ee34324b2f40d7e90345f9468328f6a00
+GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
 Directory: 3.7/alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/06e0db2: Merge pull request https://github.com/docker-library/python/pull/794 from jimnicholls/issue-792
- https://github.com/docker-library/python/commit/20c8782: Update 3.9
- https://github.com/docker-library/python/commit/a09f407: Update 3.8
- https://github.com/docker-library/python/commit/0048b55: Update 3.7
- https://github.com/docker-library/python/commit/01cc4c0: Reuse EXTRA_CFLAGS, LDFLAGS, and PROFILE_TASK across both make invokes.
- https://github.com/docker-library/python/commit/b871ae1: Update 3.12-rc
- https://github.com/docker-library/python/commit/1b9fc11: Use the linker to change rpath for python3.x binary.
- https://github.com/docker-library/python/commit/adfcf63: Update 3.11
- https://github.com/docker-library/python/commit/48f998b: Update 3.10
- https://github.com/docker-library/python/commit/74a6eda: Revert "Only change rpath for python3.x binary"