### PR TITLE
Workaround to make Storm workers run in JDK 11 and above

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -7,5 +7,5 @@ GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
 Directory: 1.2.4
 
 Tags: 2.4.0-temurin, 2.4-temurin, latest
-GitCommit: 14c749848c8ff7c955f2b29c57e327ae80fbbb7e
+GitCommit: a81f9686e8a13dbf428864482f2d0bba50e9c414
 Directory: 2.4.0


### PR DESCRIPTION
See more details at https://github.com/31z4/storm-docker/issues/39