### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev11, 2.8-dev, 2.8-dev11-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev12, 2.8-dev, 2.8-dev12-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c513a74567d7594543da2852f61f7576d83a714e
+GitCommit: 8540b3c85e62fae2c85d73e3a27c17f53da115e1
 Directory: 2.8
 
-Tags: 2.8-dev11-alpine, 2.8-dev-alpine, 2.8-dev11-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev12-alpine, 2.8-dev-alpine, 2.8-dev12-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c513a74567d7594543da2852f61f7576d83a714e
+GitCommit: 8540b3c85e62fae2c85d73e3a27c17f53da115e1
 Directory: 2.8/alpine
 
 Tags: 2.7.8, 2.7, latest, 2.7.8-bullseye, 2.7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8540b3c: Update 2.8 to 2.8-dev12