### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -8,25 +8,26 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Preston Carpenter (@timidger),
              Joseph Howell-Burke (@jhowell-burke),
              Miriam Clark (@mgclark001),
-             Ade Adetayo (@dadetayo)
+             Ade Adetayo (@dadetayo),
+             Colin McCoy (@cmccoypdx)
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.0.20230503.0
+Tags: 2023, latest, 2023.0.20230517.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: ea5a916817e6c6bd0f031358bb8f4f5c272d7de1
+amd64-GitCommit: b681ad22b5dc7d459d771a9803bea14d34fe7ee6
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 9ad73d0ab12dcffa38c120294e32ca2f0d702ad3
+arm64v8-GitCommit: d3da6408ff4eb6a00f52b3c723e78f74c26cca8b
 
-Tags: 2, 2.0.20230504.1
+Tags: 2, 2.0.20230515.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: a3064f5b88429f37824e9d9897021058f5eed6d6
+amd64-GitCommit: 414e8927d838c4ec3eec786702cd040e7e7ce8ca
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: da91f2997455ed1bc395985d1399c6261278c5b4
+arm64v8-GitCommit: 5777c67a2320ea4c2d152ec49904faed5be33660
 
-Tags: 1, 2018.03, 2018.03.0.20230501.0
+Tags: 1, 2018.03, 2018.03.0.20230515.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 28a8085038403ae42578118bc2fdad522bbcd64e
+amd64-GitCommit: 551da039c0c482176995ca033eb3753f0a490ea8


### PR DESCRIPTION
### Updated Packages for Amazon Linux 1:
- glib2-2.36.3-5.24.amzn1
#### Packages addressing CVES:
- glib2-2.36.3-5.24.amzn1
  - [CVE-2018-16429](https://alas.aws.amazon.com/cve/html/CVE-2018-16429.html)

### Updated Packages for Amazon Linux 2:
- glib2-2.56.1-9.amzn2.0.3
- libssh2-1.4.3-12.amzn2.2.4
#### Packages addressing CVES:
- glib2-2.56.1-9.amzn2.0.3
  - [CVE-2018-16428](https://alas.aws.amazon.com/cve/html/CVE-2018-16428.html)
  - [CVE-2018-16429](https://alas.aws.amazon.com/cve/html/CVE-2018-16429.html)
- libssh2-1.4.3-12.amzn2.2.4
  - [CVE-2019-3859](https://alas.aws.amazon.com/cve/html/CVE-2019-3859.html)
  - [CVE-2019-3860](https://alas.aws.amazon.com/cve/html/CVE-2019-3860.html)

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.0.20230517-0.amzn2023
- system-release-2023.0.20230517-0.amzn2023
- openssl-libs-3.0.8-1.amzn2023.0.2
#### Packages addressing CVES:
- openssl-libs-3.0.8-1.amzn2023.0.2
  - [CVE-2023-0464](https://alas.aws.amazon.com/cve/html/CVE-2023-0464.html)
  - [CVE-2023-0465](https://alas.aws.amazon.com/cve/html/CVE-2023-0465.html)
  - [CVE-2023-0466](https://alas.aws.amazon.com/cve/html/CVE-2023-0466.html)
  - [CVE-2023-1255](https://alas.aws.amazon.com/cve/html/CVE-2023-1255.html)