### PR TITLE
Update Clear Linux OS to 39230

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: a180d1a2ebd692b5c5403e698f48c98f5a1df5ce
-GitFetch: refs/heads/base-39150
+GitCommit: ee8c4c68f687355e4dd9eccd137e7c6df06ac789
+GitFetch: refs/heads/base-39230


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39230

@bryteise @djklimes @bryteise