### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f389054a408dd4a1cb6f314fd66a851f565190d3
 Directory: 2.9
 
-Tags: 2.9-dev0-alpine, 2.9-dev-alpine, 2.9-dev0-alpine3.17, 2.9-dev-alpine3.17
+Tags: 2.9-dev0-alpine, 2.9-dev-alpine, 2.9-dev0-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f389054a408dd4a1cb6f314fd66a851f565190d3
+GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.9/alpine
 
 Tags: 2.8.0, 2.8, lts, latest, 2.8.0-bullseye, 2.8-bullseye, lts-bullseye, bullseye
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 2d7b121a1dda3f7844ae094f17346be7252e2ad6
 Directory: 2.8
 
-Tags: 2.8.0-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.0-alpine3.17, 2.8-alpine3.17, lts-alpine3.17, alpine3.17
+Tags: 2.8.0-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.0-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d7b121a1dda3f7844ae094f17346be7252e2ad6
+GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.8/alpine
 
 Tags: 2.7.8, 2.7, 2.7.8-bullseye, 2.7-bullseye
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
 Directory: 2.7
 
-Tags: 2.7.8-alpine, 2.7-alpine, 2.7.8-alpine3.17, 2.7-alpine3.17
+Tags: 2.7.8-alpine, 2.7-alpine, 2.7.8-alpine3.18, 2.7-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
+GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.7/alpine
 
 Tags: 2.6.13, 2.6, 2.6.13-bullseye, 2.6-bullseye
@@ -39,9 +39,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
 Directory: 2.6
 
-Tags: 2.6.13-alpine, 2.6-alpine, 2.6.13-alpine3.17, 2.6-alpine3.17
+Tags: 2.6.13-alpine, 2.6-alpine, 2.6.13-alpine3.18, 2.6-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
+GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.6/alpine
 
 Tags: 2.4.22, 2.4, 2.4.22-bullseye, 2.4-bullseye
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 010b099f11c898314bf1e3c90c19ed3bf6cc89e2
 Directory: 2.4
 
-Tags: 2.4.22-alpine, 2.4-alpine, 2.4.22-alpine3.17, 2.4-alpine3.17
+Tags: 2.4.22-alpine, 2.4-alpine, 2.4.22-alpine3.18, 2.4-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 010b099f11c898314bf1e3c90c19ed3bf6cc89e2
+GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.4/alpine
 
 Tags: 2.2.29, 2.2, 2.2.29-bullseye, 2.2-bullseye
@@ -59,9 +59,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a341c5a4894f4f8194a5b05076767688d85d369d
 Directory: 2.2
 
-Tags: 2.2.29-alpine, 2.2-alpine, 2.2.29-alpine3.17, 2.2-alpine3.17
+Tags: 2.2.29-alpine, 2.2-alpine, 2.2.29-alpine3.18, 2.2-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a341c5a4894f4f8194a5b05076767688d85d369d
+GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.2/alpine
 
 Tags: 2.0.31, 2.0, 2.0.31-buster, 2.0-buster


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bfca65f: Merge pull request https://github.com/docker-library/haproxy/pull/212 from infosiftr/alpine3.18
- https://github.com/docker-library/haproxy/commit/8319188: Update to Alpine 3.18