### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -7,34 +7,34 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2023-04-26
 Tags: 13.1.0, 13.1, 13, latest, 13.1.0-bookworm, 13.1-bookworm, 13-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 46628bc0702798f6ff9f923650361f46f9eb2af2
+GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
 Directory: 13
 # Docker EOL: 2024-10-26
 
 # Last Modified: 2023-05-08
 Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9677600371602a897f576cf1d85852a3a26f71af
+GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
 Directory: 12
 # Docker EOL: 2024-11-08
 
 # Last Modified: 2023-05-29
-Tags: 11.4.0, 11.4, 11, 11.4.0-bookworm, 11.4-bookworm, 11-bookworm
+Tags: 11.4.0, 11.4, 11, 11.4.0-bullseye, 11.4-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8896a6fe1d596abcaea6c75c98337885ba4c27e8
+GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
 Directory: 11
 # Docker EOL: 2024-11-29
 
 # Last Modified: 2022-06-28
-Tags: 10.4.0, 10.4, 10, 10.4.0-bookworm, 10.4-bookworm, 10-bookworm
+Tags: 10.4.0, 10.4, 10, 10.4.0-bullseye, 10.4-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 392d8bf4ee9d494f03331c540c1f0d7f32259ff1
+GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
 Directory: 10
 # Docker EOL: 2023-12-28
 
 # Last Modified: 2022-05-27
-Tags: 9.5.0, 9.5, 9, 9.5.0-bookworm, 9.5-bookworm, 9-bookworm
+Tags: 9.5.0, 9.5, 9, 9.5.0-bullseye, 9.5-bullseye, 9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0d98f7923b5ed7f5baec2506413c99e920cf6661
+GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
 Directory: 9
 # Docker EOL: 2023-11-27


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/5986ef2: Merge pull request https://github.com/docker-library/gcc/pull/97 from infosiftr/more-bullseye
- https://github.com/docker-library/gcc/commit/e7e43ba: Downgrade gcc 11 back to bullseye
- https://github.com/docker-library/gcc/commit/4c74f6f: Unnecessary use of double quotes
- https://github.com/docker-library/gcc/commit/de7f7f3: Merge pull request https://github.com/docker-library/gcc/pull/94 from infosiftr/bullseye
- https://github.com/docker-library/gcc/commit/36ad58f: Downgrade 9 and 10 to bullseye
- https://github.com/docker-library/gcc/commit/9da3c87: Drop bookworm special case