### PR TITLE
re-release MariaDB

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -7,40 +7,40 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 11.1.1-rc-jammy, 11.1-rc-jammy, 11.1.1-rc, 11.1-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 11.1
 
 Tags: 11.0.2-jammy, 11.0-jammy, 11-jammy, jammy, 11.0.2, 11.0, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 11.0
 
 Tags: 10.11.4-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.4, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 10.11
 
 Tags: 10.10.5-jammy, 10.10-jammy, 10.10.5, 10.10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 10.10
 
 Tags: 10.9.7-jammy, 10.9-jammy, 10.9.7, 10.9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 10.9
 
 Tags: 10.6.14-focal, 10.6-focal, 10.6.14, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 10.6
 
 Tags: 10.5.21-focal, 10.5-focal, 10.5.21, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 10.5
 
 Tags: 10.4.30-focal, 10.4-focal, 10.4.30, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: e56b3a008e9c47c7199d28db6d77d2cfecde526d
+GitCommit: 51c2b915a19573f233424635627355bcf14057d4
 Directory: 10.4


### PR DESCRIPTION
Remove mariadb-install-db during build in pkg install that stalled on s390x. The data was thrown away anyway.

11.0 latest without mysql symlinks that saw many people discover their mysqladmin ping didn't work. It was broken anyway https://mariadb.org/mariadb-server-docker-official-images-healthcheck-without-mysqladmin/

Fix healthcheck.sh with root passwords on https://github.com/MariaDB/mariadb-docker/pull/508 with hopefully no regressions.

Tests happy on https://github.com/MariaDB/mariadb-docker/actions/runs/5372219544

Closes: #14923