### PR TITLE
GlassFish Image is back!

### DIFF
--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 12efd43d7633d89cb28edf3a5b0cf3c12ac31c1f
+GitCommit: 3e22307467c6f9557077f9eb4d481e3ede8df30f
 
 Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
 Architectures: amd64

--- a/library/glassfish
+++ b/library/glassfish
@@ -5,10 +5,6 @@ GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
 GitCommit: ac45a85358cd69e26e241d4f10cbe4c47c62cc5f
 
-Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.0
-
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.1

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: e0cdd75be537838a9c54fcec026461e03be334b6
+GitCommit: e631d3d9334fb32d17fc3155453bf2a2f70b3180
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -29,6 +29,10 @@ Tags: 7.0.6, 7.0.6-jdk17, 7.0.6-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.6
 
-Tags: latest, 7.0.7, 7.0.7-jdk17, 7.0.7-jdk17-eclipse-temurin
+Tags: 7.0.7, 7.0.7-jdk17, 7.0.7-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.7
+
+Tags: latest, 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.8

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 36560c745bacc3ac22448dd00e45288322ff8883
+GitCommit: aed9de3cf9e565b5bb71787a810554643b99e993
 
 Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
 Architectures: amd64
@@ -17,6 +17,11 @@ Tags: 7.0.2, 7.0.2-jdk17, 7.0.2-jdk17-eclipse-temurin
 Architectures: amd64
 Directory: 7.0.2
 
-Tags: latest, 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
+Tags: 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
 Architectures: amd64
 Directory: 7.0.3
+
+Tags: latest, 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
+Architectures: amd64
+Directory: 7.0.4
+

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 75f8239d93149b1d665e065b289e465d3e4de5d3
+GitCommit: e0cdd75be537838a9c54fcec026461e03be334b6
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -25,6 +25,10 @@ Tags: 7.0.5, 7.0.5-jdk17, 7.0.5-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.5
 
-Tags: latest, 7.0.6, 7.0.6-jdk17, 7.0.6-jdk17-eclipse-temurin
+Tags: 7.0.6, 7.0.6-jdk17, 7.0.6-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.6
+
+Tags: latest, 7.0.7, 7.0.7-jdk17, 7.0.7-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.7

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: e631d3d9334fb32d17fc3155453bf2a2f70b3180
+GitCommit: 6e52c231a5f50963b9fd91e8206157ae8b87c9e0
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -33,6 +33,10 @@ Tags: 7.0.7, 7.0.7-jdk17, 7.0.7-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.7
 
-Tags: latest, 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
+Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.8
+
+Tags: latest, 7.0.9, 7.0.9-jdk17, 7.0.9-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.9

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 6e52c231a5f50963b9fd91e8206157ae8b87c9e0
+GitCommit: c9f6f188fce90e105286261d4977db07e6fc5c9e
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -37,6 +37,10 @@ Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.8
 
-Tags: latest, 7.0.9, 7.0.9-jdk17, 7.0.9-jdk17-eclipse-temurin
+Tags: 7.0.9, 7.0.9-jdk17, 7.0.9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.9
+
+Tags: latest, 7.0.10, 7.0.10-jdk17, 7.0.10-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.10

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/eclipse-ee4j/glassfish.docker.git
 GitFetch: refs/heads/main
-GitCommit: 4507192e8332614e653d9a0394eb5c94955c1bfe
+GitCommit: 6aa8e66761d586e620cc08c18cb2540a0be5ff4b
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -49,6 +49,22 @@ Tags: 7.0.18, 7.0.18-jdk17, 7.0.18-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.18
 
-Tags: latest, 7.0.19, 7.0.19-jdk17, 7.0.19-jdk17-eclipse-temurin
+Tags: 7.0.19, 7.0.19-jdk17, 7.0.19-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.19
+
+Tags: 7.0.20, 7.0.20-jdk17, 7.0.20-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.20
+
+Tags: 7.0.21, 7.0.21-jdk17, 7.0.21-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.21
+
+Tags: 7.0.22, 7.0.22-jdk17, 7.0.22-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.22
+
+Tags: latest, 7.0.23, 7.0.23-jdk17, 7.0.23-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.23

--- a/library/glassfish
+++ b/library/glassfish
@@ -1,9 +1,9 @@
 Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Arjan Tijms <arjan.tijms@omnifish.ee> (@arjantijms),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
-GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
+GitRepo: https://github.com/eclipse-ee4j/glassfish.docker.git
 GitFetch: refs/heads/main
-GitCommit: ac330bd8712c5df00cb7e76d2daaf539b01ff587
+GitCommit: 36c87fcf919c1adc76746eaddb9bae54edfb0aed
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -33,6 +33,10 @@ Tags: 7.0.14, 7.0.14-jdk17, 7.0.14-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.14
 
-Tags: latest, 7.0.15, 7.0.15-jdk17, 7.0.15-jdk17-eclipse-temurin
+Tags: 7.0.15, 7.0.15-jdk17, 7.0.15-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.15
+
+Tags: latest, 7.0.16, 7.0.16-jdk17, 7.0.16-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.16

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 51431a030fa9a2eeca49a975bf9e5c3c9c072624
+GitCommit: bcb062a39a9189d0a3a2d2a3f14953cb98c682ac
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -17,6 +17,10 @@ Tags: 7.0.10, 7.0.10-jdk17, 7.0.10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.10
 
-Tags: latest, 7.0.11, 7.0.11-jdk17, 7.0.11-jdk17-eclipse-temurin
+Tags: 7.0.11, 7.0.11-jdk17, 7.0.11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.11
+
+Tags: latest, 7.0.12, 7.0.12-jdk17, 7.0.12-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.12

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: c3c491cb9e548f6eacec00bb4f29149b4ee4e05b
+GitCommit: ac330bd8712c5df00cb7e76d2daaf539b01ff587
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -29,6 +29,10 @@ Tags: 7.0.13, 7.0.13-jdk17, 7.0.13-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.13
 
-Tags: latest, 7.0.14, 7.0.14-jdk17, 7.0.14-jdk17-eclipse-temurin
+Tags: 7.0.14, 7.0.14-jdk17, 7.0.14-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.14
+
+Tags: latest, 7.0.15, 7.0.15-jdk17, 7.0.15-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.15

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,68 +3,12 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/eclipse-ee4j/glassfish.docker.git
 GitFetch: refs/heads/main
-GitCommit: 6aa8e66761d586e620cc08c18cb2540a0be5ff4b
+GitCommit: 7dd400df6a6bb7b136784a234e705813dd759261
 
-Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
+Tags: 7.0.25, 7.0.25-jdk17, 7.0.25-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
-Directory: 7.0.8
+Directory: images/server/7.0.25
 
-Tags: 7.0.9, 7.0.9-jdk17, 7.0.9-jdk17-eclipse-temurin
+Tags: latest, 7.1.0, 7.1.0-jdk17, 7.1.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
-Directory: 7.0.9
-
-Tags: 7.0.10, 7.0.10-jdk17, 7.0.10-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.10
-
-Tags: 7.0.11, 7.0.11-jdk17, 7.0.11-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.11
-
-Tags: 7.0.12, 7.0.12-jdk17, 7.0.12-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.12
-
-Tags: 7.0.13, 7.0.13-jdk17, 7.0.13-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.13
-
-Tags: 7.0.14, 7.0.14-jdk17, 7.0.14-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.14
-
-Tags: 7.0.15, 7.0.15-jdk17, 7.0.15-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.15
-
-Tags: 7.0.16, 7.0.16-jdk17, 7.0.16-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.16
-
-Tags: 7.0.17, 7.0.17-jdk17, 7.0.17-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.17
-
-Tags: 7.0.18, 7.0.18-jdk17, 7.0.18-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.18
-
-Tags: 7.0.19, 7.0.19-jdk17, 7.0.19-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.19
-
-Tags: 7.0.20, 7.0.20-jdk17, 7.0.20-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.20
-
-Tags: 7.0.21, 7.0.21-jdk17, 7.0.21-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.21
-
-Tags: 7.0.22, 7.0.22-jdk17, 7.0.22-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.22
-
-Tags: latest, 7.0.23, 7.0.23-jdk17, 7.0.23-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.23
+Directory: images/server/7.1.0

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 0fd0f38c2b0062860adfddad2c769a1c9f927c15
+GitCommit: 75f8239d93149b1d665e065b289e465d3e4de5d3
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -21,6 +21,10 @@ Tags: 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.4
 
-Tags: latest, 7.0.5, 7.0.5-jdk17, 7.0.5-jdk17-eclipse-temurin
+Tags: 7.0.5, 7.0.5-jdk17, 7.0.5-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.5
+
+Tags: latest, 7.0.6, 7.0.6-jdk17, 7.0.6-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.6

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 9854d1df6a588e6277a8be0e304382862bb978c1
+GitCommit: c3c491cb9e548f6eacec00bb4f29149b4ee4e05b
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -25,6 +25,10 @@ Tags: 7.0.12, 7.0.12-jdk17, 7.0.12-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.12
 
-Tags: latest, 7.0.13, 7.0.13-jdk17, 7.0.13-jdk17-eclipse-temurin
+Tags: 7.0.13, 7.0.13-jdk17, 7.0.13-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.13
+
+Tags: latest, 7.0.14, 7.0.14-jdk17, 7.0.14-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.14

--- a/library/glassfish
+++ b/library/glassfish
@@ -1,0 +1,14 @@
+Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
+             Arjan Tijms <arjan.tijms@omnifish.ee> (@arjantijms),
+             Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
+GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
+GitFetch: refs/heads/main
+GitCommit: f7c6e852939b321ca1f9bb2ddeacab4df2ed0bc1
+
+Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
+Architectures: amd64
+Directory: 7.0.0/src/main/docker
+
+Tags: latest, 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
+Architectures: amd64
+Directory: 7.0.1/src/main/docker

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,12 +3,20 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: 3e22307467c6f9557077f9eb4d481e3ede8df30f
+GitCommit: 36560c745bacc3ac22448dd00e45288322ff8883
 
 Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
 Architectures: amd64
-Directory: 7.0.0/src/main/docker
+Directory: 7.0.0
 
-Tags: latest, 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
+Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64
-Directory: 7.0.1/src/main/docker
+Directory: 7.0.1
+
+Tags: 7.0.2, 7.0.2-jdk17, 7.0.2-jdk17-eclipse-temurin
+Architectures: amd64
+Directory: 7.0.2
+
+Tags: latest, 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
+Architectures: amd64
+Directory: 7.0.3

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: ac45a85358cd69e26e241d4f10cbe4c47c62cc5f
+GitCommit: 0fd0f38c2b0062860adfddad2c769a1c9f927c15
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -17,6 +17,10 @@ Tags: 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.3
 
-Tags: latest, 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
+Tags: 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.4
+
+Tags: latest, 7.0.5, 7.0.5-jdk17, 7.0.5-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.5

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,35 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: c9f6f188fce90e105286261d4977db07e6fc5c9e
-
-Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.1
-
-Tags: 7.0.2, 7.0.2-jdk17, 7.0.2-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.2
-
-Tags: 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.3
-
-Tags: 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.4
-
-Tags: 7.0.5, 7.0.5-jdk17, 7.0.5-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.5
-
-Tags: 7.0.6, 7.0.6-jdk17, 7.0.6-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.6
-
-Tags: 7.0.7, 7.0.7-jdk17, 7.0.7-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: 7.0.7
+GitCommit: 51431a030fa9a2eeca49a975bf9e5c3c9c072624
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -41,6 +13,10 @@ Tags: 7.0.9, 7.0.9-jdk17, 7.0.9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.9
 
-Tags: latest, 7.0.10, 7.0.10-jdk17, 7.0.10-jdk17-eclipse-temurin
+Tags: 7.0.10, 7.0.10-jdk17, 7.0.10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.10
+
+Tags: latest, 7.0.11, 7.0.11-jdk17, 7.0.11-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.11

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/eclipse-ee4j/glassfish.docker.git
 GitFetch: refs/heads/main
-GitCommit: 36c87fcf919c1adc76746eaddb9bae54edfb0aed
+GitCommit: 4507192e8332614e653d9a0394eb5c94955c1bfe
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -37,6 +37,18 @@ Tags: 7.0.15, 7.0.15-jdk17, 7.0.15-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.15
 
-Tags: latest, 7.0.16, 7.0.16-jdk17, 7.0.16-jdk17-eclipse-temurin
+Tags: 7.0.16, 7.0.16-jdk17, 7.0.16-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.16
+
+Tags: 7.0.17, 7.0.17-jdk17, 7.0.17-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.17
+
+Tags: 7.0.18, 7.0.18-jdk17, 7.0.18-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.18
+
+Tags: latest, 7.0.19, 7.0.19-jdk17, 7.0.19-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.19

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,25 +3,24 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: aed9de3cf9e565b5bb71787a810554643b99e993
+GitCommit: ac45a85358cd69e26e241d4f10cbe4c47c62cc5f
 
 Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 7.0.0
 
 Tags: 7.0.1, 7.0.1-jdk17, 7.0.1-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 7.0.1
 
 Tags: 7.0.2, 7.0.2-jdk17, 7.0.2-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 7.0.2
 
 Tags: 7.0.3, 7.0.3-jdk17, 7.0.3-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 7.0.3
 
 Tags: latest, 7.0.4, 7.0.4-jdk17, 7.0.4-jdk17-eclipse-temurin
-Architectures: amd64
+Architectures: amd64, arm64v8
 Directory: 7.0.4
-

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: bcb062a39a9189d0a3a2d2a3f14953cb98c682ac
+GitCommit: 9854d1df6a588e6277a8be0e304382862bb978c1
 
 Tags: 7.0.8, 7.0.8-jdk17, 7.0.8-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
@@ -21,6 +21,10 @@ Tags: 7.0.11, 7.0.11-jdk17, 7.0.11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.11
 
-Tags: latest, 7.0.12, 7.0.12-jdk17, 7.0.12-jdk17-eclipse-temurin
+Tags: 7.0.12, 7.0.12-jdk17, 7.0.12-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: 7.0.12
+
+Tags: latest, 7.0.13, 7.0.13-jdk17, 7.0.13-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: 7.0.13

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,7 +3,7 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/OmniFish-EE/docker-library-glassfish.git
 GitFetch: refs/heads/main
-GitCommit: f7c6e852939b321ca1f9bb2ddeacab4df2ed0bc1
+GitCommit: 12efd43d7633d89cb28edf3a5b0cf3c12ac31c1f
 
 Tags: 7.0.0, 7.0.0-jdk17, 7.0.0-jdk17-eclipse-temurin
 Architectures: amd64

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,12 +3,16 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/eclipse-ee4j/glassfish.docker.git
 GitFetch: refs/heads/main
-GitCommit: 7dd400df6a6bb7b136784a234e705813dd759261
+GitCommit: 6b6d0c78e65f0dfc219bdf19b4d2d2c92d732d75
 
 Tags: 7.0.25, 7.0.25-jdk17, 7.0.25-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: images/server/7.0.25
 
-Tags: latest, 7.1.0, 7.1.0-jdk17, 7.1.0-jdk17-eclipse-temurin
+Tags: 7.1.0, 7.1.0-jdk17, 7.1.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: images/server/7.1.0
+
+Tags: latest, 8.0.0, 8.0.0-jdk21, 8.0.0-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: images/server/8.0.0

--- a/library/glassfish
+++ b/library/glassfish
@@ -9,7 +9,7 @@ Tags: 7.0.25, 7.0.25-jdk17, 7.0.25-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: images/server/7.0.25
 
-Tags: 7.1.0, 7.1.0-jdk17, 7.1.0-jdk17-eclipse-temurin
+Tags: 7.1.0, 7.1.0-jdk21, 7.1.0-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: images/server/7.1.0
 

--- a/library/glassfish
+++ b/library/glassfish
@@ -3,16 +3,8 @@ Maintainers: David Matejcek <david.matejcek@omnifish.ee> (@dmatej),
              Ondro Mihalyi <ondro.mihalyi@omnifish.ee> (@ondromih)
 GitRepo: https://github.com/eclipse-ee4j/glassfish.docker.git
 GitFetch: refs/heads/main
-GitCommit: 6b6d0c78e65f0dfc219bdf19b4d2d2c92d732d75
+GitCommit: 9caf97018569ba8bade9dd4edabaaaf41881fc2d
 
-Tags: 7.0.25, 7.0.25-jdk17, 7.0.25-jdk17-eclipse-temurin
+Tags: latest, 8.0.4, 8.0.4-jdk21, 8.0.4-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
-Directory: images/server/7.0.25
-
-Tags: 7.1.0, 7.1.0-jdk21, 7.1.0-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: images/server/7.1.0
-
-Tags: latest, 8.0.0, 8.0.0-jdk21, 8.0.0-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: images/server/8.0.0
+Directory: images/server/8.0.4

--- a/test/config.sh
+++ b/test/config.sh
@@ -77,6 +77,9 @@ imageTests+=(
 	[ghost]='
 		ghost-basics
 	'
+	[glassfish]='
+		glassfish
+	'
 	[golang]='
 		golang-hello-world
 	'

--- a/test/tests/glassfish/run.sh
+++ b/test/tests/glassfish/run.sh
@@ -5,17 +5,23 @@ serverImage="$1"
 containerId="$(docker run -d "$serverImage")"
 trap "docker rm -vf $containerId > /dev/null" EXIT
 
-logLine='^\s+Eclipse GlassFish\s+[\.0-9]+'
-timeout=60
+waitForLogLine() {
+    timeout="$1";
+    logLine="$2";
+    until docker logs $containerId 2>&1 | grep -q -E "$logLine"
+    do
+        if [ $timeout -eq 0 ]
+        then
+            exit 100;
+        fi
+        sleep 1
+        timeout=$((timeout-1))
+    done
+}
 
-until docker logs $containerId 2>&1 | grep -q -E "$logLine"
-do
-    if [ $timeout -eq 0 ]
-    then
-        exit 100;
-    fi
-    sleep 1
-    timeout=$((timeout-1))
-done
+waitForLogLine 60 '^\s+Eclipse GlassFish\s+[\.0-9]+';
+echo "GlassFish started as ${containerId}"
 
-echo "Success!"
+docker stop "${containerId}" &
+waitForLogLine 30 '^\s+Completed shutdown of GlassFish runtime';
+echo "GlassFish stopped OK!"

--- a/test/tests/glassfish/run.sh
+++ b/test/tests/glassfish/run.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+set -eo pipefail
+
+serverImage="$1"
+containerId="$(docker run -d "$serverImage")"
+trap "docker rm -vf $containerId > /dev/null" EXIT
+
+logLine='^\s+Eclipse GlassFish\s+[\.0-9]+'
+timeout=60
+
+until docker logs $containerId 2>&1 | grep -q -E "$logLine"
+do
+    if [ $timeout -eq 0 ]
+    then
+        exit 100;
+    fi
+    sleep 1
+    timeout=$((timeout-1))
+done
+
+echo "Success!"

--- a/test/tests/glassfish/run.sh
+++ b/test/tests/glassfish/run.sh
@@ -23,5 +23,5 @@ waitForLogLine 60 '^\s+Eclipse GlassFish\s+[\.0-9]+';
 echo "GlassFish started as ${containerId}"
 
 docker stop "${containerId}" &
-waitForLogLine 30 '^\s+Completed shutdown of GlassFish runtime';
+waitForLogLine 30 '^\s*Completed shutdown of GlassFish runtime';
 echo "GlassFish stopped OK!"


### PR DESCRIPTION
Many users (not just [here](https://github.com/eclipse-ee4j/glassfish/issues/22598)) asked for the rescue of the official [GlassFish Docker Image](https://hub.docker.com/_/glassfish), and the time has come.

I don't have an experience with creating the official Docker Images, so please, if I am doing something incorrect, don't kill me ;-)

The repository: https://github.com/eclipse-ee4j/glassfish.docker
(note - the original OmniFish repo was donated to the Eclipse Foundation which is also the owner of Eclipse GlassFish)

# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[ ] associated with or contacted upstream? 
GF: OK
-	[ ] available under [an OSI-approved license](https://opensource.org/licenses)? 
GF: OK, [EPL2](https://opensource.org/license/epl-2-0)
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution") 
GF: OK, service, well known full [Jakarta EE](https://jakarta.ee/) platform implementation.
-	[ ] is it reasonably popular, or does it solve a particular use case well? 
GF: OK, still popular after all, now growing community again.
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long). 
GF: OK, improving as we have feedback from users.
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))? 
OK, we followed this, dockerhub team recommendations, feedbacks and even advices from some tools.
-	[ ] 2+ official-images maintainer dockerization review? 
GF: TBD, we are still waiting for this. It will be 2 years soon.
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?) 
GF: OK, we use [Eclipse Temurin JDK](https://hub.docker.com/_/eclipse-temurin) as a base.
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history? 
GF: OK, not from scratch.
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test) 
GF: OK, we added start+stop test, other options are tested in our repo.