### PR TITLE
Disable buildx builder for now (cannot handle all-local builds properly yet)

### DIFF
--- a/.bin/bashbrew-buildkit-env-setup.sh
+++ b/.bin/bashbrew-buildkit-env-setup.sh
@@ -58,7 +58,7 @@ _bashbrew_buildkit_env_setup() {
 	vars="$(_jq_setenv <<<"$vars" BASHBREW_BUILDKIT_SYNTAX "$dockerfileTag")"
 
 	case "${BASHBREW_ARCH:-}" in
-		amd64 | arm64v8) # TODO add more architectures
+		nope) # amd64 | arm64v8) # TODO re-enable this once we figure out how to handle "docker build --tag X" + "FROM X" correctly all-local
 			BASHBREW_BUILDKIT_IMAGE="$(grep <<<"$externalPins" -m1 '^moby/buildkit:')"
 			BASHBREW_BUILDKIT_IMAGE="$(_resolve_external_pins "$BASHBREW_BUILDKIT_IMAGE")"
 			export BASHBREW_BUILDKIT_IMAGE


### PR DESCRIPTION
Dependencies _between_ images are still complicated and will likely require some use/abuse of `--build-context`/source policy/`oci-layout://` 😭