### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,12 +12,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2, latest, 2.0.20230221.0
+Tags: 2, latest, 2.0.20230307.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 60c92e2e9b66ec80b777a50d475166089fc52616
+amd64-GitCommit: 9d4c7e1fbf1426dd0c7f21141c20e605d8695a00
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 88d9c71a8c0ac53330dcc9b1000f8909ddebb9b1
+arm64v8-GitCommit: e3e4818ceb2a784847a65414d6e73b8a06b46804
 
 Tags: 2.0.20230207.0-with-sources, 2-with-sources, with-sources
 Architectures: amd64, arm64v8
@@ -26,19 +26,19 @@ amd64-GitCommit: 8b1a2649bc2e8cf24109954310ebe26b4566e4bd
 arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
 arm64v8-GitCommit: 7693d6669781ce34ab310d5caa4a4802fec3c115
 
-Tags: 1, 2018.03, 2018.03.0.20230221.0
+Tags: 1, 2018.03, 2018.03.0.20230306.1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 29d4697cda5572d121c93f86f130f2e1af6043c2
+amd64-GitCommit: dc3df0616bebef55e5890e320f62d2ef407c54d0
 
 Tags: 2018.03.0.20230207.0-with-sources, 2018.03-with-sources, 1-with-sources
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03-with-sources
 amd64-GitCommit: a0fbceecd65169b34c2a48d48a3ffafccc6667af
 
-Tags: 2023, devel, 2023.0.20230222.1
+Tags: 2023, devel, 2023.0.20230308.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 1602eb68be60af0dded1f358e6b7fddae82d021c
+amd64-GitCommit: 2cd2601351e5e7f0c7782751fee3da1f176668dc
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: a6bec901267d4d5b463ae2a3c2c57ab9844628fd
+arm64v8-GitCommit: 9ec41767e6a2c43a875e3f1bcf8b3266a8284b88


### PR DESCRIPTION
We have new releases for Amazon Linux 2018.03, 2, and 2023.

### 2018.03

- tzdata-2022g-1.84.amzn1

### 2

- libdb-utils-5.3.21-24.amzn2.0.4, libdb-5.3.21-24.amzn2.0.4
  - [CVE-2017-10140](https://alas.aws.amazon.com/cve/html/CVE-2017-10140.html)
- python-2.7.18-1.amzn2.0.6
  - [CVE-2022-45061](https://alas.aws.amazon.com/cve/html/CVE-2022-45061.html)
  - [CVE-2023-24329](https://alas.aws.amazon.com/cve/html/CVE-2023-24329.html)
- vim-minimal-9.0.1314-1.amzn2.0.1, vim-data-9.0.1314-1.amzn2.0.1
  - [CVE-2022-2522](https://alas.aws.amazon.com/cve/html/CVE-2022-2522.html)
  - [CVE-2022-2571](https://alas.aws.amazon.com/cve/html/CVE-2022-2571.html)
  - [CVE-2022-2580](https://alas.aws.amazon.com/cve/html/CVE-2022-2580.html)
  - [CVE-2022-2581](https://alas.aws.amazon.com/cve/html/CVE-2022-2581.html)
  - [CVE-2022-2874](https://alas.aws.amazon.com/cve/html/CVE-2022-2874.html)
  - [CVE-2022-3134](https://alas.aws.amazon.com/cve/html/CVE-2022-3134.html)
  - [CVE-2022-3153](https://alas.aws.amazon.com/cve/html/CVE-2022-3153.html)
  - [CVE-2022-3234](https://alas.aws.amazon.com/cve/html/CVE-2022-3234.html)
  - [CVE-2022-3235](https://alas.aws.amazon.com/cve/html/CVE-2022-3235.html)
  - [CVE-2022-3256](https://alas.aws.amazon.com/cve/html/CVE-2022-3256.html)
  - [CVE-2022-3278](https://alas.aws.amazon.com/cve/html/CVE-2022-3278.html)
  - [CVE-2022-3296](https://alas.aws.amazon.com/cve/html/CVE-2022-3296.html)
  - [CVE-2022-3297](https://alas.aws.amazon.com/cve/html/CVE-2022-3297.html)
  - [CVE-2022-3324](https://alas.aws.amazon.com/cve/html/CVE-2022-3324.html)
  - [CVE-2022-3352](https://alas.aws.amazon.com/cve/html/CVE-2022-3352.html)
  - [CVE-2022-3491](https://alas.aws.amazon.com/cve/html/CVE-2022-3491.html)
  - [CVE-2022-47024](https://alas.aws.amazon.com/cve/html/CVE-2022-47024.html)
  - [CVE-2023-0051](https://alas.aws.amazon.com/cve/html/CVE-2023-0051.html)
  - [CVE-2023-0054](https://alas.aws.amazon.com/cve/html/CVE-2023-0054.html)
  - [CVE-2023-0288](https://alas.aws.amazon.com/cve/html/CVE-2023-0288.html)
  - [CVE-2023-0433](https://alas.aws.amazon.com/cve/html/CVE-2023-0433.html)
  - [CVE-2023-0512](https://alas.aws.amazon.com/cve/html/CVE-2023-0512.html)
- cpio-2.12-11.amzn2
  - [CVE-2021-38185](https://alas.aws.amazon.com/cve/html/CVE-2021-38185.html)
- python-libs-2.7.18-1.amzn2.0.6
  - [CVE-2022-45061](https://alas.aws.amazon.com/cve/html/CVE-2022-45061.html)
  - [CVE-2023-24329](https://alas.aws.amazon.com/cve/html/CVE-2023-24329.html)
- curl-7.88.1-1.amzn2.0.1
- libcurl-7.88.1-1.amzn2.0.1

### 2023

- system-release-2023.0.20230308-0.amzn2023
- libnghttp2-1.51.0-1.amzn2023
- libxcrypt-4.4.33-7.amzn2023
- coreutils-single-8.32-30.amzn2023.0.3
- ca-certificates-2023.2.60-1.0.amzn2023.0.1
- libcurl-minimal-7.88.1-1.amzn2023.0.1
- python3-libs-3.9.16-1.amzn2023.0.3
  - [CVE-2020-10735](https://alas.aws.amazon.com/cve/html/CVE-2020-10735.html)
  - [CVE-2023-24329](https://alas.aws.amazon.com/cve/html/CVE-2023-24329.html)
- amazon-linux-repo-cdn-2023.0.20230308-0.amzn2023
- krb5-libs-1.20.1-8.amzn2023.0.1
- curl-minimal-7.88.1-1.amzn2023.0.1
- python3-3.9.16-1.amzn2023.0.3
  - [CVE-2020-10735](https://alas.aws.amazon.com/cve/html/CVE-2020-10735.html)
  - [CVE-2023-24329](https://alas.aws.amazon.com/cve/html/CVE-2023-24329.html)