### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -18,12 +18,12 @@ GitCommit: dfa419750ef32e01ce5715a08533397f570f1133
 Directory: 12
 # Docker EOL: 2024-11-08
 
-# Last Modified: 2022-04-21
-Tags: 11.3.0, 11.3, 11, 11.3.0-bullseye, 11.3-bullseye, 11-bullseye
+# Last Modified: 2023-05-29
+Tags: 11.4.0, 11.4, 11, 11.4.0-bullseye, 11.4-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 46628bc0702798f6ff9f923650361f46f9eb2af2
+GitCommit: 9f10f9541f9736300c811cdb3f319c038a8b9c3a
 Directory: 11
-# Docker EOL: 2023-10-21
+# Docker EOL: 2024-11-29
 
 # Last Modified: 2022-06-28
 Tags: 10.4.0, 10.4, 10, 10.4.0-bullseye, 10.4-bullseye, 10-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/9f10f95: Update 11 to 11.4.0