### PR TITLE
Bump Haskell (GHC) 9.2 to 9.2.6

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -11,14 +11,14 @@ Architectures: amd64, arm64v8
 GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
 Directory: 9.4/slim-buster
 
-Tags: 9.2.5-buster, 9.2-buster, 9.2.5, 9.2
+Tags: 9.2.6-buster, 9.2-buster, 9.2.6, 9.2
 Architectures: amd64, arm64v8
-GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
+GitCommit: b2644d1604cc9a3e868b432f4901e86541a0841d
 Directory: 9.2/buster
 
-Tags: 9.2.5-slim-buster, 9.2-slim-buster, 9.2.5-slim, 9.2-slim
+Tags: 9.2.6-slim-buster, 9.2-slim-buster, 9.2.6-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
+GitCommit: b2644d1604cc9a3e868b432f4901e86541a0841d
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0


### PR DESCRIPTION
This PR bumps the minor version of the Haskell compiler GHC from 9.2.5 to
[9.2.6].

Cc @AlistairB

[9.2.6]: https://www.haskell.org/ghc/download_ghc_9_2_6.html
