### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev2, 2.8-dev, 2.8-dev2-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev3, 2.8-dev, 2.8-dev3-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 90d3b5fa57f474d0c91dccd0a6185a6e23eec72a
+GitCommit: 09db530687ce9142df90e3dbad7dc5a5c2ce152e
 Directory: 2.8
 
-Tags: 2.8-dev2-alpine, 2.8-dev-alpine, 2.8-dev2-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev3-alpine, 2.8-dev-alpine, 2.8-dev3-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 90d3b5fa57f474d0c91dccd0a6185a6e23eec72a
+GitCommit: 09db530687ce9142df90e3dbad7dc5a5c2ce152e
 Directory: 2.8/alpine
 
 Tags: 2.7.2, 2.7, latest, 2.7.2-bullseye, 2.7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/09db530: Update 2.8 to 2.8-dev3