### PR TITLE
eclipse-temurin: add JDK20 images

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -388,130 +388,107 @@ Directory: 17/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-#------------------------------v19 images---------------------------------
-Tags: 19.0.2_7-jdk-alpine, 19-jdk-alpine, 19-alpine
+
+#------------------------------v20 images---------------------------------
+Tags: 20_36-jdk-alpine, 20-jdk-alpine, 20-alpine
 Architectures: amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/alpine
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 19.0.2_7-jdk-focal, 19-jdk-focal, 19-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/ubuntu/focal
-File: Dockerfile.releases.full
-
-Tags: 19.0.2_7-jdk-jammy, 19-jdk-jammy, 19-jammy
-SharedTags: 19.0.2_7-jdk, 19-jdk, 19, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/ubuntu/jammy
-File: Dockerfile.releases.full
-
-Tags: 19.0.2_7-jdk-centos7, 19-jdk-centos7, 19-centos7
+Tags: 20_36-jdk-jammy, 20-jdk-jammy, 20-jammy
+SharedTags: 20_36-jdk, 20-jdk, 20, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/centos
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 19.0.2_7-jdk-ubi9-minimal, 19-jdk-ubi9-minimal, 19-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/ubi/ubi9-minimal
+Tags: 20_36-jdk-ubi9-minimal, 20-jdk-ubi9-minimal, 20-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 19.0.2_7-jdk-windowsservercore-ltsc2022, 19-jdk-windowsservercore-ltsc2022, 19-windowsservercore-ltsc2022
-SharedTags: 19.0.2_7-jdk-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19.0.2_7-jdk, 19-jdk, 19, latest
+Tags: 20_36-jdk-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20_36-jdk-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20_36-jdk, 20-jdk, 20, latest
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/windows/windowsservercore-ltsc2022
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19.0.2_7-jdk-nanoserver-ltsc2022, 19-jdk-nanoserver-ltsc2022, 19-nanoserver-ltsc2022
-SharedTags: 19.0.2_7-jdk-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 20_36-jdk-nanoserver-ltsc2022, 20-jdk-nanoserver-ltsc2022, 20-nanoserver-ltsc2022
+SharedTags: 20_36-jdk-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/windows/nanoserver-ltsc2022
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 19.0.2_7-jdk-windowsservercore-1809, 19-jdk-windowsservercore-1809, 19-windowsservercore-1809
-SharedTags: 19.0.2_7-jdk-windowsservercore, 19-jdk-windowsservercore, 19-windowsservercore, 19.0.2_7-jdk, 19-jdk, 19, latest
+Tags: 20_36-jdk-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20_36-jdk-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20_36-jdk, 20-jdk, 20, latest
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/windows/windowsservercore-1809
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 19.0.2_7-jdk-nanoserver-1809, 19-jdk-nanoserver-1809, 19-nanoserver-1809
-SharedTags: 19.0.2_7-jdk-nanoserver, 19-jdk-nanoserver, 19-nanoserver
+Tags: 20_36-jdk-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20_36-jdk-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jdk/windows/nanoserver-1809
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 19.0.2_7-jre-alpine, 19-jre-alpine
+Tags: 20_36-jre-alpine, 20-jre-alpine
 Architectures: amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/alpine
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 19.0.2_7-jre-focal, 19-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/ubuntu/focal
-File: Dockerfile.releases.full
-
-Tags: 19.0.2_7-jre-jammy, 19-jre-jammy
-SharedTags: 19.0.2_7-jre, 19-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/ubuntu/jammy
-File: Dockerfile.releases.full
-
-Tags: 19.0.2_7-jre-centos7, 19-jre-centos7
+Tags: 20_36-jre-jammy, 20-jre-jammy
+SharedTags: 20_36-jre, 20-jre
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/centos
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 19.0.2_7-jre-ubi9-minimal, 19-jre-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/ubi/ubi9-minimal
+Tags: 20_36-jre-ubi9-minimal, 20-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 19.0.2_7-jre-windowsservercore-ltsc2022, 19-jre-windowsservercore-ltsc2022
-SharedTags: 19.0.2_7-jre-windowsservercore, 19-jre-windowsservercore, 19.0.2_7-jre, 19-jre
+Tags: 20_36-jre-windowsservercore-ltsc2022, 20-jre-windowsservercore-ltsc2022
+SharedTags: 20_36-jre-windowsservercore, 20-jre-windowsservercore, 20_36-jre, 20-jre
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/windows/windowsservercore-ltsc2022
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 19.0.2_7-jre-nanoserver-ltsc2022, 19-jre-nanoserver-ltsc2022
-SharedTags: 19.0.2_7-jre-nanoserver, 19-jre-nanoserver
+Tags: 20_36-jre-nanoserver-ltsc2022, 20-jre-nanoserver-ltsc2022
+SharedTags: 20_36-jre-nanoserver, 20-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/windows/nanoserver-ltsc2022
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 19.0.2_7-jre-windowsservercore-1809, 19-jre-windowsservercore-1809
-SharedTags: 19.0.2_7-jre-windowsservercore, 19-jre-windowsservercore, 19.0.2_7-jre, 19-jre
+Tags: 20_36-jre-windowsservercore-1809, 20-jre-windowsservercore-1809
+SharedTags: 20_36-jre-windowsservercore, 20-jre-windowsservercore, 20_36-jre, 20-jre
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/windows/windowsservercore-1809
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 19.0.2_7-jre-nanoserver-1809, 19-jre-nanoserver-1809
-SharedTags: 19.0.2_7-jre-nanoserver, 19-jre-nanoserver
+Tags: 20_36-jre-nanoserver-1809, 20-jre-nanoserver-1809
+SharedTags: 20_36-jre-nanoserver, 20-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a7031bd7bfbfb669ba2a4d081e87f1dd7aaed05b
-Directory: 19/jre/windows/nanoserver-1809
+GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Directory: 20/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Note that we don't currently intend to ship s390x and arm32 (this could change in the coming weeks but we want to get these updates out first)