### PR TITLE
MariaDB 2023 Q2 release 1

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/8524cfe3677c8e4d70f80df565a0c51027881857/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/b937daac76b19766b052fac35c6208d0cc26684d/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
@@ -7,50 +7,45 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 11.0.1-rc-jammy, 11.0-rc-jammy, 11.0.1-rc, 11.0-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 11.0
 
-Tags: 10.11.2-jammy, 10.11-jammy, 10-jammy, jammy, 10.11.2, 10.11, 10, latest
+Tags: 10.11.3-jammy, 10.11-jammy, 10-jammy, jammy, lts-jammy, 10.11.3, 10.11, 10, latest, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.11
 
-Tags: 10.10.3-jammy, 10.10-jammy, 10.10.3, 10.10
+Tags: 10.10.4-jammy, 10.10-jammy, 10.10.4, 10.10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.10
 
-Tags: 10.9.5-jammy, 10.9-jammy, 10.9.5, 10.9
+Tags: 10.9.6-jammy, 10.9-jammy, 10.9.6, 10.9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.9
 
-Tags: 10.8.7-jammy, 10.8-jammy, 10.8.7, 10.8
+Tags: 10.8.8-jammy, 10.8-jammy, 10.8.8, 10.8
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.8
 
-Tags: 10.7.8-focal, 10.7-focal, 10.7.8, 10.7
+Tags: 10.6.13-focal, 10.6-focal, 10.6.13, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
-Directory: 10.7
-
-Tags: 10.6.12-focal, 10.6-focal, 10.6.12, 10.6
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.6
 
-Tags: 10.5.19-focal, 10.5-focal, 10.5.19, 10.5
+Tags: 10.5.20-focal, 10.5-focal, 10.5.20, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.5
 
-Tags: 10.4.28-focal, 10.4-focal, 10.4.28, 10.4
+Tags: 10.4.29-focal, 10.4-focal, 10.4.29, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.4
 
-Tags: 10.3.38-focal, 10.3-focal, 10.3.38, 10.3
+Tags: 10.3.39-focal, 10.3-focal, 10.3.39, 10.3
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 29e2cbb9b2339627497fb3247942bd802ec81191
+GitCommit: b1f92f6f41036992f932f339ba6074ab43809368
 Directory: 10.3


### PR DESCRIPTION
Happy new release.

Adds LTS tags on the latest only.

11.0/11.1(?) bumps coming in about a week.

Adds environment variables for replication.