### PR TITLE
arangodb 3.10.6

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,17 +2,12 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.8, 3.8.9
-Architectures: amd64
-GitCommit: da21330779b93bbdd399935479d66efa8563719c
-Directory: alpine/3.8.9
-
 Tags: 3.9, 3.9.10
 Architectures: amd64
 GitCommit: 04479ca0b7f52b6f23f3739eae6994f4875990f2
 Directory: alpine/3.9.10
 
-Tags: 3.10, 3.10.5, 3.10.5.2, latest
+Tags: 3.10, 3.10.6, latest
 Architectures: amd64, arm64v8
-GitCommit: b224376c65b4c5f4e24ad8c5c6b43d1862bbbf51
-Directory: alpine/3.10.5.2
+GitCommit: a33b50b8a5c9a60f8c812016899485cc9cd78de3
+Directory: alpine/3.10.6


### PR DESCRIPTION
Updated ArangoDB 3.10 to 3.10.6 and removed 3.8 (EoL).