### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.1.0, 4.1, 4, latest
+Tags: 4.1.1, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: bbe25add57171af90838151e419b7cdafc921e3c
+GitCommit: f4c092b5dd80ccf6eaf656965b6c3738e32f6534
 Directory: 4.1
 
 Tags: 4.0.8, 4.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/f4c092b: Update 4.1 to 4.1.1