### PR TITLE
Odoo: update 14.0-16.0 to release 20230530

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 789b7ff9dc2b9647276d8497957cf19de9e83a01
+GitCommit: 42cc6f7d3a35dd7ab2353e09cfecf48c1bf50ee1
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest upgrade of Odoo supported versions.

Thanks a lot