### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -54,22 +54,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7acb59e8fbc48dabf3d7b06bae1387ac9f2ac5ce
 Directory: 2.4/alpine
 
-Tags: 2.2.29, 2.2, 2.2.29-bullseye, 2.2-bullseye
+Tags: 2.2.30, 2.2, 2.2.30-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a341c5a4894f4f8194a5b05076767688d85d369d
+GitCommit: 0e3884218d34cd77b8b59145d05e058be227b334
 Directory: 2.2
 
-Tags: 2.2.29-alpine, 2.2-alpine, 2.2.29-alpine3.18, 2.2-alpine3.18
+Tags: 2.2.30-alpine, 2.2-alpine, 2.2.30-alpine3.18, 2.2-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
+GitCommit: 0e3884218d34cd77b8b59145d05e058be227b334
 Directory: 2.2/alpine
 
-Tags: 2.0.31, 2.0, 2.0.31-buster, 2.0-buster
+Tags: 2.0.32, 2.0, 2.0.32-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1842f4392f605e9f944c7f55415ddfc828301a31
+GitCommit: 51e072f624e35ba473bb69e6d2815cb1dae0c7cc
 Directory: 2.0
 
-Tags: 2.0.31-alpine, 2.0-alpine, 2.0.31-alpine3.16, 2.0-alpine3.16
+Tags: 2.0.32-alpine, 2.0-alpine, 2.0.32-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1842f4392f605e9f944c7f55415ddfc828301a31
+GitCommit: 51e072f624e35ba473bb69e6d2815cb1dae0c7cc
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/0e38842: Update 2.2 to 2.2.30
- https://github.com/docker-library/haproxy/commit/51e072f: Update 2.0 to 2.0.32