### PR TITLE
Bump Traefik to v2.10.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,17 +13,17 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
-Tags: v2.10.0-windowsservercore-1809, 2.10.0-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.10.1-windowsservercore-1809, 2.10.1-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 47540fe012da03dbdce91617a7a2bc32ae112a16
+GitCommit: 0f5f057e1310e073297e1ed93ba6db65e0abcfef
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.10.0, 2.10.0, v2.10, 2.10, saintmarcelin, latest
+Tags: v2.10.1, 2.10.1, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 47540fe012da03dbdce91617a7a2bc32ae112a16
+GitCommit: 0f5f057e1310e073297e1ed93ba6db65e0abcfef
 Directory: alpine
 
 Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.10.1](https://github.com/traefik/traefik/releases/tag/v2.10.1).

/cc @ldez

Cheers
