### PR TITLE
kong: update 2.8.3

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -26,13 +26,13 @@ Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 2.8.3-alpine, 2.8.3, 2.8
-GitCommit: 51604ac58ec41b3a57de95933b23dc3314552073
+GitCommit: 7557a360568fb70650d35724462446064ec081b3
 GitFetch: refs/tags/2.8.3
 Directory: alpine
 Architectures: amd64, arm64v8
 
 Tags: 2.8.3-ubuntu, 2.8-ubuntu
-GitCommit: 51604ac58ec41b3a57de95933b23dc3314552073
+GitCommit: 7557a360568fb70650d35724462446064ec081b3
 GitFetch: refs/tags/2.8.3
 Directory: ubuntu
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Similarly to https://github.com/docker-library/official-images/pull/14112, correct shas, this time for Ubuntu.

We apologize for opening an extra PR, but we only found out the Ubuntu image is affected after #14112 got merged.
