### PR TITLE
Bump Traefik to v2.9.8

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
-Tags: v2.9.7-windowsservercore-1809, 2.9.7-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.9.8-windowsservercore-1809, 2.9.8-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c41ca3c5829b327dd65205a3e9bc81c0e7dd0f95
+GitCommit: cde946f16566d912ccae15cf1bd9056518ef8c3d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.9.7, 2.9.7, v2.9, 2.9, banon, latest
+Tags: v2.9.8, 2.9.8, v2.9, 2.9, banon, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c41ca3c5829b327dd65205a3e9bc81c0e7dd0f95
+GitCommit: cde946f16566d912ccae15cf1bd9056518ef8c3d
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.9.8](https://github.com/traefik/traefik/releases/tag/v2.9.8).

/cc @mpl @ldez

Cheers
