### PR TITLE
Upgrade SonarQube to 10.0

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -1,29 +1,45 @@
-Maintainers: Christophe Levis <christophe.levis@sonarsource.com> (@christophelevis),
-             Pierre Guillot <pierre.guillot@sonarsource.com> (@pierre-guillot-gh),
-             Lukasz Jarocki <lukasz.jarocki@sonarsource.com> (@lukasz-jarocki-sonarsource),
-             Aurelien Poscia <aurelien.poscia@sonarsource.com> (@aurelien-poscia-sonarsource),
-             Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassallo),
+Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassallo),
              Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: ed2071a47632c34d7639b6ad1b393ab2aee1c9a8
+GitCommit: ed2071a47632c34d7639b6ad1b393ab2aee1c9a8 #TODO: update
 
-Tags: 9.9.0-community, 9.9-community, 9-community, community, lts, lts-community, latest
+Tags: 9.9.0-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8
 Directory: 9/community
 
-Tags: 9.9.0-developer, 9.9-developer, 9-developer, developer, lts-developer
+Tags: 9.9.0-developer, 9.9-developer, 9-developer, lts-developer
 Architectures: amd64, arm64v8
 Directory: 9/developer
 
-Tags: 9.9.0-enterprise, 9.9-enterprise, 9-enterprise, enterprise, lts-enterprise
+Tags: 9.9.0-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
 Architectures: amd64, arm64v8
 Directory: 9/enterprise
 
-Tags: 9.9.0-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, datacenter-app, lts-datacenter-app
+Tags: 9.9.0-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/app
 
-Tags: 9.9.0-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, datacenter-search, lts-datacenter-search
+Tags: 9.9.0-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/search
+
+Tags: 10.0.0-community, 10.0-community, 10-community, community, latest
+Architectures: amd64, arm64v8
+Directory: 10/community
+
+Tags: 10.0.0-developer, 10.0-developer, 10-developer, developer
+Architectures: amd64, arm64v8
+Directory: 10/developer
+
+Tags: 10.0.0-enterprise, 10.0-enterprise, 10-enterprise, enterprise
+Architectures: amd64, arm64v8
+Directory: 10/enterprise
+
+Tags: 10.0.0-datacenter-app, 10.0-datacenter-app, 10-datacenter-app, datacenter-app
+Architectures: amd64, arm64v8
+Directory: 10/datacenter/app
+
+Tags: 10.0.0-datacenter-search, 10.0-datacenter-search, 10-datacenter-search, datacenter-search
+Architectures: amd64, arm64v8
+Directory: 10/datacenter/search

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -2,7 +2,7 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: e88b9307725f8338e4fb8bce74c21cf9ae5c3745
+GitCommit: 711096a093a224d37da8901d5fdb350adf455daa
 
 Tags: 9.9.0-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -2,7 +2,7 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: ed2071a47632c34d7639b6ad1b393ab2aee1c9a8 #TODO: update
+GitCommit: e88b9307725f8338e4fb8bce74c21cf9ae5c3745
 
 Tags: 9.9.0-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Dear team,

we just released SonarQube 10.0. Please merge this PR to have it released as Docker image.
