### PR TITLE
Odoo: update 14.0-16.0 to release 20230418

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 8be11ad8773c735755378d7ac6399a7bdacd2479
+GitCommit: df8788b1e0cc6e7570869a20a17f482c71bcf6c7
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

Here are the latest updates for Odoo supported versions.

Thank you.