### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -19,14 +19,14 @@ amd64-GitCommit: ea5a916817e6c6bd0f031358bb8f4f5c272d7de1
 arm64v8-GitFetch: refs/heads/al2023-arm64
 arm64v8-GitCommit: 9ad73d0ab12dcffa38c120294e32ca2f0d702ad3
 
-Tags: 2, 2.0.20230418.0
+Tags: 2, 2.0.20230504.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 8bd72a51cb5cdb1ccee4b9c6ed0120794cc63388
+amd64-GitCommit: a3064f5b88429f37824e9d9897021058f5eed6d6
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: faeb719c935672aa8c7988a733fd220436d99d27
+arm64v8-GitCommit: da91f2997455ed1bc395985d1399c6261278c5b4
 
-Tags: 1, 2018.03, 2018.03.0.20230419.0
+Tags: 1, 2018.03, 2018.03.0.20230501.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 9a31073361b306f3cf92e9dfe8cd76192e04d2f7
+amd64-GitCommit: 28a8085038403ae42578118bc2fdad522bbcd64e


### PR DESCRIPTION
AL2 Package Change List:
- libxml2-2.9.1-6.amzn2.5.8
- rpm-libs-4.11.3-48.amzn2.0.3
- python2-rpm-4.11.3-48.amzn2.0.3
- vim-minimal-9.0.1403-1.amzn2.0.2
- openldap-2.4.44-25.amzn2.0.5
- rpm-build-libs-4.11.3-48.amzn2.0.3
- vim-data-9.0.1403-1.amzn2.0.2
- ca-certificates-2021.2.50-72.amzn2.0.7
- rpm-4.11.3-48.amzn2.0.3

AL1 Package Change List:
- libxml2-2.9.1-6.6.42.amzn1
- nss-tools-3.53.1-7.88.amzn1
- openldap-2.4.40-16.36.amzn1
- ca-certificates-2018.2.22-65.1.30.amzn1
- nss-3.53.1-7.88.amzn1
- glib2-2.36.3-5.23.amzn1
- nss-sysinit-3.53.1-7.88.amzn1
- libxml2-python27-2.9.1-6.6.42.amzn1