### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/f67fe7f23477c1b80b1b49f2b5d80fff07a85fec/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/3345e54d319e7247c3adb700ded0209f26e8171c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -106,56 +106,4 @@ SharedTags: 20-ea-35-jdk-nanoserver, 20-ea-35-nanoserver, 20-ea-jdk-nanoserver, 
 Architectures: windows-amd64
 GitCommit: 65b377582250dd8cc6429d89963d3bf60a1edf47
 Directory: 20/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 18.0.2.1-jdk-oraclelinux8, 18.0.2.1-oraclelinux8, 18.0.2-jdk-oraclelinux8, 18.0.2-oraclelinux8, 18.0-jdk-oraclelinux8, 18.0-oraclelinux8, 18-jdk-oraclelinux8, 18-oraclelinux8, jdk-oraclelinux8, oraclelinux8, 18.0.2.1-jdk-oracle, 18.0.2.1-oracle, 18.0.2-jdk-oracle, 18.0.2-oracle, 18.0-jdk-oracle, 18.0-oracle, 18-jdk-oracle, 18-oracle, jdk-oracle, oracle
-SharedTags: 18.0.2.1-jdk, 18.0.2.1, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
-Architectures: amd64, arm64v8
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/oraclelinux8
-
-Tags: 18.0.2.1-jdk-oraclelinux7, 18.0.2.1-oraclelinux7, 18.0.2-jdk-oraclelinux7, 18.0.2-oraclelinux7, 18.0-jdk-oraclelinux7, 18.0-oraclelinux7, 18-jdk-oraclelinux7, 18-oraclelinux7, jdk-oraclelinux7, oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/oraclelinux7
-
-Tags: 18.0.2.1-jdk-bullseye, 18.0.2.1-bullseye, 18.0.2-jdk-bullseye, 18.0.2-bullseye, 18.0-jdk-bullseye, 18.0-bullseye, 18-jdk-bullseye, 18-bullseye, jdk-bullseye, bullseye
-Architectures: amd64, arm64v8
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/bullseye
-
-Tags: 18.0.2.1-jdk-slim-bullseye, 18.0.2.1-slim-bullseye, 18.0.2-jdk-slim-bullseye, 18.0.2-slim-bullseye, 18.0-jdk-slim-bullseye, 18.0-slim-bullseye, 18-jdk-slim-bullseye, 18-slim-bullseye, jdk-slim-bullseye, slim-bullseye, 18.0.2.1-jdk-slim, 18.0.2.1-slim, 18.0.2-jdk-slim, 18.0.2-slim, 18.0-jdk-slim, 18.0-slim, 18-jdk-slim, 18-slim, jdk-slim, slim
-Architectures: amd64, arm64v8
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/slim-bullseye
-
-Tags: 18.0.2.1-jdk-buster, 18.0.2.1-buster, 18.0.2-jdk-buster, 18.0.2-buster, 18.0-jdk-buster, 18.0-buster, 18-jdk-buster, 18-buster, jdk-buster, buster
-Architectures: amd64, arm64v8
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/buster
-
-Tags: 18.0.2.1-jdk-slim-buster, 18.0.2.1-slim-buster, 18.0.2-jdk-slim-buster, 18.0.2-slim-buster, 18.0-jdk-slim-buster, 18.0-slim-buster, 18-jdk-slim-buster, 18-slim-buster, jdk-slim-buster, slim-buster
-Architectures: amd64, arm64v8
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/slim-buster
-
-Tags: 18.0.2.1-jdk-windowsservercore-ltsc2022, 18.0.2.1-windowsservercore-ltsc2022, 18.0.2-jdk-windowsservercore-ltsc2022, 18.0.2-windowsservercore-ltsc2022, 18.0-jdk-windowsservercore-ltsc2022, 18.0-windowsservercore-ltsc2022, 18-jdk-windowsservercore-ltsc2022, 18-windowsservercore-ltsc2022, jdk-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 18.0.2.1-jdk-windowsservercore, 18.0.2.1-windowsservercore, 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2.1-jdk, 18.0.2.1, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
-Architectures: windows-amd64
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 18.0.2.1-jdk-windowsservercore-1809, 18.0.2.1-windowsservercore-1809, 18.0.2-jdk-windowsservercore-1809, 18.0.2-windowsservercore-1809, 18.0-jdk-windowsservercore-1809, 18.0-windowsservercore-1809, 18-jdk-windowsservercore-1809, 18-windowsservercore-1809, jdk-windowsservercore-1809, windowsservercore-1809
-SharedTags: 18.0.2.1-jdk-windowsservercore, 18.0.2.1-windowsservercore, 18.0.2-jdk-windowsservercore, 18.0.2-windowsservercore, 18.0-jdk-windowsservercore, 18.0-windowsservercore, 18-jdk-windowsservercore, 18-windowsservercore, jdk-windowsservercore, windowsservercore, 18.0.2.1-jdk, 18.0.2.1, 18.0.2-jdk, 18.0.2, 18.0-jdk, 18.0, 18-jdk, 18, jdk, latest
-Architectures: windows-amd64
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 18.0.2.1-jdk-nanoserver-1809, 18.0.2.1-nanoserver-1809, 18.0.2-jdk-nanoserver-1809, 18.0.2-nanoserver-1809, 18.0-jdk-nanoserver-1809, 18.0-nanoserver-1809, 18-jdk-nanoserver-1809, 18-nanoserver-1809, jdk-nanoserver-1809, nanoserver-1809
-SharedTags: 18.0.2.1-jdk-nanoserver, 18.0.2.1-nanoserver, 18.0.2-jdk-nanoserver, 18.0.2-nanoserver, 18.0-jdk-nanoserver, 18.0-nanoserver, 18-jdk-nanoserver, 18-nanoserver, jdk-nanoserver, nanoserver
-Architectures: windows-amd64
-GitCommit: 4b928d2e5767b0e12058d3b5eceabeb0aa48aec3
-Directory: 18/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/7fdff8f: Merge pull request https://github.com/docker-library/openjdk/pull/522 from infosiftr/drop-18
- https://github.com/docker-library/openjdk/commit/3345e54: JDK 18 is EOL