### PR TITLE
Releasing Neo4j 5.9.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -1,24 +1,18 @@
-# Old point releases are included in this library file so that users
-# are not forced to upgrade to the latest point releases in order to
-# get security fixes to the base image. See
-# https://github.com/docker-library/official-images/issues/1864 for a
-# discussion of this point.
-
 Maintainers: Jenny Owen <jenny.owen@neo4j.com> (@jennyowen),
              Bledi Feshti <bledi.feshti@neo4j.com> (@bfeshti),
              Eric Sporre <eric.sporre@neo4j.com> (@ericsporre)
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 
-Tags: 5.8.0, 5.8.0-community, 5.8, 5.8-community, 5, 5-community, community, latest
+Tags: 5.9.0, 5.9.0-community, 5.9, 5.9-community, 5, 5-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 20660ac29964bba2bb7432919f65df0b7f8c323e
-Directory: 5.8.0/community
+GitCommit: 9d7a9047bb1b1b736c01e50bf5d38c0a4d3d1697
+Directory: 5.9.0/community
 
-Tags: 5.8.0-enterprise, 5.8-enterprise, 5-enterprise, enterprise
+Tags: 5.9.0-enterprise, 5.9-enterprise, 5-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 20660ac29964bba2bb7432919f65df0b7f8c323e
-Directory: 5.8.0/enterprise
+GitCommit: 9d7a9047bb1b1b736c01e50bf5d38c0a4d3d1697
+Directory: 5.9.0/enterprise
 
 
 Tags: 4.4.21, 4.4.21-community, 4.4, 4.4-community


### PR DESCRIPTION
Just so you know, within the next few releases I'll be adding new neo4j images based on `redhat/ubi8-minimal`. From what I understand from the documentation, that's one of the few non-official base images we can use, right?

Anyway, thanks for your hard work as usual :heart: 