### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.2.1-apache, 6.2-apache, 6-apache, apache, 6.2.1, 6.2, 6, latest, 6.2.1-php8.0-apache, 6.2-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.2.1-php8.0, 6.2-php8.0, 6-php8.0, php8.0
+Tags: 6.2.2-apache, 6.2-apache, 6-apache, apache, 6.2.2, 6.2, 6, latest, 6.2.2-php8.0-apache, 6.2-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.2.2-php8.0, 6.2-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.0/apache
 
-Tags: 6.2.1-fpm, 6.2-fpm, 6-fpm, fpm, 6.2.1-php8.0-fpm, 6.2-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.2.2-fpm, 6.2-fpm, 6-fpm, fpm, 6.2.2-php8.0-fpm, 6.2-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.0/fpm
 
-Tags: 6.2.1-fpm-alpine, 6.2-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.2.1-php8.0-fpm-alpine, 6.2-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.2.2-fpm-alpine, 6.2-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.2.2-php8.0-fpm-alpine, 6.2-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.2.1-php8.1-apache, 6.2-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.2.1-php8.1, 6.2-php8.1, 6-php8.1, php8.1
+Tags: 6.2.2-php8.1-apache, 6.2-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.2.2-php8.1, 6.2-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.1/apache
 
-Tags: 6.2.1-php8.1-fpm, 6.2-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.2.2-php8.1-fpm, 6.2-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.1/fpm
 
-Tags: 6.2.1-php8.1-fpm-alpine, 6.2-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.2.2-php8.1-fpm-alpine, 6.2-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.2.1-php8.2-apache, 6.2-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.2.1-php8.2, 6.2-php8.2, 6-php8.2, php8.2
+Tags: 6.2.2-php8.2-apache, 6.2-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.2.2-php8.2, 6.2-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.2/apache
 
-Tags: 6.2.1-php8.2-fpm, 6.2-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.2.2-php8.2-fpm, 6.2-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.2/fpm
 
-Tags: 6.2.1-php8.2-fpm-alpine, 6.2-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.2.2-php8.2-fpm-alpine, 6.2-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9faee1bdd0e10be3b57d3962b2f0cb246d39ecad
+GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/6fa05d9: Update latest to 6.2.2
- https://github.com/docker-library/wordpress/commit/0dc83f4: Update beta to 6.2.2