### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -64,21 +64,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv6
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/sid
 
-Tags: bionic-curl, 18.04-curl
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 93d6db0797f91ab674535553b7e0e762941a02d0
-Directory: ubuntu/bionic/curl
-
-Tags: bionic-scm, 18.04-scm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
-Directory: ubuntu/bionic/scm
-
-Tags: bionic, 18.04
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 98a5ab81d47a106c458cdf90733df0ee8beea06c
-Directory: ubuntu/bionic
-
 Tags: focal-curl, 20.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 93d6db0797f91ab674535553b7e0e762941a02d0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/27aee70: Merge pull request https://github.com/docker-library/buildpack-deps/pull/143 from infosiftr/bionic
- https://github.com/docker-library/buildpack-deps/commit/67ae146: Remove Ubuntu Bionic (EOL)