### PR TITLE
Updated swipl devel to 9.1.5

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: 366d912cf8e9c8ba3783a76acf57380d7a281883
+GitCommit: 67b156afb3feb8e0a4537bfb7671662f12526156
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 9.1.4
-Directory: 9.1.4/bullseye
+Tags: latest, 9.1.5
+Directory: 9.1.5/bullseye
 
 Tags: stable, 9.0.4
 Directory: 9.0.4/bullseye


### PR DESCRIPTION
Also addresses https://github.com/SWI-Prolog/docker-swipl/issues/32 (armhf/armel builds) by dropping affected plugin on these platforms.