### PR TITLE
Update Clear Linux OS to 38640

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 76173e2f8f6d04ef5fbc2b21724b80f54f7926dc
-GitFetch: refs/heads/base-38590
+GitCommit: ded2505524da863aa66c7b314acceb7c2f6b6f3c
+GitFetch: refs/heads/base-38640


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 38640

@bryteise @djklimes @bryteise