### PR TITLE
arangodb 3.8.9

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,10 +2,10 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.8, 3.8.8
+Tags: 3.8, 3.8.9
 Architectures: amd64
-GitCommit: 6e5a02cd7f5106076a1faf24360218c3e2ca3003
-Directory: alpine/3.8.8
+GitCommit: da21330779b93bbdd399935479d66efa8563719c
+Directory: alpine/3.8.9
 
 Tags: 3.9, 3.9.10
 Architectures: amd64


### PR DESCRIPTION
Updated ArangoDB 3.8 to 3.8.9.