### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,35 +1,45 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/5c6561b04ba16b7b30ac578ca6de2160dfd1db5d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/2d7b121a1dda3f7844ae094f17346be7252e2ad6/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.8-dev13, 2.8-dev, 2.8-dev13-bullseye, 2.8-dev-bullseye
+Tags: 2.9-dev0, 2.9-dev, 2.9-dev0-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 19b0b73d7173ccc7d2f30987dedbf8ee8932b63d
+GitCommit: f389054a408dd4a1cb6f314fd66a851f565190d3
+Directory: 2.9
+
+Tags: 2.9-dev0-alpine, 2.9-dev-alpine, 2.9-dev0-alpine3.17, 2.9-dev-alpine3.17
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f389054a408dd4a1cb6f314fd66a851f565190d3
+Directory: 2.9/alpine
+
+Tags: 2.8.0, 2.8, lts, latest, 2.8.0-bullseye, 2.8-bullseye, lts-bullseye, bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2d7b121a1dda3f7844ae094f17346be7252e2ad6
 Directory: 2.8
 
-Tags: 2.8-dev13-alpine, 2.8-dev-alpine, 2.8-dev13-alpine3.17, 2.8-dev-alpine3.17
+Tags: 2.8.0-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.0-alpine3.17, 2.8-alpine3.17, lts-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 19b0b73d7173ccc7d2f30987dedbf8ee8932b63d
+GitCommit: 2d7b121a1dda3f7844ae094f17346be7252e2ad6
 Directory: 2.8/alpine
 
-Tags: 2.7.8, 2.7, latest, 2.7.8-bullseye, 2.7-bullseye, bullseye
+Tags: 2.7.8, 2.7, 2.7.8-bullseye, 2.7-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
 Directory: 2.7
 
-Tags: 2.7.8-alpine, 2.7-alpine, alpine, 2.7.8-alpine3.17, 2.7-alpine3.17, alpine3.17
+Tags: 2.7.8-alpine, 2.7-alpine, 2.7.8-alpine3.17, 2.7-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
 Directory: 2.7/alpine
 
-Tags: 2.6.13, 2.6, lts, 2.6.13-bullseye, 2.6-bullseye, lts-bullseye
+Tags: 2.6.13, 2.6, 2.6.13-bullseye, 2.6-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
 Directory: 2.6
 
-Tags: 2.6.13-alpine, 2.6-alpine, lts-alpine, 2.6.13-alpine3.17, 2.6-alpine3.17, lts-alpine3.17
+Tags: 2.6.13-alpine, 2.6-alpine, 2.6.13-alpine3.17, 2.6-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
 Directory: 2.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/aaa4189: Merge pull request https://github.com/docker-library/haproxy/pull/211 from TimWolla/haproxy-2.9
- https://github.com/docker-library/haproxy/commit/f389054: Add HAProxy 2.9
- https://github.com/docker-library/haproxy/commit/0ab952a: Merge pull request https://github.com/docker-library/haproxy/pull/210 from TimWolla/haproxy-2.8
- https://github.com/docker-library/haproxy/commit/2d7b121: Mark HAProxy 2.8 as latest+lts