### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev9, 2.8-dev, 2.8-dev9-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev10, 2.8-dev, 2.8-dev10-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 21adfa0af8cd7da14cd85ce0e03aa75b3912dfbf
+GitCommit: ce432ec1d0ed66b18ebf2418772652137dac7b94
 Directory: 2.8
 
-Tags: 2.8-dev9-alpine, 2.8-dev-alpine, 2.8-dev9-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev10-alpine, 2.8-dev-alpine, 2.8-dev10-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 21adfa0af8cd7da14cd85ce0e03aa75b3912dfbf
+GitCommit: ce432ec1d0ed66b18ebf2418772652137dac7b94
 Directory: 2.8/alpine
 
 Tags: 2.7.8, 2.7, latest, 2.7.8-bullseye, 2.7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ce432ec: Update 2.8 to 2.8-dev10