### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ELSA-2023-1332 and ELSA-2023-1335

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 985b5fe156c098018f87cae55f448d16cd4bee5f
+amd64-GitCommit: dd580014c61a48acfb494ab5a03c9e6b4e9a2e53
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 71f7331702ae8f33c5613596e5c6ab064a4f27f7
+arm64v8-GitCommit: afe28d55637d4dd49baf158e8a1924920360fe79
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-0767 and CVE-2023-0286.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-1332.html
https://linux.oracle.com/errata/ELSA-2023-1335.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>