### PR TITLE
caddy: v2.7.0-beta.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/a82cbc5b1bf43757f718d8b21adcca6a0df560c7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/6e5a266c6839d6f84eb84f8430ce13a49c1b0aae/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
 Tags: 2.6.4-alpine, 2.6-alpine, 2-alpine, alpine
@@ -14,14 +14,14 @@ Tags: 2.6.4-builder-alpine, 2.6-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.6.4-builder, 2.6-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/builder
-GitCommit: 6e5a266c6839d6f84eb84f8430ce13a49c1b0aae
+GitCommit: 8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
 Tags: 2.6.4-windowsservercore-1809, 2.6-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
 SharedTags: 2.6.4-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.4, 2.6, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/1809
-GitCommit: 6e5a266c6839d6f84eb84f8430ce13a49c1b0aae
+GitCommit: 968a9e779660c4e0711021103eebf610c7979a7e
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -29,7 +29,7 @@ Tags: 2.6.4-windowsservercore-ltsc2022, 2.6-windowsservercore-ltsc2022, 2-window
 SharedTags: 2.6.4-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.4, 2.6, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows/ltsc2022
-GitCommit: 6e5a266c6839d6f84eb84f8430ce13a49c1b0aae
+GitCommit: 968a9e779660c4e0711021103eebf610c7979a7e
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
@@ -37,7 +37,7 @@ Tags: 2.6.4-builder-windowsservercore-1809, 2.6-builder-windowsservercore-1809, 
 SharedTags: 2.6.4-builder, 2.6-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/1809
-GitCommit: 6e5a266c6839d6f84eb84f8430ce13a49c1b0aae
+GitCommit: 8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
@@ -45,7 +45,53 @@ Tags: 2.6.4-builder-windowsservercore-ltsc2022, 2.6-builder-windowsservercore-lt
 SharedTags: 2.6.4-builder, 2.6-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.6/windows-builder/ltsc2022
-GitCommit: 6e5a266c6839d6f84eb84f8430ce13a49c1b0aae
+GitCommit: 8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.7.0-beta.1-alpine, 2.7-alpine
+SharedTags: 2.7.0-beta.1, 2.7
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.7/alpine
+GitCommit: 9821d43cf53bf53071b2bc4cfca1dc3be87bed56
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.7.0-beta.1-builder-alpine, 2.7-builder-alpine
+SharedTags: 2.7.0-beta.1-builder, 2.7-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.7/builder
+GitCommit: 8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
+
+Tags: 2.7.0-beta.1-windowsservercore-1809, 2.7-windowsservercore-1809
+SharedTags: 2.7.0-beta.1-windowsservercore, 2.7-windowsservercore, 2.7.0-beta.1, 2.7
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.7/windows/1809
+GitCommit: 9821d43cf53bf53071b2bc4cfca1dc3be87bed56
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.7.0-beta.1-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022
+SharedTags: 2.7.0-beta.1-windowsservercore, 2.7-windowsservercore, 2.7.0-beta.1, 2.7
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.7/windows/ltsc2022
+GitCommit: 9821d43cf53bf53071b2bc4cfca1dc3be87bed56
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.7.0-beta.1-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809
+SharedTags: 2.7.0-beta.1-builder, 2.7-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.7/windows-builder/1809
+GitCommit: 8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+
+Tags: 2.7.0-beta.1-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022
+SharedTags: 2.7.0-beta.1-builder, 2.7-builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.7/windows-builder/ltsc2022
+GitCommit: 8a3bab4e266cc4e32c57d757890bbc1b6ff54e1d
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
Adds [v2.7.0-beta.1](https://github.com/caddyserver/caddy/releases/tag/v2.7.0-beta.1) (2.6 will be removed after 2.7.0 is released).

Also updates xcaddy to v0.3.4, and bumps Alpine to 3.18, and Go to 1.20.