### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,38 +4,38 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.9.0-beta3-bullseye, 1.9-rc-bullseye, rc-bullseye
-SharedTags: 1.9.0-beta3, 1.9-rc, rc
+Tags: 1.9.0-beta4-bullseye, 1.9-rc-bullseye, rc-bullseye
+SharedTags: 1.9.0-beta4, 1.9-rc, rc
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 657f3680cc13a72c27c2440852386341ad4480e7
+GitCommit: b9669c0c6834aca8917040e3103d039e69b536a5
 Directory: 1.9-rc/bullseye
 
-Tags: 1.9.0-beta3-buster, 1.9-rc-buster, rc-buster
+Tags: 1.9.0-beta4-buster, 1.9-rc-buster, rc-buster
 Architectures: amd64, arm64v8, i386
-GitCommit: 657f3680cc13a72c27c2440852386341ad4480e7
+GitCommit: b9669c0c6834aca8917040e3103d039e69b536a5
 Directory: 1.9-rc/buster
 
-Tags: 1.9.0-beta3-alpine3.17, 1.9-rc-alpine3.17, rc-alpine3.17, 1.9.0-beta3-alpine, 1.9-rc-alpine, rc-alpine
+Tags: 1.9.0-beta4-alpine3.17, 1.9-rc-alpine3.17, rc-alpine3.17, 1.9.0-beta4-alpine, 1.9-rc-alpine, rc-alpine
 Architectures: amd64
-GitCommit: 657f3680cc13a72c27c2440852386341ad4480e7
+GitCommit: b9669c0c6834aca8917040e3103d039e69b536a5
 Directory: 1.9-rc/alpine3.17
 
-Tags: 1.9.0-beta3-alpine3.16, 1.9-rc-alpine3.16, rc-alpine3.16
+Tags: 1.9.0-beta4-alpine3.16, 1.9-rc-alpine3.16, rc-alpine3.16
 Architectures: amd64
-GitCommit: 657f3680cc13a72c27c2440852386341ad4480e7
+GitCommit: b9669c0c6834aca8917040e3103d039e69b536a5
 Directory: 1.9-rc/alpine3.16
 
-Tags: 1.9.0-beta3-windowsservercore-ltsc2022, 1.9-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 1.9.0-beta3, 1.9-rc, rc, 1.9.0-beta3-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
+Tags: 1.9.0-beta4-windowsservercore-ltsc2022, 1.9-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 1.9.0-beta4, 1.9-rc, rc, 1.9.0-beta4-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 657f3680cc13a72c27c2440852386341ad4480e7
+GitCommit: b9669c0c6834aca8917040e3103d039e69b536a5
 Directory: 1.9-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.9.0-beta3-windowsservercore-1809, 1.9-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.9.0-beta3, 1.9-rc, rc, 1.9.0-beta3-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
+Tags: 1.9.0-beta4-windowsservercore-1809, 1.9-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.9.0-beta4, 1.9-rc, rc, 1.9.0-beta4-windowsservercore, 1.9-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 657f3680cc13a72c27c2440852386341ad4480e7
+GitCommit: b9669c0c6834aca8917040e3103d039e69b536a5
 Directory: 1.9-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/b9669c0: Update 1.9-rc to 1.9.0-beta4