### PR TITLE
Odoo: update 14.0-16.0 to release 20230430

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: df8788b1e0cc6e7570869a20a17f482c71bcf6c7
+GitCommit: f7b3182bdccd5e182ecabcb7243696961194f601
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks