### PR TITLE
Odoo: update 14.0-16.0 to release 20230613

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 42cc6f7d3a35dd7ab2353e09cfecf48c1bf50ee1
+GitCommit: 7a7169250712b280c009e6e507f0c97a68e9c5c0
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

Here are the latest updates of Odoo supported versions.

Also adds python3-magic and python3-odf to the 16.0 image.

Thanks