### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redis.git
 
-Tags: 7.2-rc1, 7.2-rc, 7.2-rc1-bullseye, 7.2-rc-bullseye
+Tags: 7.2-rc2, 7.2-rc, 7.2-rc2-bullseye, 7.2-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 47ff5548471e77c54c801a06adb85aba6446bc33
+GitCommit: 2e6e8961037d8b2838a4105bb9a761441e1ae477
 Directory: 7.2-rc
 
-Tags: 7.2-rc1-alpine, 7.2-rc-alpine, 7.2-rc1-alpine3.18, 7.2-rc-alpine3.18
+Tags: 7.2-rc2-alpine, 7.2-rc-alpine, 7.2-rc2-alpine3.18, 7.2-rc-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ef4e925387c9c4063b25e83928a85ff44dddf4d
+GitCommit: 2e6e8961037d8b2838a4105bb9a761441e1ae477
 Directory: 7.2-rc/alpine
 
 Tags: 7.0.11, 7.0, 7, latest, 7.0.11-bullseye, 7.0-bullseye, 7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/2e6e896: Update to 7.2-rc2