### PR TITLE
[security] Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 24.0.0-beta.1-cli, 24-rc-cli, rc-cli, 24.0.0-beta.1-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 43c75565e6fa4dcf3abadc51cb1c7c044aae1ef2
+GitCommit: 0e00a29925ead3f1ba1ccb77895db4963d10ad47
 Directory: 24-rc/cli
 
 Tags: 24.0.0-beta.1-dind, 24-rc-dind, rc-dind, 24.0.0-beta.1-dind-alpine3.17, 24.0.0-beta.1, 24-rc, rc, 24.0.0-beta.1-alpine3.17
@@ -41,74 +41,74 @@ Directory: 24-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
 
-Tags: 23.0.2-cli, 23.0-cli, 23-cli, cli, 23.0.2-cli-alpine3.17
+Tags: 23.0.3-cli, 23.0-cli, 23-cli, cli, 23.0.3-cli-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 47f0e5da49022e03f76c1bcaf911f640996d8288
+GitCommit: 3f5aa9dfb44948d1493342e168a1d5d650b45bd7
 Directory: 23.0/cli
 
-Tags: 23.0.2-dind, 23.0-dind, 23-dind, dind, 23.0.2-dind-alpine3.17, 23.0.2, 23.0, 23, latest, 23.0.2-alpine3.17
+Tags: 23.0.3-dind, 23.0-dind, 23-dind, dind, 23.0.3-dind-alpine3.17, 23.0.3, 23.0, 23, latest, 23.0.3-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 47f0e5da49022e03f76c1bcaf911f640996d8288
+GitCommit: 3f5aa9dfb44948d1493342e168a1d5d650b45bd7
 Directory: 23.0/dind
 
-Tags: 23.0.2-dind-rootless, 23.0-dind-rootless, 23-dind-rootless, dind-rootless
+Tags: 23.0.3-dind-rootless, 23.0-dind-rootless, 23-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 47f0e5da49022e03f76c1bcaf911f640996d8288
+GitCommit: 3f5aa9dfb44948d1493342e168a1d5d650b45bd7
 Directory: 23.0/dind-rootless
 
-Tags: 23.0.2-git, 23.0-git, 23-git, git
+Tags: 23.0.3-git, 23.0-git, 23-git, git
 Architectures: amd64, arm64v8
 GitCommit: 849b56e6c81dc509da780121352f844e8f26bb7a
 Directory: 23.0/git
 
-Tags: 23.0.2-windowsservercore-ltsc2022, 23.0-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 23.0.2-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
+Tags: 23.0.3-windowsservercore-ltsc2022, 23.0-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 23.0.3-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 47f0e5da49022e03f76c1bcaf911f640996d8288
+GitCommit: 3f5aa9dfb44948d1493342e168a1d5d650b45bd7
 Directory: 23.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 23.0.2-windowsservercore-1809, 23.0-windowsservercore-1809, 23-windowsservercore-1809, windowsservercore-1809
-SharedTags: 23.0.2-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
+Tags: 23.0.3-windowsservercore-1809, 23.0-windowsservercore-1809, 23-windowsservercore-1809, windowsservercore-1809
+SharedTags: 23.0.3-windowsservercore, 23.0-windowsservercore, 23-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 47f0e5da49022e03f76c1bcaf911f640996d8288
+GitCommit: 3f5aa9dfb44948d1493342e168a1d5d650b45bd7
 Directory: 23.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
 
-Tags: 20.10.23-cli, 20.10-cli, 20-cli, 20.10.23-cli-alpine3.17, 20.10.23, 20.10, 20, 20.10.23-alpine3.17
+Tags: 20.10.24-cli, 20.10-cli, 20-cli, 20.10.24-cli-alpine3.17, 20.10.24, 20.10, 20, 20.10.24-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 124e0288010e8b2774e56e58202a3941ac0234ff
+GitCommit: d71ed6659319c2608be2290c581787d2d4779ef2
 Directory: 20.10/cli
 
-Tags: 20.10.23-dind, 20.10-dind, 20-dind, 20.10.23-dind-alpine3.17
+Tags: 20.10.24-dind, 20.10-dind, 20-dind, 20.10.24-dind-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 289f581eae49901789a416fee2ede9a6950e7629
+GitCommit: d71ed6659319c2608be2290c581787d2d4779ef2
 Directory: 20.10/dind
 
-Tags: 20.10.23-dind-rootless, 20.10-dind-rootless, 20-dind-rootless
+Tags: 20.10.24-dind-rootless, 20.10-dind-rootless, 20-dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 289f581eae49901789a416fee2ede9a6950e7629
+GitCommit: d71ed6659319c2608be2290c581787d2d4779ef2
 Directory: 20.10/dind-rootless
 
-Tags: 20.10.23-git, 20.10-git, 20-git
+Tags: 20.10.24-git, 20.10-git, 20-git
 Architectures: amd64, arm64v8
 GitCommit: f23a2bea97f6d7ec563bc316302fb8edf620ec5b
 Directory: 20.10/git
 
-Tags: 20.10.23-windowsservercore-ltsc2022, 20.10-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20.10.23-windowsservercore, 20.10-windowsservercore, 20-windowsservercore
+Tags: 20.10.24-windowsservercore-ltsc2022, 20.10-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20.10.24-windowsservercore, 20.10-windowsservercore, 20-windowsservercore
 Architectures: windows-amd64
-GitCommit: 124e0288010e8b2774e56e58202a3941ac0234ff
+GitCommit: d71ed6659319c2608be2290c581787d2d4779ef2
 Directory: 20.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 20.10.23-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20.10.23-windowsservercore, 20.10-windowsservercore, 20-windowsservercore
+Tags: 20.10.24-windowsservercore-1809, 20.10-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20.10.24-windowsservercore, 20.10-windowsservercore, 20-windowsservercore
 Architectures: windows-amd64
-GitCommit: 124e0288010e8b2774e56e58202a3941ac0234ff
+GitCommit: d71ed6659319c2608be2290c581787d2d4779ef2
 Directory: 20.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/3f5aa9d: Update 23.0 to 23.0.3
- https://github.com/docker-library/docker/commit/d71ed66: Update 20.10 to 20.10.24
- https://github.com/docker-library/docker/commit/f9b4213: Merge pull request https://github.com/docker-library/docker/pull/419 from infosiftr/usr-local-libexec
- https://github.com/docker-library/docker/commit/0e00a29: Move CLI plugins to "/usr/local/libexec" (as they're not packaging-managed)