### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2023-3722

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6489033c7bc5cd29a6869f31dca86efe57bd644f
+amd64-GitCommit: 
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5db7bf8af2aa716c8f4b5f3eacfe1d878e413710
+arm64v8-GitCommit: 
 
 Tags: 9
 Architectures: amd64, arm64v8

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 
+amd64-GitCommit: c34bf84210f6c6ff60b80d39d64ee680af274efc
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 
+arm64v8-GitCommit: 8e66dfe39056ce980780b16a154bd18457ab95e6
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-0464, CVE-2023-0465, CVE-2023-0466, CVE-2023-1255, CVE-2023-2650.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-3722.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
