### PR TITLE
Update tomcat

### DIFF
--- a/library/tomcat
+++ b/library/tomcat
@@ -85,22 +85,22 @@ GitCommit: fb328ed4e0c36ca21299a8dad9b8dbce20dee236
 Directory: 9.0/jdk11/corretto-al2
 
 Tags: 9.0.74-jdk8-temurin-jammy, 9.0-jdk8-temurin-jammy, 9-jdk8-temurin-jammy, 9.0.74-jdk8-temurin, 9.0-jdk8-temurin, 9-jdk8-temurin, 9.0.74-jdk8, 9.0-jdk8, 9-jdk8
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: fb328ed4e0c36ca21299a8dad9b8dbce20dee236
 Directory: 9.0/jdk8/temurin-jammy
 
 Tags: 9.0.74-jre8-temurin-jammy, 9.0-jre8-temurin-jammy, 9-jre8-temurin-jammy, 9.0.74-jre8-temurin, 9.0-jre8-temurin, 9-jre8-temurin, 9.0.74-jre8, 9.0-jre8, 9-jre8
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 680850057e040405b12b2d841969a38e9c039740
 Directory: 9.0/jre8/temurin-jammy
 
 Tags: 9.0.74-jdk8-temurin-focal, 9.0-jdk8-temurin-focal, 9-jdk8-temurin-focal
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: fb328ed4e0c36ca21299a8dad9b8dbce20dee236
 Directory: 9.0/jdk8/temurin-focal
 
 Tags: 9.0.74-jre8-temurin-focal, 9.0-jre8-temurin-focal, 9-jre8-temurin-focal
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 680850057e040405b12b2d841969a38e9c039740
 Directory: 9.0/jre8/temurin-focal
 
@@ -160,22 +160,22 @@ GitCommit: fb328ed4e0c36ca21299a8dad9b8dbce20dee236
 Directory: 8.5/jdk11/corretto-al2
 
 Tags: 8.5.88-jdk8-temurin-jammy, 8.5-jdk8-temurin-jammy, 8-jdk8-temurin-jammy, 8.5.88-jdk8-temurin, 8.5-jdk8-temurin, 8-jdk8-temurin, 8.5.88-jdk8, 8.5-jdk8, 8-jdk8
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: fb328ed4e0c36ca21299a8dad9b8dbce20dee236
 Directory: 8.5/jdk8/temurin-jammy
 
 Tags: 8.5.88-jre8-temurin-jammy, 8.5-jre8-temurin-jammy, 8-jre8-temurin-jammy, 8.5.88-jre8-temurin, 8.5-jre8-temurin, 8-jre8-temurin, 8.5.88-jre8, 8.5-jre8, 8-jre8
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 44079aa2c56da8b47438f58af9c01ffdda1a8a95
 Directory: 8.5/jre8/temurin-jammy
 
 Tags: 8.5.88-jdk8-temurin-focal, 8.5-jdk8-temurin-focal, 8-jdk8-temurin-focal
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: fb328ed4e0c36ca21299a8dad9b8dbce20dee236
 Directory: 8.5/jdk8/temurin-focal
 
 Tags: 8.5.88-jre8-temurin-focal, 8.5-jre8-temurin-focal, 8-jre8-temurin-focal
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 44079aa2c56da8b47438f58af9c01ffdda1a8a95
 Directory: 8.5/jre8/temurin-focal
 


### PR DESCRIPTION
`arm32v7` is back for `eclipse-temurin` (https://github.com/docker-library/official-images/pull/14573)