### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2023-1405

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: dd580014c61a48acfb494ab5a03c9e6b4e9a2e53
+amd64-GitCommit: b147658cb92aaa5fd1b618e08b35455410168633
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: afe28d55637d4dd49baf158e8a1924920360fe79
+arm64v8-GitCommit: 366b9163418c96f8afd03acb930c224d5006d3a6
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-4304, CVE-2022-4450, CVE-2023-0215, and CVE-2023-0286.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-1405.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>