### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 22-ea-2-jdk-oraclelinux8, 22-ea-2-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-2-jdk-oracle, 22-ea-2-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-2-jdk, 22-ea-2, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-3-jdk-oraclelinux8, 22-ea-3-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-3-jdk-oracle, 22-ea-3-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-3-jdk, 22-ea-3, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-2-jdk-oraclelinux7, 22-ea-2-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-3-jdk-oraclelinux7, 22-ea-3-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-2-jdk-bookworm, 22-ea-2-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-3-jdk-bookworm, 22-ea-3-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-2-jdk-slim-bookworm, 22-ea-2-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-2-jdk-slim, 22-ea-2-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-3-jdk-slim-bookworm, 22-ea-3-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-3-jdk-slim, 22-ea-3-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-2-jdk-bullseye, 22-ea-2-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-3-jdk-bullseye, 22-ea-3-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-2-jdk-slim-bullseye, 22-ea-2-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-3-jdk-slim-bullseye, 22-ea-3-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-2-jdk-windowsservercore-ltsc2022, 22-ea-2-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-2-jdk-windowsservercore, 22-ea-2-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-2-jdk, 22-ea-2, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-3-jdk-windowsservercore-ltsc2022, 22-ea-3-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-3-jdk-windowsservercore, 22-ea-3-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-3-jdk, 22-ea-3, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-2-jdk-windowsservercore-1809, 22-ea-2-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-2-jdk-windowsservercore, 22-ea-2-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-2-jdk, 22-ea-2, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-3-jdk-windowsservercore-1809, 22-ea-3-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-3-jdk-windowsservercore, 22-ea-3-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-3-jdk, 22-ea-3, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-2-jdk-nanoserver-1809, 22-ea-2-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-2-jdk-nanoserver, 22-ea-2-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-3-jdk-nanoserver-1809, 22-ea-3-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-3-jdk-nanoserver, 22-ea-3-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: ec2bc862a7a18b5516c0f6da6d32375796038251
+GitCommit: 659785f95aae1ad14e0cbf516541718f614decdd
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 21-ea-27-jdk-oraclelinux8, 21-ea-27-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-27-jdk-oracle, 21-ea-27-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-27-jdk, 21-ea-27, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-28-jdk-oraclelinux8, 21-ea-28-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-28-jdk-oracle, 21-ea-28-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-28-jdk, 21-ea-28, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-27-jdk-oraclelinux7, 21-ea-27-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-28-jdk-oraclelinux7, 21-ea-28-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-27-jdk-bookworm, 21-ea-27-bookworm, 21-ea-jdk-bookworm, 21-ea-bookworm, 21-jdk-bookworm, 21-bookworm
+Tags: 21-ea-28-jdk-bookworm, 21-ea-28-bookworm, 21-ea-jdk-bookworm, 21-ea-bookworm, 21-jdk-bookworm, 21-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/bookworm
 
-Tags: 21-ea-27-jdk-slim-bookworm, 21-ea-27-slim-bookworm, 21-ea-jdk-slim-bookworm, 21-ea-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-ea-27-jdk-slim, 21-ea-27-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-28-jdk-slim-bookworm, 21-ea-28-slim-bookworm, 21-ea-jdk-slim-bookworm, 21-ea-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-ea-28-jdk-slim, 21-ea-28-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/slim-bookworm
 
-Tags: 21-ea-27-jdk-bullseye, 21-ea-27-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-28-jdk-bullseye, 21-ea-28-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-27-jdk-slim-bullseye, 21-ea-27-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
+Tags: 21-ea-28-jdk-slim-bullseye, 21-ea-28-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-27-jdk-windowsservercore-ltsc2022, 21-ea-27-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-27-jdk-windowsservercore, 21-ea-27-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-27-jdk, 21-ea-27, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-28-jdk-windowsservercore-ltsc2022, 21-ea-28-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-28-jdk-windowsservercore, 21-ea-28-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-28-jdk, 21-ea-28, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-27-jdk-windowsservercore-1809, 21-ea-27-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-27-jdk-windowsservercore, 21-ea-27-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-27-jdk, 21-ea-27, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-28-jdk-windowsservercore-1809, 21-ea-28-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-28-jdk-windowsservercore, 21-ea-28-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-28-jdk, 21-ea-28, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-27-jdk-nanoserver-1809, 21-ea-27-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-27-jdk-nanoserver, 21-ea-27-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-28-jdk-nanoserver-1809, 21-ea-28-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-28-jdk-nanoserver, 21-ea-28-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 1bbf5f410e2f265026991d46fe6ce6a381081389
+GitCommit: 1ad278b60158c4042d579853af17111eab2d6f97
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/659785f: Update 22 to 22-ea+3
- https://github.com/docker-library/openjdk/commit/1ad278b: Update 21 to 21-ea+28