### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -4,48 +4,48 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/python.git
 
-Tags: 3.12.0a5-bullseye, 3.12-rc-bullseye
-SharedTags: 3.12.0a5, 3.12-rc
+Tags: 3.12.0a6-bullseye, 3.12-rc-bullseye
+SharedTags: 3.12.0a6, 3.12-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/bullseye
 
-Tags: 3.12.0a5-slim-bullseye, 3.12-rc-slim-bullseye, 3.12.0a5-slim, 3.12-rc-slim
+Tags: 3.12.0a6-slim-bullseye, 3.12-rc-slim-bullseye, 3.12.0a6-slim, 3.12-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/slim-bullseye
 
-Tags: 3.12.0a5-buster, 3.12-rc-buster
+Tags: 3.12.0a6-buster, 3.12-rc-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/buster
 
-Tags: 3.12.0a5-slim-buster, 3.12-rc-slim-buster
+Tags: 3.12.0a6-slim-buster, 3.12-rc-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/slim-buster
 
-Tags: 3.12.0a5-alpine3.17, 3.12-rc-alpine3.17, 3.12.0a5-alpine, 3.12-rc-alpine
+Tags: 3.12.0a6-alpine3.17, 3.12-rc-alpine3.17, 3.12.0a6-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/alpine3.17
 
-Tags: 3.12.0a5-alpine3.16, 3.12-rc-alpine3.16
+Tags: 3.12.0a6-alpine3.16, 3.12-rc-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/alpine3.16
 
-Tags: 3.12.0a5-windowsservercore-ltsc2022, 3.12-rc-windowsservercore-ltsc2022
-SharedTags: 3.12.0a5-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a5, 3.12-rc
+Tags: 3.12.0a6-windowsservercore-ltsc2022, 3.12-rc-windowsservercore-ltsc2022
+SharedTags: 3.12.0a6-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a6, 3.12-rc
 Architectures: windows-amd64
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.12.0a5-windowsservercore-1809, 3.12-rc-windowsservercore-1809
-SharedTags: 3.12.0a5-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a5, 3.12-rc
+Tags: 3.12.0a6-windowsservercore-1809, 3.12-rc-windowsservercore-1809
+SharedTags: 3.12.0a6-windowsservercore, 3.12-rc-windowsservercore, 3.12.0a6, 3.12-rc
 Architectures: windows-amd64
-GitCommit: b987547e6b4d485163997795791017ee1e3b3155
+GitCommit: 8442e048835d470610de219443b41d477d330e86
 Directory: 3.12-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/8442e04: Update 3.12-rc to 3.12.0a6, pip 23.0.1