### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.12.0-rc.1, 3.12-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 33dceee162bbbfc0d145694c5d8d4f40c192be0d
+GitCommit: 3ba713dad126e9b30f4fb4cf5e2da3419233d890
 Directory: 3.12-rc/ubuntu
 
 Tags: 3.12.0-rc.1-management, 3.12-rc-management
@@ -17,7 +17,7 @@ Directory: 3.12-rc/ubuntu/management
 
 Tags: 3.12.0-rc.1-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 33dceee162bbbfc0d145694c5d8d4f40c192be0d
+GitCommit: 3ba713dad126e9b30f4fb4cf5e2da3419233d890
 Directory: 3.12-rc/alpine
 
 Tags: 3.12.0-rc.1-management-alpine, 3.12-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 3.12-rc/alpine/management
 
 Tags: 3.11.13, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 95fd3ddf1cb478304d6147e4fe30d56a9b0b3726
+GitCommit: acf81d56afb65945351ada4056a7a6cc6b7afcdc
 Directory: 3.11/ubuntu
 
 Tags: 3.11.13-management, 3.11-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.13-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 95fd3ddf1cb478304d6147e4fe30d56a9b0b3726
+GitCommit: acf81d56afb65945351ada4056a7a6cc6b7afcdc
 Directory: 3.11/alpine
 
 Tags: 3.11.13-management-alpine, 3.11-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.20, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
+GitCommit: e83ba26490c576005582578379678ecbbe6913fb
 Directory: 3.10/ubuntu
 
 Tags: 3.10.20-management, 3.10-management
@@ -57,7 +57,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.20-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
+GitCommit: e83ba26490c576005582578379678ecbbe6913fb
 Directory: 3.10/alpine
 
 Tags: 3.10.20-management-alpine, 3.10-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
+GitCommit: c5154e95d30f1d5ef9b99062769995f1e8578329
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -77,7 +77,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
+GitCommit: c5154e95d30f1d5ef9b99062769995f1e8578329
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/c5154e9: Update 3.9 to otp 25.3.1
- https://github.com/docker-library/rabbitmq/commit/3ba713d: Update 3.12-rc to otp 25.3.1
- https://github.com/docker-library/rabbitmq/commit/acf81d5: Update 3.11 to otp 25.3.1
- https://github.com/docker-library/rabbitmq/commit/e83ba26: Update 3.10 to otp 25.3.1