### PR TITLE
[ros] retire ROS melodic images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -2,33 +2,6 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
-# Release: melodic
-
-########################################
-# Distro: ubuntu:bionic
-
-Tags: melodic-ros-core, melodic-ros-core-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 443033d08e72da7282fe3b68167f01a2995118b8
-Directory: ros/melodic/ubuntu/bionic/ros-core
-
-Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/ubuntu/bionic/ros-base
-
-Tags: melodic-robot, melodic-robot-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/ubuntu/bionic/robot
-
-Tags: melodic-perception, melodic-perception-bionic
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/ubuntu/bionic/perception
-
-
-################################################################################
 # Release: noetic
 
 ########################################


### PR DESCRIPTION
ROS Melodic is now EOL https://discourse.ros.org/t/new-packages-for-melodic-2023-06-27/32121 
Follow-up of https://github.com/docker-library/official-images/pull/14968