### PR TITLE
Update XWiki LTS version to 14.10.9

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -14,20 +14,20 @@ GitCommit: 435c3ef09c3f34fab61a8d5804a6170d0dc21f44
 Tags: 15-mariadb-tomcat, 15.3-mariadb-tomcat, 15.3.0-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb
 Architectures: amd64, arm64v8
 Directory: 15/mariadb-tomcat
-GitCommit: 739ce67261391a70b55cf2164bce8cd4d3ccfbc6
+GitCommit: 435c3ef09c3f34fab61a8d5804a6170d0dc21f44
 
 # LTS
-Tags: 14, 14.10, 14.10.8, 14-mysql-tomcat, 14.10-mysql-tomcat, 14.10.8-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+Tags: 14, 14.10, 14.10.9, 14-mysql-tomcat, 14.10-mysql-tomcat, 14.10.9-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64, arm64v8
 Directory: 14/mysql-tomcat
-GitCommit: 8e78e120e1f3513322a34d0f8d25962fa23081f9
+GitCommit: 3bc0c850d5d1f0f66e6f6bbe07561fe0a2c1132c
 
-Tags: 14-postgres-tomcat, 14.10-postgres-tomcat, 14.10.8-postgres-tomcat, lts-postgres-tomcat, lts-postgres
+Tags: 14-postgres-tomcat, 14.10-postgres-tomcat, 14.10.9-postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 14/postgres-tomcat
-GitCommit: 8e78e120e1f3513322a34d0f8d25962fa23081f9
+GitCommit: 3bc0c850d5d1f0f66e6f6bbe07561fe0a2c1132c
 
-Tags: 14-mariadb-tomcat, 14.10-mariadb-tomcat, 14.10.8-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
+Tags: 14-mariadb-tomcat, 14.10-mariadb-tomcat, 14.10.9-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
 Architectures: amd64, arm64v8
 Directory: 14/mariadb-tomcat
-GitCommit: 8e78e120e1f3513322a34d0f8d25962fa23081f9
+GitCommit: 3bc0c850d5d1f0f66e6f6bbe07561fe0a2c1132c


### PR DESCRIPTION
* Update the LTS version to 14.10.9
* Fix the commit hash for 15-mariadb-tomcat (and related tags)