### PR TITLE
Add s390x architecture support for CouchDB 3.3.2

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -4,10 +4,10 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: 72a0aebfa3248b3df64a70049f0fb1f90c042a49
+GitCommit: b616800e739db18c19e6a8b4131528157f945bcd
 
 Tags: latest, 3.3.2, 3.3, 3
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: 3.3.2
 
 Tags: 3.2.3, 3.2


### PR DESCRIPTION
https://github.com/apache/couchdb-docker got updated to support s390x so update the official image accordingly.