### PR TITLE
archlinux: Release 20230409.0.141585

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230319.0.135218
-GitCommit: 71a836dea46c446f5e0fd3ffdcf954d2280cc01b
-GitFetch: refs/tags/v20230319.0.135218
+Tags: latest, base, base-20230409.0.141585
+GitCommit: da508aac1923a2416f68edd1be16df3aeefc92ee
+GitFetch: refs/tags/v20230409.0.141585
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230319.0.135218
-GitCommit: 71a836dea46c446f5e0fd3ffdcf954d2280cc01b
-GitFetch: refs/tags/v20230319.0.135218
+Tags: base-devel, base-devel-20230409.0.141585
+GitCommit: da508aac1923a2416f68edd1be16df3aeefc92ee
+GitFetch: refs/tags/v20230409.0.141585
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks