### PR TITLE
archlinux: Release 20230423.0.144989

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230416.0.143366
-GitCommit: 5da14a3c436b54e1f49f676330a0a2a79a6e98c7
-GitFetch: refs/tags/v20230416.0.143366
+Tags: latest, base, base-20230423.0.144989
+GitCommit: 0f35dc08d406688bc127e4f906e79549f1e6cf5f
+GitFetch: refs/tags/v20230423.0.144989
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230416.0.143366
-GitCommit: 5da14a3c436b54e1f49f676330a0a2a79a6e98c7
-GitFetch: refs/tags/v20230416.0.143366
+Tags: base-devel, base-devel-20230423.0.144989
+GitCommit: 0f35dc08d406688bc127e4f906e79549f1e6cf5f
+GitFetch: refs/tags/v20230423.0.144989
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks