### PR TITLE
Update Amazon Linux images

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2.0.20230119.1, 2, latest
+Tags: 2.0.20230207.0, 2, latest
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 8cd3a1d4d2516e33d3b26247120ecfc8d9d01d07
+amd64-GitCommit: 0a73a9be29db33fd971c3206d1f893e8df26d9b7
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: fe9ce6ed22a3ca487bf4fd0826c453bec40803ab
+arm64v8-GitCommit: 3979301804a085db0868fcaf5e67f7d510fccbd9
 
-Tags: 2.0.20230119.1-with-sources, 2-with-sources, with-sources
+Tags: 2.0.20230207.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: b5c54379aea40f6d9a0d50af4677399d0defff7b
+amd64-GitCommit: 8b1a2649bc2e8cf24109954310ebe26b4566e4bd
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: f164a83dfbb6c090bee67864e39f4cdf1f365d89
+arm64v8-GitCommit: 7693d6669781ce34ab310d5caa4a4802fec3c115
 
 Tags: 2018.03.0.20230207.0, 2018.03, 1
 Architectures: amd64


### PR DESCRIPTION
This container release contains updates for the following list of packages. Also included are any CVEs that are being addressed with these updates.

#### Package List:
- curl-7.87.0-2.amzn2.0.1
  - [CVE-2022-27781](https://alas.aws.amazon.com/cve/html/CVE-2022-27781.html)
  - [CVE-2022-43551](https://alas.aws.amazon.com/cve/html/CVE-2022-43551.html)
  - [CVE-2022-43552](https://alas.aws.amazon.com/cve/html/CVE-2022-43552.html)
- util-linux-2.30.2-2.amzn2.0.11
  - [CVE-2021-37600](https://alas.aws.amazon.com/cve/html/CVE-2021-37600.html)