### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/2e866df38b986b934df6ec6a96ace921c2e6e053/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/2829b7eded87eaa8b678e850059439c46d5c6eae/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -7,227 +7,227 @@ GitRepo: https://github.com/docker-library/python.git
 Tags: 3.12.0a5-bullseye, 3.12-rc-bullseye
 SharedTags: 3.12.0a5, 3.12-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/bullseye
 
 Tags: 3.12.0a5-slim-bullseye, 3.12-rc-slim-bullseye, 3.12.0a5-slim, 3.12-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/slim-bullseye
 
 Tags: 3.12.0a5-buster, 3.12-rc-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/buster
 
 Tags: 3.12.0a5-slim-buster, 3.12-rc-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/slim-buster
 
 Tags: 3.12.0a5-alpine3.17, 3.12-rc-alpine3.17, 3.12.0a5-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/alpine3.17
 
 Tags: 3.12.0a5-alpine3.16, 3.12-rc-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/alpine3.16
 
 Tags: 3.12.0a5-windowsservercore-ltsc2022, 3.12-rc-windowsservercore-ltsc2022
 SharedTags: 3.12.0a5-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a5, 3.12-rc
 Architectures: windows-amd64
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.12.0a5-windowsservercore-1809, 3.12-rc-windowsservercore-1809
 SharedTags: 3.12.0a5-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a5, 3.12-rc
 Architectures: windows-amd64
-GitCommit: 69d5e5ca5a4323a79668573a8de02dc96fbc7f3b
+GitCommit: b987547e6b4d485163997795791017ee1e3b3155
 Directory: 3.12-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.11.2-bullseye, 3.11-bullseye, 3-bullseye, bullseye
 SharedTags: 3.11.2, 3.11, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/bullseye
 
 Tags: 3.11.2-slim-bullseye, 3.11-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.11.2-slim, 3.11-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/slim-bullseye
 
 Tags: 3.11.2-buster, 3.11-buster, 3-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/buster
 
 Tags: 3.11.2-slim-buster, 3.11-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/slim-buster
 
 Tags: 3.11.2-alpine3.17, 3.11-alpine3.17, 3-alpine3.17, alpine3.17, 3.11.2-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/alpine3.17
 
 Tags: 3.11.2-alpine3.16, 3.11-alpine3.16, 3-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/alpine3.16
 
 Tags: 3.11.2-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.11.2-windowsservercore, 3.11-windowsservercore, 3-windowsservercore, windowsservercore, 3.11.2, 3.11, 3, latest
 Architectures: windows-amd64
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.11.2-windowsservercore-1809, 3.11-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.11.2-windowsservercore, 3.11-windowsservercore, 3-windowsservercore, windowsservercore, 3.11.2, 3.11, 3, latest
 Architectures: windows-amd64
-GitCommit: 0a56f04a07495e0ed61663c73bc0c2e175773ddc
+GitCommit: e664abbb9af1ee6aae5778d70a5df79d86d9ec57
 Directory: 3.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10.10-bullseye, 3.10-bullseye
 SharedTags: 3.10.10, 3.10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/bullseye
 
 Tags: 3.10.10-slim-bullseye, 3.10-slim-bullseye, 3.10.10-slim, 3.10-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.10-buster, 3.10-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/buster
 
 Tags: 3.10.10-slim-buster, 3.10-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/slim-buster
 
 Tags: 3.10.10-alpine3.17, 3.10-alpine3.17, 3.10.10-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/alpine3.17
 
 Tags: 3.10.10-alpine3.16, 3.10-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/alpine3.16
 
 Tags: 3.10.10-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022
 SharedTags: 3.10.10-windowsservercore, 3.10-windowsservercore, 3.10.10, 3.10
 Architectures: windows-amd64
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.10.10-windowsservercore-1809, 3.10-windowsservercore-1809
 SharedTags: 3.10.10-windowsservercore, 3.10-windowsservercore, 3.10.10, 3.10
 Architectures: windows-amd64
-GitCommit: 1a68bced0dc5b7deb6ecd2f7ddacc1089323409d
+GitCommit: a3533b1c48d968e784516470d18f3c24975df3d8
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.9.16-bullseye, 3.9-bullseye
 SharedTags: 3.9.16, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: f568f56f28fab0fe87b34db777e2c2861cef002b
 Directory: 3.9/bullseye
 
 Tags: 3.9.16-slim-bullseye, 3.9-slim-bullseye, 3.9.16-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: f568f56f28fab0fe87b34db777e2c2861cef002b
 Directory: 3.9/slim-bullseye
 
 Tags: 3.9.16-buster, 3.9-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: f568f56f28fab0fe87b34db777e2c2861cef002b
 Directory: 3.9/buster
 
 Tags: 3.9.16-slim-buster, 3.9-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: f568f56f28fab0fe87b34db777e2c2861cef002b
 Directory: 3.9/slim-buster
 
 Tags: 3.9.16-alpine3.17, 3.9-alpine3.17, 3.9.16-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: f568f56f28fab0fe87b34db777e2c2861cef002b
 Directory: 3.9/alpine3.17
 
 Tags: 3.9.16-alpine3.16, 3.9-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: f568f56f28fab0fe87b34db777e2c2861cef002b
 Directory: 3.9/alpine3.16
 
 Tags: 3.8.16-bullseye, 3.8-bullseye
 SharedTags: 3.8.16, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: a541c1b89df7d92c1027aa380454b066ffe9a315
 Directory: 3.8/bullseye
 
 Tags: 3.8.16-slim-bullseye, 3.8-slim-bullseye, 3.8.16-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: a541c1b89df7d92c1027aa380454b066ffe9a315
 Directory: 3.8/slim-bullseye
 
 Tags: 3.8.16-buster, 3.8-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: a541c1b89df7d92c1027aa380454b066ffe9a315
 Directory: 3.8/buster
 
 Tags: 3.8.16-slim-buster, 3.8-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: a541c1b89df7d92c1027aa380454b066ffe9a315
 Directory: 3.8/slim-buster
 
 Tags: 3.8.16-alpine3.17, 3.8-alpine3.17, 3.8.16-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: a541c1b89df7d92c1027aa380454b066ffe9a315
 Directory: 3.8/alpine3.17
 
 Tags: 3.8.16-alpine3.16, 3.8-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: a541c1b89df7d92c1027aa380454b066ffe9a315
 Directory: 3.8/alpine3.16
 
 Tags: 3.7.16-bullseye, 3.7-bullseye
 SharedTags: 3.7.16, 3.7
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: bdbceda203ff70da4e00693d822c8cc1b77ae040
 Directory: 3.7/bullseye
 
 Tags: 3.7.16-slim-bullseye, 3.7-slim-bullseye, 3.7.16-slim, 3.7-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: bdbceda203ff70da4e00693d822c8cc1b77ae040
 Directory: 3.7/slim-bullseye
 
 Tags: 3.7.16-buster, 3.7-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: bdbceda203ff70da4e00693d822c8cc1b77ae040
 Directory: 3.7/buster
 
 Tags: 3.7.16-slim-buster, 3.7-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: bdbceda203ff70da4e00693d822c8cc1b77ae040
 Directory: 3.7/slim-buster
 
 Tags: 3.7.16-alpine3.17, 3.7-alpine3.17, 3.7.16-alpine, 3.7-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: bdbceda203ff70da4e00693d822c8cc1b77ae040
 Directory: 3.7/alpine3.17
 
 Tags: 3.7.16-alpine3.16, 3.7-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 06e0db2fc2e32eb95771b23bc8ad36bf9450640a
+GitCommit: bdbceda203ff70da4e00693d822c8cc1b77ae040
 Directory: 3.7/alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/c517a8b: Merge pull request https://github.com/docker-library/python/pull/801 from infosiftr/no-mips-3.10
- https://github.com/docker-library/python/commit/f568f56: Update 3.9
- https://github.com/docker-library/python/commit/a541c1b: Update 3.8
- https://github.com/docker-library/python/commit/bdbceda: Update 3.7
- https://github.com/docker-library/python/commit/b987547: Update 3.12-rc
- https://github.com/docker-library/python/commit/e664abb: Update 3.11
- https://github.com/docker-library/python/commit/a3533b1: Update 3.10
- https://github.com/docker-library/python/commit/2829b7e: Remove mips64le from 3.10 as well (failing to build)