### PR TITLE
Update Backdrop CMS to Latest Release 1.24.2

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.23.1, 1.23, 1, 1.23.1-apache, 1.23-apache, 1-apache, apache, latest
+Tags: 1.24.2, 1.24, 1, 1.24.2-apache, 1.24-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 8012e0b47794605356eddc14dc56b1eda4b36f0c
+GitCommit: c6dc310e67b2b9d8778c8ed36aa38adfb90ebd9a
 Directory: 1/apache
 
-Tags: 1.23.1-fpm, 1.23-fpm, 1-fpm, fpm
+Tags: 1.24.2-fpm, 1.24-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 8012e0b47794605356eddc14dc56b1eda4b36f0c
+GitCommit: c6dc310e67b2b9d8778c8ed36aa38adfb90ebd9a
 Directory: 1/fpm


### PR DESCRIPTION
Here's a pull request to update the Backdrop CMS project to the latest security release 1.24.2

Link to Latest Release
https://github.com/backdrop/backdrop/releases/tag/1.24.2

Last commit to the updated 1.24.2 Repo
https://github.com/backdrop-ops/backdrop-docker/commit/73134b2dad1045d0783e4833c22c61edbbde7c11

Reach out if you have any questions!