### PR TITLE
[ros] move melodic to snapshots repository

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: melodic-ros-core, melodic-ros-core-bionic
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 3f4fbca923d80f834f3a89b5960bad5582652519
+GitCommit: 443033d08e72da7282fe3b68167f01a2995118b8
 Directory: ros/melodic/ubuntu/bionic/ros-core
 
 Tags: melodic-ros-base, melodic-ros-base-bionic, melodic


### PR DESCRIPTION
To trigger the final build of ROS melodic images on the bionic base image before disabling the builds
Related to https://github.com/docker-library/official-images/pull/14934#issuecomment-1608379237 and https://github.com/osrf/docker_images/issues/660