### PR TITLE
archlinux: Release 20230212.0.126025

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230205.0.123931
-GitCommit: f1a975aac18bd08475fc7d1b13812f836f7ed5d4
-GitFetch: refs/tags/v20230205.0.123931
+Tags: latest, base, base-20230212.0.126025
+GitCommit: 481324db01f26f26b8f1105e1cfc017f3dbea658
+GitFetch: refs/tags/v20230212.0.126025
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230205.0.123931
-GitCommit: f1a975aac18bd08475fc7d1b13812f836f7ed5d4
-GitFetch: refs/tags/v20230205.0.123931
+Tags: base-devel, base-devel-20230212.0.126025
+GitCommit: 481324db01f26f26b8f1105e1cfc017f3dbea658
+GitFetch: refs/tags/v20230212.0.126025
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks