### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,20 +6,20 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 4.1.0, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 16cbbcd19ecb8b2d09fc3b71ecfd5896be754b1b
+GitCommit: bbe25add57171af90838151e419b7cdafc921e3c
 Directory: 4.1
 
-Tags: 4.0.7, 4.0
+Tags: 4.0.8, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 16cbbcd19ecb8b2d09fc3b71ecfd5896be754b1b
+GitCommit: bbe25add57171af90838151e419b7cdafc921e3c
 Directory: 4.0
 
 Tags: 3.11.14, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 16cbbcd19ecb8b2d09fc3b71ecfd5896be754b1b
+GitCommit: bbe25add57171af90838151e419b7cdafc921e3c
 Directory: 3.11
 
 Tags: 3.0.28, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 16cbbcd19ecb8b2d09fc3b71ecfd5896be754b1b
+GitCommit: bbe25add57171af90838151e419b7cdafc921e3c
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/7137206: Merge pull request https://github.com/docker-library/cassandra/pull/262 from infosiftr/more-keys
- https://github.com/docker-library/cassandra/commit/bbe25ad: update from KEYS file, bump to 4.0.8