### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -9,22 +9,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5c69b4458049c150d8cc335841871aa4625dc217
 Directory: 5.0
 
-Tags: 5.0.5-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.5-alpine3.16, 5.0-alpine3.16, 5-alpine3.16, alpine3.16
+Tags: 5.0.5-alpine, 5.0-alpine, 5-alpine, alpine, 5.0.5-alpine3.18, 5.0-alpine3.18, 5-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c69b4458049c150d8cc335841871aa4625dc217
+GitCommit: cc904a5f85eb1bfd99af68c0ea3f1e5aeb5d5554
 Directory: 5.0/alpine
-
-Tags: 4.2.10, 4.2, 4, 4.2.10-bullseye, 4.2-bullseye, 4-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1f2a9a14e36002ff028ff9677deb9909670a25f9
-Directory: 4.2
-
-Tags: 4.2.10-passenger, 4.2-passenger, 4-passenger
-Architectures: amd64
-GitCommit: ec4ba2df717b0c0adbbf34dc3a1a0e65f93a11e7
-Directory: 4.2/passenger
-
-Tags: 4.2.10-alpine, 4.2-alpine, 4-alpine, 4.2.10-alpine3.16, 4.2-alpine3.16, 4-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1f2a9a14e36002ff028ff9677deb9909670a25f9
-Directory: 4.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/5202c49: Merge pull request https://github.com/docker-library/redmine/pull/294 from infosiftr/alpine-bump
- https://github.com/docker-library/redmine/commit/8fb25e7: Drop 4.x since Ruby 2.7 is EOL
- https://github.com/docker-library/redmine/commit/cc904a5: Alpine bump to 3.18