### PR TITLE
Updated Packages for Amazon Linux 1:

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.0.20230517.1
+Tags: 2023, latest, 2023.0.20230607.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: b681ad22b5dc7d459d771a9803bea14d34fe7ee6
+amd64-GitCommit: 5b32b6595a09f86581fd5c5ceadf96661b46775a
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: d3da6408ff4eb6a00f52b3c723e78f74c26cca8b
+arm64v8-GitCommit: b25ced94f7f1a09f6fa4b34ad9684b3aaaa12967
 
-Tags: 2, 2.0.20230515.0
+Tags: 2, 2.0.20230530.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 414e8927d838c4ec3eec786702cd040e7e7ce8ca
+amd64-GitCommit: 0ba6c8b0f5c91ec71e8bd3cdc7bc14d6ee765aa5
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 5777c67a2320ea4c2d152ec49904faed5be33660
+arm64v8-GitCommit: f7fc842a22cfb63dcce076b719aee601528c6153
 
-Tags: 1, 2018.03, 2018.03.0.20230515.0
+Tags: 1, 2018.03, 2018.03.0.20230601.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 551da039c0c482176995ca033eb3753f0a490ea8
+amd64-GitCommit: fdd940257ea9f92da09305181bf08c4e7d865a4c


### PR DESCRIPTION
### Updated Packages for Amazon Linux 1:
- libssh2-1.4.2-3.13.amzn1
- tar-1.26-31.24.amzn1
#### Packages addressing CVES:
- libssh2-1.4.2-3.13.amzn1
  - [CVE-2019-3859](https://alas.aws.amazon.com/cve/html/CVE-2019-3859.html)
  - [CVE-2019-3860](https://alas.aws.amazon.com/cve/html/CVE-2019-3860.html)
- tar-1.26-31.24.amzn1
  - [CVE-2019-9923](https://alas.aws.amazon.com/cve/html/CVE-2019-9923.html)

### Updated Packages for Amazon Linux 2:
- glib2-2.56.1-9.amzn2.0.5
#### Packages addressing CVES:
- glib2-2.56.1-9.amzn2.0.5
  - [CVE-2021-3800](https://alas.aws.amazon.com/cve/html/CVE-2021-3800.html)

### Updated Packages for Amazon Linux 2023:
- libcap-2.48-2.amzn2023.0.3
- libcurl-minimal-8.0.1-1.amzn2023
- curl-minimal-8.0.1-1.amzn2023
- amazon-linux-repo-cdn-2023.0.20230607-0.amzn2023
- system-release-2023.0.20230607-0.amzn2023
#### Packages addressing CVES:
- libcap-2.48-2.amzn2023.0.3
  - [CVE-2023-2602](https://alas.aws.amazon.com/cve/html/CVE-2023-2602.html)
- libcurl-minimal-8.0.1-1.amzn2023, curl-minimal-8.0.1-1.amzn2023
  - [CVE-2023-27533](https://alas.aws.amazon.com/cve/html/CVE-2023-27533.html)
  - [CVE-2023-27534](https://alas.aws.amazon.com/cve/html/CVE-2023-27534.html)
  - [CVE-2023-27535](https://alas.aws.amazon.com/cve/html/CVE-2023-27535.html)
  - [CVE-2023-27536](https://alas.aws.amazon.com/cve/html/CVE-2023-27536.html)
  - [CVE-2023-27537](https://alas.aws.amazon.com/cve/html/CVE-2023-27537.html)
  - [CVE-2023-27538](https://alas.aws.amazon.com/cve/html/CVE-2023-27538.html)