### PR TITLE
Remove CirrOS backfilled versions

### DIFF
--- a/library/cirros
+++ b/library/cirros
@@ -11,33 +11,3 @@ arm64v8-Directory: arches/arm64v8
 ppc64le-Directory: arches/ppc64le
 
 Tags: 0.6.2, 0.6, 0, latest
-
-# (hopefully) temporary backfill:
-
-Tags: 0.6.1
-GitFetch: refs/heads/dist-0.6.1
-GitCommit: ddf8fe17964242f32980c92879414cf74f8cbbff
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-amd64-Directory: arches/amd64
-arm32v7-Directory: arches/arm32v7
-arm64v8-Directory: arches/arm64v8
-ppc64le-Directory: arches/ppc64le
-
-Tags: 0.6.0
-GitFetch: refs/heads/dist-0.6.0
-GitCommit: 9e8006aaa29017ce2ee85e5373772f39f1f10ac9
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-amd64-Directory: arches/amd64
-arm32v7-Directory: arches/arm32v7
-arm64v8-Directory: arches/arm64v8
-ppc64le-Directory: arches/ppc64le
-
-Tags: 0.5.3, 0.5
-GitFetch: refs/heads/dist-0.5.3
-GitCommit: 36e8b0fd2c270f14631d1767f668a4db83890efb
-Architectures: amd64, arm32v5, arm64v8, i386, ppc64le
-amd64-Directory: arches/amd64
-arm32v5-Directory: arches/arm32v5
-arm64v8-Directory: arches/arm64v8
-i386-Directory: arches/i386
-ppc64le-Directory: arches/ppc64le


### PR DESCRIPTION
The builds aren't _quite_ done/pushed yet, but I don't want to forget to remove these. :sweat_smile:

(follow up to https://github.com/docker-library/official-images/pull/14767)