### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.37.0, 5.37, 5, latest
+Tags: 5.38.0, 5.38, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 533294af2135d3b4e64e3620e66a4f4e314e0a44
+GitCommit: f3101f9f5df01bf8928f2c04440232b6ddab0124
 Directory: 5/debian
 
-Tags: 5.37.0-alpine, 5.37-alpine, 5-alpine, alpine
+Tags: 5.38.0-alpine, 5.38-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 533294af2135d3b4e64e3620e66a4f4e314e0a44
+GitCommit: f3101f9f5df01bf8928f2c04440232b6ddab0124
 Directory: 5/alpine
 
 Tags: 4.48.9, 4.48, 4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/f3101f9: Update to 5.38.0, ghost-cli 1.24.0