### PR TITLE
Bump Traefik to v2.9.9

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
-Tags: v2.9.8-windowsservercore-1809, 2.9.8-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.9.9-windowsservercore-1809, 2.9.9-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cde946f16566d912ccae15cf1bd9056518ef8c3d
+GitCommit: 3397f06715d1f6684444c135a1b86b4f8c44d599
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.9.8, 2.9.8, v2.9, 2.9, banon, latest
+Tags: v2.9.9, 2.9.9, v2.9, 2.9, banon, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cde946f16566d912ccae15cf1bd9056518ef8c3d
+GitCommit: 3397f06715d1f6684444c135a1b86b4f8c44d599
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.9.9](https://github.com/traefik/traefik/releases/tag/v2.9.9).

/cc @mpl @rtribotte

Cheers
