### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.32, 8.0, 8, latest, 8.0.32-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.0.33, 8.0, 8, latest, 8.0.33-oracle, 8.0-oracle, 8-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 358c2e5ab6cd24b86a20a871820ecbc67a244368
+GitCommit: 1bfa4724fe112b4246672ed2b3c42142f17d5636
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.32-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.33-debian, 8.0-debian, 8-debian, debian
 Architectures: amd64
-GitCommit: 358c2e5ab6cd24b86a20a871820ecbc67a244368
+GitCommit: 1bfa4724fe112b4246672ed2b3c42142f17d5636
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.41, 5.7, 5, 5.7.41-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.42, 5.7, 5, 5.7.42-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: 358c2e5ab6cd24b86a20a871820ecbc67a244368
+GitCommit: e4bdff20153e6a05364a8fe80356dcfd502445bd
 Directory: 5.7
 File: Dockerfile.oracle
 
-Tags: 5.7.41-debian, 5.7-debian, 5-debian
+Tags: 5.7.42-debian, 5.7-debian, 5-debian
 Architectures: amd64
-GitCommit: 358c2e5ab6cd24b86a20a871820ecbc67a244368
+GitCommit: e4bdff20153e6a05364a8fe80356dcfd502445bd
 Directory: 5.7
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/1bfa472: Update 8.0 to 8.0.33, debian 8.0.33-1debian11, mysql-shell 8.0.33-1.el8, oracle 8.0.33-1.el8
- https://github.com/docker-library/mysql/commit/e4bdff2: Update 5.7 to 5.7.42, debian 5.7.42-1debian10, mysql-shell 8.0.33-1.el7, oracle 5.7.42-1.el7