### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,34 +14,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5b92c8346ddada68e89299f7b0754dcf03ec0aa8
 Directory: 2.8/alpine
 
-Tags: 2.7.4, 2.7, latest, 2.7.4-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.5, 2.7, latest, 2.7.5-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a560f7338fdb03b5d07e773f6678919f74e9185b
+GitCommit: 098bc15c52ea5cfe4375519a463b682efcb38225
 Directory: 2.7
 
-Tags: 2.7.4-alpine, 2.7-alpine, alpine, 2.7.4-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.5-alpine, 2.7-alpine, alpine, 2.7.5-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a560f7338fdb03b5d07e773f6678919f74e9185b
+GitCommit: 098bc15c52ea5cfe4375519a463b682efcb38225
 Directory: 2.7/alpine
 
-Tags: 2.6.10, 2.6, lts, 2.6.10-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.11, 2.6, lts, 2.6.11-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4ae2c3536eef4ca86d9b2d96bb97b1fb9d82f33
+GitCommit: c2ce622c339932e818d880f9d73e05c5cc4c7705
 Directory: 2.6
 
-Tags: 2.6.10-alpine, 2.6-alpine, lts-alpine, 2.6.10-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.11-alpine, 2.6-alpine, lts-alpine, 2.6.11-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f4ae2c3536eef4ca86d9b2d96bb97b1fb9d82f33
+GitCommit: c2ce622c339932e818d880f9d73e05c5cc4c7705
 Directory: 2.6/alpine
 
-Tags: 2.5.12, 2.5, 2.5.12-bullseye, 2.5-bullseye
+Tags: 2.5.13, 2.5, 2.5.13-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 57fdd931dfdce22ddc38fa7bad81b7c09b5b1caa
+GitCommit: 8bb4f9f4a41b5c3531a6cb4a070c25be7a254ccd
 Directory: 2.5
 
-Tags: 2.5.12-alpine, 2.5-alpine, 2.5.12-alpine3.17, 2.5-alpine3.17
+Tags: 2.5.13-alpine, 2.5-alpine, 2.5.13-alpine3.17, 2.5-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 57fdd931dfdce22ddc38fa7bad81b7c09b5b1caa
+GitCommit: 8bb4f9f4a41b5c3531a6cb4a070c25be7a254ccd
 Directory: 2.5/alpine
 
 Tags: 2.4.22, 2.4, 2.4.22-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/098bc15: Update 2.7 to 2.7.5
- https://github.com/docker-library/haproxy/commit/c2ce622: Update 2.6 to 2.6.11
- https://github.com/docker-library/haproxy/commit/8bb4f9f: Update 2.5 to 2.5.13