### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2023-1701

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f4e1fd9ae9c126ccb821e30e0e7a43933ea07716
+amd64-GitCommit: f62c9d80cf69f0ab09ace5f1ba3b6fb5575c814e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 60f47f9aac17197762cba0eaf2dbe70133c81e9f
+arm64v8-GitCommit: 7939dce10af0b15e9b83bd6da5756e752a77eece
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-23916.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-1701.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>