### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2023-0835 ELSA-2023-0837 ELSA-2023-0833

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 014054e724acbb6e092178675ec6a649350e9216
+amd64-GitCommit: b42a4ac92cf22a1b724b3f44fcfd5af9fe19e7f5
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 3574d6ebcbc3a10569cf5f782259e78c2697196a
+arm64v8-GitCommit: 1947e98c8d9e0b520d96a7ceb052f63eeeb8105c
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-40897, CVE-2022-4415, CVE-2020-10735, CVE-2021-28861, CVE-2022-45061

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-0835.html
https://linux.oracle.com/errata/ELSA-2023-0837.html
https://linux.oracle.com/errata/ELSA-2023-0833.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>