### PR TITLE
Add "import dbm.ndbm" to "python-imports" test

### DIFF
--- a/test/tests/python-imports/container.py
+++ b/test/tests/python-imports/container.py
@@ -12,6 +12,7 @@ if not isWindows:
         import gdbm
     else:
         import dbm.gnu
+        import dbm.ndbm
 
 import bz2
 assert(bz2.decompress(bz2.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')


### PR DESCRIPTION
Adding a test for https://github.com/docker-library/python/issues/814 :see_no_evil:

```console
$ bashbrew list --uniq --arch-filter python pypy | xargs -rtn1 -P20 docker pull
...
$ bashbrew list --uniq --arch-filter python pypy | xargs -rt ./test/run.sh -t python-imports
./test/run.sh -t python-imports python:3.12.0a6-bullseye python:3.12.0a6-slim-bullseye python:3.12.0a6-buster python:3.12.0a6-slim-buster python:3.12.0a6-alpine3.17 python:3.12.0a6-alpine3.16 python:3.11.2-bullseye python:3.11.2-slim-bullseye python:3.11.2-buster python:3.11.2-slim-buster python:3.11.2-alpine3.17 python:3.11.2-alpine3.16 python:3.10.10-bullseye python:3.10.10-slim-bullseye python:3.10.10-buster python:3.10.10-slim-buster python:3.10.10-alpine3.17 python:3.10.10-alpine3.16 python:3.9.16-bullseye python:3.9.16-slim-bullseye python:3.9.16-buster python:3.9.16-slim-buster python:3.9.16-alpine3.17 python:3.9.16-alpine3.16 python:3.8.16-bullseye python:3.8.16-slim-bullseye python:3.8.16-buster python:3.8.16-slim-buster python:3.8.16-alpine3.17 python:3.8.16-alpine3.16 python:3.7.16-bullseye python:3.7.16-slim-bullseye python:3.7.16-buster python:3.7.16-slim-buster python:3.7.16-alpine3.17 python:3.7.16-alpine3.16 pypy:3.9-7.3.11-bullseye pypy:3.9-7.3.11-slim pypy:3.9-7.3.11-buster pypy:3.9-7.3.11-slim-buster pypy:3.8-7.3.11-bullseye pypy:3.8-7.3.11-slim pypy:3.8-7.3.11-buster pypy:3.8-7.3.11-slim-buster pypy:2.7-7.3.11-bullseye pypy:2.7-7.3.11-slim pypy:2.7-7.3.11-buster pypy:2.7-7.3.11-slim-buster
testing python:3.12.0a6-bullseye
	'python-imports' [1/1]...passed
testing python:3.12.0a6-slim-bullseye
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.12/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.12.0a6-buster
	'python-imports' [1/1]...passed
testing python:3.12.0a6-slim-buster
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.12/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.12.0a6-alpine3.17
	'python-imports' [1/1]...passed
testing python:3.12.0a6-alpine3.16
	'python-imports' [1/1]...passed
testing python:3.11.2-bullseye
	'python-imports' [1/1]...passed
testing python:3.11.2-slim-bullseye
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.11/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.11.2-buster
	'python-imports' [1/1]...passed
testing python:3.11.2-slim-buster
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.11/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.11.2-alpine3.17
	'python-imports' [1/1]...passed
testing python:3.11.2-alpine3.16
	'python-imports' [1/1]...passed
testing python:3.10.10-bullseye
	'python-imports' [1/1]...passed
testing python:3.10.10-slim-bullseye
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.10/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.10.10-buster
	'python-imports' [1/1]...passed
testing python:3.10.10-slim-buster
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.10/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.10.10-alpine3.17
	'python-imports' [1/1]...passed
testing python:3.10.10-alpine3.16
	'python-imports' [1/1]...passed
testing python:3.9.16-bullseye
	'python-imports' [1/1]...passed
testing python:3.9.16-slim-bullseye
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.9/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.9.16-buster
	'python-imports' [1/1]...passed
testing python:3.9.16-slim-buster
	'python-imports' [1/1]...Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.9/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.9.16-alpine3.17
	'python-imports' [1/1]...passed
testing python:3.9.16-alpine3.16
	'python-imports' [1/1]...passed
testing python:3.8.16-bullseye
	'python-imports' [1/1]...passed
testing python:3.8.16-slim-bullseye
	'python-imports' [1/1]...Traceback (most recent call last):
  File "./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.8/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.8.16-buster
	'python-imports' [1/1]...passed
testing python:3.8.16-slim-buster
	'python-imports' [1/1]...Traceback (most recent call last):
  File "./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.8/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.8.16-alpine3.17
	'python-imports' [1/1]...passed
testing python:3.8.16-alpine3.16
	'python-imports' [1/1]...passed
testing python:3.7.16-bullseye
	'python-imports' [1/1]...passed
testing python:3.7.16-slim-bullseye
	'python-imports' [1/1]...Traceback (most recent call last):
  File "./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.7/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.7.16-buster
	'python-imports' [1/1]...passed
testing python:3.7.16-slim-buster
	'python-imports' [1/1]...Traceback (most recent call last):
  File "./container.py", line 15, in <module>
    import dbm.ndbm
  File "/usr/local/lib/python3.7/dbm/ndbm.py", line 3, in <module>
    from _dbm import *
ModuleNotFoundError: No module named '_dbm'
failed
testing python:3.7.16-alpine3.17
	'python-imports' [1/1]...passed
testing python:3.7.16-alpine3.16
	'python-imports' [1/1]...passed
testing pypy:3.9-7.3.11-bullseye
	'python-imports' [1/1]...passed
testing pypy:3.9-7.3.11-slim
	'python-imports' [1/1]...passed
testing pypy:3.9-7.3.11-buster
	'python-imports' [1/1]...passed
testing pypy:3.9-7.3.11-slim-buster
	'python-imports' [1/1]...passed
testing pypy:3.8-7.3.11-bullseye
	'python-imports' [1/1]...passed
testing pypy:3.8-7.3.11-slim
	'python-imports' [1/1]...passed
testing pypy:3.8-7.3.11-buster
	'python-imports' [1/1]...passed
testing pypy:3.8-7.3.11-slim-buster
	'python-imports' [1/1]...passed
testing pypy:2.7-7.3.11-bullseye
	'python-imports' [1/1]...passed
testing pypy:2.7-7.3.11-slim
	'python-imports' [1/1]...passed
testing pypy:2.7-7.3.11-buster
	'python-imports' [1/1]...passed
testing pypy:2.7-7.3.11-slim-buster
	'python-imports' [1/1]...passed
```

(As expected, all failures are in `python:*-slim-*` images :+1:)