### PR TITLE
Validate all naughty even in the face of one naughty

### DIFF
--- a/.github/workflows/naughty.sh
+++ b/.github/workflows/naughty.sh
@@ -17,6 +17,8 @@ export BASHBREW_LIBRARY="$PWD/library"
 
 bashbrew from --uniq "$@" > /dev/null
 
+numNaughty=0
+
 if badTags="$(bashbrew list "$@" | grep -E ':.+latest.*|:.*latest.+')" && [ -n "$badTags" ]; then
 	echo >&2
 	echo >&2 "Incorrectly formatted 'latest' tags detected:"
@@ -24,7 +26,7 @@ if badTags="$(bashbrew list "$@" | grep -E ':.+latest.*|:.*latest.+')" && [ -n "
 	echo >&2
 	echo >&2 'Read https://github.com/docker-library/official-images#tags-and-aliases for more details.'
 	echo >&2
-	exit 1
+	(( ++numNaughty ))
 fi
 
 naughtyFrom="$(./naughty-from.sh "$@")"
@@ -36,7 +38,7 @@ if [ -n "$naughtyFrom" ]; then
 	echo >&2
 	echo >&2 'Read https://github.com/docker-library/official-images#multiple-architectures for more details.'
 	echo >&2
-	exit 1
+	(( ++numNaughty ))
 fi
 
 naughtyConstraints="$(./naughty-constraints.sh "$@")"
@@ -46,7 +48,7 @@ if [ -n "$naughtyConstraints" ]; then
 	echo >&2
 	echo >&2 "$naughtyConstraints"
 	echo >&2
-	exit 1
+	(( ++numNaughty ))
 fi
 
 naughtyCommits="$(./naughty-commits.sh "$@")"
@@ -56,5 +58,7 @@ if [ -n "$naughtyCommits" ]; then
 	echo >&2
 	echo >&2 "$naughtyCommits"
 	echo >&2
-	exit 1
+	(( ++numNaughty ))
 fi
+
+exit "$numNaughty"


### PR DESCRIPTION
If one of our "naughty" tests returns a result, we should continue looking for more failures (since a given validation might have multiple problems and it's easier to fix them all at once than one at a time).