### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-16-jdk-oraclelinux8, 21-ea-16-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-16-jdk-oracle, 21-ea-16-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-16-jdk, 21-ea-16, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-17-jdk-oraclelinux8, 21-ea-17-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-17-jdk-oracle, 21-ea-17-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-17-jdk, 21-ea-17, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-16-jdk-oraclelinux7, 21-ea-16-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-17-jdk-oraclelinux7, 21-ea-17-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-16-jdk-bullseye, 21-ea-16-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-17-jdk-bullseye, 21-ea-17-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-16-jdk-slim-bullseye, 21-ea-16-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-16-jdk-slim, 21-ea-16-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-17-jdk-slim-bullseye, 21-ea-17-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-17-jdk-slim, 21-ea-17-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-16-jdk-buster, 21-ea-16-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-17-jdk-buster, 21-ea-17-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/buster
 
-Tags: 21-ea-16-jdk-slim-buster, 21-ea-16-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-17-jdk-slim-buster, 21-ea-17-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-16-jdk-windowsservercore-ltsc2022, 21-ea-16-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-16-jdk-windowsservercore, 21-ea-16-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-16-jdk, 21-ea-16, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-17-jdk-windowsservercore-ltsc2022, 21-ea-17-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-17-jdk-windowsservercore, 21-ea-17-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-17-jdk, 21-ea-17, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-16-jdk-windowsservercore-1809, 21-ea-16-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-16-jdk-windowsservercore, 21-ea-16-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-16-jdk, 21-ea-16, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-17-jdk-windowsservercore-1809, 21-ea-17-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-17-jdk-windowsservercore, 21-ea-17-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-17-jdk, 21-ea-17, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-16-jdk-nanoserver-1809, 21-ea-16-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-16-jdk-nanoserver, 21-ea-16-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-17-jdk-nanoserver-1809, 21-ea-17-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-17-jdk-nanoserver, 21-ea-17-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: bec3544e0bfe83e3abf893c33c1b5eb446576bde
+GitCommit: 71f03cacacddcd740c5b9102f34ec973b9081767
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/71f03ca: Update 21 to 21-ea+17