### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/2ffc9e1fded12441017a163acf40e7192dbc769c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/26a1dafd81f4798c0aa44942412fe0465ce3c30d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -24,15 +24,15 @@ Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/slim-buster
 
-Tags: 3.2.2-alpine3.17, 3.2-alpine3.17, 3-alpine3.17, alpine3.17, 3.2.2-alpine, 3.2-alpine, 3-alpine, alpine
+Tags: 3.2.2-alpine3.18, 3.2-alpine3.18, 3-alpine3.18, alpine3.18, 3.2.2-alpine, 3.2-alpine, 3-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3ac53a7fe039d4299aca9b49ad53e1cc85cc6498
+Directory: 3.2/alpine3.18
+
+Tags: 3.2.2-alpine3.17, 3.2-alpine3.17, 3-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
 Directory: 3.2/alpine3.17
-
-Tags: 3.2.2-alpine3.16, 3.2-alpine3.16, 3-alpine3.16, alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4041b21f3e11111846e6b6043da2da92e1da7019
-Directory: 3.2/alpine3.16
 
 Tags: 3.1.4-bullseye, 3.1-bullseye, 3.1.4, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -54,15 +54,15 @@ Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/slim-buster
 
-Tags: 3.1.4-alpine3.17, 3.1-alpine3.17, 3.1.4-alpine, 3.1-alpine
+Tags: 3.1.4-alpine3.18, 3.1-alpine3.18, 3.1.4-alpine, 3.1-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 3ac53a7fe039d4299aca9b49ad53e1cc85cc6498
+Directory: 3.1/alpine3.18
+
+Tags: 3.1.4-alpine3.17, 3.1-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
 Directory: 3.1/alpine3.17
-
-Tags: 3.1.4-alpine3.16, 3.1-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 564fdfe2e1451d2f56a815b1213e54c7f8639cb4
-Directory: 3.1/alpine3.16
 
 Tags: 3.0.6-bullseye, 3.0-bullseye, 3.0.6, 3.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
@@ -88,28 +88,3 @@ Tags: 3.0.6-alpine3.16, 3.0-alpine3.16, 3.0.6-alpine, 3.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 1cd75932f3d072dbbe2a866951fc47ff5a5bb2fc
 Directory: 3.0/alpine3.16
-
-Tags: 2.7.8-bullseye, 2.7-bullseye, 2-bullseye, 2.7.8, 2.7, 2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
-Directory: 2.7/bullseye
-
-Tags: 2.7.8-slim-bullseye, 2.7-slim-bullseye, 2-slim-bullseye, 2.7.8-slim, 2.7-slim, 2-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
-Directory: 2.7/slim-bullseye
-
-Tags: 2.7.8-buster, 2.7-buster, 2-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
-Directory: 2.7/buster
-
-Tags: 2.7.8-slim-buster, 2.7-slim-buster, 2-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
-Directory: 2.7/slim-buster
-
-Tags: 2.7.8-alpine3.16, 2.7-alpine3.16, 2-alpine3.16, 2.7.8-alpine, 2.7-alpine, 2-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7117899e1b7d3d8230fe8021acf76ead8d2f5230
-Directory: 2.7/alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/c11f10e: Merge pull request https://github.com/docker-library/ruby/pull/418 from infosiftr/eol-2.7
- https://github.com/docker-library/ruby/commit/26a1daf: Drop EOL 2.7
- https://github.com/docker-library/ruby/commit/9fa3f32: Merge pull request https://github.com/docker-library/ruby/pull/417 from wheatevo/add-alpine-3-18
- https://github.com/docker-library/ruby/commit/10e743e: Remove Alpine 3.16 from most versions (max 2 supported Alpine versions at a time), fix ordering
- https://github.com/docker-library/ruby/commit/3ac53a7: Add Alpine 3.18