### PR TITLE
arangodb 3.10.9

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,10 +7,10 @@ Architectures: amd64
 GitCommit: 2f0e4d0d5f501633e6254812320283bf0c710757
 Directory: alpine/3.9.11
 
-Tags: 3.10, 3.10.7
+Tags: 3.10, 3.10.9
 Architectures: amd64, arm64v8
-GitCommit: 5c926a243d7c952a58f97488781f5eaf6d6704b9
-Directory: alpine/3.10.7
+GitCommit: bdd1fadac33809b6344b6ce1adceef73717e576e
+Directory: alpine/3.10.9
 
 Tags: 3.11, 3.11.1, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated ArangoDB 3.10 to 3.10.9.