### PR TITLE
Update Nextcloud tests

### DIFF
--- a/test/tests/nextcloud-apache-run/real-run.sh
+++ b/test/tests/nextcloud-apache-run/real-run.sh
@@ -31,7 +31,7 @@ _request() {
 }
 
 # Make sure that Apache is listening and ready
-. "$dir/../../retry.sh" --tries 30 '_request GET / --output /dev/null'
+. "$dir/../../retry.sh" --tries 10 --sleep 5 '_request GET / --output /dev/null'
 
 # Check that we can request / and that it contains the pattern "Install" somewhere
 # <input type="submit" class="primary" value="Install" data-finishing="Installing …">

--- a/test/tests/nextcloud-cli-mysql/run.sh
+++ b/test/tests/nextcloud-cli-mysql/run.sh
@@ -37,7 +37,7 @@ _occ() {
 }
 
 # Give some time to install
-. "$dir/../../retry.sh" --tries 30 '_occ app:list' > /dev/null
+. "$dir/../../retry.sh" --tries 10 --sleep 5 '_occ app:list' > /dev/null
 
 # Check if NextCloud is installed
 _occ status | grep -iq 'installed: true'

--- a/test/tests/nextcloud-cli-mysql/run.sh
+++ b/test/tests/nextcloud-cli-mysql/run.sh
@@ -3,7 +3,7 @@ set -eo pipefail
 
 dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 
-dbImage='mariadb:10.5'
+dbImage='mariadb:10.6'
 # ensure the dbImage is ready and available
 if ! docker image inspect "$dbImage" &> /dev/null; then
 	docker pull "$dbImage" > /dev/null

--- a/test/tests/nextcloud-cli-postgres/run.sh
+++ b/test/tests/nextcloud-cli-postgres/run.sh
@@ -38,7 +38,7 @@ _occ() {
 }
 
 # Give some time to install
-. "$dir/../../retry.sh" --tries 60 '_occ app:list' > /dev/null
+. "$dir/../../retry.sh" --tries 10 --sleep 5 '_occ app:list' > /dev/null
 
 # Check if NextCloud is installed
 _occ status | grep -iq 'installed: true'

--- a/test/tests/nextcloud-cli-sqlite/run.sh
+++ b/test/tests/nextcloud-cli-sqlite/run.sh
@@ -19,7 +19,7 @@ _occ() {
 }
 
 # Give some time to install
-. "$dir/../../retry.sh" --tries 30 '_occ app:list' > /dev/null
+. "$dir/../../retry.sh" --tries 10 --sleep 5 '_occ app:list' > /dev/null
 
 # Check if NextCloud is installed
 _occ status | grep -iq 'installed: true'

--- a/test/tests/nextcloud-fpm-run/real-run.sh
+++ b/test/tests/nextcloud-fpm-run/real-run.sh
@@ -41,7 +41,7 @@ fcgi-request() {
 }
 
 # Make sure that PHP-FPM is listening and ready
-. "$dir/../../retry.sh" --tries 30 'fcgi-request GET /index.php' > /dev/null 2>&1
+. "$dir/../../retry.sh" --tries 10 --sleep 5 'fcgi-request GET /index.php' > /dev/null 2>&1
 
 # Check that we can request / and that it contains the pattern "Install" somewhere
 # <input type="submit" class="primary" value="Install" data-finishing="Installing …">


### PR DESCRIPTION
Recent versions of Nextcloud tend to consume more time to install. This shouldn't increase the test time but hopefully reduce the flakiness.