### PR TITLE
mariadb: 2023q1 release batch 1

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,45 +6,45 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 10.11.1-rc-jammy, 10.11-rc-jammy, 10.11.1-rc, 10.11-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: ac276eb82f0535ff1849018f46be5e5ed396bda1
 Directory: 10.11
 
-Tags: 10.10.2-jammy, 10.10-jammy, 10-jammy, jammy, 10.10.2, 10.10, 10, latest
+Tags: 10.10.3-jammy, 10.10-jammy, 10-jammy, jammy, 10.10.3, 10.10, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.10
 
-Tags: 10.9.4-jammy, 10.9-jammy, 10.9.4, 10.9
+Tags: 10.9.5-jammy, 10.9-jammy, 10.9.5, 10.9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.9
 
-Tags: 10.8.6-jammy, 10.8-jammy, 10.8.6, 10.8
+Tags: 10.8.7-jammy, 10.8-jammy, 10.8.7, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.8
 
-Tags: 10.7.7-focal, 10.7-focal, 10.7.7, 10.7
+Tags: 10.7.8-focal, 10.7-focal, 10.7.8, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.7
 
-Tags: 10.6.11-focal, 10.6-focal, 10.6.11, 10.6
+Tags: 10.6.12-focal, 10.6-focal, 10.6.12, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.6
 
-Tags: 10.5.18-focal, 10.5-focal, 10.5.18, 10.5
+Tags: 10.5.19-focal, 10.5-focal, 10.5.19, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.5
 
-Tags: 10.4.27-focal, 10.4-focal, 10.4.27, 10.4
+Tags: 10.4.28-focal, 10.4-focal, 10.4.28, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.4
 
-Tags: 10.3.37-focal, 10.3-focal, 10.3.37, 10.3
+Tags: 10.3.38-focal, 10.3-focal, 10.3.38, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 56ef6d9f842e1ddf50e4359625a6e5cef1748c38
+GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
 Directory: 10.3


### PR DESCRIPTION
release batch one.

10.11 and 11.0 in a week or so.

Added --no-install-recommands for mariadb-server, there was only a perl-html package there for some reason (probably mytop special option but not generally used).