### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,100 +5,100 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.20.1-bullseye, 1.20-bullseye, 1-bullseye, bullseye
-SharedTags: 1.20.1, 1.20, 1, latest
+Tags: 1.20.2-bullseye, 1.20-bullseye, 1-bullseye, bullseye
+SharedTags: 1.20.2, 1.20, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b4411e7f38f2505c4fd3fd0aa579481c2aa85b2
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/bullseye
 
-Tags: 1.20.1-buster, 1.20-buster, 1-buster, buster
+Tags: 1.20.2-buster, 1.20-buster, 1-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 8b4411e7f38f2505c4fd3fd0aa579481c2aa85b2
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/buster
 
-Tags: 1.20.1-alpine3.17, 1.20-alpine3.17, 1-alpine3.17, alpine3.17, 1.20.1-alpine, 1.20-alpine, 1-alpine, alpine
+Tags: 1.20.2-alpine3.17, 1.20-alpine3.17, 1-alpine3.17, alpine3.17, 1.20.2-alpine, 1.20-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 067ba62265c51b96ca29de9faf37b831ad90da2a
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/alpine3.17
 
-Tags: 1.20.1-alpine3.16, 1.20-alpine3.16, 1-alpine3.16, alpine3.16
+Tags: 1.20.2-alpine3.16, 1.20-alpine3.16, 1-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 067ba62265c51b96ca29de9faf37b831ad90da2a
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/alpine3.16
 
-Tags: 1.20.1-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.20.1-windowsservercore, 1.20-windowsservercore, 1-windowsservercore, windowsservercore, 1.20.1, 1.20, 1, latest
+Tags: 1.20.2-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.20.2-windowsservercore, 1.20-windowsservercore, 1-windowsservercore, windowsservercore, 1.20.2, 1.20, 1, latest
 Architectures: windows-amd64
-GitCommit: 067ba62265c51b96ca29de9faf37b831ad90da2a
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.20.1-windowsservercore-1809, 1.20-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.20.1-windowsservercore, 1.20-windowsservercore, 1-windowsservercore, windowsservercore, 1.20.1, 1.20, 1, latest
+Tags: 1.20.2-windowsservercore-1809, 1.20-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.20.2-windowsservercore, 1.20-windowsservercore, 1-windowsservercore, windowsservercore, 1.20.2, 1.20, 1, latest
 Architectures: windows-amd64
-GitCommit: 067ba62265c51b96ca29de9faf37b831ad90da2a
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.20.1-nanoserver-ltsc2022, 1.20-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.20.1-nanoserver, 1.20-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.20.2-nanoserver-ltsc2022, 1.20-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.20.2-nanoserver, 1.20-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 067ba62265c51b96ca29de9faf37b831ad90da2a
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.20.1-nanoserver-1809, 1.20-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.20.1-nanoserver, 1.20-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.20.2-nanoserver-1809, 1.20-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.20.2-nanoserver, 1.20-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 067ba62265c51b96ca29de9faf37b831ad90da2a
+GitCommit: 25111f48afaae26f17e15459dd125f0e3776be66
 Directory: 1.20/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.19.6-bullseye, 1.19-bullseye
-SharedTags: 1.19.6, 1.19
+Tags: 1.19.7-bullseye, 1.19-bullseye
+SharedTags: 1.19.7, 1.19
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/bullseye
 
-Tags: 1.19.6-buster, 1.19-buster
+Tags: 1.19.7-buster, 1.19-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/buster
 
-Tags: 1.19.6-alpine3.17, 1.19-alpine3.17, 1.19.6-alpine, 1.19-alpine
+Tags: 1.19.7-alpine3.17, 1.19-alpine3.17, 1.19.7-alpine, 1.19-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/alpine3.17
 
-Tags: 1.19.6-alpine3.16, 1.19-alpine3.16
+Tags: 1.19.7-alpine3.16, 1.19-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/alpine3.16
 
-Tags: 1.19.6-windowsservercore-ltsc2022, 1.19-windowsservercore-ltsc2022
-SharedTags: 1.19.6-windowsservercore, 1.19-windowsservercore, 1.19.6, 1.19
+Tags: 1.19.7-windowsservercore-ltsc2022, 1.19-windowsservercore-ltsc2022
+SharedTags: 1.19.7-windowsservercore, 1.19-windowsservercore, 1.19.7, 1.19
 Architectures: windows-amd64
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.19.6-windowsservercore-1809, 1.19-windowsservercore-1809
-SharedTags: 1.19.6-windowsservercore, 1.19-windowsservercore, 1.19.6, 1.19
+Tags: 1.19.7-windowsservercore-1809, 1.19-windowsservercore-1809
+SharedTags: 1.19.7-windowsservercore, 1.19-windowsservercore, 1.19.7, 1.19
 Architectures: windows-amd64
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.19.6-nanoserver-ltsc2022, 1.19-nanoserver-ltsc2022
-SharedTags: 1.19.6-nanoserver, 1.19-nanoserver
+Tags: 1.19.7-nanoserver-ltsc2022, 1.19-nanoserver-ltsc2022
+SharedTags: 1.19.7-nanoserver, 1.19-nanoserver
 Architectures: windows-amd64
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.19.6-nanoserver-1809, 1.19-nanoserver-1809
-SharedTags: 1.19.6-nanoserver, 1.19-nanoserver
+Tags: 1.19.7-nanoserver-1809, 1.19-nanoserver-1809
+SharedTags: 1.19.7-nanoserver, 1.19-nanoserver
 Architectures: windows-amd64
-GitCommit: 076ce38f04eada5a57ebd716345481669e9d8283
+GitCommit: 3c664b90a9cd0d73b89435b7a022d3e3066b3b72
 Directory: 1.19/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/25111f4: Update 1.20 to 1.20.2
- https://github.com/docker-library/golang/commit/3c664b9: Update 1.19 to 1.19.7