### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -22,7 +22,7 @@ File: Dockerfile.python3.11-alpine3.16
 
 Tags: 0.26.0-python3.10-bullseye, 0.26-python3.10-bullseye, 0-python3.10-bullseye, python3.10-bullseye
 SharedTags: 0.26.0-python3.10, 0.26-python3.10, 0-python3.10, python3.10
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-bullseye
 
 Tags: 0.26.0-python3.10-buster, 0.26-python3.10-buster, 0-python3.10-buster, python3.10-buster


### PR DESCRIPTION
(Removing MIPS to match Python)