### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-12-jdk-oraclelinux8, 21-ea-12-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-12-jdk-oracle, 21-ea-12-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-12-jdk, 21-ea-12, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-13-jdk-oraclelinux8, 21-ea-13-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-13-jdk-oracle, 21-ea-13-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-13-jdk, 21-ea-13, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-12-jdk-oraclelinux7, 21-ea-12-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-13-jdk-oraclelinux7, 21-ea-13-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-12-jdk-bullseye, 21-ea-12-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-13-jdk-bullseye, 21-ea-13-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-12-jdk-slim-bullseye, 21-ea-12-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-12-jdk-slim, 21-ea-12-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-13-jdk-slim-bullseye, 21-ea-13-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-13-jdk-slim, 21-ea-13-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-12-jdk-buster, 21-ea-12-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-13-jdk-buster, 21-ea-13-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/buster
 
-Tags: 21-ea-12-jdk-slim-buster, 21-ea-12-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-13-jdk-slim-buster, 21-ea-13-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-12-jdk-windowsservercore-ltsc2022, 21-ea-12-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-12-jdk-windowsservercore, 21-ea-12-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-12-jdk, 21-ea-12, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-13-jdk-windowsservercore-ltsc2022, 21-ea-13-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-13-jdk-windowsservercore, 21-ea-13-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-13-jdk, 21-ea-13, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-12-jdk-windowsservercore-1809, 21-ea-12-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-12-jdk-windowsservercore, 21-ea-12-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-12-jdk, 21-ea-12, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-13-jdk-windowsservercore-1809, 21-ea-13-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-13-jdk-windowsservercore, 21-ea-13-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-13-jdk, 21-ea-13, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-12-jdk-nanoserver-1809, 21-ea-12-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-12-jdk-nanoserver, 21-ea-12-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-13-jdk-nanoserver-1809, 21-ea-13-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-13-jdk-nanoserver, 21-ea-13-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 64dec30c9bf68865c9ee214377b0b05e8ad10caf
+GitCommit: 17df0c31225094e6be01d843a50bd3863eda8870
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/17df0c3: Update 21 to 21-ea+13