### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,47 +4,137 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 4.3.1, 4.3, 4, latest, 4.3.1-apache, 4.3-apache, 4-apache, apache, 4.3.1-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.1-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 5.0.0-alpha1, 5.0, 5.0.alpha, 5.0.0-alpha, 5.0.0-alpha1-apache, 5.0-apache, 5.0.alpha-apache, 5.0.0-alpha-apache, 5.0.0-alpha1-php8.1, 5.0-php8.1, 5.0.alpha-php8.1, 5.0.0-alpha-php8.1, 5.0.0-alpha1-php8.1-apache, 5.0-php8.1-apache, 5.0.alpha-php8.1-apache, 5.0.0-alpha-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+Directory: 5.0.alpha/php8.1/apache
+
+Tags: 5.0.0-alpha1-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.alpha-php8.1-fpm-alpine, 5.0.0-alpha-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+Directory: 5.0.alpha/php8.1/fpm-alpine
+
+Tags: 5.0.0-alpha1-php8.1-fpm, 5.0-php8.1-fpm, 5.0.alpha-php8.1-fpm, 5.0.0-alpha-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+Directory: 5.0.alpha/php8.1/fpm
+
+Tags: 5.0.0-alpha1-php8.2-apache, 5.0-php8.2-apache, 5.0.alpha-php8.2-apache, 5.0.0-alpha-php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+Directory: 5.0.alpha/php8.2/apache
+
+Tags: 5.0.0-alpha1-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.alpha-php8.2-fpm-alpine, 5.0.0-alpha-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+Directory: 5.0.alpha/php8.2/fpm-alpine
+
+Tags: 5.0.0-alpha1-php8.2-fpm, 5.0-php8.2-fpm, 5.0.alpha-php8.2-fpm, 5.0.0-alpha-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+Directory: 5.0.alpha/php8.2/fpm
+
+Tags: 4.4.0-alpha1-php8.0-apache, 4.4-php8.0-apache, 4.4.alpha-php8.0-apache, 4.4.0-alpha-php8.0-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.0/apache
+
+Tags: 4.4.0-alpha1-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.alpha-php8.0-fpm-alpine, 4.4.0-alpha-php8.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.0/fpm-alpine
+
+Tags: 4.4.0-alpha1-php8.0-fpm, 4.4-php8.0-fpm, 4.4.alpha-php8.0-fpm, 4.4.0-alpha-php8.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.0/fpm
+
+Tags: 4.4.0-alpha1, 4.4, 4.4.alpha, 4.4.0-alpha, 4.4.0-alpha1-apache, 4.4-apache, 4.4.alpha-apache, 4.4.0-alpha-apache, 4.4.0-alpha1-php8.1, 4.4-php8.1, 4.4.alpha-php8.1, 4.4.0-alpha-php8.1, 4.4.0-alpha1-php8.1-apache, 4.4-php8.1-apache, 4.4.alpha-php8.1-apache, 4.4.0-alpha-php8.1-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.1/apache
+
+Tags: 4.4.0-alpha1-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.alpha-php8.1-fpm-alpine, 4.4.0-alpha-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.1/fpm-alpine
+
+Tags: 4.4.0-alpha1-php8.1-fpm, 4.4-php8.1-fpm, 4.4.alpha-php8.1-fpm, 4.4.0-alpha-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.1/fpm
+
+Tags: 4.4.0-alpha1-php8.2-apache, 4.4-php8.2-apache, 4.4.alpha-php8.2-apache, 4.4.0-alpha-php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.2/apache
+
+Tags: 4.4.0-alpha1-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.alpha-php8.2-fpm-alpine, 4.4.0-alpha-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.2/fpm-alpine
+
+Tags: 4.4.0-alpha1-php8.2-fpm, 4.4-php8.2-fpm, 4.4.alpha-php8.2-fpm, 4.4.0-alpha-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+Directory: 4.4.alpha/php8.2/fpm
+
+Tags: 4.3.2, 4.3, 4, latest, 4.3.2-apache, 4.3-apache, 4-apache, apache, 4.3.2-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.2-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
 Directory: 4.3/php8.0/apache
 
-Tags: 4.3.1-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.3.2-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
 Directory: 4.3/php8.0/fpm-alpine
 
-Tags: 4.3.1-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.3.2-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
 Directory: 4.3/php8.0/fpm
 
-Tags: 4.3.1-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.3.2-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
 Directory: 4.3/php8.1/apache
 
-Tags: 4.3.1-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.3.2-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
 Directory: 4.3/php8.1/fpm-alpine
 
-Tags: 4.3.1-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.3.2-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: efba6bb87ef113bfa2a9d60b52095f942fce3671
+GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
 Directory: 4.3/php8.1/fpm
+
+Tags: 4.3.2-php8.2-apache, 4.3-php8.2-apache, 4-php8.2-apache, php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: d1f02139287395a0d5ccc3211cea4c6df184377b
+Directory: 4.3/php8.2/apache
+
+Tags: 4.3.2-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: d1f02139287395a0d5ccc3211cea4c6df184377b
+Directory: 4.3/php8.2/fpm-alpine
+
+Tags: 4.3.2-php8.2-fpm, 4.3-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: d1f02139287395a0d5ccc3211cea4c6df184377b
+Directory: 4.3/php8.2/fpm
 
 Tags: 3.10.11, 3.10, 3, 3.10.11-apache, 3.10-apache, 3-apache, 3.10.11-php8.0, 3.10-php8.0, 3-php8.0, 3.10.11-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cf7f1e8d3306c30c1ea909794ce30f353376d8d3
+GitCommit: 5c118d93f57608d779ae61d75bf122f2f03d2d9b
 Directory: 3.10/php8.0/apache
 
 Tags: 3.10.11-php8.0-fpm-alpine, 3.10-php8.0-fpm-alpine, 3-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cf7f1e8d3306c30c1ea909794ce30f353376d8d3
+GitCommit: 5c118d93f57608d779ae61d75bf122f2f03d2d9b
 Directory: 3.10/php8.0/fpm-alpine
 
 Tags: 3.10.11-php8.0-fpm, 3.10-php8.0-fpm, 3-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cf7f1e8d3306c30c1ea909794ce30f353376d8d3
+GitCommit: 5c118d93f57608d779ae61d75bf122f2f03d2d9b
 Directory: 3.10/php8.0/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@5c118d9: Fixed APCu version (typo)
- joomla-docker/docker-joomla@c83dfed: Adds Joomla 5.0.alpha to images
- joomla-docker/docker-joomla@869c8d0: Adds Joomla 4.4.alpha to images
- joomla-docker/docker-joomla@d1f0213: Adds PHP8.2 to Joomla 4.3 Images
- joomla-docker/docker-joomla@eaf2304: Update images of Joomla! 4.3.1 to 4.3.2
- joomla-docker/docker-joomla@32b9670: Update version of Joomla! 4.3.1 to 4.3.2