### PR TITLE
Update Clear Linux OS to 39110

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: b490e027e92877683f967ec1f4709f2fbad749a3
-GitFetch: refs/heads/base-39050
+GitCommit: 3632d8b1f5ae9aba67c3b693838ab9a52f282408
+GitFetch: refs/heads/base-39110


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39110

@bryteise @djklimes @bryteise