### PR TITLE
[ros] point buster and foxy to snapshots repository

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -59,7 +59,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: noetic-ros-core-buster
 Architectures: amd64, arm64v8
-GitCommit: 3f4fbca923d80f834f3a89b5960bad5582652519
+GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
 Directory: ros/noetic/debian/buster/ros-core
 
 Tags: noetic-ros-base-buster
@@ -86,7 +86,7 @@ Directory: ros/noetic/debian/buster/perception
 
 Tags: foxy-ros-core, foxy-ros-core-focal
 Architectures: amd64, arm64v8
-GitCommit: 3f4fbca923d80f834f3a89b5960bad5582652519
+GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
 Directory: ros/foxy/ubuntu/focal/ros-core
 
 Tags: foxy-ros-base, foxy-ros-base-focal, foxy
@@ -96,7 +96,7 @@ Directory: ros/foxy/ubuntu/focal/ros-base
 
 Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
 Architectures: amd64, arm64v8
-GitCommit: c40ef6e5116c88f44e9ef3694614c1e8a60725a0
+GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
 Directory: ros/foxy/ubuntu/focal/ros1-bridge
 
 


### PR DESCRIPTION
ROS Foxy is now EOL : https://discourse.ros.org/t/new-packages-for-foxy-fitzroy-2023-06-20/32039
Debian buster has been EOl for a while.

This PR make them build from the ROS snapshots repository before disabling the builds
