### PR TITLE
Update Clear Linux OS to 39450

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 4bc0150ac3a529e2fb267d72b102eabf96395edf
-GitFetch: refs/heads/base-39400
+GitCommit: 2d758eb599096aa42323ea60678beb145bf98500
+GitFetch: refs/heads/base-39450


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39450

@bryteise @djklimes @bryteise