### PR TITLE
GHC 9.4.4 -> 9.4.5

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,14 +2,14 @@ Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB),
              Albert Krewinkel <albert+docker@tarleb.com> (@tarleb)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.4.4-buster, 9.4-buster, 9-buster, buster, 9.4.4, 9.4, 9, latest
+Tags: 9.4.5-buster, 9.4-buster, 9-buster, buster, 9.4.5, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
+GitCommit: 6a4bd2d6ac51a08af489476145b1f83c8d20e575
 Directory: 9.4/buster
 
-Tags: 9.4.4-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.4-slim, 9.4-slim, 9-slim, slim
+Tags: 9.4.5-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.5-slim, 9.4-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
+GitCommit: 6a4bd2d6ac51a08af489476145b1f83c8d20e575
 Directory: 9.4/slim-buster
 
 Tags: 9.2.7-buster, 9.2-buster, 9.2.7, 9.2


### PR DESCRIPTION
Bumping GHC 9.4.4 to 9.4.5.

Relevant PR: https://github.com/haskell/docker-haskell/pull/104
Merge commit with complete changeset: https://github.com/haskell/docker-haskell/commit/6a4bd2d6ac51a08af489476145b1f83c8d20e575