### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.12.0-beta.5, 3.12-rc
+Tags: 3.12.0-beta.6, 3.12-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 954b05e8e8a352116a25085c06fb1d8a9b49302a
+GitCommit: 6bce1f24efb19c3a8b4120759cac58f34e8203e3
 Directory: 3.12-rc/ubuntu
 
-Tags: 3.12.0-beta.5-management, 3.12-rc-management
+Tags: 3.12.0-beta.6-management, 3.12-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.12-rc/ubuntu/management
 
-Tags: 3.12.0-beta.5-alpine, 3.12-rc-alpine
+Tags: 3.12.0-beta.6-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 954b05e8e8a352116a25085c06fb1d8a9b49302a
+GitCommit: 6bce1f24efb19c3a8b4120759cac58f34e8203e3
 Directory: 3.12-rc/alpine
 
-Tags: 3.12.0-beta.5-management-alpine, 3.12-rc-management-alpine
+Tags: 3.12.0-beta.6-management-alpine, 3.12-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.12-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/6bce1f2: Update 3.12-rc to 3.12.0-beta.6