### PR TITLE
Add images for Rocky Linux 9.2 and 8.8

### DIFF
--- a/library/rockylinux
+++ b/library/rockylinux
@@ -2,38 +2,34 @@ Maintainers: The Rocky Linux Foundation <infrastructure@rockylinux.org> (@rocky-
              Neil Hanlon <neil@resf.org> (@neilhanlon)
 GitRepo: https://github.com/rocky-linux/sig-cloud-instance-images.git
 
-Tags: 9.1.20230215, 9.1, 9
-GitFetch: refs/heads/Rocky-9.1.20230215-Base-x86_64
-GitCommit: c554918c3fb7432f70802459ee942fead8121cae
-arm64v8-GitFetch: refs/heads/Rocky-9.1.20230215-Base-aarch64
-arm64v8-GitCommit: a44de1cb9192969dacd996beb22c152020908532
-s390x-GitFetch: refs/heads/Rocky-9.1.20230215-Base-s390x
-s390x-GitCommit: 3bd8af8923fd7b0611f1599e347897a6cb9c156b
-ppc64le-GitFetch: refs/heads/Rocky-9.1.20230215-Base-ppc64le
-ppc64le-GitCommit: 0aee39d093db7f0732854729a0e46bc8092bf607
-Architectures: amd64, arm64v8, ppc64le, s390x
+Tags: 9.2.20230513, 9.2, 9
+GitFetch: refs/heads/Rocky-9.2.20230513-Base-x86_64
+GitCommit: 5534796e428e5ac942d820bc96a36a5d0404a8a4
+arm64v8-GitFetch: refs/heads/Rocky-9.2.20230513-Base-aarch64
+arm64v8-GitCommit: 9dc2a99760aa37f4fde4cd35a8fe12ce3991e16c
+s390x-GitFetch: refs/heads/Rocky-9.2.20230513-Base-s390x
+s390x-GitCommit: 1d9cb06268ba4a479b814a2e191a5fa42048872c
+Architectures: amd64, arm64v8, s390x
 
-Tags: 9.1.20230215-minimal, 9.1-minimal, 9-minimal
-GitFetch: refs/heads/Rocky-9.1.20230215-Minimal-x86_64
-GitCommit: 957dce1794c27b8fc1666f7e283db2ba7ef5b182
-arm64v8-GitFetch: refs/heads/Rocky-9.1.20230215-Minimal-aarch64
-arm64v8-GitCommit: 499b1eeb324a768228963568a9b3afdaf5da74dc
-s390x-GitFetch: refs/heads/Rocky-9.1.20230215-Minimal-s390x
-s390x-GitCommit: db6eddbb6b6cd097f625a014dcd50a9f152720d2
-ppc64le-GitFetch: refs/heads/Rocky-9.1.20230215-Minimal-ppc64le
-ppc64le-GitCommit: 4e11f6cf490d560b37bc6b9dffff204d2bc6e5b3
-Architectures: amd64, arm64v8, ppc64le, s390x
+Tags: 9.2.20230513-minimal, 9.2-minimal, 9-minimal
+GitFetch: refs/heads/Rocky-9.2.20230513-Minimal-x86_64
+GitCommit: 7be807edccbbb7b64872f1a6b6c24cc2edabf3bd
+arm64v8-GitFetch: refs/heads/Rocky-9.2.20230513-Minimal-aarch64
+arm64v8-GitCommit: e21f7b51dee45dbcea532cbbbae68da7428c7916
+s390x-GitFetch: refs/heads/Rocky-9.2.20230513-Minimal-s390x
+s390x-GitCommit: 275f589f6bcc73828387dc3f1d9d1fc45fef1b07
+Architectures: amd64, arm64v8, s390x
 
-Tags: 8.7.20230215, 8.7, 8
-GitFetch: refs/heads/Rocky-8.7.20230215-Base-x86_64
-GitCommit: 65d3f79aa8b5d0a9ed1270470e585539f7d59cd1
-arm64v8-GitFetch: refs/heads/Rocky-8.7.20230215-Base-aarch64
-arm64v8-GitCommit: f509fe83af8a893dff234befbc76458f6343b665
+Tags: 8.8.20230518, 8.8, 8
+GitFetch: refs/heads/Rocky-8.8.20230518-Base-x86_64
+GitCommit: 1c46fd092fd28c6192435baa61e66a00e66f7029
+arm64v8-GitFetch: refs/heads/Rocky-8.8.20230518-Base-aarch64
+arm64v8-GitCommit: 6f4942bfa1d8785ef62f43a8c7daf827b1034796
 Architectures: amd64, arm64v8
 
-Tags: 8.7.20230215-minimal, 8.7-minimal, 8-minimal
-GitFetch: refs/heads/Rocky-8.7.20230215-Minimal-x86_64
-GitCommit: a923b0d8957fa92feafaa4f6b00f8df08db796ab
-arm64v8-GitFetch: refs/heads/Rocky-8.7.20230215-Minimal-aarch64
-arm64v8-GitCommit: 5e843c299faaa855b6e3810cbf3fa25474415954
+Tags: 8.8.20230518-minimal, 8.8-minimal, 8-minimal
+GitFetch: refs/heads/Rocky-8.8.20230518-Minimal-x86_64
+GitCommit: 62c9ffd4470199b37a57ac260d1368ad239d476c
+arm64v8-GitFetch: refs/heads/Rocky-8.8.20230518-Minimal-aarch64
+arm64v8-GitCommit: d96540550efe61b047d17d11d4a7d9f4a9976537
 Architectures: amd64, arm64v8


### PR DESCRIPTION
NOTE - We currently are not providing 9.2 for ppc64le due to an upstream
bug[1], so the difference there is expected for now. We will add the
ppc64le image once a fix is found for the bug.

[1] https://bugzilla.redhat.com/show_bug.cgi?id=2203919
