### PR TITLE
Odoo: update 14.0-16.0 to release 20230310

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: ff99b5f50135f74c22f163dacfde34189857c13b
+GitCommit: 870aef4a7a3f0befdd7fc8ef7ffe8f9d07df7794
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

you 'll find here the latest updates of Odoo supported versions.

Thanks