### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev6, 2.8-dev, 2.8-dev6-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev7, 2.8-dev, 2.8-dev7-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8c3d54e118f694d0a06ce94d8f83a0a2cad5c56
+GitCommit: cc787a7b72dcba589f35e0ec89daa7a36a38f608
 Directory: 2.8
 
-Tags: 2.8-dev6-alpine, 2.8-dev-alpine, 2.8-dev6-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev7-alpine, 2.8-dev-alpine, 2.8-dev7-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8c3d54e118f694d0a06ce94d8f83a0a2cad5c56
+GitCommit: cc787a7b72dcba589f35e0ec89daa7a36a38f608
 Directory: 2.8/alpine
 
 Tags: 2.7.6, 2.7, latest, 2.7.6-bullseye, 2.7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/cc787a7: Update 2.8 to 2.8-dev7