### PR TITLE
Updated Packages for Amazon Linux 1:

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.0.20230607.0
+Tags: 2023, latest, 2023.0.20230614.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 5b32b6595a09f86581fd5c5ceadf96661b46775a
+amd64-GitCommit: 6a80b496dddec729b610e3fb60b235124b929710
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: b25ced94f7f1a09f6fa4b34ad9684b3aaaa12967
+arm64v8-GitCommit: cd84ce65bcd61b3187daee68e2494bb918b97072
 
-Tags: 2, 2.0.20230530.0
+Tags: 2, 2.0.20230612.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0ba6c8b0f5c91ec71e8bd3cdc7bc14d6ee765aa5
+amd64-GitCommit: c37b0b93a914f22f910edc26a1a83d6f7403d821
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: f7fc842a22cfb63dcce076b719aee601528c6153
+arm64v8-GitCommit: 43590d06b6d64d9a9237f92d753537789c90e1f1
 
-Tags: 1, 2018.03, 2018.03.0.20230601.0
+Tags: 1, 2018.03, 2018.03.0.20230607.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: fdd940257ea9f92da09305181bf08c4e7d865a4c
+amd64-GitCommit: 9a66082b2100b382b5adaa526b8b63515639bbfd


### PR DESCRIPTION
### Updated Packages for Amazon Linux 1:
- pcre-8.21-7.9.amzn1
- openssl-1.0.2k-16.163.amzn1
#### Packages addressing CVES:
- pcre-8.21-7.9.amzn1
  - [CVE-2015-5073](https://alas.aws.amazon.com/cve/html/CVE-2015-5073.html)
  - [CVE-2015-8390](https://alas.aws.amazon.com/cve/html/CVE-2015-8390.html)
  - [CVE-2015-8394](https://alas.aws.amazon.com/cve/html/CVE-2015-8394.html)
- openssl-1.0.2k-16.163.amzn1
  - [CVE-2023-0464](https://alas.aws.amazon.com/cve/html/CVE-2023-0464.html)
  - [CVE-2023-0465](https://alas.aws.amazon.com/cve/html/CVE-2023-0465.html)
  - [CVE-2023-0466](https://alas.aws.amazon.com/cve/html/CVE-2023-0466.html)
  - [CVE-2023-2650](https://alas.aws.amazon.com/cve/html/CVE-2023-2650.html)

### Updated Packages for Amazon Linux 2:
- vim-minimal-9.0.1592-1.amzn2.0.1
- vim-data-9.0.1592-1.amzn2.0.1
#### Packages addressing CVES:
- vim-minimal-9.0.1592-1.amzn2.0.1, vim-data-9.0.1592-1.amzn2.0.1
  - [CVE-2023-2609](https://alas.aws.amazon.com/cve/html/CVE-2023-2609.html)
  - [CVE-2023-2610](https://alas.aws.amazon.com/cve/html/CVE-2023-2610.html)

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.0.20230614-0.amzn2023
- system-release-2023.0.20230614-0.amzn2023
- gnupg2-minimal-2.3.7-1.amzn2023.0.4
#### Packages addressing CVES: