### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -50,17 +50,17 @@ GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/buster
 
 Tags: sid-curl, unstable-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
 Directory: debian/sid/curl
 
 Tags: sid-scm, unstable-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/sid/scm
 
 Tags: sid, unstable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/sid
 


### PR DESCRIPTION
(Adding back riscv64 thanks to Debian)