### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2023-1569

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 50dea704d5881997acaf7fe35c6d6a85e67a7d3b
+amd64-GitCommit: f4e1fd9ae9c126ccb821e30e0e7a43933ea07716
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0dbb31b1fe4477a5086fcd073a283290f99453aa
+arm64v8-GitCommit: 60f47f9aac17197762cba0eaf2dbe70133c81e9f
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-0361.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-1569.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>