### PR TITLE
bump git commit sha on neo4j 5.4.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -12,12 +12,12 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 Tags: 5.4.0, 5.4.0-community, 5.4, 5, 5-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 77b1e4cd57fd08148938ff39ea22a393df0cd8c2
+GitCommit: 3aea9c3039e2db1a5adfb994f6b6d8c315f3f867
 Directory: 5.4.0/community
 
 Tags: 5.4.0-enterprise, 5.4-enterprise, 5-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 77b1e4cd57fd08148938ff39ea22a393df0cd8c2
+GitCommit: 3aea9c3039e2db1a5adfb994f6b6d8c315f3f867
 Directory: 5.4.0/enterprise
 
 


### PR DESCRIPTION
I just needed to make some minor changes to the existing 5.4.0 neo4j release. 
Thanks.