### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.6.1
+Tags: 8.6.2
 Architectures: amd64, arm64v8
-GitCommit: 8001c62c84bb3fa9f19a2725d20d4e5f404dda5e
+GitCommit: 90e34ca306d9800d3c0ab1c59387b93e89c69796
 Directory: 8
 
 Tags: 7.17.9

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.6.1
+Tags: 8.6.2
 Architectures: amd64, arm64v8
-GitCommit: 99dfd6ecee59bd6e72c85c2f6b4ded17e3180c5e
+GitCommit: da3edfaa4c3735e2fa17d70f0f26c64488fcb06c
 Directory: 8
 
 Tags: 7.17.9

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.6.1
+Tags: 8.6.2
 Architectures: amd64, arm64v8
-GitCommit: 9061b36c4de1baca7642d05c31111515873ab7cb
+GitCommit: 8ecac06ee232b47787ae8f1673fa0aa539b482fa
 Directory: 8
 
 Tags: 7.17.9


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/90e34ca: Update to 8.6.2

logstash:
- https://github.com/docker-library/logstash/commit/8ecac06: Update to 8.6.2

kibana:
- https://github.com/docker-library/kibana/commit/da3edfa: Update to 8.6.2