### PR TITLE
[oraclelinux] Updating 7 and 7-slim for ELSA-2023-3555

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0ca79a2bcffcfd0abe7aabba221908a255267f21
+amd64-GitCommit: e5fc5f1cf944480d569edb035ae17e3000064bc7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 429a521e2cca537dc487fea82017c2769008827e
+arm64v8-GitCommit: d18cc4c44ab3cd1fa8d84e8693fef8d16f7f9ec9
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-24329.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-3555.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>