### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.6.2
+Tags: 8.7.0
 Architectures: amd64, arm64v8
-GitCommit: 90e34ca306d9800d3c0ab1c59387b93e89c69796
+GitCommit: ffa0104f45677975eb6fcb0a52829618143bdad7
 Directory: 8
 
 Tags: 7.17.9

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.6.2
+Tags: 8.7.0
 Architectures: amd64, arm64v8
-GitCommit: da3edfaa4c3735e2fa17d70f0f26c64488fcb06c
+GitCommit: 1ac2c313dc7c1636b6c14bfd0d6e929357a0b43a
 Directory: 8
 
 Tags: 7.17.9

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.6.2
+Tags: 8.7.0
 Architectures: amd64, arm64v8
-GitCommit: 8ecac06ee232b47787ae8f1673fa0aa539b482fa
+GitCommit: 5d9c639d3f66808b1fe45bd714c8ff14c8b22f8e
 Directory: 8
 
 Tags: 7.17.9


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/ffa0104: Update to 8.7.0
- https://github.com/docker-library/elasticsearch/commit/7ea88de: Update actions/checkout to v3
- https://github.com/docker-library/elasticsearch/commit/f04f67e: Ignore buildkit-isms during build/history check

logstash:
- https://github.com/docker-library/logstash/commit/5d9c639: Update to 8.7.0
- https://github.com/docker-library/logstash/commit/0d38870: Update actions/checkout to v3
- https://github.com/docker-library/logstash/commit/f858371: Ignore buildkit-isms during build/history check

kibana:
- https://github.com/docker-library/kibana/commit/1ac2c31: Update to 8.7.0
- https://github.com/docker-library/kibana/commit/60b6d71: Update actions/checkout to v3
- https://github.com/docker-library/kibana/commit/4b8ed1e: Improve buildkit-isms ignoring during build/history check