### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.36.0, 5.36, 5, latest
+Tags: 5.36.1, 5.36, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 74b45e1eb046bebb53045579b4fee02960ebf9b7
+GitCommit: 18a1280458a85a3f0ef26e013b8a997f041e898d
 Directory: 5/debian
 
-Tags: 5.36.0-alpine, 5.36-alpine, 5-alpine, alpine
+Tags: 5.36.1-alpine, 5.36-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 74b45e1eb046bebb53045579b4fee02960ebf9b7
+GitCommit: 18a1280458a85a3f0ef26e013b8a997f041e898d
 Directory: 5/alpine
 
 Tags: 4.48.9, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/18a1280: Update to 5.36.1, ghost-cli 1.24.0