### PR TITLE
archlinux: Release 20230618.0.159075

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230611.0.157136
-GitCommit: 8c107a2ed9ee79927da495f556a81a6999221bab
-GitFetch: refs/tags/v20230611.0.157136
+Tags: latest, base, base-20230618.0.159075
+GitCommit: 39bda44640a0885634ec919a3c0641f5f1bbda72
+GitFetch: refs/tags/v20230618.0.159075
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230611.0.157136
-GitCommit: 8c107a2ed9ee79927da495f556a81a6999221bab
-GitFetch: refs/tags/v20230611.0.157136
+Tags: base-devel, base-devel-20230618.0.159075
+GitCommit: 39bda44640a0885634ec919a3c0641f5f1bbda72
+GitFetch: refs/tags/v20230618.0.159075
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks