### PR TITLE
Updates for release 23.0.0.6

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 5539b65a4b2733610d7cf99bc2f301a71cf0e309
+GitCommit: 30700d72a85a7afc758d779691062ea7ec80dc34
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: d75f1a08566ee919548e70ab53efb8b9572135b2
+GitCommit: 5539b65a4b2733610d7cf99bc2f301a71cf0e309
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -1,5 +1,4 @@
-Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
-             Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
+Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
 GitCommit: 30700d72a85a7afc758d779691062ea7ec80dc34

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 897ef0c2c740dd79a8b08b08d711a58677713d26
+GitCommit: d75f1a08566ee919548e70ab53efb8b9572135b2
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -50,33 +50,33 @@ Directory: releases/latest/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 23.0.0.5-kernel-slim-java8-openj9
-Directory: releases/23.0.0.5/kernel-slim
+Tags: 23.0.0.6-kernel-slim-java8-openj9
+Directory: releases/23.0.0.6/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 23.0.0.5-kernel-slim-java11-openj9
-Directory: releases/23.0.0.5/kernel-slim
+Tags: 23.0.0.6-kernel-slim-java11-openj9
+Directory: releases/23.0.0.6/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 23.0.0.5-kernel-slim-java17-openj9
-Directory: releases/23.0.0.5/kernel-slim
+Tags: 23.0.0.6-kernel-slim-java17-openj9
+Directory: releases/23.0.0.6/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 23.0.0.5-full-java8-openj9
-Directory: releases/23.0.0.5/full
+Tags: 23.0.0.6-full-java8-openj9
+Directory: releases/23.0.0.6/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 23.0.0.5-full-java11-openj9
-Directory: releases/23.0.0.5/full
+Tags: 23.0.0.6-full-java11-openj9
+Directory: releases/23.0.0.6/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 23.0.0.5-full-java17-openj9
-Directory: releases/23.0.0.5/full
+Tags: 23.0.0.6-full-java17-openj9
+Directory: releases/23.0.0.6/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
@@ -107,35 +107,5 @@ File: Dockerfile.ubuntu.openjdk11
 
 Tags: 23.0.0.3-full-java17-openj9
 Directory: releases/23.0.0.3/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.12-kernel-slim-java8-openj9
-Directory: releases/22.0.0.12/kernel-slim
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 22.0.0.12-kernel-slim-java11-openj9
-Directory: releases/22.0.0.12/kernel-slim
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.12-kernel-slim-java17-openj9
-Directory: releases/22.0.0.12/kernel-slim
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.12-full-java8-openj9
-Directory: releases/22.0.0.12/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 22.0.0.12-full-java11-openj9
-Directory: releases/22.0.0.12/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.12-full-java17-openj9
-Directory: releases/22.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -4,7 +4,7 @@ GitFetch: refs/heads/main
 GitCommit: 6dd8b6cfd9b80860001ccba31f2c27508f27bf45
 Architectures: amd64, ppc64le, s390x
 
-Tags: kernel
+Tags: kernel, kernel-java8-ibmjava
 Directory: ga/latest/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
@@ -18,7 +18,7 @@ Directory: ga/latest/kernel
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: full, latest
+Tags: full, latest, full-java8-ibmjava
 Directory: ga/latest/full
 File: Dockerfile.ubuntu.ibmjava8
 

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 25106db8bbc11db4fef48f54d99647ef2fd279a4
+GitCommit: d34dff42709c97b9e7a790e55ae9892e15510556
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 9531d83e7185483c7cc08d4f985b6a067e2180f2
+GitCommit: 2c88c48b5706996a9f219277e9d88596a3234377
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 991330f33547ea6bbc796c198c4b2d0dacc7cc8d
+GitCommit: 9531d83e7185483c7cc08d4f985b6a067e2180f2
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel
@@ -33,31 +33,31 @@ Directory: ga/latest/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 23.0.0.5-kernel-java8-ibmjava
-Directory: ga/23.0.0.5/kernel
+Tags: 23.0.0.6-kernel-java8-ibmjava
+Directory: ga/23.0.0.6/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 23.0.0.5-kernel-java11-openj9
-Directory: ga/23.0.0.5/kernel
+Tags: 23.0.0.6-kernel-java11-openj9
+Directory: ga/23.0.0.6/kernel
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 23.0.0.5-kernel-java17-openj9
-Directory: ga/23.0.0.5/kernel
+Tags: 23.0.0.6-kernel-java17-openj9
+Directory: ga/23.0.0.6/kernel
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 23.0.0.5-full-java8-ibmjava
-Directory: ga/23.0.0.5/full
+Tags: 23.0.0.6-full-java8-ibmjava
+Directory: ga/23.0.0.6/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 23.0.0.5-full-java11-openj9
-Directory: ga/23.0.0.5/full
+Tags: 23.0.0.6-full-java11-openj9
+Directory: ga/23.0.0.6/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 23.0.0.5-full-java17-openj9
-Directory: ga/23.0.0.5/full
+Tags: 23.0.0.6-full-java17-openj9
+Directory: ga/23.0.0.6/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
@@ -86,33 +86,5 @@ File: Dockerfile.ubuntu.openjdk11
 
 Tags: 23.0.0.3-full-java17-openj9
 Directory: ga/23.0.0.3/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.12-kernel-java8-ibmjava
-Directory: ga/22.0.0.12/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 22.0.0.12-kernel-java11-openj9
-Directory: ga/22.0.0.12/kernel
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.12-kernel-java17-openj9
-Directory: ga/22.0.0.12/kernel
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 22.0.0.12-full-java8-ibmjava
-Directory: ga/22.0.0.12/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 22.0.0.12-full-java11-openj9
-Directory: ga/22.0.0.12/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 22.0.0.12-full-java17-openj9
-Directory: ga/22.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -1,8 +1,7 @@
-Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
-             Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
+Maintainers: Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: d34dff42709c97b9e7a790e55ae9892e15510556
+GitCommit: 6dd8b6cfd9b80860001ccba31f2c27508f27bf45
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: e18244a20a64f26fd5bdd9c1daaef52664a8798d
+GitCommit: 25106db8bbc11db4fef48f54d99647ef2fd279a4
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -2,7 +2,7 @@ Maintainers: Chris Potter <crpotter@us.ibm.com> (@crpotter),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 2c88c48b5706996a9f219277e9d88596a3234377
+GitCommit: e18244a20a64f26fd5bdd9c1daaef52664a8798d
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel


### PR DESCRIPTION
These are updates needed to publish WebSphere and Open Liberty 23.0.0.6 containers. Thank you.