### PR TITLE
Add Java-20-based clojure images & remove broken boot variants

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: arm64v8, amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: c4a11b0a9f67eed505b0203d29887e093ae691eb
+GitCommit: 7caf3d96139463c8e9cbcff711d563674c59ee88
 
 
 Tags: latest
@@ -52,10 +52,6 @@ Directory: target/eclipse-temurin-8-jdk-focal/tools-deps
 Tags: temurin-8-jammy, temurin-8-tools-deps, temurin-8-tools-deps-1.11.1.1257, temurin-8-tools-deps-1.11.1.1257-jammy, temurin-8-tools-deps-jammy
 Directory: target/eclipse-temurin-8-jdk-jammy/tools-deps
 
-Tags: temurin-11-boot-2.8.3-alpine, temurin-11-boot-alpine
-Architectures: amd64
-Directory: target/eclipse-temurin-11-jdk-alpine/boot
-
 Tags: temurin-11-boot-2.8.3-bullseye, temurin-11-boot-bullseye
 Directory: target/debian-bullseye-11/boot
 
@@ -99,10 +95,6 @@ Directory: target/eclipse-temurin-11-jdk-focal/tools-deps
 
 Tags: temurin-11-jammy, temurin-11-tools-deps, temurin-11-tools-deps-1.11.1.1257, temurin-11-tools-deps-1.11.1.1257-jammy, temurin-11-tools-deps-jammy
 Directory: target/eclipse-temurin-11-jdk-jammy/tools-deps
-
-Tags: boot-2.8.3-alpine, boot-alpine, temurin-17-boot-2.8.3-alpine, temurin-17-boot-alpine
-Architectures: amd64
-Directory: target/eclipse-temurin-17-jdk-alpine/boot
 
 Tags: temurin-17-boot-2.8.3-bullseye, temurin-17-boot-bullseye
 Directory: target/debian-bullseye-17/boot
@@ -148,10 +140,6 @@ Directory: target/eclipse-temurin-17-jdk-focal/tools-deps
 Tags: temurin-17-jammy, temurin-17-tools-deps, temurin-17-tools-deps-1.11.1.1257, temurin-17-tools-deps-1.11.1.1257-jammy, temurin-17-tools-deps-jammy, tools-deps, tools-deps-1.11.1.1257, tools-deps-1.11.1.1257-jammy, tools-deps-jammy
 Directory: target/eclipse-temurin-17-jdk-jammy/tools-deps
 
-Tags: temurin-19-boot-2.8.3-alpine, temurin-19-boot-alpine
-Architectures: amd64
-Directory: target/eclipse-temurin-19-jdk-alpine/boot
-
 Tags: temurin-19-boot-2.8.3-bullseye, temurin-19-boot-bullseye
 Directory: target/debian-bullseye-19/boot
 
@@ -195,3 +183,29 @@ Directory: target/eclipse-temurin-19-jdk-focal/tools-deps
 
 Tags: temurin-19-jammy, temurin-19-tools-deps, temurin-19-tools-deps-1.11.1.1257, temurin-19-tools-deps-1.11.1.1257-jammy, temurin-19-tools-deps-jammy
 Directory: target/eclipse-temurin-19-jdk-jammy/tools-deps
+
+Tags: temurin-20-lein-2.10.0-alpine, temurin-20-lein-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-20-jdk-alpine/lein
+
+Tags: temurin-20-lein-2.10.0-bullseye, temurin-20-lein-bullseye
+Directory: target/debian-bullseye-20/lein
+
+Tags: temurin-20-lein-2.10.0-bullseye-slim, temurin-20-lein-bullseye-slim
+Directory: target/debian-bullseye-slim-20/lein
+
+Tags: temurin-20-lein, temurin-20-lein-2.10.0, temurin-20-lein-2.10.0-jammy, temurin-20-lein-jammy
+Directory: target/eclipse-temurin-20-jdk-jammy/lein
+
+Tags: temurin-20-alpine, temurin-20-tools-deps-1.11.1.1257-alpine, temurin-20-tools-deps-alpine
+Architectures: amd64
+Directory: target/eclipse-temurin-20-jdk-alpine/tools-deps
+
+Tags: temurin-20-bullseye, temurin-20-tools-deps-1.11.1.1257-bullseye, temurin-20-tools-deps-bullseye
+Directory: target/debian-bullseye-20/tools-deps
+
+Tags: temurin-20-bullseye-slim, temurin-20-tools-deps-1.11.1.1257-bullseye-slim, temurin-20-tools-deps-bullseye-slim
+Directory: target/debian-bullseye-slim-20/tools-deps
+
+Tags: temurin-20-jammy, temurin-20-tools-deps, temurin-20-tools-deps-1.11.1.1257, temurin-20-tools-deps-1.11.1.1257-jammy, temurin-20-tools-deps-jammy
+Directory: target/eclipse-temurin-20-jdk-jammy/tools-deps

--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: arm64v8, amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 7caf3d96139463c8e9cbcff711d563674c59ee88
+GitCommit: a265c5972b18bde93301ce5775fcdc563e2d2d39
 
 
 Tags: latest
@@ -36,20 +36,20 @@ Directory: target/eclipse-temurin-8-jdk-focal/lein
 Tags: temurin-8-lein, temurin-8-lein-2.10.0, temurin-8-lein-2.10.0-jammy, temurin-8-lein-jammy
 Directory: target/eclipse-temurin-8-jdk-jammy/lein
 
-Tags: temurin-8-alpine, temurin-8-tools-deps-1.11.1.1257-alpine, temurin-8-tools-deps-alpine
+Tags: temurin-8-alpine, temurin-8-tools-deps-1.11.1.1267-alpine, temurin-8-tools-deps-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-8-jdk-alpine/tools-deps
 
-Tags: temurin-8-bullseye, temurin-8-tools-deps-1.11.1.1257-bullseye, temurin-8-tools-deps-bullseye
+Tags: temurin-8-bullseye, temurin-8-tools-deps-1.11.1.1267-bullseye, temurin-8-tools-deps-bullseye
 Directory: target/debian-bullseye-8/tools-deps
 
-Tags: temurin-8-bullseye-slim, temurin-8-tools-deps-1.11.1.1257-bullseye-slim, temurin-8-tools-deps-bullseye-slim
+Tags: temurin-8-bullseye-slim, temurin-8-tools-deps-1.11.1.1267-bullseye-slim, temurin-8-tools-deps-bullseye-slim
 Directory: target/debian-bullseye-slim-8/tools-deps
 
-Tags: temurin-8-focal, temurin-8-tools-deps-1.11.1.1257-focal, temurin-8-tools-deps-focal
+Tags: temurin-8-focal, temurin-8-tools-deps-1.11.1.1267-focal, temurin-8-tools-deps-focal
 Directory: target/eclipse-temurin-8-jdk-focal/tools-deps
 
-Tags: temurin-8-jammy, temurin-8-tools-deps, temurin-8-tools-deps-1.11.1.1257, temurin-8-tools-deps-1.11.1.1257-jammy, temurin-8-tools-deps-jammy
+Tags: temurin-8-jammy, temurin-8-tools-deps, temurin-8-tools-deps-1.11.1.1267, temurin-8-tools-deps-1.11.1.1267-jammy, temurin-8-tools-deps-jammy
 Directory: target/eclipse-temurin-8-jdk-jammy/tools-deps
 
 Tags: temurin-11-boot-2.8.3-bullseye, temurin-11-boot-bullseye
@@ -80,20 +80,20 @@ Directory: target/eclipse-temurin-11-jdk-focal/lein
 Tags: temurin-11-lein, temurin-11-lein-2.10.0, temurin-11-lein-2.10.0-jammy, temurin-11-lein-jammy
 Directory: target/eclipse-temurin-11-jdk-jammy/lein
 
-Tags: temurin-11-alpine, temurin-11-tools-deps-1.11.1.1257-alpine, temurin-11-tools-deps-alpine
+Tags: temurin-11-alpine, temurin-11-tools-deps-1.11.1.1267-alpine, temurin-11-tools-deps-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-11-jdk-alpine/tools-deps
 
-Tags: temurin-11-bullseye, temurin-11-tools-deps-1.11.1.1257-bullseye, temurin-11-tools-deps-bullseye
+Tags: temurin-11-bullseye, temurin-11-tools-deps-1.11.1.1267-bullseye, temurin-11-tools-deps-bullseye
 Directory: target/debian-bullseye-11/tools-deps
 
-Tags: temurin-11-bullseye-slim, temurin-11-tools-deps-1.11.1.1257-bullseye-slim, temurin-11-tools-deps-bullseye-slim
+Tags: temurin-11-bullseye-slim, temurin-11-tools-deps-1.11.1.1267-bullseye-slim, temurin-11-tools-deps-bullseye-slim
 Directory: target/debian-bullseye-slim-11/tools-deps
 
-Tags: temurin-11-focal, temurin-11-tools-deps-1.11.1.1257-focal, temurin-11-tools-deps-focal
+Tags: temurin-11-focal, temurin-11-tools-deps-1.11.1.1267-focal, temurin-11-tools-deps-focal
 Directory: target/eclipse-temurin-11-jdk-focal/tools-deps
 
-Tags: temurin-11-jammy, temurin-11-tools-deps, temurin-11-tools-deps-1.11.1.1257, temurin-11-tools-deps-1.11.1.1257-jammy, temurin-11-tools-deps-jammy
+Tags: temurin-11-jammy, temurin-11-tools-deps, temurin-11-tools-deps-1.11.1.1267, temurin-11-tools-deps-1.11.1.1267-jammy, temurin-11-tools-deps-jammy
 Directory: target/eclipse-temurin-11-jdk-jammy/tools-deps
 
 Tags: temurin-17-boot-2.8.3-bullseye, temurin-17-boot-bullseye
@@ -124,65 +124,21 @@ Directory: target/eclipse-temurin-17-jdk-focal/lein
 Tags: lein, lein-2.10.0, lein-2.10.0-jammy, lein-jammy, temurin-17-lein, temurin-17-lein-2.10.0, temurin-17-lein-2.10.0-jammy, temurin-17-lein-jammy
 Directory: target/eclipse-temurin-17-jdk-jammy/lein
 
-Tags: temurin-17-alpine, temurin-17-tools-deps-1.11.1.1257-alpine, temurin-17-tools-deps-alpine, tools-deps-1.11.1.1257-alpine, tools-deps-alpine
+Tags: temurin-17-alpine, temurin-17-tools-deps-1.11.1.1267-alpine, temurin-17-tools-deps-alpine, tools-deps-1.11.1.1267-alpine, tools-deps-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-17-jdk-alpine/tools-deps
 
-Tags: temurin-17-bullseye, temurin-17-tools-deps-1.11.1.1257-bullseye, temurin-17-tools-deps-bullseye
+Tags: temurin-17-bullseye, temurin-17-tools-deps-1.11.1.1267-bullseye, temurin-17-tools-deps-bullseye
 Directory: target/debian-bullseye-17/tools-deps
 
-Tags: temurin-17-bullseye-slim, temurin-17-tools-deps-1.11.1.1257-bullseye-slim, temurin-17-tools-deps-bullseye-slim
+Tags: temurin-17-bullseye-slim, temurin-17-tools-deps-1.11.1.1267-bullseye-slim, temurin-17-tools-deps-bullseye-slim
 Directory: target/debian-bullseye-slim-17/tools-deps
 
-Tags: temurin-17-focal, temurin-17-tools-deps-1.11.1.1257-focal, temurin-17-tools-deps-focal, tools-deps-1.11.1.1257-focal, tools-deps-focal
+Tags: temurin-17-focal, temurin-17-tools-deps-1.11.1.1267-focal, temurin-17-tools-deps-focal, tools-deps-1.11.1.1267-focal, tools-deps-focal
 Directory: target/eclipse-temurin-17-jdk-focal/tools-deps
 
-Tags: temurin-17-jammy, temurin-17-tools-deps, temurin-17-tools-deps-1.11.1.1257, temurin-17-tools-deps-1.11.1.1257-jammy, temurin-17-tools-deps-jammy, tools-deps, tools-deps-1.11.1.1257, tools-deps-1.11.1.1257-jammy, tools-deps-jammy
+Tags: temurin-17-jammy, temurin-17-tools-deps, temurin-17-tools-deps-1.11.1.1267, temurin-17-tools-deps-1.11.1.1267-jammy, temurin-17-tools-deps-jammy, tools-deps, tools-deps-1.11.1.1267, tools-deps-1.11.1.1267-jammy, tools-deps-jammy
 Directory: target/eclipse-temurin-17-jdk-jammy/tools-deps
-
-Tags: temurin-19-boot-2.8.3-bullseye, temurin-19-boot-bullseye
-Directory: target/debian-bullseye-19/boot
-
-Tags: temurin-19-boot-2.8.3-bullseye-slim, temurin-19-boot-bullseye-slim
-Directory: target/debian-bullseye-slim-19/boot
-
-Tags: temurin-19-boot-2.8.3-focal, temurin-19-boot-focal
-Directory: target/eclipse-temurin-19-jdk-focal/boot
-
-Tags: temurin-19-boot, temurin-19-boot-2.8.3, temurin-19-boot-2.8.3-jammy, temurin-19-boot-jammy
-Directory: target/eclipse-temurin-19-jdk-jammy/boot
-
-Tags: temurin-19-lein-2.10.0-alpine, temurin-19-lein-alpine
-Architectures: amd64
-Directory: target/eclipse-temurin-19-jdk-alpine/lein
-
-Tags: temurin-19-lein-2.10.0-bullseye, temurin-19-lein-bullseye
-Directory: target/debian-bullseye-19/lein
-
-Tags: temurin-19-lein-2.10.0-bullseye-slim, temurin-19-lein-bullseye-slim
-Directory: target/debian-bullseye-slim-19/lein
-
-Tags: temurin-19-lein-2.10.0-focal, temurin-19-lein-focal
-Directory: target/eclipse-temurin-19-jdk-focal/lein
-
-Tags: temurin-19-lein, temurin-19-lein-2.10.0, temurin-19-lein-2.10.0-jammy, temurin-19-lein-jammy
-Directory: target/eclipse-temurin-19-jdk-jammy/lein
-
-Tags: temurin-19-alpine, temurin-19-tools-deps-1.11.1.1257-alpine, temurin-19-tools-deps-alpine
-Architectures: amd64
-Directory: target/eclipse-temurin-19-jdk-alpine/tools-deps
-
-Tags: temurin-19-bullseye, temurin-19-tools-deps-1.11.1.1257-bullseye, temurin-19-tools-deps-bullseye
-Directory: target/debian-bullseye-19/tools-deps
-
-Tags: temurin-19-bullseye-slim, temurin-19-tools-deps-1.11.1.1257-bullseye-slim, temurin-19-tools-deps-bullseye-slim
-Directory: target/debian-bullseye-slim-19/tools-deps
-
-Tags: temurin-19-focal, temurin-19-tools-deps-1.11.1.1257-focal, temurin-19-tools-deps-focal
-Directory: target/eclipse-temurin-19-jdk-focal/tools-deps
-
-Tags: temurin-19-jammy, temurin-19-tools-deps, temurin-19-tools-deps-1.11.1.1257, temurin-19-tools-deps-1.11.1.1257-jammy, temurin-19-tools-deps-jammy
-Directory: target/eclipse-temurin-19-jdk-jammy/tools-deps
 
 Tags: temurin-20-lein-2.10.0-alpine, temurin-20-lein-alpine
 Architectures: amd64
@@ -197,15 +153,15 @@ Directory: target/debian-bullseye-slim-20/lein
 Tags: temurin-20-lein, temurin-20-lein-2.10.0, temurin-20-lein-2.10.0-jammy, temurin-20-lein-jammy
 Directory: target/eclipse-temurin-20-jdk-jammy/lein
 
-Tags: temurin-20-alpine, temurin-20-tools-deps-1.11.1.1257-alpine, temurin-20-tools-deps-alpine
+Tags: temurin-20-alpine, temurin-20-tools-deps-1.11.1.1267-alpine, temurin-20-tools-deps-alpine
 Architectures: amd64
 Directory: target/eclipse-temurin-20-jdk-alpine/tools-deps
 
-Tags: temurin-20-bullseye, temurin-20-tools-deps-1.11.1.1257-bullseye, temurin-20-tools-deps-bullseye
+Tags: temurin-20-bullseye, temurin-20-tools-deps-1.11.1.1267-bullseye, temurin-20-tools-deps-bullseye
 Directory: target/debian-bullseye-20/tools-deps
 
-Tags: temurin-20-bullseye-slim, temurin-20-tools-deps-1.11.1.1257-bullseye-slim, temurin-20-tools-deps-bullseye-slim
+Tags: temurin-20-bullseye-slim, temurin-20-tools-deps-1.11.1.1267-bullseye-slim, temurin-20-tools-deps-bullseye-slim
 Directory: target/debian-bullseye-slim-20/tools-deps
 
-Tags: temurin-20-jammy, temurin-20-tools-deps, temurin-20-tools-deps-1.11.1.1257, temurin-20-tools-deps-1.11.1.1257-jammy, temurin-20-tools-deps-jammy
+Tags: temurin-20-jammy, temurin-20-tools-deps, temurin-20-tools-deps-1.11.1.1267, temurin-20-tools-deps-1.11.1.1267-jammy, temurin-20-tools-deps-jammy
 Directory: target/eclipse-temurin-20-jdk-jammy/tools-deps


### PR DESCRIPTION
New upstream Java release. We're deprecating the boot variants in alpine variants and in all images from Java 20 forward. It hasn't had a release since 2019 and is breaking in more and more builds.