### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2023-3106

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 66ad1d007635040c8cf05d3e39e0bac42c008dfc
+amd64-GitCommit: 0ca79a2bcffcfd0abe7aabba221908a255267f21
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2e02ff40aaa866edf5c7c7762a534c2dd9d9e8e8
+arm64v8-GitCommit: 429a521e2cca537dc487fea82017c2769008827e
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-27535.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-3106.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>