### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.12.0-rc.2, 3.12-rc
+Tags: 3.12.0-rc.3, 3.12-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c0b2f923c9606ce2581869344928f0146241e099
+GitCommit: d4a5dd93da59ff2d187bf9ee646496af737ac10f
 Directory: 3.12-rc/ubuntu
 
-Tags: 3.12.0-rc.2-management, 3.12-rc-management
+Tags: 3.12.0-rc.3-management, 3.12-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.12-rc/ubuntu/management
 
-Tags: 3.12.0-rc.2-alpine, 3.12-rc-alpine
+Tags: 3.12.0-rc.3-alpine, 3.12-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c0b2f923c9606ce2581869344928f0146241e099
+GitCommit: d4a5dd93da59ff2d187bf9ee646496af737ac10f
 Directory: 3.12-rc/alpine
 
-Tags: 3.12.0-rc.2-management-alpine, 3.12-rc-management-alpine
+Tags: 3.12.0-rc.3-management-alpine, 3.12-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.12-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/d4a5dd9: Update 3.12-rc to 3.12.0-rc.3
- https://github.com/docker-library/rabbitmq/commit/f6e28c0: Update README architectures