### PR TITLE
Update registry to 2.8.2 (GA)

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -2,11 +2,7 @@ Maintainers: Milos Gajdos (@milosgajdos),
              Sebastiaan van Stijn (@thajeztah)
 GitRepo: https://github.com/docker/distribution-library-image.git
 GitFetch: refs/heads/master
-GitCommit: fa2dfdbfe65663972eaf9882447203c71f4ccb12
+GitCommit: e42103a5670538e10ac42f5284e2a25912f17973
 
-Tags: 2.8.1, 2.8, 2, latest
+Tags: 2.8.2, 2.8, 2, latest
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.8.2-beta.2
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-File: Dockerfile.rc


### PR DESCRIPTION
https://github.com/docker/distribution-library-image/pull/148