### PR TITLE
[security] Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 7.0.9, 7.0, 7, latest, 7.0.9-bullseye, 7.0-bullseye, 7-bullseye, bullseye
+Tags: 7.0.10, 7.0, 7, latest, 7.0.10-bullseye, 7.0-bullseye, 7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d77143afb3dc8d0b05225ab23b001cf6c41e1b62
+GitCommit: e331696f8226fb5b89d7bd190fecbfaea3cac571
 Directory: 7.0
 
-Tags: 7.0.9-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.9-alpine3.17, 7.0-alpine3.17, 7-alpine3.17, alpine3.17
+Tags: 7.0.10-alpine, 7.0-alpine, 7-alpine, alpine, 7.0.10-alpine3.17, 7.0-alpine3.17, 7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d77143afb3dc8d0b05225ab23b001cf6c41e1b62
+GitCommit: e331696f8226fb5b89d7bd190fecbfaea3cac571
 Directory: 7.0/alpine
 
 Tags: 6.2.11, 6.2, 6, 6.2.11-bullseye, 6.2-bullseye, 6-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/e331696: Update to 7.0.10

https://github.com/redis/redis/releases/tag/7.0.10