### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,16 +34,6 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
 Directory: 2.6/alpine
 
-Tags: 2.5.14, 2.5, 2.5.14-bullseye, 2.5-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a90674f66bb5f9a61a42abfb38d3bebfa879af3f
-Directory: 2.5
-
-Tags: 2.5.14-alpine, 2.5-alpine, 2.5.14-alpine3.17, 2.5-alpine3.17
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a90674f66bb5f9a61a42abfb38d3bebfa879af3f
-Directory: 2.5/alpine
-
 Tags: 2.4.22, 2.4, 2.4.22-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 010b099f11c898314bf1e3c90c19ed3bf6cc89e2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/672045d: Merge pull request https://github.com/docker-library/haproxy/pull/208 from TimWolla/2.5-eol
- https://github.com/docker-library/haproxy/commit/da2d46e: Remove EOL 2.5