### PR TITLE
Odoo: update 14.0-16.0 to release 20230629

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 7a7169250712b280c009e6e507f0c97a68e9c5c0
+GitCommit: 672d5cda913ff3ef6eaa1ae25de0ca7c0336f05b
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thank you.