### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/b9ecc0684d3c71fab45eb9166b8033f575777599/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/3e64b132d4353dcdb23ea12baedcd3b8a48d1839/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: b9ecc0684d3c71fab45eb9166b8033f575777599
+GitCommit: 3e64b132d4353dcdb23ea12baedcd3b8a48d1839
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 035784654e7c42ce45e84617eeec327191fa84fd
+amd64-GitCommit: 170608f188ec1bf80276c8e84faea9dcaa881c09
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 57feac0dd2c99797fb4ac198d9ef0ab6c6956b1f
+arm32v5-GitCommit: 384e6e2d57050d9c8336d227a2f12050f004f444
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 543ac89ed18881d966f9a6739107097473cf4aaf
+arm32v6-GitCommit: 9f2b1d5c79dac3405886abf107cc0a873a2f9bea
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0c9e7eb974732bcd7792aa2dfad10b7d3d2f088c
+arm32v7-GitCommit: b39cabd892090dfa335f903d5b2a46d7d8d9867b
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f2b267aca5949ab3ed91816d8ad61a4b6079030c
+arm64v8-GitCommit: dcb202f7c94c6d3ae69bb84a6085a13208871a7a
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 7c5198e7dfed0d274607436e10f79e4398af653a
+i386-GitCommit: 31341daaf98d5c58f5ac24d40ae9bbde710002fc
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 9b8f6786af6d1dec18e1137359475cb5ffb3e2f0
+mips64le-GitCommit: ec78f2a2ae9cbe8017fabdcf00c970c5c4dc2470
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 2e583fee6d15fdb103b072c5b72018e57fb717db
+ppc64le-GitCommit: 6be9e35bc33ddc15a9e8391a5e6281447c82a9ea
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: ca713d27d06d409055ab346cc90fdfe055758ad0
+riscv64-GitCommit: 1ee65239c76eae558ab84391ec132b1407c346d3
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: cfe541022d50d7338e8fd884dd6d5329af4842f9
+s390x-GitCommit: b3d764d5f4d34a38141f150a072896b4755b4d95
 
 Tags: 1.36.0-glibc, 1.36-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/3e64b13: disable hwaccel closing issue with sha1sum and sha256sum (https://github.com/docker-library/busybox/pull/167)
- https://github.com/docker-library/busybox/commit/367f4fd: Merge pull request https://github.com/docker-library/busybox/pull/168 from infosiftr/buildroot-2022.11.2
- https://github.com/docker-library/busybox/commit/b8cf0a0: Update buildroot to 2022.11.2