### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,24 +34,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 078ca80d6479126a48c24c8ada4b174241bccea3
 Directory: 2.7/alpine
 
-Tags: 2.6.13, 2.6, 2.6.13-bullseye, 2.6-bullseye
+Tags: 2.6.14, 2.6, 2.6.14-bullseye, 2.6-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aad0f7b69e95354996d9cfd7ed8cdc9cd28d3298
+GitCommit: 3eeba1e19f5660c9584b378e93ec9115f590ccfb
 Directory: 2.6
 
-Tags: 2.6.13-alpine, 2.6-alpine, 2.6.13-alpine3.18, 2.6-alpine3.18
+Tags: 2.6.14-alpine, 2.6-alpine, 2.6.14-alpine3.18, 2.6-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
+GitCommit: 3eeba1e19f5660c9584b378e93ec9115f590ccfb
 Directory: 2.6/alpine
 
-Tags: 2.4.22, 2.4, 2.4.22-bullseye, 2.4-bullseye
+Tags: 2.4.23, 2.4, 2.4.23-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 010b099f11c898314bf1e3c90c19ed3bf6cc89e2
+GitCommit: 7acb59e8fbc48dabf3d7b06bae1387ac9f2ac5ce
 Directory: 2.4
 
-Tags: 2.4.22-alpine, 2.4-alpine, 2.4.22-alpine3.18, 2.4-alpine3.18
+Tags: 2.4.23-alpine, 2.4-alpine, 2.4.23-alpine3.18, 2.4-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
+GitCommit: 7acb59e8fbc48dabf3d7b06bae1387ac9f2ac5ce
 Directory: 2.4/alpine
 
 Tags: 2.2.29, 2.2, 2.2.29-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7acb59e: Update 2.4 to 2.4.23
- https://github.com/docker-library/haproxy/commit/3eeba1e: Update 2.6 to 2.6.14