### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,107 +4,107 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-8-jdk-oraclelinux8, 21-ea-8-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-8-jdk-oracle, 21-ea-8-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-8-jdk, 21-ea-8, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-9-jdk-oraclelinux8, 21-ea-9-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-9-jdk-oracle, 21-ea-9-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-9-jdk, 21-ea-9, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-8-jdk-oraclelinux7, 21-ea-8-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-9-jdk-oraclelinux7, 21-ea-9-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-8-jdk-bullseye, 21-ea-8-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-9-jdk-bullseye, 21-ea-9-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-8-jdk-slim-bullseye, 21-ea-8-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-8-jdk-slim, 21-ea-8-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-9-jdk-slim-bullseye, 21-ea-9-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-9-jdk-slim, 21-ea-9-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-8-jdk-buster, 21-ea-8-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-9-jdk-buster, 21-ea-9-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/buster
 
-Tags: 21-ea-8-jdk-slim-buster, 21-ea-8-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-9-jdk-slim-buster, 21-ea-9-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-8-jdk-windowsservercore-ltsc2022, 21-ea-8-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-8-jdk-windowsservercore, 21-ea-8-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-8-jdk, 21-ea-8, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-9-jdk-windowsservercore-ltsc2022, 21-ea-9-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-9-jdk-windowsservercore, 21-ea-9-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-9-jdk, 21-ea-9, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-8-jdk-windowsservercore-1809, 21-ea-8-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-8-jdk-windowsservercore, 21-ea-8-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-8-jdk, 21-ea-8, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-9-jdk-windowsservercore-1809, 21-ea-9-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-9-jdk-windowsservercore, 21-ea-9-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-9-jdk, 21-ea-9, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-8-jdk-nanoserver-1809, 21-ea-8-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-8-jdk-nanoserver, 21-ea-8-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-9-jdk-nanoserver-1809, 21-ea-9-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-9-jdk-nanoserver, 21-ea-9-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 83e5fb4087bfcd3492802a394fbab279305ca5b6
+GitCommit: c54013c65130eb1c41268ab45a7a04e41b47c612
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 20-ea-34-jdk-oraclelinux8, 20-ea-34-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-34-jdk-oracle, 20-ea-34-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
-SharedTags: 20-ea-34-jdk, 20-ea-34, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-35-jdk-oraclelinux8, 20-ea-35-oraclelinux8, 20-ea-jdk-oraclelinux8, 20-ea-oraclelinux8, 20-jdk-oraclelinux8, 20-oraclelinux8, 20-ea-35-jdk-oracle, 20-ea-35-oracle, 20-ea-jdk-oracle, 20-ea-oracle, 20-jdk-oracle, 20-oracle
+SharedTags: 20-ea-35-jdk, 20-ea-35, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: amd64, arm64v8
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/oraclelinux8
 
-Tags: 20-ea-34-jdk-oraclelinux7, 20-ea-34-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
+Tags: 20-ea-35-jdk-oraclelinux7, 20-ea-35-oraclelinux7, 20-ea-jdk-oraclelinux7, 20-ea-oraclelinux7, 20-jdk-oraclelinux7, 20-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/oraclelinux7
 
-Tags: 20-ea-34-jdk-bullseye, 20-ea-34-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
+Tags: 20-ea-35-jdk-bullseye, 20-ea-35-bullseye, 20-ea-jdk-bullseye, 20-ea-bullseye, 20-jdk-bullseye, 20-bullseye
 Architectures: amd64, arm64v8
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/bullseye
 
-Tags: 20-ea-34-jdk-slim-bullseye, 20-ea-34-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-34-jdk-slim, 20-ea-34-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
+Tags: 20-ea-35-jdk-slim-bullseye, 20-ea-35-slim-bullseye, 20-ea-jdk-slim-bullseye, 20-ea-slim-bullseye, 20-jdk-slim-bullseye, 20-slim-bullseye, 20-ea-35-jdk-slim, 20-ea-35-slim, 20-ea-jdk-slim, 20-ea-slim, 20-jdk-slim, 20-slim
 Architectures: amd64, arm64v8
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/slim-bullseye
 
-Tags: 20-ea-34-jdk-buster, 20-ea-34-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
+Tags: 20-ea-35-jdk-buster, 20-ea-35-buster, 20-ea-jdk-buster, 20-ea-buster, 20-jdk-buster, 20-buster
 Architectures: amd64, arm64v8
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/buster
 
-Tags: 20-ea-34-jdk-slim-buster, 20-ea-34-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
+Tags: 20-ea-35-jdk-slim-buster, 20-ea-35-slim-buster, 20-ea-jdk-slim-buster, 20-ea-slim-buster, 20-jdk-slim-buster, 20-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/slim-buster
 
-Tags: 20-ea-34-jdk-windowsservercore-ltsc2022, 20-ea-34-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20-ea-34-jdk-windowsservercore, 20-ea-34-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-34-jdk, 20-ea-34, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-35-jdk-windowsservercore-ltsc2022, 20-ea-35-windowsservercore-ltsc2022, 20-ea-jdk-windowsservercore-ltsc2022, 20-ea-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20-ea-35-jdk-windowsservercore, 20-ea-35-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-35-jdk, 20-ea-35, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20-ea-34-jdk-windowsservercore-1809, 20-ea-34-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20-ea-34-jdk-windowsservercore, 20-ea-34-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-34-jdk, 20-ea-34, 20-ea-jdk, 20-ea, 20-jdk, 20
+Tags: 20-ea-35-jdk-windowsservercore-1809, 20-ea-35-windowsservercore-1809, 20-ea-jdk-windowsservercore-1809, 20-ea-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20-ea-35-jdk-windowsservercore, 20-ea-35-windowsservercore, 20-ea-jdk-windowsservercore, 20-ea-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20-ea-35-jdk, 20-ea-35, 20-ea-jdk, 20-ea, 20-jdk, 20
 Architectures: windows-amd64
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 20-ea-34-jdk-nanoserver-1809, 20-ea-34-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20-ea-34-jdk-nanoserver, 20-ea-34-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20-ea-35-jdk-nanoserver-1809, 20-ea-35-nanoserver-1809, 20-ea-jdk-nanoserver-1809, 20-ea-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20-ea-35-jdk-nanoserver, 20-ea-35-nanoserver, 20-ea-jdk-nanoserver, 20-ea-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: a399b8da36a0620f31735f87fa2c0300be32ba61
+GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/c54013c: Update 21 to 21-ea+9
- https://github.com/docker-library/openjdk/commit/65b3775: Update 20 to 20-ea+35