### PR TITLE
Odoo: update 14.0-16.0 to release 20230710

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 672d5cda913ff3ef6eaa1ae25de0ca7c0336f05b
+GitCommit: 36d6e05b76d56ce637c2f39fd4745c6d2fa3809f
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,


here are the latest updates of Odoo supported versions.

Thanks.