### PR TITLE
Bump Traefik to v2.10.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,30 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
-Tags: v2.9.10-windowsservercore-1809, 2.9.10-windowsservercore-1809, v2.9-windowsservercore-1809, 2.9-windowsservercore-1809, banon-windowsservercore-1809, windowsservercore-1809
+Tags: v2.10.0-windowsservercore-1809, 2.10.0-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a74a21441e1185fc0ff9e4139524544e54db1226
+GitCommit: 47540fe012da03dbdce91617a7a2bc32ae112a16
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.9.10, 2.9.10, v2.9, 2.9, banon, latest
+Tags: v2.10.0, 2.10.0, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a74a21441e1185fc0ff9e4139524544e54db1226
-Directory: alpine
-
-Tags: v2.10.0-rc2-windowsservercore-1809, 2.10.0-rc2-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2e2af4d37b83c23a252154454fb25a8c9e48b801
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v2.10.0-rc2, 2.10.0-rc2, v2.10, 2.10, saintmarcelin
-Architectures: amd64, arm32v6, arm64v8, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2e2af4d37b83c23a252154454fb25a8c9e48b801
+GitCommit: 47540fe012da03dbdce91617a7a2bc32ae112a16
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.10.0](https://github.com/traefik/traefik/releases/tag/v2.10.0).

/cc @ldez

Cheers
