### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -11,12 +11,12 @@ GitCommit: 46628bc0702798f6ff9f923650361f46f9eb2af2
 Directory: 13
 # Docker EOL: 2024-10-26
 
-# Last Modified: 2022-08-19
-Tags: 12.2.0, 12.2, 12, 12.2.0-bullseye, 12.2-bullseye, 12-bullseye
+# Last Modified: 2023-05-08
+Tags: 12.3.0, 12.3, 12, 12.3.0-bullseye, 12.3-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 46628bc0702798f6ff9f923650361f46f9eb2af2
+GitCommit: dfa419750ef32e01ce5715a08533397f570f1133
 Directory: 12
-# Docker EOL: 2024-02-19
+# Docker EOL: 2024-11-08
 
 # Last Modified: 2022-04-21
 Tags: 11.3.0, 11.3, 11, 11.3.0-bullseye, 11.3-bullseye, 11-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/dfa4197: Update 12 to 12.3.0