### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.2/alpine
 
-Tags: beta-6.2-RC1-apache, beta-6.2-apache, beta-6-apache, beta-apache, beta-6.2-RC1, beta-6.2, beta-6, beta, beta-6.2-RC1-php8.0-apache, beta-6.2-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.2-RC1-php8.0, beta-6.2-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.2-RC2-apache, beta-6.2-apache, beta-6-apache, beta-apache, beta-6.2-RC2, beta-6.2, beta-6, beta, beta-6.2-RC2-php8.0-apache, beta-6.2-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.2-RC2-php8.0, beta-6.2-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.0/apache
 
-Tags: beta-6.2-RC1-fpm, beta-6.2-fpm, beta-6-fpm, beta-fpm, beta-6.2-RC1-php8.0-fpm, beta-6.2-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.2-RC2-fpm, beta-6.2-fpm, beta-6-fpm, beta-fpm, beta-6.2-RC2-php8.0-fpm, beta-6.2-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.2-RC1-fpm-alpine, beta-6.2-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.2-RC1-php8.0-fpm-alpine, beta-6.2-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.2-RC2-fpm-alpine, beta-6.2-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.2-RC2-php8.0-fpm-alpine, beta-6.2-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.2-RC1-php8.1-apache, beta-6.2-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.2-RC1-php8.1, beta-6.2-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.2-RC2-php8.1-apache, beta-6.2-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.2-RC2-php8.1, beta-6.2-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.1/apache
 
-Tags: beta-6.2-RC1-php8.1-fpm, beta-6.2-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.2-RC2-php8.1-fpm, beta-6.2-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.2-RC1-php8.1-fpm-alpine, beta-6.2-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.2-RC2-php8.1-fpm-alpine, beta-6.2-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.2-RC1-php8.2-apache, beta-6.2-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.2-RC1-php8.2, beta-6.2-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.2-RC2-php8.2-apache, beta-6.2-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.2-RC2-php8.2, beta-6.2-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.2/apache
 
-Tags: beta-6.2-RC1-php8.2-fpm, beta-6.2-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.2-RC2-php8.2-fpm, beta-6.2-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.2-RC1-php8.2-fpm-alpine, beta-6.2-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.2-RC2-php8.2-fpm-alpine, beta-6.2-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 754bbdf0146845c3e507af189bc4047feccc4a14
+GitCommit: c2b59a29c069b2d1d29b58ec8ac8b6bcd605c9dc
 Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/c2b59a2: Update beta to 6.2-RC2