### PR TITLE
Resolve "buildkit" related images to the host architecture instead of target

### DIFF
--- a/.bin/bashbrew-buildkit-env-setup.sh
+++ b/.bin/bashbrew-buildkit-env-setup.sh
@@ -18,16 +18,10 @@ _resolve_external_pins() {
 		[ "$wc" -eq 1 ]
 
 		local file digest
-		if [ -n "${BASHBREW_ARCH:-}" ]; then
-			digest="$("$oiDir/.buildkit-build-contexts.sh" "$image")"
-			image="${digest#*=docker-image://}"
-			[ "$image" != "$digest" ]
-		else
-			file="$("$oiDir/.external-pins/file.sh" "$image")"
-			digest="$(< "$file")"
-			[ -n "$digest" ]
-			image+="@$digest"
-		fi
+		file="$("$oiDir/.external-pins/file.sh" "$image")"
+		digest="$(< "$file")"
+		[ -n "$digest" ]
+		image+="@$digest"
 
 		echo "$image"
 	done


### PR DESCRIPTION
It _should_ be reasonably harmless to build, for example, `linux/arm/v6` on top of a `linux/arm64/v8` buildkitd + frontend (and even SBOM generator).

We can reevaluate this again if/when we have some other image we need to resolve more particularly involved in the buildkit environment setup.