### PR TITLE
alpine:3.15 for arangodb 3.9

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -4,7 +4,7 @@ GitFetch: refs/heads/official
 
 Tags: 3.9, 3.9.10
 Architectures: amd64
-GitCommit: 04479ca0b7f52b6f23f3739eae6994f4875990f2
+GitCommit: 83dcd50e8af2210c1315074d8c9260b9ff572e9f
 Directory: alpine/3.9.10
 
 Tags: 3.10, 3.10.6, latest


### PR DESCRIPTION
Update Alpine base to 3.15 for ArangoDB 3.9. Related to https://github.com/docker-library/official-images/pull/14607.