### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.2.0-apache, 6.2-apache, 6-apache, apache, 6.2.0, 6.2, 6, latest, 6.2.0-php8.0-apache, 6.2-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.2.0-php8.0, 6.2-php8.0, 6-php8.0, php8.0
+Tags: 6.2.1-apache, 6.2-apache, 6-apache, apache, 6.2.1, 6.2, 6, latest, 6.2.1-php8.0-apache, 6.2-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.2.1-php8.0, 6.2-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.0/apache
 
-Tags: 6.2.0-fpm, 6.2-fpm, 6-fpm, fpm, 6.2.0-php8.0-fpm, 6.2-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.2.1-fpm, 6.2-fpm, 6-fpm, fpm, 6.2.1-php8.0-fpm, 6.2-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.0/fpm
 
-Tags: 6.2.0-fpm-alpine, 6.2-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.2.0-php8.0-fpm-alpine, 6.2-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.2.1-fpm-alpine, 6.2-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.2.1-php8.0-fpm-alpine, 6.2-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.2.0-php8.1-apache, 6.2-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.2.0-php8.1, 6.2-php8.1, 6-php8.1, php8.1
+Tags: 6.2.1-php8.1-apache, 6.2-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.2.1-php8.1, 6.2-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.1/apache
 
-Tags: 6.2.0-php8.1-fpm, 6.2-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.2.1-php8.1-fpm, 6.2-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.1/fpm
 
-Tags: 6.2.0-php8.1-fpm-alpine, 6.2-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.2.1-php8.1-fpm-alpine, 6.2-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.2.0-php8.2-apache, 6.2-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.2.0-php8.2, 6.2-php8.2, 6-php8.2, php8.2
+Tags: 6.2.1-php8.2-apache, 6.2-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.2.1-php8.2, 6.2-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.2/apache
 
-Tags: 6.2.0-php8.2-fpm, 6.2-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.2.1-php8.2-fpm, 6.2-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.2/fpm
 
-Tags: 6.2.0-php8.2-fpm-alpine, 6.2-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.2.1-php8.2-fpm-alpine, 6.2-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5f5172057791d1deb1919fdd1c5c45e7daae3362
+GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
@@ -63,48 +63,3 @@ Tags: cli-2.7.1-php8.2, cli-2.7-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
 Directory: cli/php8.2/alpine
-
-Tags: beta-6.2.1-RC1-apache, beta-6.2.1-apache, beta-6.2-apache, beta-6-apache, beta-apache, beta-6.2.1-RC1, beta-6.2.1, beta-6.2, beta-6, beta, beta-6.2.1-RC1-php8.0-apache, beta-6.2.1-php8.0-apache, beta-6.2-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.2.1-RC1-php8.0, beta-6.2.1-php8.0, beta-6.2-php8.0, beta-6-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.0/apache
-
-Tags: beta-6.2.1-RC1-fpm, beta-6.2.1-fpm, beta-6.2-fpm, beta-6-fpm, beta-fpm, beta-6.2.1-RC1-php8.0-fpm, beta-6.2.1-php8.0-fpm, beta-6.2-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.0/fpm
-
-Tags: beta-6.2.1-RC1-fpm-alpine, beta-6.2.1-fpm-alpine, beta-6.2-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.2.1-RC1-php8.0-fpm-alpine, beta-6.2.1-php8.0-fpm-alpine, beta-6.2-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.0/fpm-alpine
-
-Tags: beta-6.2.1-RC1-php8.1-apache, beta-6.2.1-php8.1-apache, beta-6.2-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.2.1-RC1-php8.1, beta-6.2.1-php8.1, beta-6.2-php8.1, beta-6-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.1/apache
-
-Tags: beta-6.2.1-RC1-php8.1-fpm, beta-6.2.1-php8.1-fpm, beta-6.2-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.1/fpm
-
-Tags: beta-6.2.1-RC1-php8.1-fpm-alpine, beta-6.2.1-php8.1-fpm-alpine, beta-6.2-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.1/fpm-alpine
-
-Tags: beta-6.2.1-RC1-php8.2-apache, beta-6.2.1-php8.2-apache, beta-6.2-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.2.1-RC1-php8.2, beta-6.2.1-php8.2, beta-6.2-php8.2, beta-6-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.2/apache
-
-Tags: beta-6.2.1-RC1-php8.2-fpm, beta-6.2.1-php8.2-fpm, beta-6.2-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.2/fpm
-
-Tags: beta-6.2.1-RC1-php8.2-fpm-alpine, beta-6.2.1-php8.2-fpm-alpine, beta-6.2-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3d57821c005706c263394d0dc28d36010c0bbb82
-Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/9faee1b: Update latest to 6.2.1
- https://github.com/docker-library/wordpress/commit/d050b06: Update beta to 6.2.1