### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 5951b45c36ee557b33cd8a108f5e08f1654ef5e8
 Directory: 4.0
 
-Tags: 3.11.14, 3.11, 3
+Tags: 3.11.15, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5951b45c36ee557b33cd8a108f5e08f1654ef5e8
+GitCommit: 7f0ca5fd56b2397688f4de64cd5d15ef54b581ec
 Directory: 3.11
 
 Tags: 3.0.28, 3.0


### PR DESCRIPTION
`3.0.29` is probably imminent: https://github.com/apache/cassandra/releases/tag/3.0.29-tentative

Changes:

- https://github.com/docker-library/cassandra/commit/7f0ca5f: Update 3.11 to 3.11.15