### PR TITLE
archlinux: Release 20230702.0.161694

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230625.0.160368
-GitCommit: 97c654858f99b6fef7f7634ba851d017d028bdb9
-GitFetch: refs/tags/v20230625.0.160368
+Tags: latest, base, base-20230702.0.161694
+GitCommit: 05b1c93ddc7653bebc91eb42561cddf99f6e410e
+GitFetch: refs/tags/v20230702.0.161694
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230625.0.160368
-GitCommit: 97c654858f99b6fef7f7634ba851d017d028bdb9
-GitFetch: refs/tags/v20230625.0.160368
+Tags: base-devel, base-devel-20230702.0.161694
+GitCommit: 05b1c93ddc7653bebc91eb42561cddf99f6e410e
+GitFetch: refs/tags/v20230702.0.161694
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks