### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -19,7 +19,7 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 7f0ca5fd56b2397688f4de64cd5d15ef54b581ec
 Directory: 3.11
 
-Tags: 3.0.28, 3.0
+Tags: 3.0.29, 3.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5951b45c36ee557b33cd8a108f5e08f1654ef5e8
+GitCommit: 0472adffa9e3b3361f2dbe4b089592d1cb84d36d
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/0472adf: Update 3.0 to 3.0.29