### PR TITLE
Bump IBM Java version to 8.0.8.0,ubuntu version upgraded to 22.04 and i386 support is removed. 

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -2,7 +2,7 @@
 
 Maintainers: Jayashree Gopi <jayasg12@in.ibm.com> (@jayasg12)
 GitRepo: https://github.com/ibmruntimes/ci.docker.git
-GitFetch: ref/heads/main
+GitFetch: refs/heads/main
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, ppc64le, s390x

--- a/library/ibmjava
+++ b/library/ibmjava
@@ -2,19 +2,20 @@
 
 Maintainers: Jayashree Gopi <jayasg12@in.ibm.com> (@jayasg12)
 GitRepo: https://github.com/ibmruntimes/ci.docker.git
+GitFetch: ref/heads/main
 
 Tags: 8-jre, jre, 8, latest
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: a596914862ee05bb419b7644e57135f8674e9161
+Architectures: amd64, ppc64le, s390x
+GitCommit: 17c4cdb127eb02ebcb83a95737547cc0f86a3af7
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-sfj, sfj
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: a596914862ee05bb419b7644e57135f8674e9161
+Architectures: amd64, ppc64le, s390x
+GitCommit: 17c4cdb127eb02ebcb83a95737547cc0f86a3af7
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sdk, sdk
-Architectures: amd64, i386, ppc64le, s390x
-GitCommit: a596914862ee05bb419b7644e57135f8674e9161
+Architectures: amd64, ppc64le, s390x
+GitCommit: 17c4cdb127eb02ebcb83a95737547cc0f86a3af7
 Directory: ibmjava/8/sdk/ubuntu
 


### PR DESCRIPTION
IBM Java version is updated to 8.0.8.0 from 8.0.7.20 version.
Ubuntu version is upgraded to 22.04 from 18.04.
i386 support removed for IBM java docker image as ubuntu stopped supporting i386 architecture from 20.04 release.