### PR TITLE
bump neo4j 5.8.0 gitcommit sha to fix bug

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -12,12 +12,12 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 Tags: 5.8.0, 5.8.0-community, 5.8, 5.8-community, 5, 5-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: a9b3464e378d969401dce828e6000453677c0b3e
+GitCommit: 20660ac29964bba2bb7432919f65df0b7f8c323e
 Directory: 5.8.0/community
 
 Tags: 5.8.0-enterprise, 5.8-enterprise, 5-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: a9b3464e378d969401dce828e6000453677c0b3e
+GitCommit: 20660ac29964bba2bb7432919f65df0b7f8c323e
 Directory: 5.8.0/enterprise
 
 
@@ -30,5 +30,3 @@ Tags: 4.4.21-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
 GitCommit: 9dea28f9da8f5792752853a1be16309950d03204
 Directory: 4.4.21/enterprise
-
-


### PR DESCRIPTION
I made a mistake in the recent 5.8.0 neo4j image and need to push a fix. Sorry about that!