### PR TITLE
eclipse-mosquitto: Update for alpine 3.18

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,6 +1,6 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: a8448a9c7b14bdaee6ec80419d43fd6544e789b6
+GitCommit: cc1aac336ecbbc251ed4a5126257f6f4fe3ed27c
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
 Tags: 2.0.15, 2.0, 2, latest
@@ -9,11 +9,5 @@ Directory: docker/2.0
 Tags: 2.0.15-openssl, 2.0-openssl, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
-Tags: 1.6.15, 1.6
-Directory: docker/1.6
-
 Tags: 1.6.15-openssl, 1.6-openssl
 Directory: docker/1.6-openssl
-
-Tags: 1.5.11, 1.5
-Directory: docker/1.5


### PR DESCRIPTION
Remove 1.5* image.
Remove 1.6 libressl image.