### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.49.3, 5.49, 5, latest
+Tags: 5.51.0, 5.51, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7244a7250289a74268d00712232c91413213c612
+GitCommit: f872b8e6f20ccf9cd86b04e412e2f67d4e6aebe9
 Directory: 5/debian
 
-Tags: 5.49.3-alpine, 5.49-alpine, 5-alpine, alpine
+Tags: 5.51.0-alpine, 5.51-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 7244a7250289a74268d00712232c91413213c612
+GitCommit: f872b8e6f20ccf9cd86b04e412e2f67d4e6aebe9
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/f872b8e: Update to 5.51.0, ghost-cli 1.24.0
- https://github.com/docker-library/ghost/commit/e7970d1: Merge pull request https://github.com/docker-library/ghost/pull/385 from infosiftr/alpine-bump
- https://github.com/docker-library/ghost/commit/e7cad6f: Alpine bump to supported node image