### PR TITLE
archlinux: Release 20230528.0.154326

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230521.0.152478
-GitCommit: dbd59f669a2b422b67fc86350e7691fec43083a8
-GitFetch: refs/tags/v20230521.0.152478
+Tags: latest, base, base-20230528.0.154326
+GitCommit: d8e9ebde1718f8f26185afa99e795fa6fec6f931
+GitFetch: refs/tags/v20230528.0.154326
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230521.0.152478
-GitCommit: dbd59f669a2b422b67fc86350e7691fec43083a8
-GitFetch: refs/tags/v20230521.0.152478
+Tags: base-devel, base-devel-20230528.0.154326
+GitCommit: d8e9ebde1718f8f26185afa99e795fa6fec6f931
+GitFetch: refs/tags/v20230528.0.154326
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks