### PR TITLE
Bump Traefik to v2.9.10

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
-Tags: v2.9.9-windowsservercore-1809, 2.9.9-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.9.10-windowsservercore-1809, 2.9.10-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 3397f06715d1f6684444c135a1b86b4f8c44d599
+GitCommit: a74a21441e1185fc0ff9e4139524544e54db1226
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.9.9, 2.9.9, v2.9, 2.9, banon, latest
+Tags: v2.9.10, 2.9.10, v2.9, 2.9, banon, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 3397f06715d1f6684444c135a1b86b4f8c44d599
+GitCommit: a74a21441e1185fc0ff9e4139524544e54db1226
 Directory: alpine
 
 Tags: v2.10.0-rc1-windowsservercore-1809, 2.10.0-rc1-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.9.10](https://github.com/traefik/traefik/releases/tag/v2.9.10).

/cc @mpl @rtribotte

Cheers
