### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev12, 2.8-dev, 2.8-dev12-bullseye, 2.8-dev-bullseye
+Tags: 2.8-dev13, 2.8-dev, 2.8-dev13-bullseye, 2.8-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8540b3c85e62fae2c85d73e3a27c17f53da115e1
+GitCommit: 19b0b73d7173ccc7d2f30987dedbf8ee8932b63d
 Directory: 2.8
 
-Tags: 2.8-dev12-alpine, 2.8-dev-alpine, 2.8-dev12-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8-dev13-alpine, 2.8-dev-alpine, 2.8-dev13-alpine3.17, 2.8-dev-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8540b3c85e62fae2c85d73e3a27c17f53da115e1
+GitCommit: 19b0b73d7173ccc7d2f30987dedbf8ee8932b63d
 Directory: 2.8/alpine
 
 Tags: 2.7.8, 2.7, latest, 2.7.8-bullseye, 2.7-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/19b0b73: Update 2.8 to 2.8-dev13