### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
 Directory: 2.8/alpine
 
-Tags: 2.7.8, 2.7, 2.7.8-bullseye, 2.7-bullseye
+Tags: 2.7.9, 2.7, 2.7.9-bullseye, 2.7-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b5e4baa466adb533d8f644e1ef514a4301addcb1
+GitCommit: 078ca80d6479126a48c24c8ada4b174241bccea3
 Directory: 2.7
 
-Tags: 2.7.8-alpine, 2.7-alpine, 2.7.8-alpine3.18, 2.7-alpine3.18
+Tags: 2.7.9-alpine, 2.7-alpine, 2.7.9-alpine3.18, 2.7-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
+GitCommit: 078ca80d6479126a48c24c8ada4b174241bccea3
 Directory: 2.7/alpine
 
 Tags: 2.6.13, 2.6, 2.6.13-bullseye, 2.6-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/078ca80: Update 2.7 to 2.7.9