### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.35.0, 5.35, 5, latest
+Tags: 5.35.1, 5.35, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 146fc3a73e6f219f4d55c47c46cf2efdb724d397
+GitCommit: 64a043e41c841defaa52ff2f789fc0f36d1e8629
 Directory: 5/debian
 
-Tags: 5.35.0-alpine, 5.35-alpine, 5-alpine, alpine
+Tags: 5.35.1-alpine, 5.35-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 146fc3a73e6f219f4d55c47c46cf2efdb724d397
+GitCommit: 64a043e41c841defaa52ff2f789fc0f36d1e8629
 Directory: 5/alpine
 
 Tags: 4.48.9, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/64a043e: Update to 5.35.1, ghost-cli 1.24.0