### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,21 +12,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.0.20230322.0
+Tags: 2023, latest, 2023.0.20230419.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 292aeb369bf259202dae0fefee00210edb3dcd54
+amd64-GitCommit: 0944d157d07e5e5f0cae60956d76a0f1a180a565
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 7865f83b98d21f5a8713160cd5653f38b89a629e
+arm64v8-GitCommit: cbbfe96fe1450226ecc9e2e48959124d56b1096b
 
-Tags: 2, 2.0.20230320.0
+Tags: 2, 2.0.20230418.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 8bd6e8ab85a58c9bc06cc0b6a8bd94ed47d5b89d
+amd64-GitCommit: 8bd72a51cb5cdb1ccee4b9c6ed0120794cc63388
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: bf61b77a2d69e2a1e3f939ce167798563410b2f3
+arm64v8-GitCommit: faeb719c935672aa8c7988a733fd220436d99d27
 
-Tags: 1, 2018.03, 2018.03.0.20230322.0
+Tags: 1, 2018.03, 2018.03.0.20230419.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: a01e35072fd6710b02953f2f6e84c4a501cdd381
+amd64-GitCommit: 9a31073361b306f3cf92e9dfe8cd76192e04d2f7


### PR DESCRIPTION
### AL2023 Package Change List:
- tzdata-2023c-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.0.20230419-0.amzn2023
- system-release-2023.0.20230419-0.amzn2023

### AL2 Package Change List:
- glibc-2.26-63.amzn2
- libcrypt-2.26-63.amzn2
- tzdata-2023c-1.amzn2.0.1
- glibc-common-2.26-63.amzn2
- glibc-minimal-langpack-2.26-63.amzn2
- glibc-langpack-en-2.26-63.amzn2

### AL1 Package Change List:
- libcurl-7.61.1-12.105.amzn1
- curl-7.61.1-12.105.amzn1
- tzdata-2023c-1.85.amzn1

Packages addressing CVES:
- libcurl-7.61.1-12.105.amzn1, curl-7.61.1-12.105.amzn1
  - [CVE-2023-27533](https://alas.aws.amazon.com/cve/html/CVE-2023-27533.html)
  - [CVE-2023-27535](https://alas.aws.amazon.com/cve/html/CVE-2023-27535.html)
  - [CVE-2023-27536](https://alas.aws.amazon.com/cve/html/CVE-2023-27536.html)