### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 65d44dfa2cbf47591cebd41db32d377280d91392
 Directory: 2.8/alpine
 
-Tags: 2.7.6, 2.7, latest, 2.7.6-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.7, 2.7, latest, 2.7.7-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3e8ddb695fb46f902afea21ce0de1d481c1c71ab
+GitCommit: 5eb1e943ec682afdd6591e474bba6045c246bba5
 Directory: 2.7
 
-Tags: 2.7.6-alpine, 2.7-alpine, alpine, 2.7.6-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.7-alpine, 2.7-alpine, alpine, 2.7.7-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e8ddb695fb46f902afea21ce0de1d481c1c71ab
+GitCommit: 5eb1e943ec682afdd6591e474bba6045c246bba5
 Directory: 2.7/alpine
 
 Tags: 2.6.12, 2.6, lts, 2.6.12-bullseye, 2.6-bullseye, lts-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5eb1e94: Update 2.7 to 2.7.7