### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev4, 2.8-dev, 2.8-dev4-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev5, 2.8-dev, 2.8-dev5-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b2760306614878ff8530e5bfe872cdc8384d9342
+GitCommit: 5b92c8346ddada68e89299f7b0754dcf03ec0aa8
 Directory: 2.8
 
-Tags: 2.8-dev4-alpine, 2.8-dev-alpine, 2.8-dev4-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev5-alpine, 2.8-dev-alpine, 2.8-dev5-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b2760306614878ff8530e5bfe872cdc8384d9342
+GitCommit: 5b92c8346ddada68e89299f7b0754dcf03ec0aa8
 Directory: 2.8/alpine
 
-Tags: 2.7.3, 2.7, latest, 2.7.3-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.4, 2.7, latest, 2.7.4-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c1f665d9f400192386f780dbea76481ebe4252e9
+GitCommit: a560f7338fdb03b5d07e773f6678919f74e9185b
 Directory: 2.7
 
-Tags: 2.7.3-alpine, 2.7-alpine, alpine, 2.7.3-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.4-alpine, 2.7-alpine, alpine, 2.7.4-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c1f665d9f400192386f780dbea76481ebe4252e9
+GitCommit: a560f7338fdb03b5d07e773f6678919f74e9185b
 Directory: 2.7/alpine
 
-Tags: 2.6.9, 2.6, lts, 2.6.9-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.10, 2.6, lts, 2.6.10-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e678a5620de6784d8dbe42d1c81f5db47f9e8cbc
+GitCommit: f4ae2c3536eef4ca86d9b2d96bb97b1fb9d82f33
 Directory: 2.6
 
-Tags: 2.6.9-alpine, 2.6-alpine, lts-alpine, 2.6.9-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.10-alpine, 2.6-alpine, lts-alpine, 2.6.10-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e678a5620de6784d8dbe42d1c81f5db47f9e8cbc
+GitCommit: f4ae2c3536eef4ca86d9b2d96bb97b1fb9d82f33
 Directory: 2.6/alpine
 
 Tags: 2.5.12, 2.5, 2.5.12-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5b92c83: Update 2.8 to 2.8-dev5
- https://github.com/docker-library/haproxy/commit/a560f73: Update 2.7 to 2.7.4
- https://github.com/docker-library/haproxy/commit/f4ae2c3: Update 2.6 to 2.6.10