### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -12,29 +12,29 @@ Directory: 13
 # Docker EOL: 2024-10-26
 
 # Last Modified: 2023-05-08
-Tags: 12.3.0, 12.3, 12, 12.3.0-bullseye, 12.3-bullseye, 12-bullseye
+Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: dfa419750ef32e01ce5715a08533397f570f1133
+GitCommit: 9677600371602a897f576cf1d85852a3a26f71af
 Directory: 12
 # Docker EOL: 2024-11-08
 
 # Last Modified: 2023-05-29
-Tags: 11.4.0, 11.4, 11, 11.4.0-bullseye, 11.4-bullseye, 11-bullseye
+Tags: 11.4.0, 11.4, 11, 11.4.0-bookworm, 11.4-bookworm, 11-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9f10f9541f9736300c811cdb3f319c038a8b9c3a
+GitCommit: 8896a6fe1d596abcaea6c75c98337885ba4c27e8
 Directory: 11
 # Docker EOL: 2024-11-29
 
 # Last Modified: 2022-06-28
-Tags: 10.4.0, 10.4, 10, 10.4.0-bullseye, 10.4-bullseye, 10-bullseye
+Tags: 10.4.0, 10.4, 10, 10.4.0-bookworm, 10.4-bookworm, 10-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 46628bc0702798f6ff9f923650361f46f9eb2af2
+GitCommit: 392d8bf4ee9d494f03331c540c1f0d7f32259ff1
 Directory: 10
 # Docker EOL: 2023-12-28
 
 # Last Modified: 2022-05-27
-Tags: 9.5.0, 9.5, 9, 9.5.0-bullseye, 9.5-bullseye, 9-bullseye
+Tags: 9.5.0, 9.5, 9, 9.5.0-bookworm, 9.5-bookworm, 9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 46628bc0702798f6ff9f923650361f46f9eb2af2
+GitCommit: 0d98f7923b5ed7f5baec2506413c99e920cf6661
 Directory: 9
 # Docker EOL: 2023-11-27


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/0d98f79: Update 9 to debian bookworm
- https://github.com/docker-library/gcc/commit/9677600: Update 12 to debian bookworm
- https://github.com/docker-library/gcc/commit/8896a6f: Update 11 to debian bookworm
- https://github.com/docker-library/gcc/commit/392d8bf: Update 10 to debian bookworm