### PR TITLE
[ros] retire foxy and buster based images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -54,51 +54,6 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/noetic/ubuntu/focal/perception
 
-########################################
-# Distro: debian:buster
-
-Tags: noetic-ros-core-buster
-Architectures: amd64, arm64v8
-GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
-Directory: ros/noetic/debian/buster/ros-core
-
-Tags: noetic-ros-base-buster
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/debian/buster/ros-base
-
-Tags: noetic-robot-buster
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/debian/buster/robot
-
-Tags: noetic-perception-buster
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/debian/buster/perception
-
-
-################################################################################
-# Release: foxy
-
-########################################
-# Distro: ubuntu:focal
-
-Tags: foxy-ros-core, foxy-ros-core-focal
-Architectures: amd64, arm64v8
-GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
-Directory: ros/foxy/ubuntu/focal/ros-core
-
-Tags: foxy-ros-base, foxy-ros-base-focal, foxy
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/foxy/ubuntu/focal/ros-base
-
-Tags: foxy-ros1-bridge, foxy-ros1-bridge-focal
-Architectures: amd64, arm64v8
-GitCommit: 0c31bf0bc023e3ddb663b9934513270401d82a97
-Directory: ros/foxy/ubuntu/focal/ros1-bridge
-
 
 ################################################################################
 # Release: humble


### PR DESCRIPTION
follow-up of https://github.com/docker-library/official-images/pull/14934
Retire images now that the final version has been built