### PR TITLE
traefik: remove v1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -25,22 +25,3 @@ Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 0f5f057e1310e073297e1ed93ba6db65e0abcfef
 Directory: alpine
-
-Tags: v1.7.34-windowsservercore-1809, 1.7.34-windowsservercore-1809, v1.7-windowsservercore-1809, 1.7-windowsservercore-1809, maroilles-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4434758cf14bbd1ec9511b3f2a37b0a6ce846db6
-Directory: windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v1.7.34-alpine, 1.7.34-alpine, v1.7-alpine, 1.7-alpine, maroilles-alpine
-Architectures: amd64, arm32v6, arm64v8
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4434758cf14bbd1ec9511b3f2a37b0a6ce846db6
-Directory: alpine
-
-Tags: v1.7.34, 1.7.34, v1.7, 1.7, maroilles
-Architectures: amd64, arm32v6, arm64v8
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4434758cf14bbd1ec9511b3f2a37b0a6ce846db6
-Directory: scratch


### PR DESCRIPTION
Related to #14607

We stopped to support Traefik v1 for 2 years now so that we can drop it.