### PR TITLE
chore: release Kapacitor 1.6.6

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -1,8 +1,6 @@
-Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
-             j. Emrys Landivar <landivar@gmail.com> (@docmerlin),
-             Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife)
+Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 410d53519af0edd30a985eacc3bb060258a2705d
+GitCommit: 409aa55a78db9cbe9e4e0c94b1e67785d63ffd32
 
 Tags: 1.5, 1.5.9
 Architectures: amd64, arm32v7, arm64v8
@@ -11,9 +9,9 @@ Directory: kapacitor/1.5
 Tags: 1.5-alpine, 1.5.9-alpine
 Directory: kapacitor/1.5/alpine
 
-Tags: 1.6, 1.6.5, latest
+Tags: 1.6, 1.6.6, latest
 Architectures: amd64, arm64v8
 Directory: kapacitor/1.6
 
-Tags: 1.6-alpine, 1.6.5-alpine, alpine
+Tags: 1.6-alpine, 1.6.6-alpine, alpine
 Directory: kapacitor/1.6/alpine


### PR DESCRIPTION
This removes maintainers who are no longer with InfluxData.