### PR TITLE
update rocket.chat

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,25 +1,21 @@
-# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/dbb5e8eb972d7a32f28e7bdc0b03d0d3c6f58d60/generate-stackbrew-library.sh
+# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/4d5970d5e4859f43d8760d48fe492ebbdb828502/generate-stackbrew-library.sh
 
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 5.4.0, 5.4, 5, latest
-GitCommit: dbb5e8eb972d7a32f28e7bdc0b03d0d3c6f58d60
+Tags: 6.0.0, 6.0, 6, latest
+GitCommit: e83ffa0338dd62eed46fcf031fdd4bf919b631d6
+Directory: 6.0
+
+Tags: 5.4.4, 5.4, 5
+GitCommit: e83ffa0338dd62eed46fcf031fdd4bf919b631d6
 Directory: 5.4
 
-Tags: 5.3.5, 5.3
-GitCommit: dbb5e8eb972d7a32f28e7bdc0b03d0d3c6f58d60
+Tags: 5.3.6, 5.3
+GitCommit: e83ffa0338dd62eed46fcf031fdd4bf919b631d6
 Directory: 5.3
 
-Tags: 5.2.1, 5.2
-GitCommit: dbb5e8eb972d7a32f28e7bdc0b03d0d3c6f58d60
+Tags: 5.2.2, 5.2
+GitCommit: e83ffa0338dd62eed46fcf031fdd4bf919b631d6
 Directory: 5.2
-
-Tags: 5.1.5, 5.1
-GitCommit: dbb5e8eb972d7a32f28e7bdc0b03d0d3c6f58d60
-Directory: 5.1
-
-Tags: 4.8.7, 4.8, 4
-GitCommit: dbb5e8eb972d7a32f28e7bdc0b03d0d3c6f58d60
-Directory: 4.8
 


### PR DESCRIPTION
- Unsupported version 4.x was removed
- Update versions 5.x
- Add new version 6.0