### PR TITLE
Remove latest tag for official Consul images

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,6 +1,6 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
 
-Tags: 1.15.4, 1.15, latest
+Tags: 1.15.4, 1.15
 Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
 GitCommit: aedd0844f06e9eac9c4e130206219b1ff044a8c4


### PR DESCRIPTION
In alignment with https://github.com/docker-library/docs/pull/2283 and https://github.com/docker-library/official-images/pull/14940, we'd like to:

- remove the `latest` tag here for consul
- request that the existing `latest` tag be deleted