### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,6 +5,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
+Tags: 3.12.2-beta.1, 3.12-rc
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: ab0188c3c2114781aa4a4c826457b9c2bdf692ef
+Directory: 3.12-rc/ubuntu
+
+Tags: 3.12.2-beta.1-management, 3.12-rc-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: ab0188c3c2114781aa4a4c826457b9c2bdf692ef
+Directory: 3.12-rc/ubuntu/management
+
+Tags: 3.12.2-beta.1-alpine, 3.12-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ab0188c3c2114781aa4a4c826457b9c2bdf692ef
+Directory: 3.12-rc/alpine
+
+Tags: 3.12.2-beta.1-management-alpine, 3.12-rc-management-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: ab0188c3c2114781aa4a4c826457b9c2bdf692ef
+Directory: 3.12-rc/alpine/management
+
 Tags: 3.12.1, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: faaae425d4266dfef0c9ab24e3c3b334855a40e5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/ab0188c: Update 3.12-rc to 3.12.2-beta.1, alpine 3.18, openssl 3.1.1, otp 25.3.2.3, ubuntu 22.04