### PR TITLE
[oraclelinux] Updating 8, 8-slim and 9 for ELSA-2023-3595, ELSA-2023-3591

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e5fc5f1cf944480d569edb035ae17e3000064bc7
+amd64-GitCommit: 6489033c7bc5cd29a6869f31dca86efe57bd644f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d18cc4c44ab3cd1fa8d84e8693fef8d16f7f9ec9
+arm64v8-GitCommit: 5db7bf8af2aa716c8f4b5f3eacfe1d878e413710
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-24329.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-3591.html
https://linux.oracle.com/errata/ELSA-2023-3595.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>