### PR TITLE
[oraclelinux] Updating 8, 8-slim, 9 and 9-slim for ELSA-2023-0625, ELSA-2023-0626

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ad17dede93fdaec2315c283a64ed47621e1d4a6d
+amd64-GitCommit: 956a0a98a1e0416c35ddc026daf42e2b7de8df4f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 409967fa7cd110ee8f2a248c5f345154ea933b07
+arm64v8-GitCommit: 7d2423b1e2c67d22f3026154b24555f7bf1e13fc
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-47629.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-0625.html
https://linux.oracle.com/errata/ELSA-2023-0626.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>