### PR TITLE
archlinux: Release 20230611.0.157136

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230604.0.155602
-GitCommit: 4693da54ba7cef37ecbe495d378eb9d9c4deba56
-GitFetch: refs/tags/v20230604.0.155602
+Tags: latest, base, base-20230611.0.157136
+GitCommit: 8c107a2ed9ee79927da495f556a81a6999221bab
+GitFetch: refs/tags/v20230611.0.157136
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230604.0.155602
-GitCommit: 4693da54ba7cef37ecbe495d378eb9d9c4deba56
-GitFetch: refs/tags/v20230604.0.155602
+Tags: base-devel, base-devel-20230611.0.157136
+GitCommit: 8c107a2ed9ee79927da495f556a81a6999221bab
+GitFetch: refs/tags/v20230611.0.157136
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks