### PR TITLE
archlinux: Release 20230312.0.133040

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230305.0.131236
-GitCommit: f8e06670e7752bf2601d455aa99caa845da7fb4b
-GitFetch: refs/tags/v20230305.0.131236
+Tags: latest, base, base-20230312.0.133040
+GitCommit: 0592f44ec7e14bf385677b3d99ded87e57ef8446
+GitFetch: refs/tags/v20230312.0.133040
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230305.0.131236
-GitCommit: f8e06670e7752bf2601d455aa99caa845da7fb4b
-GitFetch: refs/tags/v20230305.0.131236
+Tags: base-devel, base-devel-20230312.0.133040
+GitCommit: 0592f44ec7e14bf385677b3d99ded87e57ef8446
+GitFetch: refs/tags/v20230312.0.133040
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks