### PR TITLE
[nats] Release v2.9.16

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -5,25 +5,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 70a8e44e947f7d1f58b940838804b13ec4abb785
+GitCommit: 60c28617a9e994d560b6de582570a7ac17623d35
 
-Tags: 2.9.15-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.15-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.16-alpine3.17, 2.9-alpine3.17, 2-alpine3.17, alpine3.17, 2.9.16-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.15/alpine3.17
+Directory: 2.9.16/alpine3.17
 
-Tags: 2.9.15-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.15-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.15, 2.9, 2, latest
+Tags: 2.9.16-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.16-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.16, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.15/scratch
+Directory: 2.9.16/scratch
 
-Tags: 2.9.15-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.15-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.16-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.16-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.15/windowsservercore-1809
+Directory: 2.9.16/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.15-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.15-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.15, 2.9, 2, latest
+Tags: 2.9.16-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.16-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.16, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.15/nanoserver-1809
+Directory: 2.9.16/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.16)