### PR TITLE
maven: 3.9.1

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -2,107 +2,132 @@ Maintainers: Carlos Sanchez <carlos@apache.org> (@carlossg)
 Builder: buildkit
 GitRepo: https://github.com/carlossg/docker-maven.git
 
-Tags: 3.9.0-eclipse-temurin-11, 3.9-eclipse-temurin-11, 3-eclipse-temurin-11
+Tags: 3.9.1-eclipse-temurin-11, 3.9-eclipse-temurin-11, 3-eclipse-temurin-11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: de70b3e783c1c9b2835b6be4c3826d6221bf4fca
+GitCommit: f99b8cd582524a58a73b23b97e9b8c17001573af
 Directory: eclipse-temurin-11
 
-Tags: 3.9.0-eclipse-temurin-11-alpine, 3.9-eclipse-temurin-11-alpine, 3-eclipse-temurin-11-alpine
+Tags: 3.9.1-eclipse-temurin-11-alpine, 3.9-eclipse-temurin-11-alpine, 3-eclipse-temurin-11-alpine
 Architectures: amd64
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-11-alpine
 
-Tags: 3.9.0-eclipse-temurin-11-focal, 3.9-eclipse-temurin-11-focal, 3-eclipse-temurin-11-focal
+Tags: 3.9.1-eclipse-temurin-11-focal, 3.9-eclipse-temurin-11-focal, 3-eclipse-temurin-11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-11-focal
 
-Tags: 3.9.0-eclipse-temurin-17, 3.9.0, 3.9.0-eclipse-temurin, 3.9-eclipse-temurin-17, 3.9, 3.9-eclipse-temurin, 3-eclipse-temurin-17, 3, latest, 3-eclipse-temurin, eclipse-temurin
+Tags: 3.9.1-eclipse-temurin-17, 3.9.1, 3.9.1-eclipse-temurin, 3.9-eclipse-temurin-17, 3.9, 3.9-eclipse-temurin, 3-eclipse-temurin-17, 3, latest, 3-eclipse-temurin, eclipse-temurin
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-17
 
-Tags: 3.9.0-eclipse-temurin-17-alpine, 3.9-eclipse-temurin-17-alpine, 3-eclipse-temurin-17-alpine
+Tags: 3.9.1-eclipse-temurin-17-alpine, 3.9-eclipse-temurin-17-alpine, 3-eclipse-temurin-17-alpine
 Architectures: amd64
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-17-alpine
 
-Tags: 3.9.0-eclipse-temurin-17-focal, 3.9-eclipse-temurin-17-focal, 3-eclipse-temurin-17-focal
+Tags: 3.9.1-eclipse-temurin-17-focal, 3.9-eclipse-temurin-17-focal, 3-eclipse-temurin-17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-17-focal
 
-Tags: 3.9.0-eclipse-temurin-19, 3.9-eclipse-temurin-19, 3-eclipse-temurin-19
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: de70b3e783c1c9b2835b6be4c3826d6221bf4fca
-Directory: eclipse-temurin-19
+Tags: 3.9.1-eclipse-temurin-20, 3.9-eclipse-temurin-20, 3-eclipse-temurin-20
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: d84a7d025072e7f0de644de36e86236e83414837
+Directory: eclipse-temurin-20
 
-Tags: 3.9.0-eclipse-temurin-19-alpine, 3.9-eclipse-temurin-19-alpine, 3-eclipse-temurin-19-alpine
+Tags: 3.9.1-eclipse-temurin-20-alpine, 3.9-eclipse-temurin-20-alpine, 3-eclipse-temurin-20-alpine
 Architectures: amd64
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
-Directory: eclipse-temurin-19-alpine
+GitCommit: d84a7d025072e7f0de644de36e86236e83414837
+Directory: eclipse-temurin-20-alpine
 
-Tags: 3.9.0-eclipse-temurin-19-focal, 3.9-eclipse-temurin-19-focal, 3-eclipse-temurin-19-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
-Directory: eclipse-temurin-19-focal
-
-Tags: 3.9.0-eclipse-temurin-8, 3.9-eclipse-temurin-8, 3-eclipse-temurin-8
+Tags: 3.9.1-eclipse-temurin-8, 3.9-eclipse-temurin-8, 3-eclipse-temurin-8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-8
 
-Tags: 3.9.0-eclipse-temurin-8-alpine, 3.9-eclipse-temurin-8-alpine, 3-eclipse-temurin-8-alpine
+Tags: 3.9.1-eclipse-temurin-8-alpine, 3.9-eclipse-temurin-8-alpine, 3-eclipse-temurin-8-alpine
 Architectures: amd64
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-8-alpine
 
-Tags: 3.9.0-eclipse-temurin-8-focal, 3.9-eclipse-temurin-8-focal, 3-eclipse-temurin-8-focal
+Tags: 3.9.1-eclipse-temurin-8-focal, 3.9-eclipse-temurin-8-focal, 3-eclipse-temurin-8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: eclipse-temurin-8-focal
 
-Tags: 3.9.0-ibmjava-8, 3.9.0-ibmjava, 3.9-ibmjava-8, 3.9-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
+Tags: 3.9.1-ibmjava-8, 3.9.1-ibmjava, 3.9-ibmjava-8, 3.9-ibmjava, 3-ibmjava-8, 3-ibmjava, ibmjava
 Architectures: amd64, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: ibmjava-8
 
-Tags: 3.9.0-ibm-semeru-11-focal, 3.9-ibm-semeru-11-focal, 3-ibm-semeru-11-focal
+Tags: 3.9.1-ibm-semeru-11-focal, 3.9-ibm-semeru-11-focal, 3-ibm-semeru-11-focal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: ibm-semeru-11-focal
 
-Tags: 3.9.0-ibm-semeru-17-focal, 3.9-ibm-semeru-17-focal, 3-ibm-semeru-17-focal
+Tags: 3.9.1-ibm-semeru-17-focal, 3.9-ibm-semeru-17-focal, 3-ibm-semeru-17-focal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: ibm-semeru-17-focal
 
-Tags: 3.9.0-amazoncorretto-11, 3.9.0-amazoncorretto, 3.9-amazoncorretto-11, 3.9-amazoncorretto, 3-amazoncorretto-11, 3-amazoncorretto, amazoncorretto
+Tags: 3.9.1-amazoncorretto-11, 3.9.1-amazoncorretto, 3.9-amazoncorretto-11, 3.9-amazoncorretto, 3-amazoncorretto-11, 3-amazoncorretto, amazoncorretto
 Architectures: amd64, arm64v8
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-11
 
-Tags: 3.9.0-amazoncorretto-17, 3.9-amazoncorretto-17, 3-amazoncorretto-17
+Tags: 3.9.1-amazoncorretto-11-debian-slim, 3.9-amazoncorretto-11-debian-slim, 3-amazoncorretto-11-debian-slim
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
+Directory: amazoncorretto-11-debian-slim
+
+Tags: 3.9.1-amazoncorretto-17, 3.9-amazoncorretto-17, 3-amazoncorretto-17
 Architectures: amd64, arm64v8
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-17
 
-Tags: 3.9.0-amazoncorretto-19, 3.9-amazoncorretto-19, 3-amazoncorretto-19
+Tags: 3.9.1-amazoncorretto-17-debian-slim, 3.9-amazoncorretto-17-debian-slim, 3-amazoncorretto-17-debian-slim
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
+Directory: amazoncorretto-17-debian-slim
+
+Tags: 3.9.1-amazoncorretto-19, 3.9-amazoncorretto-19, 3-amazoncorretto-19
 Architectures: amd64, arm64v8
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-19
 
-Tags: 3.9.0-amazoncorretto-8, 3.9-amazoncorretto-8, 3-amazoncorretto-8
+Tags: 3.9.1-amazoncorretto-19-debian-slim, 3.9-amazoncorretto-19-debian-slim, 3-amazoncorretto-19-debian-slim
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
+Directory: amazoncorretto-19-debian-slim
+
+Tags: 3.9.1-amazoncorretto-20, 3.9-amazoncorretto-20, 3-amazoncorretto-20
 Architectures: amd64, arm64v8
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: d84a7d025072e7f0de644de36e86236e83414837
+Directory: amazoncorretto-20
+
+Tags: 3.9.1-amazoncorretto-20-debian-slim, 3.9-amazoncorretto-20-debian-slim, 3-amazoncorretto-20-debian-slim
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
+Directory: amazoncorretto-20-debian-slim
+
+Tags: 3.9.1-amazoncorretto-8, 3.9-amazoncorretto-8, 3-amazoncorretto-8
+Architectures: amd64, arm64v8
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-8
 
-Tags: 3.9.0-sapmachine-11, 3.9-sapmachine-11, 3-sapmachine-11
+Tags: 3.9.1-amazoncorretto-8-debian-slim, 3.9-amazoncorretto-8-debian-slim, 3-amazoncorretto-8-debian-slim
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
+Directory: amazoncorretto-8-debian-slim
+
+Tags: 3.9.1-sapmachine-11, 3.9-sapmachine-11, 3-sapmachine-11
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: sapmachine-11
 
-Tags: 3.9.0-sapmachine-17, 3.9.0-sapmachine, 3.9-sapmachine-17, 3.9-sapmachine, 3-sapmachine-17, 3-sapmachine, sapmachine
+Tags: 3.9.1-sapmachine-17, 3.9.1-sapmachine, 3.9-sapmachine-17, 3.9-sapmachine, 3-sapmachine-17, 3-sapmachine, sapmachine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ba0653e9cbde55b7806b4b99a5afcbf7ca8485d7
+GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: sapmachine-17

--- a/library/maven
+++ b/library/maven
@@ -77,50 +77,25 @@ Architectures: amd64, arm64v8
 GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-11
 
-Tags: 3.9.1-amazoncorretto-11-debian-slim, 3.9-amazoncorretto-11-debian-slim, 3-amazoncorretto-11-debian-slim
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
-Directory: amazoncorretto-11-debian-slim
-
 Tags: 3.9.1-amazoncorretto-17, 3.9-amazoncorretto-17, 3-amazoncorretto-17
 Architectures: amd64, arm64v8
 GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-17
-
-Tags: 3.9.1-amazoncorretto-17-debian-slim, 3.9-amazoncorretto-17-debian-slim, 3-amazoncorretto-17-debian-slim
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
-Directory: amazoncorretto-17-debian-slim
 
 Tags: 3.9.1-amazoncorretto-19, 3.9-amazoncorretto-19, 3-amazoncorretto-19
 Architectures: amd64, arm64v8
 GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-19
 
-Tags: 3.9.1-amazoncorretto-19-debian-slim, 3.9-amazoncorretto-19-debian-slim, 3-amazoncorretto-19-debian-slim
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
-Directory: amazoncorretto-19-debian-slim
-
 Tags: 3.9.1-amazoncorretto-20, 3.9-amazoncorretto-20, 3-amazoncorretto-20
 Architectures: amd64, arm64v8
 GitCommit: d84a7d025072e7f0de644de36e86236e83414837
 Directory: amazoncorretto-20
 
-Tags: 3.9.1-amazoncorretto-20-debian-slim, 3.9-amazoncorretto-20-debian-slim, 3-amazoncorretto-20-debian-slim
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
-Directory: amazoncorretto-20-debian-slim
-
 Tags: 3.9.1-amazoncorretto-8, 3.9-amazoncorretto-8, 3-amazoncorretto-8
 Architectures: amd64, arm64v8
 GitCommit: 8f9adaf3d78df6ed956b0a717d51876f71f0fdfe
 Directory: amazoncorretto-8
-
-Tags: 3.9.1-amazoncorretto-8-debian-slim, 3.9-amazoncorretto-8-debian-slim, 3-amazoncorretto-8-debian-slim
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9ba9e534d45aefbadde22ebe79e3694cb43f0a95
-Directory: amazoncorretto-8-debian-slim
 
 Tags: 3.9.1-sapmachine-11, 3.9-sapmachine-11, 3-sapmachine-11
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
I have realized that there is a chicken and egg problem. I cannot build the other variants without the eclipse-temurin-11 and this will fail as references no longer exist.
Any good solution used in other images ?