### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,47 +4,47 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.2.9, 4.2, 4, latest, 4.2.9-apache, 4.2-apache, 4-apache, apache, 4.2.9-php8.0, 4.2-php8.0, 4-php8.0, php8.0, 4.2.9-php8.0-apache, 4.2-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.3.1, 4.3, 4, latest, 4.3.1-apache, 4.3-apache, 4-apache, apache, 4.3.1-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.1-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f03a7cf52841e92c26990e4884ba7f389b935735
-Directory: 4.2/php8.0/apache
+GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+Directory: 4.3/php8.0/apache
 
-Tags: 4.2.9-php8.0-fpm-alpine, 4.2-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.3.1-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f03a7cf52841e92c26990e4884ba7f389b935735
-Directory: 4.2/php8.0/fpm-alpine
+GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+Directory: 4.3/php8.0/fpm-alpine
 
-Tags: 4.2.9-php8.0-fpm, 4.2-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.3.1-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f03a7cf52841e92c26990e4884ba7f389b935735
-Directory: 4.2/php8.0/fpm
+GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+Directory: 4.3/php8.0/fpm
 
-Tags: 4.2.9-php8.1-apache, 4.2-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.3.1-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f03a7cf52841e92c26990e4884ba7f389b935735
-Directory: 4.2/php8.1/apache
+GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+Directory: 4.3/php8.1/apache
 
-Tags: 4.2.9-php8.1-fpm-alpine, 4.2-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.3.1-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f03a7cf52841e92c26990e4884ba7f389b935735
-Directory: 4.2/php8.1/fpm-alpine
+GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+Directory: 4.3/php8.1/fpm-alpine
 
-Tags: 4.2.9-php8.1-fpm, 4.2-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.3.1-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f03a7cf52841e92c26990e4884ba7f389b935735
-Directory: 4.2/php8.1/fpm
+GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+Directory: 4.3/php8.1/fpm
 
 Tags: 3.10.11, 3.10, 3, 3.10.11-apache, 3.10-apache, 3-apache, 3.10.11-php8.0, 3.10-php8.0, 3-php8.0, 3.10.11-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 17df17a732daa119f17bbcc6fb7759d7bf175d0a
+GitCommit: cf7f1e8d3306c30c1ea909794ce30f353376d8d3
 Directory: 3.10/php8.0/apache
 
 Tags: 3.10.11-php8.0-fpm-alpine, 3.10-php8.0-fpm-alpine, 3-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 17df17a732daa119f17bbcc6fb7759d7bf175d0a
+GitCommit: cf7f1e8d3306c30c1ea909794ce30f353376d8d3
 Directory: 3.10/php8.0/fpm-alpine
 
 Tags: 3.10.11-php8.0-fpm, 3.10-php8.0-fpm, 3-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 17df17a732daa119f17bbcc6fb7759d7bf175d0a
+GitCommit: cf7f1e8d3306c30c1ea909794ce30f353376d8d3
 Directory: 3.10/php8.0/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@efba6bb: Remove the 4.2 build. Update version of Joomla! 4.2.9 to 4.3.1
- joomla-docker/docker-joomla@cf7f1e8: Updated all images with pgsql compatibility joomla-docker/docker-joomla#42 
- joomla-docker/docker-joomla@8487653: Adds pgsql compatibility joomla-docker/docker-joomla#42