### PR TITLE
Add amazonlinux 2023 GA release

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,33 +12,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2, latest, 2.0.20230307.0
+Tags: 2, 2.0.20230307.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
 amd64-GitCommit: 9d4c7e1fbf1426dd0c7f21141c20e605d8695a00
 arm64v8-GitFetch: refs/heads/amzn2-arm64
 arm64v8-GitCommit: e3e4818ceb2a784847a65414d6e73b8a06b46804
 
-Tags: 2.0.20230207.0-with-sources, 2-with-sources, with-sources
-Architectures: amd64, arm64v8
-amd64-GitFetch: refs/heads/amzn2-with-sources
-amd64-GitCommit: 8b1a2649bc2e8cf24109954310ebe26b4566e4bd
-arm64v8-GitFetch: refs/heads/amzn2-arm64-with-sources
-arm64v8-GitCommit: 7693d6669781ce34ab310d5caa4a4802fec3c115
-
 Tags: 1, 2018.03, 2018.03.0.20230306.1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
 amd64-GitCommit: dc3df0616bebef55e5890e320f62d2ef407c54d0
 
-Tags: 2018.03.0.20230207.0-with-sources, 2018.03-with-sources, 1-with-sources
-Architectures: amd64
-amd64-GitFetch: refs/heads/2018.03-with-sources
-amd64-GitCommit: a0fbceecd65169b34c2a48d48a3ffafccc6667af
-
-Tags: 2023, devel, 2023.0.20230308.0
+Tags: 2023, latest, 2023.0.20230315.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 2cd2601351e5e7f0c7782751fee3da1f176668dc
+amd64-GitCommit: 09b67eed139db3fdcb58d682c893df26b69dc462
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 9ec41767e6a2c43a875e3f1bcf8b3266a8284b88
+arm64v8-GitCommit: 39afc3081af5ecf6c8a9e60924f33355e1793dd9


### PR DESCRIPTION
AL2023 Package Change List
- system-release-2023.0.20230315-1.amzn2023
- amazon-linux-repo-cdn-2023.0.20230315-1.amzn2023
- krb5-libs-1.20.1-8.amzn2023.0.2