### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.7.1
+Tags: 8.8.0
 Architectures: amd64, arm64v8
-GitCommit: 229361a202bcd5b7c1ddfd7b52ebc4c79e884958
+GitCommit: 3ecc4007656f868f1811566a766bff0c65d26242
 Directory: 8
 
 Tags: 7.17.10

--- a/library/kibana
+++ b/library/kibana
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.7.1
+Tags: 8.8.0
 Architectures: amd64, arm64v8
-GitCommit: e577f15420a471649acd96a337cf5f575924a18f
+GitCommit: 2770daca005958cbb53a576d90254567cc06100a
 Directory: 8
 
 Tags: 7.17.10

--- a/library/logstash
+++ b/library/logstash
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.7.1
+Tags: 8.8.0
 Architectures: amd64, arm64v8
-GitCommit: da79914ffa9715c6db2f084ff5aec2700fefbab4
+GitCommit: 6b04b9094d63927600bee099ab482d6b7467d038
 Directory: 8
 
 Tags: 7.17.10


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/3ecc400: Update to 8.8.0

logstash:
- https://github.com/docker-library/logstash/commit/6b04b90: Update to 8.8.0

kibana:
- https://github.com/docker-library/kibana/commit/2770dac: Update to 8.8.0

Fixes #14788