### PR TITLE
arangodb 3.10.7, 3.11.1

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,12 +7,12 @@ Architectures: amd64
 GitCommit: 2f0e4d0d5f501633e6254812320283bf0c710757
 Directory: alpine/3.9.11
 
-Tags: 3.10, 3.10.6
+Tags: 3.10, 3.10.7
 Architectures: amd64, arm64v8
-GitCommit: a33b50b8a5c9a60f8c812016899485cc9cd78de3
-Directory: alpine/3.10.6
+GitCommit: 5c926a243d7c952a58f97488781f5eaf6d6704b9
+Directory: alpine/3.10.7
 
-Tags: 3.11, 3.11.0, latest
+Tags: 3.11, 3.11.1, latest
 Architectures: amd64, arm64v8
-GitCommit: 900b2e2b330a213b9c965badd073df63eb3b615d
-Directory: alpine/3.11.0
+GitCommit: 5c926a243d7c952a58f97488781f5eaf6d6704b9
+Directory: alpine/3.11.1


### PR DESCRIPTION
Updated ArangoDB 3.10 to 3.10.7 and 3.11 to 3.11.1.