### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 23.0.0-cli, 23.0-cli, 23-cli, cli, 23.0.0-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 849b56e6c81dc509da780121352f844e8f26bb7a
+GitCommit: f7c1eb20c9898f56999cb594a99418e93e772d5d
 Directory: 23.0/cli
 
 Tags: 23.0.0-dind, 23.0-dind, 23-dind, dind, 23.0.0-dind-alpine3.17, 23.0.0, 23.0, 23, latest, 23.0.0-alpine3.17
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.23-cli, 20.10-cli, 20-cli, 20.10.23-cli-alpine3.17, 20.10.23, 20.10, 20, 20.10.23-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 4855ede4876923c0c5a663cd23e1d314d3e3d5e5
+GitCommit: dbd6b97c257242d05f1ade073acd1b3195ac2c75
 Directory: 20.10/cli
 
 Tags: 20.10.23-dind, 20.10-dind, 20-dind, 20.10.23-dind-alpine3.17


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/f7c1eb2: Update 23.0 to compose 2.16.0
- https://github.com/docker-library/docker/commit/dbd6b97: Update 20.10 to compose 2.16.0