### PR TITLE
Fix buildkit registry mirrors generating code

### DIFF
--- a/.bin/docker-buildx-ensure.sh
+++ b/.bin/docker-buildx-ensure.sh
@@ -26,7 +26,7 @@ platform="$(bashbrew cat --format '{{ ociPlatform arch }}' <(echo 'Maintainers: 
 
 hubMirrors="$(docker info --format '{{ json .RegistryConfig.Mirrors }}' | jq -c '
 	[ env.DOCKERHUB_PUBLIC_PROXY // empty, .[] ]
-	| map(rtrimstr("/"))
+	| map(select(startswith("https://")) | ltrimstr("https://") | rtrimstr("/") | select(contains("/") | not))
 	| reduce .[] as $item ( # "unique" but order-preserving (we want DOCKERHUB_PUBLIC_PROXY first followed by everything else set in the dockerd mirrors config without duplication)
 		[];
 		if index($item) then . else . + [ $item ] end


### PR DESCRIPTION
See https://github.com/moby/buildkit/blob/v0.11.4/docs/buildkitd.toml.md (`mirrors` expects an array of hostnames, not fully qualified URIs like what Docker gives us)