### PR TITLE
Update Fedora 2023-02-08

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,19 +1,10 @@
 Maintainers: Clement Verna <cverna@fedoraproject.org> (@cverna), Vipul Siddharth <siddharthvipul1@fedoraproject.org> (@siddharthvipul)
 GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 
-Tags: 35
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitFetch: refs/heads/35
-GitCommit: 493d6eda2434bfdac64d61016aa6b9dc33cf4bc5
-amd64-Directory: x86_64/
-arm64v8-Directory: aarch64/
-s390x-Directory: s390x/
-ppc64le-Directory: ppc64le/
-
 Tags: 36
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/36
-GitCommit: 6c310b8b652eb03e5e895b0d47a6d1fde84d5e26
+GitCommit: 3f975633c8a42e4ef23d4171b8c7099807f06861
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
@@ -22,7 +13,7 @@ ppc64le-Directory: ppc64le/
 Tags: 37, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/37
-GitCommit: 1853328a811b98a580c4d3ca50d10cd788ba9d64
+GitCommit: 7ce19eafa9a8336d467ab74c20bd414b658228be
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
@@ -31,7 +22,7 @@ ppc64le-Directory: ppc64le/
 Tags: 38, rawhide
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/38
-GitCommit: e7136a4190768fa604776d6535269a6b52189a4c
+GitCommit: 3126e73eb4689d071d894d882e3419b9fbc1548b
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/


### PR DESCRIPTION
Fedora 35 is EOL

Signed-off-by: Clement Verna <cverna@tutanota.com>