### PR TITLE
Odoo: update 14.0-16.0 to release 20230317

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 870aef4a7a3f0befdd7fc8ef7ffe8f9d07df7794
+GitCommit: c61918a02765974a17097ec65695828422afe519
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,


here are the latest Odoo updates for 14.0, 15.0 and 16.0.

Thanks.