### PR TITLE
Updated swipl devel to 9.1.8

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: 67b156afb3feb8e0a4537bfb7671662f12526156
+GitCommit: 6b9f59764967f0b615220c939aedc9eec22cce23
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 9.1.5
-Directory: 9.1.5/bullseye
+Tags: latest, 9.1.8
+Directory: 9.1.8/bullseye
 
 Tags: stable, 9.0.4
 Directory: 9.0.4/bullseye


### PR DESCRIPTION
Note that the 9.1.7 update (which was not released to the official library) also includes discussed updates to skip compilation of some C++ extensions that do not compile on armel en armhf.    Eventually these platforms will include these packages of the new, more portable, C++ interface is ready and used for these extensions.