### PR TITLE
Bump Traefik to v2.10.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,15 +13,15 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: e2fc89bcccd185a9e332deae22a71e209aca1fb3
 Directory: alpine
 
-Tags: v2.10.1-windowsservercore-1809, 2.10.1-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.10.3-windowsservercore-1809, 2.10.3-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0f5f057e1310e073297e1ed93ba6db65e0abcfef
+GitCommit: 45ebd782ec472b47b90058b27253874297242a26
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.10.1, 2.10.1, v2.10, 2.10, saintmarcelin, latest
+Tags: v2.10.3, 2.10.3, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0f5f057e1310e073297e1ed93ba6db65e0abcfef
+GitCommit: 45ebd782ec472b47b90058b27253874297242a26
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.10.3](https://github.com/traefik/traefik/releases/tag/v2.10.3).

/cc @mmatur @rtribotte

Cheers
