### PR TITLE
Update Clear Linux OS to 38860

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: b3276e05f6a6f3b37679aaa78463910f8c23b16a
-GitFetch: refs/heads/base-38800
+GitCommit: cc882385cb5d21370876c0c67234efe985d17673
+GitFetch: refs/heads/base-38860


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 38860

@bryteise @djklimes @bryteise