### PR TITLE
eclipse-temurin: april PSU updates

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -6,488 +6,488 @@ GitRepo: https://github.com/adoptium/containers.git
 GitFetch: refs/heads/main
 
 #------------------------------v8 images---------------------------------
-Tags: 8u362-b09-jdk-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u372-b07-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jdk-focal, 8-jdk-focal, 8-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+Tags: 8u372-b07-jdk-focal, 8-jdk-focal, 8-focal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jdk-jammy, 8-jdk-jammy, 8-jammy
-SharedTags: 8u362-b09-jdk, 8-jdk, 8
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+Tags: 8u372-b07-jdk-jammy, 8-jdk-jammy, 8-jammy
+SharedTags: 8u372-b07-jdk, 8-jdk, 8
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jdk-centos7, 8-jdk-centos7, 8-centos7
+Tags: 8u372-b07-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Tags: 8u372-b07-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u362-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u362-b09-jdk, 8-jdk, 8
+Tags: 8u372-b07-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u372-b07-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u372-b07-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u362-b09-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
-SharedTags: 8u362-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u372-b07-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
+SharedTags: 8u372-b07-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u362-b09-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u362-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u362-b09-jdk, 8-jdk, 8
+Tags: 8u372-b07-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u372-b07-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u372-b07-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u362-b09-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u362-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u372-b07-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u372-b07-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u362-b09-jre-alpine, 8-jre-alpine
+Tags: 8u372-b07-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jre-focal, 8-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+Tags: 8u372-b07-jre-focal, 8-jre-focal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jre-jammy, 8-jre-jammy
-SharedTags: 8u362-b09-jre, 8-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+Tags: 8u372-b07-jre-jammy, 8-jre-jammy
+SharedTags: 8u372-b07-jre, 8-jre
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jre-centos7, 8-jre-centos7
+Tags: 8u372-b07-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Tags: 8u372-b07-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 8u362-b09-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u362-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u362-b09-jre, 8-jre
+Tags: 8u372-b07-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u372-b07-jre-windowsservercore, 8-jre-windowsservercore, 8u372-b07-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u362-b09-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
-SharedTags: 8u362-b09-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u372-b07-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
+SharedTags: 8u372-b07-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u362-b09-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u362-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u362-b09-jre, 8-jre
+Tags: 8u372-b07-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u372-b07-jre-windowsservercore, 8-jre-windowsservercore, 8u372-b07-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 8u362-b09-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u362-b09-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u372-b07-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u372-b07-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: faa5fb7621fd9b0672b83f398d3c6ee579534015
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 8/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.18_10-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.19_7-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jdk-focal, 11-jdk-focal, 11-focal
+Tags: 11.0.19_7-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jdk-jammy, 11-jdk-jammy, 11-jammy
-SharedTags: 11.0.18_10-jdk, 11-jdk, 11
+Tags: 11.0.19_7-jdk-jammy, 11-jdk-jammy, 11-jammy
+SharedTags: 11.0.19_7-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jdk-centos7, 11-jdk-centos7, 11-centos7
+Tags: 11.0.19_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Tags: 11.0.19_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.18_10-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.18_10-jdk, 11-jdk, 11
+Tags: 11.0.19_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.19_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.19_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.18_10-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.18_10-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.19_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.19_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.18_10-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.18_10-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.18_10-jdk, 11-jdk, 11
+Tags: 11.0.19_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.19_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.19_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.18_10-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.18_10-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.19_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.19_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.18_10-jre-alpine, 11-jre-alpine
+Tags: 11.0.19_7-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jre-focal, 11-jre-focal
+Tags: 11.0.19_7-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jre-jammy, 11-jre-jammy
-SharedTags: 11.0.18_10-jre, 11-jre
+Tags: 11.0.19_7-jre-jammy, 11-jre-jammy
+SharedTags: 11.0.19_7-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jre-centos7, 11-jre-centos7
+Tags: 11.0.19_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Tags: 11.0.19_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 11.0.18_10-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.18_10-jre-windowsservercore, 11-jre-windowsservercore, 11.0.18_10-jre, 11-jre
+Tags: 11.0.19_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.19_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.19_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.18_10-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.18_10-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.19_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.19_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.18_10-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.18_10-jre-windowsservercore, 11-jre-windowsservercore, 11.0.18_10-jre, 11-jre
+Tags: 11.0.19_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.19_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.19_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.18_10-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.18_10-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.19_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.19_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 02264a4d3e57b92e02dc415fa4fc8aec7a4e3d62
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 11/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.6_10-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.7_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jdk-focal, 17-jdk-focal, 17-focal
+Tags: 17.0.7_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.6_10-jdk, 17-jdk, 17
+Tags: 17.0.7_7-jdk-jammy, 17-jdk-jammy, 17-jammy
+SharedTags: 17.0.7_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jdk-centos7, 17-jdk-centos7, 17-centos7
+Tags: 17.0.7_7-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.7_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.6_10-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.6_10-jdk, 17-jdk, 17
+Tags: 17.0.7_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.7_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.7_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.6_10-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.6_10-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.7_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.7_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.6_10-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.6_10-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.6_10-jdk, 17-jdk, 17
+Tags: 17.0.7_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.7_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.7_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.6_10-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.6_10-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.7_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.7_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17.0.6_10-jre-alpine, 17-jre-alpine
+Tags: 17.0.7_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jre-focal, 17-jre-focal
+Tags: 17.0.7_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.6_10-jre, 17-jre
+Tags: 17.0.7_7-jre-jammy, 17-jre-jammy
+SharedTags: 17.0.7_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jre-centos7, 17-jre-centos7
+Tags: 17.0.7_7-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.7_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 17.0.6_10-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.6_10-jre-windowsservercore, 17-jre-windowsservercore, 17.0.6_10-jre, 17-jre
+Tags: 17.0.7_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.7_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.7_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.6_10-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.6_10-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.7_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.7_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.6_10-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.6_10-jre-windowsservercore, 17-jre-windowsservercore, 17.0.6_10-jre, 17-jre
+Tags: 17.0.7_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.7_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.7_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.6_10-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.6_10-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.7_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.7_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 0a0eef5b0673a25403d4b0fe87e4f4e07a4297ab
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 17/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v20 images---------------------------------
-Tags: 20_36-jdk-alpine, 20-jdk-alpine, 20-alpine
+Tags: 20.0.1_9-jdk-alpine, 20-jdk-alpine, 20-alpine
 Architectures: amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 20_36-jdk-jammy, 20-jdk-jammy, 20-jammy
-SharedTags: 20_36-jdk, 20-jdk, 20, latest
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Tags: 20.0.1_9-jdk-jammy, 20-jdk-jammy, 20-jammy
+SharedTags: 20.0.1_9-jdk, 20-jdk, 20, latest
+Architectures: amd64, arm64v8
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 20_36-jdk-ubi9-minimal, 20-jdk-ubi9-minimal, 20-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Tags: 20.0.1_9-jdk-ubi9-minimal, 20-jdk-ubi9-minimal, 20-ubi9-minimal
+Architectures: amd64, arm64v8
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 20_36-jdk-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
-SharedTags: 20_36-jdk-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20_36-jdk, 20-jdk, 20, latest
+Tags: 20.0.1_9-jdk-windowsservercore-ltsc2022, 20-jdk-windowsservercore-ltsc2022, 20-windowsservercore-ltsc2022
+SharedTags: 20.0.1_9-jdk-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20.0.1_9-jdk, 20-jdk, 20, latest
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20_36-jdk-nanoserver-ltsc2022, 20-jdk-nanoserver-ltsc2022, 20-nanoserver-ltsc2022
-SharedTags: 20_36-jdk-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20.0.1_9-jdk-nanoserver-ltsc2022, 20-jdk-nanoserver-ltsc2022, 20-nanoserver-ltsc2022
+SharedTags: 20.0.1_9-jdk-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 20_36-jdk-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
-SharedTags: 20_36-jdk-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20_36-jdk, 20-jdk, 20, latest
+Tags: 20.0.1_9-jdk-windowsservercore-1809, 20-jdk-windowsservercore-1809, 20-windowsservercore-1809
+SharedTags: 20.0.1_9-jdk-windowsservercore, 20-jdk-windowsservercore, 20-windowsservercore, 20.0.1_9-jdk, 20-jdk, 20, latest
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 20_36-jdk-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
-SharedTags: 20_36-jdk-nanoserver, 20-jdk-nanoserver, 20-nanoserver
+Tags: 20.0.1_9-jdk-nanoserver-1809, 20-jdk-nanoserver-1809, 20-nanoserver-1809
+SharedTags: 20.0.1_9-jdk-nanoserver, 20-jdk-nanoserver, 20-nanoserver
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 20_36-jre-alpine, 20-jre-alpine
+Tags: 20.0.1_9-jre-alpine, 20-jre-alpine
 Architectures: amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 20_36-jre-jammy, 20-jre-jammy
-SharedTags: 20_36-jre, 20-jre
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Tags: 20.0.1_9-jre-jammy, 20-jre-jammy
+SharedTags: 20.0.1_9-jre, 20-jre
+Architectures: amd64, arm64v8
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 20_36-jre-ubi9-minimal, 20-jre-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+Tags: 20.0.1_9-jre-ubi9-minimal, 20-jre-ubi9-minimal
+Architectures: amd64, arm64v8
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 20_36-jre-windowsservercore-ltsc2022, 20-jre-windowsservercore-ltsc2022
-SharedTags: 20_36-jre-windowsservercore, 20-jre-windowsservercore, 20_36-jre, 20-jre
+Tags: 20.0.1_9-jre-windowsservercore-ltsc2022, 20-jre-windowsservercore-ltsc2022
+SharedTags: 20.0.1_9-jre-windowsservercore, 20-jre-windowsservercore, 20.0.1_9-jre, 20-jre
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 20_36-jre-nanoserver-ltsc2022, 20-jre-nanoserver-ltsc2022
-SharedTags: 20_36-jre-nanoserver, 20-jre-nanoserver
+Tags: 20.0.1_9-jre-nanoserver-ltsc2022, 20-jre-nanoserver-ltsc2022
+SharedTags: 20.0.1_9-jre-nanoserver, 20-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 20_36-jre-windowsservercore-1809, 20-jre-windowsservercore-1809
-SharedTags: 20_36-jre-windowsservercore, 20-jre-windowsservercore, 20_36-jre, 20-jre
+Tags: 20.0.1_9-jre-windowsservercore-1809, 20-jre-windowsservercore-1809
+SharedTags: 20.0.1_9-jre-windowsservercore, 20-jre-windowsservercore, 20.0.1_9-jre, 20-jre
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 20_36-jre-nanoserver-1809, 20-jre-nanoserver-1809
-SharedTags: 20_36-jre-nanoserver, 20-jre-nanoserver
+Tags: 20.0.1_9-jre-nanoserver-1809, 20-jre-nanoserver-1809
+SharedTags: 20.0.1_9-jre-nanoserver, 20-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 8ea9a9bfe1c1cf1ddd791f5af9ceb123118bd5bc
+GitCommit: 99918327b8e861a673f9d5edd58078eb54b50a1a
 Directory: 20/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Two things to note:

1. JDK8 arm32v7 has been delayed and we can't wait any longer so we'll have to break users here
2. JDK20 we've made the decision to hold off publishing ppc64le until we've found a fix for a test case. This means breaking a small subset of users relying on the latest tag