### PR TITLE
Disable garbage collection in buildkit builders

### DIFF
--- a/.bin/docker-buildx-ensure.sh
+++ b/.bin/docker-buildx-ensure.sh
@@ -38,9 +38,13 @@ read -r -d '' buildkitdConfig <<-EOF || :
 
 	[worker.oci]
 		platforms = [ "$platform" ]
+		gc = false # we want to do GC manually
 
+	# this should be unused (for now?), but included for completeness/safety
 	[worker.containerd]
 		platforms = [ "$platform" ]
+		namespace = "buildkit-$builderName"
+		gc = false
 
 	[registry."docker.io"]
 		mirrors = $hubMirrors


### PR DESCRIPTION
We ran into a race condition that we _think_ might be GC related, but we don't want automatic GC generally anyhow so we'll just disable this entirely and keep our eyes open for that race to resurface.

```console
$ printf 'FROM ubuntu:20.04\n' | docker buildx build --builder bashbrew-arm64v8 --output type=oci --build-arg BUILDKIT_SYNTAX=docker/dockerfile:1@sha256:7f44e51970d0422c2cbff3b20b6b5ef861f6244c396a06e1a96f7aa4fa83a4e6 --provenance=mode=max --sbom generator=docker/buildkit-syft-scanner:stable-1@sha256:71c6aab70e25388abf054da2eaaf121727e3a4f464ddfb1987052b83c9419949 --platform linux/arm64/v8 - > oci.tar
#1 [internal] load .dockerignore
#1 transferring context: 2B done
#1 DONE 0.0s

#2 [internal] load build definition from Dockerfile
#2 transferring dockerfile: 55B done
#2 DONE 0.0s

#3 resolve image config for docker.io/docker/dockerfile:1@sha256:7f44e51970d0422c2cbff3b20b6b5ef861f6244c396a06e1a96f7aa4fa83a4e6
#3 DONE 0.1s

#4 docker-image://docker.io/docker/dockerfile:1@sha256:7f44e51970d0422c2cbff3b20b6b5ef861f6244c396a06e1a96f7aa4fa83a4e6
#4 resolve docker.io/docker/dockerfile:1@sha256:7f44e51970d0422c2cbff3b20b6b5ef861f6244c396a06e1a96f7aa4fa83a4e6 done
#4 DONE 0.0s

#4 docker-image://docker.io/docker/dockerfile:1@sha256:7f44e51970d0422c2cbff3b20b6b5ef861f6244c396a06e1a96f7aa4fa83a4e6
#4 CACHED

#5 resolve image config for docker.io/docker/buildkit-syft-scanner:stable-1@sha256:71c6aab70e25388abf054da2eaaf121727e3a4f464ddfb1987052b83c9419949
#5 DONE 0.1s

#6 [internal] load metadata for docker.io/library/ubuntu:20.04
#6 DONE 0.6s

#7 docker-image://docker.io/docker/buildkit-syft-scanner:stable-1@sha256:71c6aab70e25388abf054da2eaaf121727e3a4f464ddfb1987052b83c9419949
#7 resolve docker.io/docker/buildkit-syft-scanner:stable-1@sha256:71c6aab70e25388abf054da2eaaf121727e3a4f464ddfb1987052b83c9419949 0.0s done
#7 DONE 0.0s

#8 [linux/arm64] generating sbom using docker.io/docker/buildkit-syft-scanner:stable-1@sha256:71c6aab70e25388abf054da2eaaf121727e3a4f464ddfb1987052b83c9419949
#8 CACHED

#9 [1/1] FROM docker.io/library/ubuntu:20.04@sha256:24a0df437301598d1a4b62ddf59fa0ed2969150d70d748c84225e6501e9c36b9
#9 resolve docker.io/library/ubuntu:20.04@sha256:24a0df437301598d1a4b62ddf59fa0ed2969150d70d748c84225e6501e9c36b9 0.0s done
#9 DONE 0.0s

#10 exporting to oci image format
#10 exporting layers done
#10 exporting manifest sha256:7ee27ad7ace5741767778121ad82066c09383c68e462efcfaad124cc074b48a8 0.0s done
#10 exporting config sha256:b559481b22258f45e33c28e36cab179693b1d6ca1bfa8d7acf2b068cd61d4b39 done
#10 ERROR: content digest sha256:a774dfcdedc7c7c4f0009ddadc2f33557d60452450684534df5625f9693df81a: not found
------
 > exporting to oci image format:
------
ERROR: failed to solve: content digest sha256:a774dfcdedc7c7c4f0009ddadc2f33557d60452450684534df5625f9693df81a: not found
```