### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -15,11 +15,11 @@ GitCommit: 5951b45c36ee557b33cd8a108f5e08f1654ef5e8
 Directory: 4.0
 
 Tags: 3.11.14, 3.11, 3
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 5951b45c36ee557b33cd8a108f5e08f1654ef5e8
 Directory: 3.11
 
 Tags: 3.0.28, 3.0
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 5951b45c36ee557b33cd8a108f5e08f1654ef5e8
 Directory: 3.0


### PR DESCRIPTION
`arm32v7` is back for `eclipse-temurin` (https://github.com/docker-library/official-images/pull/14573)