### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3e64b132d4353dcdb23ea12baedcd3b8a48d1839/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/38f129cf836c6f884ad61724a2bf9abe9a6d1278/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3e64b132d4353dcdb23ea12baedcd3b8a48d1839
+GitCommit: 38f129cf836c6f884ad61724a2bf9abe9a6d1278
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 170608f188ec1bf80276c8e84faea9dcaa881c09
+amd64-GitCommit: c4c1b1f404daebc67a32c5949d5d5b3af3b14302
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 384e6e2d57050d9c8336d227a2f12050f004f444
+arm32v5-GitCommit: af7a10e45060122362d8fbb355b83151f3d58add
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 9f2b1d5c79dac3405886abf107cc0a873a2f9bea
+arm32v6-GitCommit: 3251c50e8a5a95b70ebd66b6c9445c337389d4c5
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: b39cabd892090dfa335f903d5b2a46d7d8d9867b
+arm32v7-GitCommit: a34138b30517a30b79a2a2b623b8107eb2d3aa1d
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: dcb202f7c94c6d3ae69bb84a6085a13208871a7a
+arm64v8-GitCommit: 905f4a7acda06df4b1d1884bd25f98f522f5afa8
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 31341daaf98d5c58f5ac24d40ae9bbde710002fc
+i386-GitCommit: 70d4dbc68ae635877da52318e5871014ae302e77
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: ec78f2a2ae9cbe8017fabdcf00c970c5c4dc2470
+mips64le-GitCommit: 2a60636094cbda7e071db5ba73871b777d31d0ba
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 6be9e35bc33ddc15a9e8391a5e6281447c82a9ea
+ppc64le-GitCommit: 1a8d828e317a782249cb83ca3bae442b48f5f41c
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 1ee65239c76eae558ab84391ec132b1407c346d3
+riscv64-GitCommit: c122eb4d92682b7ec9ddd44c215e728309a3e78e
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: b3d764d5f4d34a38141f150a072896b4755b4d95
+s390x-GitCommit: 19bd231d0c6e8d7156bbfd29d8bad0a7faa89503
 
 Tags: 1.36.0-glibc, 1.36-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/38f129c: Merge pull request https://github.com/docker-library/busybox/pull/169 from infosiftr/buildroot-2023.02
- https://github.com/docker-library/busybox/commit/a03dcef: Update buildroot to 2023.02