### PR TITLE
Update Clear Linux OS to 39340

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ee8c4c68f687355e4dd9eccd137e7c6df06ac789
-GitFetch: refs/heads/base-39230
+GitCommit: 43edaa58caa74272b3c5c5b122dfa0b10cc0a53c
+GitFetch: refs/heads/base-39340


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39340

@bryteise @djklimes @bryteise