### PR TITLE
Replace AL2022 images with AL2023

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,14 +1,14 @@
 Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
-            Frédérick Lefebvre (@fred-lefebvre),
-            Stewart Smith (@stewartsmith),
-            Christopher Miller (@mysteriouspants),
-            Sumit Tomer (@sktomer),
-            Tanu Rampal (@trampal),
-            Sam Thornton (@mrthornazon),
-            Preston Carpenter (@timidger),
-            Joseph Howell-Burke (@jhowell-burke),
-            Miriam Clark (@mgclark001),
-            Ade Adetayo (@dadetayo)
+             Frédérick Lefebvre (@fred-lefebvre),
+             Stewart Smith (@stewartsmith),
+             Christopher Miller (@mysteriouspants),
+             Sumit Tomer (@sktomer),
+             Tanu Rampal (@trampal),
+             Sam Thornton (@mrthornazon),
+             Preston Carpenter (@timidger),
+             Joseph Howell-Burke (@jhowell-burke),
+             Miriam Clark (@mgclark001),
+             Ade Adetayo (@dadetayo)
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
@@ -36,16 +36,9 @@ Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: a0fbceecd65169b34c2a48d48a3ffafccc6667af
 
-Tags: 2022.0.20230118.3, 2022, devel
+Tags: 2023, devel, 2023.0.20230222.1
 Architectures: amd64, arm64v8
-amd64-GitFetch: refs/heads/al2022
-amd64-GitCommit: 8f394a73f3747b9f1c80e98b65d1f845b2c36e36
-arm64v8-GitFetch: refs/heads/al2022-arm64
-arm64v8-GitCommit: 40d063d4db18d8b62afbb080d75bd5fa6994d78e
-
-Tags: 2022.0.20230118.3-with-sources, 2022-with-sources, devel-with-sources
-Architectures: amd64, arm64v8
-amd64-GitFetch: refs/heads/al2022-with-sources
-amd64-GitCommit: 87e3b7a4ed4bbdeba86d64cd68fbefe3f5d7acc2
-arm64v8-GitFetch: refs/heads/al2022-arm64-with-sources
-arm64v8-GitCommit: e7dfe3b5d4058022a00cad9812d6624a136f93ce
+amd64-GitFetch: refs/heads/al2023
+amd64-GitCommit: 1602eb68be60af0dded1f358e6b7fddae82d021c
+arm64v8-GitFetch: refs/heads/al2023-arm64
+arm64v8-GitCommit: a6bec901267d4d5b463ae2a3c2c57ab9844628fd


### PR DESCRIPTION
Hi,

This PR includes the pilot container image for AL 2023.
AL 2023 is a rename of the formerly known OS variant AL 2022.
AL 2023 (like AL 2022) is still in tech-preview phase and is not recommended for production workloads.

Regards,
Sumit