### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.2.2-apache, 6.2-apache, 6-apache, apache, 6.2.2, 6.2, 6, latest, 6.2.2-php8.0-apache, 6.2-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.2.2-php8.0, 6.2-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
+GitCommit: a0aacf3dbe87fde423bde4ef292dc1a929025d36
 Directory: latest/php8.0/apache
 
 Tags: 6.2.2-fpm, 6.2-fpm, 6-fpm, fpm, 6.2.2-php8.0-fpm, 6.2-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
@@ -21,7 +21,7 @@ Directory: latest/php8.0/fpm-alpine
 
 Tags: 6.2.2-php8.1-apache, 6.2-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.2.2-php8.1, 6.2-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
+GitCommit: a0aacf3dbe87fde423bde4ef292dc1a929025d36
 Directory: latest/php8.1/apache
 
 Tags: 6.2.2-php8.1-fpm, 6.2-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
@@ -36,7 +36,7 @@ Directory: latest/php8.1/fpm-alpine
 
 Tags: 6.2.2-php8.2-apache, 6.2-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.2.2-php8.2, 6.2-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
+GitCommit: a0aacf3dbe87fde423bde4ef292dc1a929025d36
 Directory: latest/php8.2/apache
 
 Tags: 6.2.2-php8.2-fpm, 6.2-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
@@ -49,17 +49,17 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
 Directory: latest/php8.2/fpm-alpine
 
-Tags: cli-2.7.1, cli-2.7, cli-2, cli, cli-2.7.1-php8.0, cli-2.7-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.8.1, cli-2.8, cli-2, cli, cli-2.8.1-php8.0, cli-2.8-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
+GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
 Directory: cli/php8.0/alpine
 
-Tags: cli-2.7.1-php8.1, cli-2.7-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.8.1-php8.1, cli-2.8-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
+GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.7.1-php8.2, cli-2.7-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.8.1-php8.2, cli-2.8-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 809519cc86bee0d6c7f2743976a850267983e2c2
+GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
 Directory: cli/php8.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/d0c948b: Merge pull request https://github.com/docker-library/wordpress/pull/830 from mossroy/replace-RemoteIPTrustedProxy-by-RemoteIPInternalProxy
- https://github.com/docker-library/wordpress/commit/68ba8ed: Update cli to 2.8.1
- https://github.com/docker-library/wordpress/commit/8cd1ab8: Update cli to 2.8.0
- https://github.com/docker-library/wordpress/commit/a0aacf3: Replace RemoteIPTrustedProxy by RemoteIPInternalProxy in remoteip.conf