### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.7.0
+Tags: 8.7.1
 Architectures: amd64, arm64v8
-GitCommit: ffa0104f45677975eb6fcb0a52829618143bdad7
+GitCommit: 229361a202bcd5b7c1ddfd7b52ebc4c79e884958
 Directory: 8
 
-Tags: 7.17.9
+Tags: 7.17.10
 Architectures: amd64, arm64v8
-GitCommit: 584687331345cc631249925517b78b2f1058914c
+GitCommit: e95712a301d6adacde7ef3d31d54dd9bca752426
 Directory: 7

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.7.0
+Tags: 8.7.1
 Architectures: amd64, arm64v8
-GitCommit: 1ac2c313dc7c1636b6c14bfd0d6e929357a0b43a
+GitCommit: e577f15420a471649acd96a337cf5f575924a18f
 Directory: 8
 
-Tags: 7.17.9
+Tags: 7.17.10
 Architectures: amd64, arm64v8
-GitCommit: fd40461903be40051a19f81fc7a1630e8049343f
+GitCommit: 6dc8cf4590a7259135398fe84648b76fdb79ac2e
 Directory: 7

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.7.0
+Tags: 8.7.1
 Architectures: amd64, arm64v8
-GitCommit: 5d9c639d3f66808b1fe45bd714c8ff14c8b22f8e
+GitCommit: da79914ffa9715c6db2f084ff5aec2700fefbab4
 Directory: 8
 
-Tags: 7.17.9
+Tags: 7.17.10
 Architectures: amd64, arm64v8
-GitCommit: 19eccdc220a6c1d80ddb3a0e48e2bf5d2414682e
+GitCommit: 963070bbacb3ca9dd3aea80abf24da2113254f81
 Directory: 7


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/229361a: Update to 8.7.1
- https://github.com/docker-library/elasticsearch/commit/e95712a: Update to 7.17.10

logstash:
- https://github.com/docker-library/logstash/commit/da79914: Update to 8.7.1
- https://github.com/docker-library/logstash/commit/963070b: Update to 7.17.10

kibana:
- https://github.com/docker-library/kibana/commit/e577f15: Update to 8.7.1
- https://github.com/docker-library/kibana/commit/6dc8cf4: Update to 7.17.10