### PR TITLE
archlinux: Release 20230507.0.148551

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230430.0.146624
-GitCommit: 60929acedfaddae560cdde459ebb2fc64b0b51a7
-GitFetch: refs/tags/v20230430.0.146624
+Tags: latest, base, base-20230507.0.148551
+GitCommit: a4485766c3fd1502a512a724f7a3620cf5693c5a
+GitFetch: refs/tags/v20230507.0.148551
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230430.0.146624
-GitCommit: 60929acedfaddae560cdde459ebb2fc64b0b51a7
-GitFetch: refs/tags/v20230430.0.146624
+Tags: base-devel, base-devel-20230507.0.148551
+GitCommit: a4485766c3fd1502a512a724f7a3620cf5693c5a
+GitFetch: refs/tags/v20230507.0.148551
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks