### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev5, 2.8-dev, 2.8-dev5-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev6, 2.8-dev, 2.8-dev6-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5b92c8346ddada68e89299f7b0754dcf03ec0aa8
+GitCommit: b8c3d54e118f694d0a06ce94d8f83a0a2cad5c56
 Directory: 2.8
 
-Tags: 2.8-dev5-alpine, 2.8-dev-alpine, 2.8-dev5-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev6-alpine, 2.8-dev-alpine, 2.8-dev6-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5b92c8346ddada68e89299f7b0754dcf03ec0aa8
+GitCommit: b8c3d54e118f694d0a06ce94d8f83a0a2cad5c56
 Directory: 2.8/alpine
 
-Tags: 2.7.5, 2.7, latest, 2.7.5-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.6, 2.7, latest, 2.7.6-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 098bc15c52ea5cfe4375519a463b682efcb38225
+GitCommit: 3e8ddb695fb46f902afea21ce0de1d481c1c71ab
 Directory: 2.7
 
-Tags: 2.7.5-alpine, 2.7-alpine, alpine, 2.7.5-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.6-alpine, 2.7-alpine, alpine, 2.7.6-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 098bc15c52ea5cfe4375519a463b682efcb38225
+GitCommit: 3e8ddb695fb46f902afea21ce0de1d481c1c71ab
 Directory: 2.7/alpine
 
-Tags: 2.6.11, 2.6, lts, 2.6.11-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.12, 2.6, lts, 2.6.12-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2ce622c339932e818d880f9d73e05c5cc4c7705
+GitCommit: 791843a38289bd3b5238715cbe6ed993214b2d73
 Directory: 2.6
 
-Tags: 2.6.11-alpine, 2.6-alpine, lts-alpine, 2.6.11-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.12-alpine, 2.6-alpine, lts-alpine, 2.6.12-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2ce622c339932e818d880f9d73e05c5cc4c7705
+GitCommit: 791843a38289bd3b5238715cbe6ed993214b2d73
 Directory: 2.6/alpine
 
 Tags: 2.5.13, 2.5, 2.5.13-bullseye, 2.5-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b8c3d54: Update 2.8 to 2.8-dev6
- https://github.com/docker-library/haproxy/commit/791843a: Update 2.6 to 2.6.12
- https://github.com/docker-library/haproxy/commit/3e8ddb6: Update 2.7 to 2.7.6