### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,44 +4,44 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev8, 2.8-dev, 2.8-dev8-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev9, 2.8-dev, 2.8-dev9-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 65d44dfa2cbf47591cebd41db32d377280d91392
+GitCommit: 21adfa0af8cd7da14cd85ce0e03aa75b3912dfbf
 Directory: 2.8
 
-Tags: 2.8-dev8-alpine, 2.8-dev-alpine, 2.8-dev8-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev9-alpine, 2.8-dev-alpine, 2.8-dev9-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 65d44dfa2cbf47591cebd41db32d377280d91392
+GitCommit: 21adfa0af8cd7da14cd85ce0e03aa75b3912dfbf
 Directory: 2.8/alpine
 
-Tags: 2.7.7, 2.7, latest, 2.7.7-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.8, 2.7, latest, 2.7.8-bullseye, 2.7-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5eb1e943ec682afdd6591e474bba6045c246bba5
+GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
 Directory: 2.7
 
-Tags: 2.7.7-alpine, 2.7-alpine, alpine, 2.7.7-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.8-alpine, 2.7-alpine, alpine, 2.7.8-alpine3.17, 2.7-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5eb1e943ec682afdd6591e474bba6045c246bba5
+GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
 Directory: 2.7/alpine
 
-Tags: 2.6.12, 2.6, lts, 2.6.12-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.13, 2.6, lts, 2.6.13-bullseye, 2.6-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 791843a38289bd3b5238715cbe6ed993214b2d73
+GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
 Directory: 2.6
 
-Tags: 2.6.12-alpine, 2.6-alpine, lts-alpine, 2.6.12-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.13-alpine, 2.6-alpine, lts-alpine, 2.6.13-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 791843a38289bd3b5238715cbe6ed993214b2d73
+GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
 Directory: 2.6/alpine
 
-Tags: 2.5.13, 2.5, 2.5.13-bullseye, 2.5-bullseye
+Tags: 2.5.14, 2.5, 2.5.14-bullseye, 2.5-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8bb4f9f4a41b5c3531a6cb4a070c25be7a254ccd
+GitCommit: a90674f66bb5f9a61a42abfb38d3bebfa879af3f
 Directory: 2.5
 
-Tags: 2.5.13-alpine, 2.5-alpine, 2.5.13-alpine3.17, 2.5-alpine3.17
+Tags: 2.5.14-alpine, 2.5-alpine, 2.5.14-alpine3.17, 2.5-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bb4f9f4a41b5c3531a6cb4a070c25be7a254ccd
+GitCommit: a90674f66bb5f9a61a42abfb38d3bebfa879af3f
 Directory: 2.5/alpine
 
 Tags: 2.4.22, 2.4, 2.4.22-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b5e4baa: Update 2.7 to 2.7.8
- https://github.com/docker-library/haproxy/commit/aad0f7b: Update 2.6 to 2.6.13
- https://github.com/docker-library/haproxy/commit/a90674f: Update 2.5 to 2.5.14
- https://github.com/docker-library/haproxy/commit/21adfa0: Update 2.8 to 2.8-dev9