### PR TITLE
[oraclelinux] Updating 7,7-slim,8,8-slim,9 and 9-slim for ELSA-2023-1095, ELSA-2023-1140 and ELSA-2023-1141

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6f72069cb7ecd138d338e2fac8a0236f84e742fb
+amd64-GitCommit: 985b5fe156c098018f87cae55f448d16cd4bee5f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 3517e9b583a5c5c02356ba595747967ae9055e63
+arm64v8-GitCommit: 71f7331702ae8f33c5613596e5c6ab064a4f27f7
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-37434, CVE-2023-23916,
and CVE-2023-0361.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-1095.html
https://linux.oracle.com/errata/ELSA-2023-1140.html
https://linux.oracle.com/errata/ELSA-2023-1141.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>