### PR TITLE
Update Clear Linux OS to 39400

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 43edaa58caa74272b3c5c5b122dfa0b10cc0a53c
-GitFetch: refs/heads/base-39340
+GitCommit: 4bc0150ac3a529e2fb267d72b102eabf96395edf
+GitFetch: refs/heads/base-39400


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39400

@bryteise @djklimes @bryteise