### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.12.0, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b7d3633626f3dff15433626045bfcfdba7a5fa3e
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.12/ubuntu
 
 Tags: 3.12.0-management, 3.12-management, 3-management, management
@@ -17,7 +17,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.0-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b7d3633626f3dff15433626045bfcfdba7a5fa3e
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.12/alpine
 
 Tags: 3.12.0-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 3.12/alpine/management
 
 Tags: 3.11.18, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 14833a0939f0cb97caf54270c9c90aca1a35c949
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.11/ubuntu
 
 Tags: 3.11.18-management, 3.11-management
@@ -37,7 +37,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.18-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 14833a0939f0cb97caf54270c9c90aca1a35c949
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.11/alpine
 
 Tags: 3.11.18-management-alpine, 3.11-management-alpine
@@ -47,7 +47,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.24, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 56b13d64f8314bcfe11e74afaa8f0e0882456a41
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.10/ubuntu
 
 Tags: 3.10.24-management, 3.10-management
@@ -57,7 +57,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.24-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 56b13d64f8314bcfe11e74afaa8f0e0882456a41
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.10/alpine
 
 Tags: 3.10.24-management-alpine, 3.10-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8b63feadd40dbf009de8d0282ec9037e00560707
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -77,7 +77,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8b63feadd40dbf009de8d0282ec9037e00560707
+GitCommit: 0192a912d656a74b27e8d3ebe0df1aa0d08dd92c
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/0192a91: Use Ubuntu 22.04 for RabbitMQ 3.12.x (https://github.com/docker-library/rabbitmq/pull/644)