### PR TITLE
Update Clear Linux OS to 39590

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 7d83e2f10265a66b21a83d8fa60d6c76ff4454fe
-GitFetch: refs/heads/base-39540
+GitCommit: 11a8acec1e58aab06d40c35dad429daa6518d532
+GitFetch: refs/heads/base-39590


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39590

@bryteise @djklimes @bryteise