### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 23.0.1-cli, 23.0-cli, 23-cli, cli, 23.0.1-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 50d102385f2d5198a043317f63abb8ac7f9347c9
+GitCommit: 06e0b8a8b836ee66175685592bcadfe149c92896
 Directory: 23.0/cli
 
 Tags: 23.0.1-dind, 23.0-dind, 23-dind, dind, 23.0.1-dind-alpine3.17, 23.0.1, 23.0, 23, latest, 23.0.1-alpine3.17
@@ -40,17 +40,17 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.23-cli, 20.10-cli, 20-cli, 20.10.23-cli-alpine3.17, 20.10.23, 20.10, 20, 20.10.23-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 8a0590b0033d0922237ea0937a0ed4b112e01b29
+GitCommit: 36100cd12d15c411b097727a2a84a09c656d2d24
 Directory: 20.10/cli
 
 Tags: 20.10.23-dind, 20.10-dind, 20-dind, 20.10.23-dind-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 94129ecd12de7acbc9d5a15d25d535ee091770b1
+GitCommit: 289f581eae49901789a416fee2ede9a6950e7629
 Directory: 20.10/dind
 
 Tags: 20.10.23-dind-rootless, 20.10-dind-rootless, 20-dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 4abc6d9dadc3876b11aac5abf84d501d7ee0d318
+GitCommit: 289f581eae49901789a416fee2ede9a6950e7629
 Directory: 20.10/dind-rootless
 
 Tags: 20.10.23-git, 20.10-git, 20-git


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/06e0b8a: Update 23.0 to buildx 0.10.4
- https://github.com/docker-library/docker/commit/36100cd: Update 20.10 to buildx 0.10.4
- https://github.com/docker-library/docker/commit/289f581: Add back amd64 and make sure we don't lose it again
- https://github.com/docker-library/docker/commit/01e35e2: Update 20.10
- https://github.com/docker-library/docker/commit/5ca2408: Update 23.0 to compose 2.16.0
- https://github.com/docker-library/docker/commit/6661557: Update 20.10 to compose 2.16.0
- https://github.com/docker-library/docker/commit/9bb3dd2: Skip compose RCs
- https://github.com/docker-library/docker/commit/96fd373: Update 23.0 to compose 2.17.0-rc.1
- https://github.com/docker-library/docker/commit/2b9081b: Update 20.10 to compose 2.17.0-rc.1