### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,11 +1,18 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/c3775be3e5c9e2098cd3e9b68487ae73e4bcf1cd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/00b26e718cb2a42fca77676383917c1e5c15b6ca/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
+# Last Modified: 2023-04-26
+Tags: 13.1.0, 13.1, 13, latest, 13.1.0-bookworm, 13.1-bookworm, 13-bookworm, bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 00b26e718cb2a42fca77676383917c1e5c15b6ca
+Directory: 13
+# Docker EOL: 2024-10-26
+
 # Last Modified: 2022-08-19
-Tags: 12.2.0, 12.2, 12, latest, 12.2.0-bullseye, 12.2-bullseye, 12-bullseye, bullseye
+Tags: 12.2.0, 12.2, 12, 12.2.0-bullseye, 12.2-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 523e01b2ccf43f1fd702aa9fdc2f71c827b76525
 Directory: 12
@@ -19,15 +26,15 @@ Directory: 11
 # Docker EOL: 2023-10-21
 
 # Last Modified: 2022-06-28
-Tags: 10.4.0, 10.4, 10, 10.4.0-buster, 10.4-buster, 10-buster
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1e3174f36d64a3ce1373a7004a7f0d4f98de307b
+Tags: 10.4.0, 10.4, 10, 10.4.0-bullseye, 10.4-bullseye, 10-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 00b26e718cb2a42fca77676383917c1e5c15b6ca
 Directory: 10
 # Docker EOL: 2023-12-28
 
 # Last Modified: 2022-05-27
-Tags: 9.5.0, 9.5, 9, 9.5.0-buster, 9.5-buster, 9-buster
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 6c40a41a202b2996b26b52e94762fe9aa8830766
+Tags: 9.5.0, 9.5, 9, 9.5.0-bullseye, 9.5-bullseye, 9-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 00b26e718cb2a42fca77676383917c1e5c15b6ca
 Directory: 9
 # Docker EOL: 2023-11-27


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/fa720a9: Merge pull request https://github.com/docker-library/gcc/pull/89 from infosiftr/gcc-13-bullseye
- https://github.com/docker-library/gcc/commit/00b26e7: Add 13.1 (based on bookworm, soon to be stable) and update other versions to bullseye
- https://github.com/docker-library/gcc/commit/5c8dd1f: Update generated README
- https://github.com/docker-library/gcc/commit/282a381: Use new "bashbrew" composite action
- https://github.com/docker-library/gcc/commit/851c36f: Merge pull request https://github.com/docker-library/gcc/pull/87 from infosiftr/ci-updates
- https://github.com/docker-library/gcc/commit/98ac85e: Switch to "$GITHUB_OUTPUT"; update actions/checkout to v3