### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -4,37 +4,37 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/docker.git
 
-Tags: 23.0.0-cli, 23.0-cli, 23-cli, cli, 23.0.0-cli-alpine3.17
+Tags: 23.0.1-cli, 23.0-cli, 23-cli, cli, 23.0.1-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: f7c1eb20c9898f56999cb594a99418e93e772d5d
+GitCommit: 9a3b24b5b115d368c1aecf92dfadacc7cf49da12
 Directory: 23.0/cli
 
-Tags: 23.0.0-dind, 23.0-dind, 23-dind, dind, 23.0.0-dind-alpine3.17, 23.0.0, 23.0, 23, latest, 23.0.0-alpine3.17
+Tags: 23.0.1-dind, 23.0-dind, 23-dind, dind, 23.0.1-dind-alpine3.17, 23.0.1, 23.0, 23, latest, 23.0.1-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 38e13c81eb5cb5b10d4477467547b0823d877720
+GitCommit: 9a3b24b5b115d368c1aecf92dfadacc7cf49da12
 Directory: 23.0/dind
 
-Tags: 23.0.0-dind-rootless, 23.0-dind-rootless, 23-dind-rootless, dind-rootless
+Tags: 23.0.1-dind-rootless, 23.0-dind-rootless, 23-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 849b56e6c81dc509da780121352f844e8f26bb7a
+GitCommit: 9a3b24b5b115d368c1aecf92dfadacc7cf49da12
 Directory: 23.0/dind-rootless
 
-Tags: 23.0.0-git, 23.0-git, 23-git, git
+Tags: 23.0.1-git, 23.0-git, 23-git, git
 Architectures: amd64, arm64v8
 GitCommit: 849b56e6c81dc509da780121352f844e8f26bb7a
 Directory: 23.0/git
 
-Tags: 23.0.0-windowsservercore-ltsc2022, 23.0-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 23.0.0-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
+Tags: 23.0.1-windowsservercore-ltsc2022, 23.0-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 23.0.1-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 849b56e6c81dc509da780121352f844e8f26bb7a
+GitCommit: 9a3b24b5b115d368c1aecf92dfadacc7cf49da12
 Directory: 23.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23.0.0-windowsservercore-1809, 23.0-windowsservercore-1809, 23-windowsservercore-1809, windowsservercore-1809
-SharedTags: 23.0.0-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
+Tags: 23.0.1-windowsservercore-1809, 23.0-windowsservercore-1809, 23-windowsservercore-1809, windowsservercore-1809
+SharedTags: 23.0.1-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 849b56e6c81dc509da780121352f844e8f26bb7a
+GitCommit: 9a3b24b5b115d368c1aecf92dfadacc7cf49da12
 Directory: 23.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
@@ -45,7 +45,7 @@ Directory: 20.10/cli
 
 Tags: 20.10.23-dind, 20.10-dind, 20-dind, 20.10.23-dind-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 38e13c81eb5cb5b10d4477467547b0823d877720
+GitCommit: 6b3d48a87bee74f096bd28a23385972994a4f313
 Directory: 20.10/dind
 
 Tags: 20.10.23-dind-rootless, 20.10-dind-rootless, 20-dind-rootless


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/9a3b24b: Update 23.0 to 23.0.1
- https://github.com/docker-library/docker/commit/aba0ad9: Merge pull request https://github.com/docker-library/docker/pull/402 from infosiftr/optional-tls-generation
- https://github.com/docker-library/docker/commit/6b3d48a: Adjust DOCKER_TLS_CERTDIR behavior to allow providing server certs without CA