### PR TITLE
Update Vault for 1.12.3, 1.11.7, and 1.10.10

### DIFF
--- a/library/vault
+++ b/library/vault
@@ -3,19 +3,19 @@ Maintainers: Meggie Ladlow <meggie@hashicorp.com> (@mladlow),
              Nick Cabatoff <ncabatoff@hashicorp.com> (@ncabatoff)
 GitRepo: https://github.com/hashicorp/docker-vault.git
 
-Tags: 1.12.2, latest
+Tags: 1.12.3, latest
 Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: 2cba27a16dc7bea0857561ab0424de1bb6e0ffd3
+GitCommit: 79972dce1c4487ae46ba37dc629aa15d09d0410b
 Directory: 0.X
 
-Tags: 1.11.6
+Tags: 1.11.7
 Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: a7bb73b2f1c8ed40ca8baf5ba2a4c2191e70d506
+GitCommit: 056fdf2cf0f61b008057f480d1ab2be9efc16416
 Directory: 0.X
 
-Tags: 1.10.9
+Tags: 1.10.10
 Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: cfafe61e0b2679ca8aa24d8ea457767acccb3e1d
+GitCommit: 1314eec7432841d038cbd435f9d2fa97a7dfd3f5
 Directory: 0.X
 
 Tags: 1.9.10


### PR DESCRIPTION
Edit: I think we did merge commits instead of squashed commits at a part of our process, which I am hoping doesn't mess anything up for this PR.