### PR TITLE
arangodb 3.9.10, 3.10.5

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,12 +7,12 @@ Architectures: amd64
 GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
 Directory: alpine/3.8.8
 
-Tags: 3.9, 3.9.9
+Tags: 3.9, 3.9.10
 Architectures: amd64
-GitCommit: 6d01f6e7130208aea68d0e341bb9b009dcc3da79
-Directory: alpine/3.9.9
+GitCommit: 04479ca0b7f52b6f23f3739eae6994f4875990f2
+Directory: alpine/3.9.10
 
-Tags: 3.10, 3.10.4, latest
+Tags: 3.10, 3.10.5, latest
 Architectures: amd64, arm64v8
-GitCommit: 6d01f6e7130208aea68d0e341bb9b009dcc3da79
-Directory: alpine/3.10.4
+GitCommit: 04479ca0b7f52b6f23f3739eae6994f4875990f2
+Directory: alpine/3.10.5


### PR DESCRIPTION
Updated ArangoDB 3.9 to 3.9.10 and 3.10 to 3.10.5.