### PR TITLE
Update Clear Linux OS to 39540

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 2d758eb599096aa42323ea60678beb145bf98500
-GitFetch: refs/heads/base-39450
+GitCommit: 7d83e2f10265a66b21a83d8fa60d6c76ff4454fe
+GitFetch: refs/heads/base-39540


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39540

@bryteise @djklimes @bryteise