### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,112 +4,112 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.2.1-bullseye, 3.2-bullseye, 3-bullseye, bullseye, 3.2.1, 3.2, 3, latest
+Tags: 3.2.2-bullseye, 3.2-bullseye, 3-bullseye, bullseye, 3.2.2, 3.2, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/bullseye
 
-Tags: 3.2.1-slim-bullseye, 3.2-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.2.1-slim, 3.2-slim, 3-slim, slim
+Tags: 3.2.2-slim-bullseye, 3.2-slim-bullseye, 3-slim-bullseye, slim-bullseye, 3.2.2-slim, 3.2-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/slim-bullseye
 
-Tags: 3.2.1-buster, 3.2-buster, 3-buster, buster
+Tags: 3.2.2-buster, 3.2-buster, 3-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/buster
 
-Tags: 3.2.1-slim-buster, 3.2-slim-buster, 3-slim-buster, slim-buster
+Tags: 3.2.2-slim-buster, 3.2-slim-buster, 3-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/slim-buster
 
-Tags: 3.2.1-alpine3.17, 3.2-alpine3.17, 3-alpine3.17, alpine3.17, 3.2.1-alpine, 3.2-alpine, 3-alpine, alpine
+Tags: 3.2.2-alpine3.17, 3.2-alpine3.17, 3-alpine3.17, alpine3.17, 3.2.2-alpine, 3.2-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/alpine3.17
 
-Tags: 3.2.1-alpine3.16, 3.2-alpine3.16, 3-alpine3.16, alpine3.16
+Tags: 3.2.2-alpine3.16, 3.2-alpine3.16, 3-alpine3.16, alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/alpine3.16
 
-Tags: 3.1.3-bullseye, 3.1-bullseye, 3.1.3, 3.1
+Tags: 3.1.4-bullseye, 3.1-bullseye, 3.1.4, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/bullseye
 
-Tags: 3.1.3-slim-bullseye, 3.1-slim-bullseye, 3.1.3-slim, 3.1-slim
+Tags: 3.1.4-slim-bullseye, 3.1-slim-bullseye, 3.1.4-slim, 3.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/slim-bullseye
 
-Tags: 3.1.3-buster, 3.1-buster
+Tags: 3.1.4-buster, 3.1-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/buster
 
-Tags: 3.1.3-slim-buster, 3.1-slim-buster
+Tags: 3.1.4-slim-buster, 3.1-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/slim-buster
 
-Tags: 3.1.3-alpine3.17, 3.1-alpine3.17, 3.1.3-alpine, 3.1-alpine
+Tags: 3.1.4-alpine3.17, 3.1-alpine3.17, 3.1.4-alpine, 3.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/alpine3.17
 
-Tags: 3.1.3-alpine3.16, 3.1-alpine3.16
+Tags: 3.1.4-alpine3.16, 3.1-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/alpine3.16
 
-Tags: 3.0.5-bullseye, 3.0-bullseye, 3.0.5, 3.0
+Tags: 3.0.6-bullseye, 3.0-bullseye, 3.0.6, 3.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 1cd75932f3d072dbbe2a866951fc47ff5a5bb2fc
 Directory: 3.0/bullseye
 
-Tags: 3.0.5-slim-bullseye, 3.0-slim-bullseye, 3.0.5-slim, 3.0-slim
+Tags: 3.0.6-slim-bullseye, 3.0-slim-bullseye, 3.0.6-slim, 3.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 1cd75932f3d072dbbe2a866951fc47ff5a5bb2fc
 Directory: 3.0/slim-bullseye
 
-Tags: 3.0.5-buster, 3.0-buster
+Tags: 3.0.6-buster, 3.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 1cd75932f3d072dbbe2a866951fc47ff5a5bb2fc
 Directory: 3.0/buster
 
-Tags: 3.0.5-slim-buster, 3.0-slim-buster
+Tags: 3.0.6-slim-buster, 3.0-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 1cd75932f3d072dbbe2a866951fc47ff5a5bb2fc
 Directory: 3.0/slim-buster
 
-Tags: 3.0.5-alpine3.16, 3.0-alpine3.16, 3.0.5-alpine, 3.0-alpine
+Tags: 3.0.6-alpine3.16, 3.0-alpine3.16, 3.0.6-alpine, 3.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 1cd75932f3d072dbbe2a866951fc47ff5a5bb2fc
 Directory: 3.0/alpine3.16
 
-Tags: 2.7.7-bullseye, 2.7-bullseye, 2-bullseye, 2.7.7, 2.7, 2
+Tags: 2.7.8-bullseye, 2.7-bullseye, 2-bullseye, 2.7.8, 2.7, 2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
 Directory: 2.7/bullseye
 
-Tags: 2.7.7-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.7-slim, 2.7-slim, 2-slim
+Tags: 2.7.8-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.8-slim, 2.7-slim, 2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
 Directory: 2.7/slim-bullseye
 
-Tags: 2.7.7-buster, 2.7-buster, 2-buster
+Tags: 2.7.8-buster, 2.7-buster, 2-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
 Directory: 2.7/buster
 
-Tags: 2.7.7-slim-buster, 2.7-slim-buster, 2-slim-buster
+Tags: 2.7.8-slim-buster, 2.7-slim-buster, 2-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
 Directory: 2.7/slim-buster
 
-Tags: 2.7.7-alpine3.16, 2.7-alpine3.16, 2-alpine3.16, 2.7.7-alpine, 2.7-alpine, 2-alpine
+Tags: 2.7.8-alpine3.16, 2.7-alpine3.16, 2-alpine3.16, 2.7.8-alpine, 2.7-alpine, 2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e1866b57c27f0828f75eb9704f5804be47bd1c98
+GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
 Directory: 2.7/alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/4041b21: Update 3.2 to 3.2.2
- https://github.com/docker-library/ruby/commit/564fdfe: Update 3.1 to 3.1.4
- https://github.com/docker-library/ruby/commit/1cd7593: Update 3.0 to 3.0.6
- https://github.com/docker-library/ruby/commit/7117899: Update 2.7 to 2.7.8