### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2023-2650

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: bd1ac81bc48c810f5ae7dc469f0a97f6ad3c0a86
+amd64-GitCommit: 802631282c68adb27b87a537548a202f457ade23
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 05435a708d907f14a74acca1e9ff014b0a7ba220
+arm64v8-GitCommit: fac3e43b6977f88bd16d4bdeb83d748a3695001a
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-27535.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-2650.html

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com