### PR TITLE
[security] Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,72 +4,72 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev3, 2.8-dev, 2.8-dev3-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev4, 2.8-dev, 2.8-dev4-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 09db530687ce9142df90e3dbad7dc5a5c2ce152e
+GitCommit: b2760306614878ff8530e5bfe872cdc8384d9342
 Directory: 2.8
 
-Tags: 2.8-dev3-alpine, 2.8-dev-alpine, 2.8-dev3-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev4-alpine, 2.8-dev-alpine, 2.8-dev4-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 09db530687ce9142df90e3dbad7dc5a5c2ce152e
+GitCommit: b2760306614878ff8530e5bfe872cdc8384d9342
 Directory: 2.8/alpine
 
-Tags: 2.7.2, 2.7, latest, 2.7.2-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.3, 2.7, latest, 2.7.3-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: c1f665d9f400192386f780dbea76481ebe4252e9
 Directory: 2.7
 
-Tags: 2.7.2-alpine, 2.7-alpine, alpine, 2.7.2-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.3-alpine, 2.7-alpine, alpine, 2.7.3-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: c1f665d9f400192386f780dbea76481ebe4252e9
 Directory: 2.7/alpine
 
-Tags: 2.6.8, 2.6, lts, 2.6.8-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.9, 2.6, lts, 2.6.9-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3f34d251e1eaa353070197444bf36ccfe222756f
+GitCommit: e678a5620de6784d8dbe42d1c81f5db47f9e8cbc
 Directory: 2.6
 
-Tags: 2.6.8-alpine, 2.6-alpine, lts-alpine, 2.6.8-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.9-alpine, 2.6-alpine, lts-alpine, 2.6.9-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3f34d251e1eaa353070197444bf36ccfe222756f
+GitCommit: e678a5620de6784d8dbe42d1c81f5db47f9e8cbc
 Directory: 2.6/alpine
 
-Tags: 2.5.11, 2.5, 2.5.11-bullseye, 2.5-bullseye
+Tags: 2.5.12, 2.5, 2.5.12-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1e16cda4e30596c084edea399d3e6b41c0b1d015
+GitCommit: 57fdd931dfdce22ddc38fa7bad81b7c09b5b1caa
 Directory: 2.5
 
-Tags: 2.5.11-alpine, 2.5-alpine, 2.5.11-alpine3.17, 2.5-alpine3.17
+Tags: 2.5.12-alpine, 2.5-alpine, 2.5.12-alpine3.17, 2.5-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1e16cda4e30596c084edea399d3e6b41c0b1d015
+GitCommit: 57fdd931dfdce22ddc38fa7bad81b7c09b5b1caa
 Directory: 2.5/alpine
 
-Tags: 2.4.21, 2.4, 2.4.21-bullseye, 2.4-bullseye
+Tags: 2.4.22, 2.4, 2.4.22-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ba547847c5a78e92688dd52e539a2ced84b42657
+GitCommit: 010b099f11c898314bf1e3c90c19ed3bf6cc89e2
 Directory: 2.4
 
-Tags: 2.4.21-alpine, 2.4-alpine, 2.4.21-alpine3.17, 2.4-alpine3.17
+Tags: 2.4.22-alpine, 2.4-alpine, 2.4.22-alpine3.17, 2.4-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ba547847c5a78e92688dd52e539a2ced84b42657
+GitCommit: 010b099f11c898314bf1e3c90c19ed3bf6cc89e2
 Directory: 2.4/alpine
 
-Tags: 2.2.28, 2.2, 2.2.28-bullseye, 2.2-bullseye
+Tags: 2.2.29, 2.2, 2.2.29-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7b38ae30f782f574772f1a4b2dafbea73a77f6a0
+GitCommit: a341c5a4894f4f8194a5b05076767688d85d369d
 Directory: 2.2
 
-Tags: 2.2.28-alpine, 2.2-alpine, 2.2.28-alpine3.17, 2.2-alpine3.17
+Tags: 2.2.29-alpine, 2.2-alpine, 2.2.29-alpine3.17, 2.2-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b38ae30f782f574772f1a4b2dafbea73a77f6a0
+GitCommit: a341c5a4894f4f8194a5b05076767688d85d369d
 Directory: 2.2/alpine
 
-Tags: 2.0.30, 2.0, 2.0.30-buster, 2.0-buster
+Tags: 2.0.31, 2.0, 2.0.31-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: 1842f4392f605e9f944c7f55415ddfc828301a31
 Directory: 2.0
 
-Tags: 2.0.30-alpine, 2.0-alpine, 2.0.30-alpine3.16, 2.0-alpine3.16
+Tags: 2.0.31-alpine, 2.0-alpine, 2.0.31-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079f57941442130b1f47fbb30181390c8fdfd708
+GitCommit: 1842f4392f605e9f944c7f55415ddfc828301a31
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b276030: Update 2.8 to 2.8-dev4
- https://github.com/docker-library/haproxy/commit/c1f665d: Update 2.7 to 2.7.3
- https://github.com/docker-library/haproxy/commit/e678a56: Update 2.6 to 2.6.9
- https://github.com/docker-library/haproxy/commit/57fdd93: Update 2.5 to 2.5.12
- https://github.com/docker-library/haproxy/commit/010b099: Update 2.4 to 2.4.22
- https://github.com/docker-library/haproxy/commit/a341c5a: Update 2.2 to 2.2.29
- https://github.com/docker-library/haproxy/commit/1842f43: Update 2.0 to 2.0.31