### PR TITLE
archlinux: Release 20230521.0.152478

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230514.0.150299
-GitCommit: 346fa38826610687e75ba90fb6e0797d0111e483
-GitFetch: refs/tags/v20230514.0.150299
+Tags: latest, base, base-20230521.0.152478
+GitCommit: dbd59f669a2b422b67fc86350e7691fec43083a8
+GitFetch: refs/tags/v20230521.0.152478
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230514.0.150299
-GitCommit: 346fa38826610687e75ba90fb6e0797d0111e483
-GitFetch: refs/tags/v20230514.0.150299
+Tags: base-devel, base-devel-20230521.0.152478
+GitCommit: dbd59f669a2b422b67fc86350e7691fec43083a8
+GitFetch: refs/tags/v20230521.0.152478
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks