### PR TITLE
Update Clear Linux OS to 38740

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 31405aa6183f586d6d268e217c088cc8a21191ee
-GitFetch: refs/heads/base-38680
+GitCommit: 19f37b86de0d05ba16333af3804baf6b54b4c782
+GitFetch: refs/heads/base-38740


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 38740

@bryteise @djklimes @bryteise