### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.12.0-rc.1, 3.12-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3ba713dad126e9b30f4fb4cf5e2da3419233d890
+GitCommit: 6445a8d1b16de9188bccfb0b29ab0cf448eadbb3
 Directory: 3.12-rc/ubuntu
 
 Tags: 3.12.0-rc.1-management, 3.12-rc-management
@@ -17,7 +17,7 @@ Directory: 3.12-rc/ubuntu/management
 
 Tags: 3.12.0-rc.1-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ba713dad126e9b30f4fb4cf5e2da3419233d890
+GitCommit: 6445a8d1b16de9188bccfb0b29ab0cf448eadbb3
 Directory: 3.12-rc/alpine
 
 Tags: 3.12.0-rc.1-management-alpine, 3.12-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 3.12-rc/alpine/management
 
 Tags: 3.11.15, 3.11, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e667276a6f89ce21af3da179fd2178795f73c94e
+GitCommit: 8de237303dee7eece27df0c56a13cf97714341d4
 Directory: 3.11/ubuntu
 
 Tags: 3.11.15-management, 3.11-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.15-alpine, 3.11-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e667276a6f89ce21af3da179fd2178795f73c94e
+GitCommit: 8de237303dee7eece27df0c56a13cf97714341d4
 Directory: 3.11/alpine
 
 Tags: 3.11.15-management-alpine, 3.11-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.22, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 49dac61352d0cca4f2c6628092c4576f390fa5fd
+GitCommit: 78a7915ab3099eac44a3819f5057592b2fa65bb9
 Directory: 3.10/ubuntu
 
 Tags: 3.10.22-management, 3.10-management
@@ -57,7 +57,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.22-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 49dac61352d0cca4f2c6628092c4576f390fa5fd
+GitCommit: 78a7915ab3099eac44a3819f5057592b2fa65bb9
 Directory: 3.10/alpine
 
 Tags: 3.10.22-management-alpine, 3.10-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c5154e95d30f1d5ef9b99062769995f1e8578329
+GitCommit: aabb3c5c755e78eecdc16d51cc1e814d357a3745
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -77,7 +77,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c5154e95d30f1d5ef9b99062769995f1e8578329
+GitCommit: aabb3c5c755e78eecdc16d51cc1e814d357a3745
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/aabb3c5: Update 3.9 to otp 25.3.2
- https://github.com/docker-library/rabbitmq/commit/6445a8d: Update 3.12-rc to otp 25.3.2
- https://github.com/docker-library/rabbitmq/commit/8de2373: Update 3.11 to otp 25.3.2
- https://github.com/docker-library/rabbitmq/commit/78a7915: Update 3.10 to otp 25.3.2