### PR TITLE
Bump Haskell ghc 9.2.7 -> 9.2.8, stack 2.9.3 -> 2.11.1

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,30 +4,30 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.4.5-buster, 9.4-buster, 9-buster, buster, 9.4.5, 9.4, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 6a4bd2d6ac51a08af489476145b1f83c8d20e575
+GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
 Directory: 9.4/buster
 
 Tags: 9.4.5-slim-buster, 9.4-slim-buster, 9-slim-buster, slim-buster, 9.4.5-slim, 9.4-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 6a4bd2d6ac51a08af489476145b1f83c8d20e575
+GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
 Directory: 9.4/slim-buster
 
-Tags: 9.2.7-buster, 9.2-buster, 9.2.7, 9.2
+Tags: 9.2.8-buster, 9.2-buster, 9.2.8, 9.2
 Architectures: amd64, arm64v8
-GitCommit: 47c8a1ef9ecdfe9603dfa5e3ee0bdfc4b64a944a
+GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
 Directory: 9.2/buster
 
-Tags: 9.2.7-slim-buster, 9.2-slim-buster, 9.2.7-slim, 9.2-slim
+Tags: 9.2.8-slim-buster, 9.2-slim-buster, 9.2.8-slim, 9.2-slim
 Architectures: amd64, arm64v8
-GitCommit: 47c8a1ef9ecdfe9603dfa5e3ee0bdfc4b64a944a
+GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
 Directory: 9.2/slim-buster
 
 Tags: 9.0.2-buster, 9.0-buster, 9.0.2, 9.0
 Architectures: amd64, arm64v8
-GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
+GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
 Directory: 9.0/buster
 
 Tags: 9.0.2-slim-buster, 9.0-slim-buster, 9.0.2-slim, 9.0-slim
 Architectures: amd64, arm64v8
-GitCommit: 12cd297d7ccc2e97fe5e94548ae502b0cbb6735f
+GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
 Directory: 9.0/slim-buster


### PR DESCRIPTION
Includes changes from https://github.com/haskell/docker-haskell/pull/106 and https://github.com/haskell/docker-haskell/pull/107