### PR TITLE
maven: refactor build process

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -63,7 +63,7 @@ GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-8-focal
 
 Tags: 3.9.0-ibmjava-8, 3.9.0-ibmjava, 3.9-ibmjava-8, 3.9-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
-Architectures: amd64, i386, ppc64le, s390x
+Architectures: amd64, ppc64le, s390x
 GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: ibmjava-8
 

--- a/library/maven
+++ b/library/maven
@@ -1,107 +1,108 @@
 Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)
+Builder: buildkit
 GitRepo: https://github.com/carlossg/docker-maven.git
 
 Tags: 3.9.0-eclipse-temurin-11, 3.9-eclipse-temurin-11, 3-eclipse-temurin-11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: de70b3e783c1c9b2835b6be4c3826d6221bf4fca
 Directory: eclipse-temurin-11
 
 Tags: 3.9.0-eclipse-temurin-11-alpine, 3.9-eclipse-temurin-11-alpine, 3-eclipse-temurin-11-alpine
 Architectures: amd64
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-11-alpine
 
 Tags: 3.9.0-eclipse-temurin-11-focal, 3.9-eclipse-temurin-11-focal, 3-eclipse-temurin-11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-11-focal
 
 Tags: 3.9.0-eclipse-temurin-17, 3.9.0, 3.9.0-eclipse-temurin, 3.9-eclipse-temurin-17, 3.9, 3.9-eclipse-temurin, 3-eclipse-temurin-17, 3, latest, 3-eclipse-temurin, eclipse-temurin
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-17
 
 Tags: 3.9.0-eclipse-temurin-17-alpine, 3.9-eclipse-temurin-17-alpine, 3-eclipse-temurin-17-alpine
 Architectures: amd64
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-17-alpine
 
 Tags: 3.9.0-eclipse-temurin-17-focal, 3.9-eclipse-temurin-17-focal, 3-eclipse-temurin-17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-17-focal
 
 Tags: 3.9.0-eclipse-temurin-19, 3.9-eclipse-temurin-19, 3-eclipse-temurin-19
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: de70b3e783c1c9b2835b6be4c3826d6221bf4fca
 Directory: eclipse-temurin-19
 
 Tags: 3.9.0-eclipse-temurin-19-alpine, 3.9-eclipse-temurin-19-alpine, 3-eclipse-temurin-19-alpine
 Architectures: amd64
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-19-alpine
 
 Tags: 3.9.0-eclipse-temurin-19-focal, 3.9-eclipse-temurin-19-focal, 3-eclipse-temurin-19-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-19-focal
 
 Tags: 3.9.0-eclipse-temurin-8, 3.9-eclipse-temurin-8, 3-eclipse-temurin-8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-8
 
 Tags: 3.9.0-eclipse-temurin-8-alpine, 3.9-eclipse-temurin-8-alpine, 3-eclipse-temurin-8-alpine
 Architectures: amd64
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-8-alpine
 
 Tags: 3.9.0-eclipse-temurin-8-focal, 3.9-eclipse-temurin-8-focal, 3-eclipse-temurin-8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: eclipse-temurin-8-focal
 
 Tags: 3.9.0-ibmjava-8, 3.9.0-ibmjava, 3.9-ibmjava-8, 3.9-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
 Architectures: amd64, i386, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: ibmjava-8
 
 Tags: 3.9.0-ibm-semeru-11-focal, 3.9-ibm-semeru-11-focal, 3-ibm-semeru-11-focal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: ibm-semeru-11-focal
 
 Tags: 3.9.0-ibm-semeru-17-focal, 3.9-ibm-semeru-17-focal, 3-ibm-semeru-17-focal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: ibm-semeru-17-focal
 
 Tags: 3.9.0-amazoncorretto-11, 3.9.0-amazoncorretto, 3.9-amazoncorretto-11, 3.9-amazoncorretto, 3-amazoncorretto-11, 3-amazoncorretto, amazoncorretto
 Architectures: amd64, arm64v8
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: amazoncorretto-11
 
 Tags: 3.9.0-amazoncorretto-17, 3.9-amazoncorretto-17, 3-amazoncorretto-17
 Architectures: amd64, arm64v8
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: amazoncorretto-17
 
 Tags: 3.9.0-amazoncorretto-19, 3.9-amazoncorretto-19, 3-amazoncorretto-19
 Architectures: amd64, arm64v8
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: amazoncorretto-19
 
 Tags: 3.9.0-amazoncorretto-8, 3.9-amazoncorretto-8, 3-amazoncorretto-8
 Architectures: amd64, arm64v8
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: amazoncorretto-8
 
 Tags: 3.9.0-sapmachine-11, 3.9-sapmachine-11, 3-sapmachine-11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: sapmachine-11
 
 Tags: 3.9.0-sapmachine-17, 3.9.0-sapmachine, 3.9-sapmachine-17, 3.9-sapmachine, 3-sapmachine-17, 3-sapmachine, sapmachine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 32760466401d45fabb8166b5dcf9003b07598918
+GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
 Directory: sapmachine-17


### PR DESCRIPTION
to have one image as base and others using --copy-from

Following advice from https://github.com/docker-library/official-images/pull/14083#issuecomment-1433740677