### PR TITLE
arangodb 3.9.9, 3.10.4

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,12 +7,12 @@ Architectures: amd64
 GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
 Directory: alpine/3.8.8
 
-Tags: 3.9, 3.9.8
+Tags: 3.9, 3.9.9
 Architectures: amd64
-GitCommit: 42d86d150782ccdfdf848bd5e4dc3b51d85f4364
-Directory: alpine/3.9.8
+GitCommit: 6d01f6e7130208aea68d0e341bb9b009dcc3da79
+Directory: alpine/3.9.9
 
-Tags: 3.10, 3.10.3, latest
+Tags: 3.10, 3.10.4, latest
 Architectures: amd64, arm64v8
-GitCommit: 42d86d150782ccdfdf848bd5e4dc3b51d85f4364
-Directory: alpine/3.10.3
+GitCommit: 6d01f6e7130208aea68d0e341bb9b009dcc3da79
+Directory: alpine/3.10.4


### PR DESCRIPTION
Updated ArangoDB 3.9 to 3.9.9 and 3.10 to 3.10.4.