### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,12 +25,12 @@ GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
 Directory: 11
 # Docker EOL: 2024-11-29
 
-# Last Modified: 2022-06-28
-Tags: 10.4.0, 10.4, 10, 10.4.0-bullseye, 10.4-bullseye, 10-bullseye
+# Last Modified: 2023-07-07
+Tags: 10.5.0, 10.5, 10, 10.5.0-bullseye, 10.5-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
+GitCommit: 82cd9a2f8eb0da43f9b938b92ee78d8747eb16d1
 Directory: 10
-# Docker EOL: 2023-12-28
+# Docker EOL: 2025-01-07
 
 # Last Modified: 2022-05-27
 Tags: 9.5.0, 9.5, 9, 9.5.0-bullseye, 9.5-bullseye, 9-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/82cd9a2: Update 10 to 10.5.0