### PR TITLE
Adding AL2 native rpm images

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -8,11 +8,11 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Victor Rudometov <vicrud@amazon.com> (@Rudometov)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: ef6f5a60332e35d72fee88ce86e195f62efa6ab4
+GitCommit: b3911c583ac27a9b5801eba2373a9dd8fe10a3a0
 
-Tags: 8, 8u372, 8u372-al2, 8-al2-full, 8-al2-jdk, latest
+Tags: 8, 8u372, 8u372-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u372-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
-Directory: 8/jdk/al2
+Directory: 8/jdk/al2-generic
 
 Tags: 8-al2023, 8u372-al2023, 8-al2023-jdk
 Architectures: amd64, arm64v8
@@ -22,13 +22,13 @@ Tags: 8-al2023-jre, 8u372-al2023-jre
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-alpine3.14, 8u372-alpine3.14, 8-alpine3.14-full, 8-alpine3.14-jdk
+Tags: 8-al2-native-RC-jre, 8u372-al2-native-RC-jre
 Architectures: amd64, arm64v8
-Directory: 8/jdk/alpine/3.14
+Directory: 8/jre/al2
 
-Tags: 8-alpine3.14-jre, 8u372-alpine3.14-jre
+Tags: 8-al2-native-RC-jdk, 8u372-al2-native-RC-jdk
 Architectures: amd64, arm64v8
-Directory: 8/jre/alpine/3.14
+Directory: 8/jdk/al2
 
 Tags: 8-alpine3.15, 8u372-alpine3.15, 8-alpine3.15-full, 8-alpine3.15-jdk
 Architectures: amd64, arm64v8
@@ -54,9 +54,9 @@ Tags: 8-alpine3.17-jre, 8u372-alpine3.17-jre, 8-alpine-jre, 8u372-alpine-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.17
 
-Tags: 11, 11.0.19, 11.0.19-al2, 11-al2-full, 11-al2-jdk
+Tags: 11, 11.0.19, 11.0.19-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.19-al2-generic, 11-al2-generic-jdk
 Architectures: amd64, arm64v8
-Directory: 11/jdk/al2
+Directory: 11/jdk/al2-generic
 
 Tags: 11-al2023, 11.0.19-al2023, 11-al2023-jdk
 Architectures: amd64, arm64v8
@@ -70,9 +70,13 @@ Tags: 11-al2023-headful, 11.0.19-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 11/headful/al2023
 
-Tags: 11-alpine3.14, 11.0.19-alpine3.14, 11-alpine3.14-full, 11-alpine3.14-jdk
+Tags: 11-al2-native-RC-headless, 11.0.19-al2-native-RC-headless
 Architectures: amd64, arm64v8
-Directory: 11/jdk/alpine/3.14
+Directory: 11/headless/al2
+
+Tags: 11-al2-native-RC-jdk, 11.0.19-al2-native-RC-jdk
+Architectures: amd64, arm64v8
+Directory: 11/jdk/al2
 
 Tags: 11-alpine3.15, 11.0.19-alpine3.15, 11-alpine3.15-full, 11-alpine3.15-jdk
 Architectures: amd64, arm64v8
@@ -86,9 +90,9 @@ Tags: 11-alpine3.17, 11.0.19-alpine3.17, 11-alpine3.17-full, 11-alpine3.17-jdk, 
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.17
 
-Tags: 17, 17.0.7, 17.0.7-al2, 17-al2-full, 17-al2-jdk
+Tags: 17, 17.0.7, 17.0.7-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.7-al2-generic, 17-al2-generic-jdk
 Architectures: amd64, arm64v8
-Directory: 17/jdk/al2
+Directory: 17/jdk/al2-generic
 
 Tags: 17-al2023, 17.0.7-al2023, 17-al2023-jdk
 Architectures: amd64, arm64v8
@@ -102,9 +106,17 @@ Tags: 17-al2023-headful, 17.0.7-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2023
 
-Tags: 17-alpine3.14, 17.0.7-alpine3.14, 17-alpine3.14-full, 17-alpine3.14-jdk
+Tags: 17-al2-native-RC-headless, 17.0.7-al2-native-RC-headless
 Architectures: amd64, arm64v8
-Directory: 17/jdk/alpine/3.14
+Directory: 17/headless/al2
+
+Tags: 17-al2-native-RC-headful, 17.0.7-al2-native-RC-headful
+Architectures: amd64, arm64v8
+Directory: 17/headful/al2
+
+Tags: 17-al2-native-RC-jdk, 17.0.7-al2-native-RC-jdk
+Architectures: amd64, arm64v8
+Directory: 17/jdk/al2
 
 Tags: 17-alpine3.15, 17.0.7-alpine3.15, 17-alpine3.15-full, 17-alpine3.15-jdk
 Architectures: amd64, arm64v8
@@ -118,13 +130,9 @@ Tags: 17-alpine3.17, 17.0.7-alpine3.17, 17-alpine3.17-full, 17-alpine3.17-jdk, 1
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.17
 
-Tags: 20, 20.0.1, 20.0.1-al2, 20-al2-full, 20-al2-jdk
+Tags: 20, 20.0.1, 20.0.1-al2, 20-al2-full, 20-al2-jdk, 20-al2-generic, 20.0.1-al2-generic, 20-al2-generic-jdk
 Architectures: amd64, arm64v8
-Directory: 20/jdk/al2
-
-Tags: 20-alpine3.14, 20.0.1-alpine3.14, 20-alpine3.14-full, 20-alpine3.14-jdk
-Architectures: amd64, arm64v8
-Directory: 20/jdk/alpine/3.14
+Directory: 20/jdk/al2-generic
 
 Tags: 20-alpine3.15, 20.0.1-alpine3.15, 20-alpine3.15-full, 20-alpine3.15-jdk
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This adds new tags to the existing AL2 images which customers will be able to use in the future to continue using the same images. New AL2-native images are being added that use the AL2 targeted RPMs rather than the Generic Linux RPMs. At some point in the future the default AL2 images will be changed to use the native RPMs.


The old Alpine 3.14 images are also being removed.