### PR TITLE
Almalinux auto-update - 200949

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,64 +1,64 @@
-# This file is generated using https://github.com/almalinux/docker-images/blob/1ccad05a5de6b620625de5574bc0240a789d7175/gen_docker_official_library
+# This file is generated using https://github.com/almalinux/docker-images/blob/0f287a463b6c372fb358d8f9f993c2c65361b6a7/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 
-Tags: latest, 8, 8.7, 8.7-20230407
-GitFetch: refs/heads/al8-20230407-amd64
-GitCommit: 1ff85558b2d001adef31a5910aff262d2cea0e3d
+Tags: 8, 8.8, 8.8-20230523
+GitFetch: refs/heads/al8-20230523-amd64
+GitCommit: 1c57b1458cdbd3473e76f54ba390476876a1ab56
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20230407-arm64v8
-arm64v8-GitCommit: 0f815bc8a63ba2f84ad3dfdf4b8350fb690754ea
+arm64v8-GitFetch: refs/heads/al8-20230523-arm64v8
+arm64v8-GitCommit: b651ba7b31c1c72b66bc62f83a8d4c299a62f2e7
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20230407-ppc64le
-ppc64le-GitCommit: 56e0cbe084e9662a216203f1a0008e2f87ad93c5
+ppc64le-GitFetch: refs/heads/al8-20230523-ppc64le
+ppc64le-GitCommit: 4f39119c7d230bc86a9c874643f810de90ff36df
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20230407-s390x
-s390x-GitCommit: 12e7e9abc3a7ab6867ab896b28419d150ab8a4ba
+s390x-GitFetch: refs/heads/al8-20230523-s390x
+s390x-GitCommit: 1c15065a270eb9511509d0cd0c78ad2ec13f3174
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 8-minimal, 8.7-minimal, 8.7-minimal-20230407
-GitFetch: refs/heads/al8-20230407-amd64
-GitCommit: 1ff85558b2d001adef31a5910aff262d2cea0e3d
+Tags: 8-minimal, 8.8-minimal, 8.8-minimal-20230523
+GitFetch: refs/heads/al8-20230523-amd64
+GitCommit: 1c57b1458cdbd3473e76f54ba390476876a1ab56
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20230407-arm64v8
-arm64v8-GitCommit: 0f815bc8a63ba2f84ad3dfdf4b8350fb690754ea
+arm64v8-GitFetch: refs/heads/al8-20230523-arm64v8
+arm64v8-GitCommit: b651ba7b31c1c72b66bc62f83a8d4c299a62f2e7
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20230407-ppc64le
-ppc64le-GitCommit: 56e0cbe084e9662a216203f1a0008e2f87ad93c5
+ppc64le-GitFetch: refs/heads/al8-20230523-ppc64le
+ppc64le-GitCommit: 4f39119c7d230bc86a9c874643f810de90ff36df
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20230407-s390x
-s390x-GitCommit: 12e7e9abc3a7ab6867ab896b28419d150ab8a4ba
+s390x-GitFetch: refs/heads/al8-20230523-s390x
+s390x-GitCommit: 1c15065a270eb9511509d0cd0c78ad2ec13f3174
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9, 9.1, 9.1-20230407
-GitFetch: refs/heads/al9-20230407-amd64
-GitCommit: 660a18fb2ff21cc4528bb36429626bd43025518d
+Tags: latest, 9, 9.2, 9.2-20230512
+GitFetch: refs/heads/al9-20230512-amd64
+GitCommit: 600467393dc75d3768196215ea1c122b552b9728
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20230407-arm64v8
-arm64v8-GitCommit: 0c161bb887e777bb233527ba748574d3556c6f3b
+arm64v8-GitFetch: refs/heads/al9-20230512-arm64v8
+arm64v8-GitCommit: 1b341d33f81c8402ef8d9532277495f92e4414b8
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20230407-ppc64le
-ppc64le-GitCommit: d4d1a02991efd2d60632c8b88f2ec3af9ce441a2
+ppc64le-GitFetch: refs/heads/al9-20230512-ppc64le
+ppc64le-GitCommit: 7fc5ec9ff0146d00072a3185fa00f2972c804b93
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20230407-s390x
-s390x-GitCommit: e7b72b8711d7ed2ed2b5f6dcc29047698830f09d
+s390x-GitFetch: refs/heads/al9-20230512-s390x
+s390x-GitCommit: c1d1785d246bad9715a5d3f290443d1ab5b086e8
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 9-minimal,  9.1-minimal, 9.1-minimal-20230407
-GitFetch: refs/heads/al9-20230407-amd64
-GitCommit: 660a18fb2ff21cc4528bb36429626bd43025518d
+Tags: minimal, 9-minimal,  9.2-minimal, 9.2-minimal-20230512
+GitFetch: refs/heads/al9-20230512-amd64
+GitCommit: 600467393dc75d3768196215ea1c122b552b9728
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20230407-arm64v8
-arm64v8-GitCommit: 0c161bb887e777bb233527ba748574d3556c6f3b
+arm64v8-GitFetch: refs/heads/al9-20230512-arm64v8
+arm64v8-GitCommit: 1b341d33f81c8402ef8d9532277495f92e4414b8
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20230407-ppc64le
-ppc64le-GitCommit: d4d1a02991efd2d60632c8b88f2ec3af9ce441a2
+ppc64le-GitFetch: refs/heads/al9-20230512-ppc64le
+ppc64le-GitCommit: 7fc5ec9ff0146d00072a3185fa00f2972c804b93
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20230407-s390x
-s390x-GitCommit: e7b72b8711d7ed2ed2b5f6dcc29047698830f09d
+s390x-GitFetch: refs/heads/al9-20230512-s390x
+s390x-GitCommit: c1d1785d246bad9715a5d3f290443d1ab5b086e8
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @LKHN or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `almalinux-release` changed from 8.7-3.el8 to 8.8-1.el8
- `binutils` changed from 2.30-117.el8 to 2.30-119.el8
- `coreutils-single` changed from 8.30-13.el8 to 8.30-15.el8
- `crypto-policies` changed from 20211116-1.gitae470d6.el8 to 20221215-1.gitece0092.el8
- `cryptsetup-libs` changed from 2.3.7-2.el8 to 2.3.7-5.el8
- `curl` changed from 7.61.1-25.el8_7.3 to 7.61.1-30.el8_8.2
- `dbus` changed from 1.12.8-23.el8_7.1 to 1.12.8-24.el8
- `dbus-common` changed from 1.12.8-23.el8_7.1 to 1.12.8-24.el8
- `dbus-daemon` changed from 1.12.8-23.el8_7.1 to 1.12.8-24.el8
- `dbus-libs` changed from 1.12.8-23.el8_7.1 to 1.12.8-24.el8
- `dbus-tools` changed from 1.12.8-23.el8_7.1 to 1.12.8-24.el8
- `device-mapper` changed from 1.02.181-6.el8 to 1.02.181-9.el8
- `device-mapper-libs` changed from 1.02.181-6.el8 to 1.02.181-9.el8
- `dnf` changed from 4.7.0-11.el8.alma to 4.7.0-16.el8_8.alma
- `dnf-data` changed from 4.7.0-11.el8.alma to 4.7.0-16.el8_8.alma
- `elfutils-default-yama-scope` changed from 0.187-4.el8 to 0.188-3.el8
- `elfutils-libelf` changed from 0.187-4.el8 to 0.188-3.el8
- `elfutils-libs` changed from 0.187-4.el8 to 0.188-3.el8
- `expat` changed from 2.2.5-10.el8_7.1 to 2.2.5-11.el8
- `file-libs` changed from 5.33-21.el8 to 5.33-24.el8
- `glib2` changed from 2.56.4-159.el8 to 2.56.4-161.el8
- `glibc` changed from 2.28-211.el8 to 2.28-225.el8
- `glibc-common` changed from 2.28-211.el8 to 2.28-225.el8
- `glibc-minimal-langpack` changed from 2.28-211.el8 to 2.28-225.el8
- `libarchive` changed from 3.3.3-4.el8 to 3.3.3-5.el8
- `libblkid` changed from 2.32.1-39.el8_7 to 2.32.1-42.el8_8
- `libcurl-minimal` changed from 7.61.1-25.el8_7.3 to 7.61.1-30.el8_8.2
- `libdnf` changed from 0.63.0-11.1.el8.alma to 0.63.0-14.el8_8.alma
- `libfdisk` changed from 2.32.1-39.el8_7 to 2.32.1-42.el8_8
- `libffi` changed from 3.1-23.el8 to 3.1-24.el8
- `libgcc` changed from 8.5.0-16.el8_7.alma to 8.5.0-18.el8.alma
- `libmount` changed from 2.32.1-39.el8_7 to 2.32.1-42.el8_8
- `libpwquality` changed from 1.4.4-5.el8 to 1.4.4-6.el8
- `librepo` changed from 1.14.2-3.el8 to 1.14.2-4.el8
- `libselinux` changed from 2.9-6.el8 to 2.9-8.el8
- `libsmartcols` changed from 2.32.1-39.el8_7 to 2.32.1-42.el8_8
- `libstdc++` changed from 8.5.0-16.el8_7.alma to 8.5.0-18.el8.alma
- `libuuid` changed from 2.32.1-39.el8_7 to 2.32.1-42.el8_8
- `libxml2` changed from 2.9.7-15.el8_7.1 to 2.9.7-16.el8
- `pam` changed from 1.3.1-22.el8 to 1.3.1-25.el8
- `platform-python` changed from 3.6.8-48.el8_7.1.alma to 3.6.8-51.el8.alma
- `platform-python-setuptools` changed from 39.2.0-6.el8_7.1 to 39.2.0-7.el8
- `python3-dnf` changed from 4.7.0-11.el8.alma to 4.7.0-16.el8_8.alma
- `python3-hawkey` changed from 0.63.0-11.1.el8.alma to 0.63.0-14.el8_8.alma
- `python3-libdnf` changed from 0.63.0-11.1.el8.alma to 0.63.0-14.el8_8.alma
- `python3-libs` changed from 3.6.8-48.el8_7.1.alma to 3.6.8-51.el8.alma
- `python3-rpm` changed from 4.14.3-24.el8_7 to 4.14.3-26.el8
- `python3-setuptools-wheel` changed from 39.2.0-6.el8_7.1 to 39.2.0-7.el8
- `rpm` changed from 4.14.3-24.el8_7 to 4.14.3-26.el8
- `rpm-build-libs` changed from 4.14.3-24.el8_7 to 4.14.3-26.el8
- `rpm-libs` changed from 4.14.3-24.el8_7 to 4.14.3-26.el8
- `setup` changed from 2.12.2-7.el8 to 2.12.2-9.el8
- `systemd` changed from 239-68.el8_7.4 to 239-74.el8_8
- `systemd-libs` changed from 239-68.el8_7.4 to 239-74.el8_8
- `systemd-pam` changed from 239-68.el8_7.4 to 239-74.el8_8
- `tar` changed from 1.30-6.el8_7.1 to 1.30-9.el8
- `util-linux` changed from 2.32.1-39.el8_7 to 2.32.1-42.el8_8
- `yum` changed from 4.7.0-11.el8.alma to 4.7.0-16.el8_8.alma


