### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -15,11 +15,11 @@ GitCommit: b5915c67f0cd255700a71a24f3b314a0280f81c6
 Directory: 4.0
 
 Tags: 3.11.14, 3.11, 3
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le
 GitCommit: 1737da9eb0a7ba2e691778355730816f9fa7bad9
 Directory: 3.11
 
 Tags: 3.0.28, 3.0
-Architectures: amd64, arm32v7, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le
 GitCommit: 1737da9eb0a7ba2e691778355730816f9fa7bad9
 Directory: 3.0


### PR DESCRIPTION
> JDK8 arm32v7 has been delayed and we can't wait any longer so we'll have to break users here

https://github.com/docker-library/official-images/pull/14507#issue-1684771285