### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.12.0-beta.8, 3.12-rc
+Tags: 3.12.0-rc.1, 3.12-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fb2d010b5ba1205250722d5e1febc62ee7a98d76
+GitCommit: 33dceee162bbbfc0d145694c5d8d4f40c192be0d
 Directory: 3.12-rc/ubuntu
 
-Tags: 3.12.0-beta.8-management, 3.12-rc-management
+Tags: 3.12.0-rc.1-management, 3.12-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.12-rc/ubuntu/management
 
-Tags: 3.12.0-beta.8-alpine, 3.12-rc-alpine
+Tags: 3.12.0-rc.1-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fb2d010b5ba1205250722d5e1febc62ee7a98d76
+GitCommit: 33dceee162bbbfc0d145694c5d8d4f40c192be0d
 Directory: 3.12-rc/alpine
 
-Tags: 3.12.0-beta.8-management-alpine, 3.12-rc-management-alpine
+Tags: 3.12.0-rc.1-management-alpine, 3.12-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.12-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/33dceee: Update 3.12-rc to 3.12.0-rc.1