### PR TITLE
library/perl: Add Perl 5.38.0

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,38 +1,94 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 9f2129d089866dd0d7353284cc231b9af10b71e3
+GitCommit: 9651038c99b01fa3ace3e9259b8ab7b317bd6c19
 Architectures: amd64, arm32v7, arm64v8, i386
 
-Tags: 5.36.1, 5.36, 5, latest, stable, 5.36.1-bullseye, 5.36-bullseye, 5-bullseye, bullseye, stable-bullseye
+Tags: 5.38.0, 5.38, 5, latest, stable, 5.38.0-bookworm, 5.38-bookworm, 5-bookworm, bookworm, stable-bookworm
+Directory: 5.038.000-main-bookworm
+
+Tags: 5.38.0-bullseye, 5.38-bullseye, 5-bullseye, bullseye, stable-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.038.000-main-bullseye
+
+Tags: 5.38.0-buster, 5.38-buster, 5-buster, buster, stable-buster
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: 5.038.000-main-buster
+
+Tags: 5.38.0-slim, 5.38-slim, 5-slim, slim, stable-slim, 5.38.0-slim-bookworm, 5.38-slim-bookworm, 5-slim-bookworm, slim-bookworm, stable-slim-bookworm
+Directory: 5.038.000-slim-bookworm
+
+Tags: 5.38.0-slim-bullseye, 5.38-slim-bullseye, 5-slim-bullseye, slim-bullseye, stable-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.038.000-slim-bullseye
+
+Tags: 5.38.0-slim-buster, 5.38-slim-buster, 5-slim-buster, slim-buster, stable-slim-buster
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: 5.038.000-slim-buster
+
+Tags: 5.38.0-threaded, 5.38-threaded, 5-threaded, threaded, stable-threaded, 5.38.0-threaded-bookworm, 5.38-threaded-bookworm, 5-threaded-bookworm, threaded-bookworm, stable-threaded-bookworm
+Directory: 5.038.000-main,threaded-bookworm
+
+Tags: 5.38.0-threaded-bullseye, 5.38-threaded-bullseye, 5-threaded-bullseye, threaded-bullseye, stable-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.038.000-main,threaded-bullseye
+
+Tags: 5.38.0-threaded-buster, 5.38-threaded-buster, 5-threaded-buster, threaded-buster, stable-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: 5.038.000-main,threaded-buster
+
+Tags: 5.38.0-slim-threaded, 5.38-slim-threaded, 5-slim-threaded, slim-threaded, stable-slim-threaded, 5.38.0-slim-threaded-bookworm, 5.38-slim-threaded-bookworm, 5-slim-threaded-bookworm, slim-threaded-bookworm, stable-slim-threaded-bookworm
+Directory: 5.038.000-slim,threaded-bookworm
+
+Tags: 5.38.0-slim-threaded-bullseye, 5.38-slim-threaded-bullseye, 5-slim-threaded-bullseye, slim-threaded-bullseye, stable-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5.038.000-slim,threaded-bullseye
+
+Tags: 5.38.0-slim-threaded-buster, 5.38-slim-threaded-buster, 5-slim-threaded-buster, slim-threaded-buster, stable-slim-threaded-buster
+Architectures: amd64, arm32v7, arm64v8, i386
+Directory: 5.038.000-slim,threaded-buster
+
+Tags: 5.36.1, 5.36, 5.36.1-bookworm, 5.36-bookworm
+Directory: 5.036.001-main-bookworm
+
+Tags: 5.36.1-bullseye, 5.36-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.036.001-main-bullseye
 
-Tags: 5.36.1-buster, 5.36-buster, 5-buster, buster, stable-buster
+Tags: 5.36.1-buster, 5.36-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.036.001-main-buster
 
-Tags: 5.36.1-slim, 5.36-slim, 5-slim, slim, stable-slim, 5.36.1-slim-bullseye, 5.36-slim-bullseye, 5-slim-bullseye, slim-bullseye, stable-slim-bullseye
+Tags: 5.36.1-slim, 5.36-slim, 5.36.1-slim-bookworm, 5.36-slim-bookworm
+Directory: 5.036.001-slim-bookworm
+
+Tags: 5.36.1-slim-bullseye, 5.36-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.036.001-slim-bullseye
 
-Tags: 5.36.1-slim-buster, 5.36-slim-buster, 5-slim-buster, slim-buster, stable-slim-buster
+Tags: 5.36.1-slim-buster, 5.36-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.036.001-slim-buster
 
-Tags: 5.36.1-threaded, 5.36-threaded, 5-threaded, threaded, stable-threaded, 5.36.1-threaded-bullseye, 5.36-threaded-bullseye, 5-threaded-bullseye, threaded-bullseye, stable-threaded-bullseye
+Tags: 5.36.1-threaded, 5.36-threaded, 5.36.1-threaded-bookworm, 5.36-threaded-bookworm
+Directory: 5.036.001-main,threaded-bookworm
+
+Tags: 5.36.1-threaded-bullseye, 5.36-threaded-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.036.001-main,threaded-bullseye
 
-Tags: 5.36.1-threaded-buster, 5.36-threaded-buster, 5-threaded-buster, threaded-buster, stable-threaded-buster
+Tags: 5.36.1-threaded-buster, 5.36-threaded-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.036.001-main,threaded-buster
 
-Tags: 5.36.1-slim-threaded, 5.36-slim-threaded, 5-slim-threaded, slim-threaded, stable-slim-threaded, 5.36.1-slim-threaded-bullseye, 5.36-slim-threaded-bullseye, 5-slim-threaded-bullseye, slim-threaded-bullseye, stable-slim-threaded-bullseye
+Tags: 5.36.1-slim-threaded, 5.36-slim-threaded, 5.36.1-slim-threaded-bookworm, 5.36-slim-threaded-bookworm
+Directory: 5.036.001-slim,threaded-bookworm
+
+Tags: 5.36.1-slim-threaded-bullseye, 5.36-slim-threaded-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5.036.001-slim,threaded-bullseye
 
-Tags: 5.36.1-slim-threaded-buster, 5.36-slim-threaded-buster, 5-slim-threaded-buster, slim-threaded-buster, stable-slim-threaded-buster
+Tags: 5.36.1-slim-threaded-buster, 5.36-slim-threaded-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.036.001-slim,threaded-buster
 
@@ -67,38 +123,6 @@ Directory: 5.034.001-slim,threaded-bullseye
 Tags: 5.34.1-slim-threaded-buster, 5.34-slim-threaded-buster
 Architectures: amd64, arm32v7, arm64v8, i386
 Directory: 5.034.001-slim,threaded-buster
-
-Tags: 5.32.1, 5.32, 5.32.1-bullseye, 5.32-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-Directory: 5.032.001-main-bullseye
-
-Tags: 5.32.1-buster, 5.32-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-main-buster
-
-Tags: 5.32.1-slim, 5.32-slim, 5.32.1-slim-bullseye, 5.32-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-Directory: 5.032.001-slim-bullseye
-
-Tags: 5.32.1-slim-buster, 5.32-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-slim-buster
-
-Tags: 5.32.1-threaded, 5.32-threaded, 5.32.1-threaded-bullseye, 5.32-threaded-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-Directory: 5.032.001-main,threaded-bullseye
-
-Tags: 5.32.1-threaded-buster, 5.32-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-main,threaded-buster
-
-Tags: 5.32.1-slim-threaded, 5.32-slim-threaded, 5.32.1-slim-threaded-bullseye, 5.32-slim-threaded-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-Directory: 5.032.001-slim,threaded-bullseye
-
-Tags: 5.32.1-slim-threaded-buster, 5.32-slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.032.001-slim,threaded-buster
 
 Tags: 5.37.11, 5.37, devel, 5.37.11-bullseye, 5.37-bullseye, devel-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
- https://github.com/Perl/docker-perl/pull/136
- https://www.nntp.perl.org/group/perl.perl5.porters/2023/07/msg266602.html

This also enables builds of 5.36.1 and 5.38.0 on Debian bookworm, and removes 5.32.1.