### PR TITLE
[oraclelinux] Updating 8 and 8-slim for ELSA-2023-3840, ELSA-2023-3839

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c34bf84210f6c6ff60b80d39d64ee680af274efc
+amd64-GitCommit: dbd5f24abbe089f39db8a1e4eceb4d754d9ed976
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8e66dfe39056ce980780b16a154bd18457ab95e6
+arm64v8-GitCommit: 8f1d929b0000e53d2f7e13af930eea9e3523f8ff
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2020-24736, CVE-2023-1667, CVE-2023-2283

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-3840.html
https://linux.oracle.com/errata/ELSA-2023-3839.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>