### PR TITLE
Update CrateDB to 5.3.1 (latest)

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -4,9 +4,9 @@ Maintainers: Mathias Fußenegger <mathias@crate.io> (@mfussenegger),
              Andreas Motl <andreas.motl@crate.io> (@amotl)
 GitRepo: https://github.com/crate/docker-crate.git
 
-Tags: 5.3.0, 5.3, latest
+Tags: 5.3.1, 5.3, latest
 Architectures: amd64, arm64v8
-GitCommit: 2a7bfa53ecd5fdd4c0c4aa9c9bb3c9fd97e1df20
+GitCommit: 7b386ec1fc97ff17205fe10e145604de5fb758ed
 
 Tags: 5.2.6, 5.2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Keep in mind that although for `5.3.0` we used almalinux minimal, we had to switch back to the normal images because of some issues we've experienced, see: https://github.com/crate/docker-crate/pull/222