### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev0, 2.9-dev, 2.9-dev0-bullseye, 2.9-dev-bullseye
+Tags: 2.9-dev1, 2.9-dev, 2.9-dev1-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f389054a408dd4a1cb6f314fd66a851f565190d3
+GitCommit: 9b1ce2eb7fb65a923b414c8d8ffec6990d73d4bc
 Directory: 2.9
 
-Tags: 2.9-dev0-alpine, 2.9-dev-alpine, 2.9-dev0-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9-dev1-alpine, 2.9-dev-alpine, 2.9-dev1-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
+GitCommit: 9b1ce2eb7fb65a923b414c8d8ffec6990d73d4bc
 Directory: 2.9/alpine
 
-Tags: 2.8.0, 2.8, lts, latest, 2.8.0-bullseye, 2.8-bullseye, lts-bullseye, bullseye
+Tags: 2.8.1, 2.8, lts, latest, 2.8.1-bullseye, 2.8-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2d7b121a1dda3f7844ae094f17346be7252e2ad6
+GitCommit: 4fe74fe536642ccfe90c0753767a7f344f820047
 Directory: 2.8
 
-Tags: 2.8.0-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.0-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
+Tags: 2.8.1-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.1-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8319188779e45910b4cbf471e993bbc5ecac9b86
+GitCommit: 4fe74fe536642ccfe90c0753767a7f344f820047
 Directory: 2.8/alpine
 
 Tags: 2.7.9, 2.7, 2.7.9-bullseye, 2.7-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4fe74fe: Update 2.8 to 2.8.1
- https://github.com/docker-library/haproxy/commit/9b1ce2e: Update 2.9 to 2.9-dev1