### PR TITLE
Updated Unit to 1.30.0.

### DIFF
--- a/library/unit
+++ b/library/unit
@@ -1,60 +1,60 @@
-# this file is generated via https://github.com/nginx/unit/blob/b9bc222021e77bbdfb12576b3e315b962cf6b399/pkg/docker/Makefile
+# this file is generated via https://github.com/nginx/unit/blob/92ffcb89f8e145299e837438f0a0de93d73ffede/pkg/docker/Makefile
 
 Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/unit.git
 
-Tags: 1.29.1-go1.20, go1.20, go1, go
+Tags: 1.30.0-go1.20, go1.20, go1, go
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.go1.20
 
-Tags: 1.29.1-jsc11, jsc11, jsc
+Tags: 1.30.0-jsc11, jsc11, jsc
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.jsc11
 
-Tags: 1.29.1-node18, node18, node
+Tags: 1.30.0-node18, node18, node
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.node18
 
-Tags: 1.29.1-perl5.36, perl5.36, perl5, perl
+Tags: 1.30.0-perl5.36, perl5.36, perl5, perl
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.perl5.36
 
-Tags: 1.29.1-php8.2, php8.2, php8, php
+Tags: 1.30.0-php8.2, php8.2, php8, php
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.php8.2
 
-Tags: 1.29.1-python3.11, python3.11, python3, python
+Tags: 1.30.0-python3.11, python3.11, python3, python
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.python3.11
 
-Tags: 1.29.1-ruby3.2, ruby3.2, ruby3, ruby
+Tags: 1.30.0-ruby3.2, ruby3.2, ruby3, ruby
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.ruby3.2
 
-Tags: 1.29.1-minimal, minimal
+Tags: 1.30.0-minimal, minimal, latest
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: b9bc222021e77bbdfb12576b3e315b962cf6b399
+GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
 Directory: pkg/docker
 File: Dockerfile.minimal


### PR DESCRIPTION
Notable Dockerfile changes include:
 - renamed configure arguments and changed build paths
 - added njs support for image builds
 - added loadable js modules to entrypoint
 - made curl fail with non-zero exit code on server errors
 - added a way to generate multiple versions of a language-based image
 - tagged minimal variant as latest
 - added a default "welcome" configuration