### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2023-0952 ELSA-2023-0957 ELSA-2023-0953 ELSA-2023-0946 ELSA-2023-0958 ELSA-2023-0954

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b42a4ac92cf22a1b724b3f44fcfd5af9fe19e7f5
+amd64-GitCommit: 6f72069cb7ecd138d338e2fac8a0236f84e742fb
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1947e98c8d9e0b520d96a7ceb052f63eeeb8105c
+arm64v8-GitCommit: 3517e9b583a5c5c02356ba595747967ae9055e63
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-40897, CVE-2021-43519, CVE-2021-44964, CVE-2022-45061, CVE-2022-4203, CVE-2022-4304, CVE-2022-4450, CVE-2023-0215, CVE-2023-0216, CVE-2023-0217, CVE-2023-0286, CVE-2023-0401, CVE-2022-47024, CVE-2022-4415, CVE-2022-45873

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-0952.html
https://linux.oracle.com/errata/ELSA-2023-0957.html
https://linux.oracle.com/errata/ELSA-2023-0953.html
https://linux.oracle.com/errata/ELSA-2023-0946.html
https://linux.oracle.com/errata/ELSA-2023-0958.html
https://linux.oracle.com/errata/ELSA-2023-0954.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>