### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/docker.git
 
 Tags: 23.0.1-cli, 23.0-cli, 23-cli, cli, 23.0.1-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 06e0b8a8b836ee66175685592bcadfe149c92896
+GitCommit: 2efbb5c7c69a0104f0c965e7cc7b33658fdf9602
 Directory: 23.0/cli
 
 Tags: 23.0.1-dind, 23.0-dind, 23-dind, dind, 23.0.1-dind-alpine3.17, 23.0.1, 23.0, 23, latest, 23.0.1-alpine3.17
@@ -40,7 +40,7 @@ Constraints: windowsservercore-1809
 
 Tags: 20.10.23-cli, 20.10-cli, 20-cli, 20.10.23-cli-alpine3.17, 20.10.23, 20.10, 20, 20.10.23-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 36100cd12d15c411b097727a2a84a09c656d2d24
+GitCommit: 2efbb5c7c69a0104f0c965e7cc7b33658fdf9602
 Directory: 20.10/cli
 
 Tags: 20.10.23-dind, 20.10-dind, 20-dind, 20.10.23-dind-alpine3.17


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/4f2323a: Merge pull request https://github.com/docker-library/docker/pull/411 from infosiftr/23-no-compat
- https://github.com/docker-library/docker/commit/2efbb5c: Ditch libc6-compat in 23+