### PR TITLE
Update Clear Linux OS to 38680

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ded2505524da863aa66c7b314acceb7c2f6b6f3c
-GitFetch: refs/heads/base-38640
+GitCommit: 31405aa6183f586d6d268e217c088cc8a21191ee
+GitFetch: refs/heads/base-38680


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 38680

@bryteise @djklimes @bryteise