### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 21-ea-21-jdk-oraclelinux8, 21-ea-21-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-21-jdk-oracle, 21-ea-21-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-21-jdk, 21-ea-21, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-22-jdk-oraclelinux8, 21-ea-22-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-22-jdk-oracle, 21-ea-22-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-22-jdk, 21-ea-22, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-21-jdk-oraclelinux7, 21-ea-21-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-22-jdk-oraclelinux7, 21-ea-22-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-21-jdk-bullseye, 21-ea-21-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-22-jdk-bullseye, 21-ea-22-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-21-jdk-slim-bullseye, 21-ea-21-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-21-jdk-slim, 21-ea-21-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-22-jdk-slim-bullseye, 21-ea-22-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye, 21-ea-22-jdk-slim, 21-ea-22-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-21-jdk-buster, 21-ea-21-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
+Tags: 21-ea-22-jdk-buster, 21-ea-22-buster, 21-ea-jdk-buster, 21-ea-buster, 21-jdk-buster, 21-buster
 Architectures: amd64, arm64v8
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/buster
 
-Tags: 21-ea-21-jdk-slim-buster, 21-ea-21-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
+Tags: 21-ea-22-jdk-slim-buster, 21-ea-22-slim-buster, 21-ea-jdk-slim-buster, 21-ea-slim-buster, 21-jdk-slim-buster, 21-slim-buster
 Architectures: amd64, arm64v8
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/slim-buster
 
-Tags: 21-ea-21-jdk-windowsservercore-ltsc2022, 21-ea-21-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-21-jdk-windowsservercore, 21-ea-21-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-21-jdk, 21-ea-21, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-22-jdk-windowsservercore-ltsc2022, 21-ea-22-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-22-jdk-windowsservercore, 21-ea-22-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-22-jdk, 21-ea-22, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-21-jdk-windowsservercore-1809, 21-ea-21-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-21-jdk-windowsservercore, 21-ea-21-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-21-jdk, 21-ea-21, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-22-jdk-windowsservercore-1809, 21-ea-22-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-22-jdk-windowsservercore, 21-ea-22-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-22-jdk, 21-ea-22, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-21-jdk-nanoserver-1809, 21-ea-21-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-21-jdk-nanoserver, 21-ea-21-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-22-jdk-nanoserver-1809, 21-ea-22-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-22-jdk-nanoserver, 21-ea-22-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 65fd649daf1e75d18011ed81d64cdfec4edae268
+GitCommit: 2f8a93985ffc1522535d57a31490f63b9e00f785
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/2f8a939: Update 21 to 21-ea+22