### PR TITLE
2023 q1 release + mysql tests upgrade

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,51 +1,56 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/20d60f126b3c6d438d62b15b17092cdf948e9fe5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/8524cfe3677c8e4d70f80df565a0c51027881857/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
              Faustin Lammler <faustin@mariadb.org> (@fauust)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
+Tags: 11.0.1-rc-jammy, 11.0-rc-jammy, 11.0.1-rc, 11.0-rc
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+Directory: 11.0
+
 Tags: 10.11.2-jammy, 10.11-jammy, 10-jammy, jammy, 10.11.2, 10.11, 10, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 97200971ae9d24a700acc65055eaf9edc4df91f1
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.11
 
 Tags: 10.10.3-jammy, 10.10-jammy, 10.10.3, 10.10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.10
 
 Tags: 10.9.5-jammy, 10.9-jammy, 10.9.5, 10.9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.9
 
 Tags: 10.8.7-jammy, 10.8-jammy, 10.8.7, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.8
 
 Tags: 10.7.8-focal, 10.7-focal, 10.7.8, 10.7
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.7
 
 Tags: 10.6.12-focal, 10.6-focal, 10.6.12, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.6
 
 Tags: 10.5.19-focal, 10.5-focal, 10.5.19, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.5
 
 Tags: 10.4.28-focal, 10.4-focal, 10.4.28, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.4
 
 Tags: 10.3.38-focal, 10.3-focal, 10.3.38, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 051d37a079b9d068692513a11e1e6bde3fda4223
+GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
 Directory: 10.3

--- a/test/tests/mysql-basics/run.sh
+++ b/test/tests/mysql-basics/run.sh
@@ -25,9 +25,10 @@ trap "docker rm -vf $cid > /dev/null" EXIT
 mysql() {
 	docker run --rm -i \
 		--link "$cname":mysql \
-		--entrypoint mysql \
+		--entrypoint sh \
 		-e MYSQL_PWD="$MYSQL_PASSWORD" \
 		"$image" \
+		-euc 'if command -v mariadb > /dev/null; then exec mariadb "$@"; else exec mysql "$@"; fi' -- \
 		-hmysql \
 		-u"$MYSQL_USER" \
 		--silent \
@@ -35,7 +36,7 @@ mysql() {
 		"$MYSQL_DATABASE"
 }
 
-. "$dir/../../retry.sh" --tries 30 "echo 'SELECT 1' | mysql"
+. "$dir/../../retry.sh" --tries 30 "mysql -e 'SELECT 1'"
 
 echo 'CREATE TABLE test (a INT, b INT, c VARCHAR(255))' | mysql
 [ "$(echo 'SELECT COUNT(*) FROM test' | mysql)" = 0 ]

--- a/test/tests/mysql-initdb/run.sh
+++ b/test/tests/mysql-initdb/run.sh
@@ -31,9 +31,10 @@ trap "docker rm -vf $cid > /dev/null" EXIT
 mysql() {
 	docker run --rm -i \
 		--link "$cname":mysql \
-		--entrypoint mysql \
+		--entrypoint sh \
 		-e MYSQL_PWD="$MYSQL_PASSWORD" \
 		"$image" \
+		-euc 'if command -v mariadb > /dev/null; then exec mariadb "$@"; else exec mysql "$@"; fi' -- \
 		-hmysql \
 		-u"$MYSQL_USER" \
 		--silent \

--- a/test/tests/mysql-log-bin/run.sh
+++ b/test/tests/mysql-log-bin/run.sh
@@ -19,8 +19,9 @@ trap "docker rm -vf $cid > /dev/null" EXIT
 mysql() {
 	docker run --rm -i \
 		--link "$cname":mysql \
-		--entrypoint mysql \
+		--entrypoint sh \
 		"$image" \
+		-euc 'if command -v mariadb > /dev/null; then exec mariadb "$@"; else exec mysql "$@"; fi' -- \
 		-uroot \
 		-hmysql \
 		--silent \


### PR DESCRIPTION
Last part of release, the 11.0 new version.

Due to this not including the mysql executable, it uses mariadb instead, a small compatible change has been done to the mysql tests.

Closes #14140 