### PR TITLE
Updated couchdb 3.3.1, 3.3, 3, latest, 3.2.2 and 3.2.2

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -1,10 +1,10 @@
 # see https://couchdb.apache.org/
 # also the announce@couchdb.apache.org mailing list
 
-Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl)
+Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: bdaa3681c0c16d2c3bc1bdc451be9ff5b74f2d62
+GitCommit: a29d12f0dd4d73f1dcefb07212af4b9ba3185d9e
 
 Tags: latest, 3.3.1, 3.3, 3
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
 * Erlang version bumped to 24.3.4.10 to fix a memory leak
 * gosu <-> setpriv fix https://github.com/apache/couchdb-docker/pull/237

Also added myself to the list of maintainers.