### PR TITLE
Update irssi

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -4,12 +4,12 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.4.4, 1.4, 1, latest, 1.4.4-bullseye, 1.4-bullseye, 1-bullseye, bullseye
+Tags: 1.4.4, 1.4, 1, latest, 1.4.4-bookworm, 1.4-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 663b9b815d858c94ae6224183afed602d291587e
+GitCommit: b4d59338769521e17730ff1741c8502a9e210846
 Directory: debian
 
-Tags: 1.4.4-alpine, 1.4-alpine, 1-alpine, alpine, 1.4.4-alpine3.17, 1.4-alpine3.17, 1-alpine3.17, alpine3.17
+Tags: 1.4.4-alpine, 1.4-alpine, 1-alpine, alpine, 1.4.4-alpine3.18, 1.4-alpine3.18, 1-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6806daa0d17eae1cd10df10ff3a533d3655ac9f8
+GitCommit: 105374db8e9ecf2782c5302f17464547dd5c8609
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/jessfraz/irssi/commit/105374d: Update to Alpine 3.18 (https://github.com/jessfraz/irssi/pull/32)
- https://github.com/jessfraz/irssi/commit/b4d5933: Update to Debian Bookworm (https://github.com/jessfraz/irssi/pull/31)

(This one should wait until https://github.com/docker-library/official-images/pull/14903 is actually pushed :innocent:)