### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,137 +4,137 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.0.0-alpha1, 5.0, 5.0.alpha, 5.0.0-alpha, 5.0.0-alpha1-apache, 5.0-apache, 5.0.alpha-apache, 5.0.0-alpha-apache, 5.0.0-alpha1-php8.1, 5.0-php8.1, 5.0.alpha-php8.1, 5.0.0-alpha-php8.1, 5.0.0-alpha1-php8.1-apache, 5.0-php8.1-apache, 5.0.alpha-php8.1-apache, 5.0.0-alpha-php8.1-apache
+Tags: 5.0.0-alpha2, 5.0, 5.0.alpha, 5.0.0-alpha, 5.0.0-alpha2-apache, 5.0-apache, 5.0.alpha-apache, 5.0.0-alpha-apache, 5.0.0-alpha2-php8.1, 5.0-php8.1, 5.0.alpha-php8.1, 5.0.0-alpha-php8.1, 5.0.0-alpha2-php8.1-apache, 5.0-php8.1-apache, 5.0.alpha-php8.1-apache, 5.0.0-alpha-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 5.0.alpha/php8.1/apache
 
-Tags: 5.0.0-alpha1-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.alpha-php8.1-fpm-alpine, 5.0.0-alpha-php8.1-fpm-alpine
+Tags: 5.0.0-alpha2-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.alpha-php8.1-fpm-alpine, 5.0.0-alpha-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 5.0.alpha/php8.1/fpm-alpine
 
-Tags: 5.0.0-alpha1-php8.1-fpm, 5.0-php8.1-fpm, 5.0.alpha-php8.1-fpm, 5.0.0-alpha-php8.1-fpm
+Tags: 5.0.0-alpha2-php8.1-fpm, 5.0-php8.1-fpm, 5.0.alpha-php8.1-fpm, 5.0.0-alpha-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 5.0.alpha/php8.1/fpm
 
-Tags: 5.0.0-alpha1-php8.2-apache, 5.0-php8.2-apache, 5.0.alpha-php8.2-apache, 5.0.0-alpha-php8.2-apache
+Tags: 5.0.0-alpha2-php8.2-apache, 5.0-php8.2-apache, 5.0.alpha-php8.2-apache, 5.0.0-alpha-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 5.0.alpha/php8.2/apache
 
-Tags: 5.0.0-alpha1-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.alpha-php8.2-fpm-alpine, 5.0.0-alpha-php8.2-fpm-alpine
+Tags: 5.0.0-alpha2-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.alpha-php8.2-fpm-alpine, 5.0.0-alpha-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 5.0.alpha/php8.2/fpm-alpine
 
-Tags: 5.0.0-alpha1-php8.2-fpm, 5.0-php8.2-fpm, 5.0.alpha-php8.2-fpm, 5.0.0-alpha-php8.2-fpm
+Tags: 5.0.0-alpha2-php8.2-fpm, 5.0-php8.2-fpm, 5.0.alpha-php8.2-fpm, 5.0.0-alpha-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c83dfeda66de5f07be8422408a7b1d552a8c59b9
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 5.0.alpha/php8.2/fpm
 
-Tags: 4.4.0-alpha1-php8.0-apache, 4.4-php8.0-apache, 4.4.alpha-php8.0-apache, 4.4.0-alpha-php8.0-apache
+Tags: 4.4.0-alpha2-php8.0-apache, 4.4-php8.0-apache, 4.4.alpha-php8.0-apache, 4.4.0-alpha-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.0/apache
 
-Tags: 4.4.0-alpha1-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.alpha-php8.0-fpm-alpine, 4.4.0-alpha-php8.0-fpm-alpine
+Tags: 4.4.0-alpha2-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.alpha-php8.0-fpm-alpine, 4.4.0-alpha-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.0/fpm-alpine
 
-Tags: 4.4.0-alpha1-php8.0-fpm, 4.4-php8.0-fpm, 4.4.alpha-php8.0-fpm, 4.4.0-alpha-php8.0-fpm
+Tags: 4.4.0-alpha2-php8.0-fpm, 4.4-php8.0-fpm, 4.4.alpha-php8.0-fpm, 4.4.0-alpha-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.0/fpm
 
-Tags: 4.4.0-alpha1, 4.4, 4.4.alpha, 4.4.0-alpha, 4.4.0-alpha1-apache, 4.4-apache, 4.4.alpha-apache, 4.4.0-alpha-apache, 4.4.0-alpha1-php8.1, 4.4-php8.1, 4.4.alpha-php8.1, 4.4.0-alpha-php8.1, 4.4.0-alpha1-php8.1-apache, 4.4-php8.1-apache, 4.4.alpha-php8.1-apache, 4.4.0-alpha-php8.1-apache
+Tags: 4.4.0-alpha2, 4.4, 4.4.alpha, 4.4.0-alpha, 4.4.0-alpha2-apache, 4.4-apache, 4.4.alpha-apache, 4.4.0-alpha-apache, 4.4.0-alpha2-php8.1, 4.4-php8.1, 4.4.alpha-php8.1, 4.4.0-alpha-php8.1, 4.4.0-alpha2-php8.1-apache, 4.4-php8.1-apache, 4.4.alpha-php8.1-apache, 4.4.0-alpha-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.1/apache
 
-Tags: 4.4.0-alpha1-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.alpha-php8.1-fpm-alpine, 4.4.0-alpha-php8.1-fpm-alpine
+Tags: 4.4.0-alpha2-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.alpha-php8.1-fpm-alpine, 4.4.0-alpha-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.1/fpm-alpine
 
-Tags: 4.4.0-alpha1-php8.1-fpm, 4.4-php8.1-fpm, 4.4.alpha-php8.1-fpm, 4.4.0-alpha-php8.1-fpm
+Tags: 4.4.0-alpha2-php8.1-fpm, 4.4-php8.1-fpm, 4.4.alpha-php8.1-fpm, 4.4.0-alpha-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.1/fpm
 
-Tags: 4.4.0-alpha1-php8.2-apache, 4.4-php8.2-apache, 4.4.alpha-php8.2-apache, 4.4.0-alpha-php8.2-apache
+Tags: 4.4.0-alpha2-php8.2-apache, 4.4-php8.2-apache, 4.4.alpha-php8.2-apache, 4.4.0-alpha-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.2/apache
 
-Tags: 4.4.0-alpha1-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.alpha-php8.2-fpm-alpine, 4.4.0-alpha-php8.2-fpm-alpine
+Tags: 4.4.0-alpha2-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.alpha-php8.2-fpm-alpine, 4.4.0-alpha-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.2/fpm-alpine
 
-Tags: 4.4.0-alpha1-php8.2-fpm, 4.4-php8.2-fpm, 4.4.alpha-php8.2-fpm, 4.4.0-alpha-php8.2-fpm
+Tags: 4.4.0-alpha2-php8.2-fpm, 4.4-php8.2-fpm, 4.4.alpha-php8.2-fpm, 4.4.0-alpha-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 869c8d0fcda0e2e19b716b84bd9ff08e2071ea0e
+GitCommit: 052a38d620ce0bcf6bd3f61fa29a4e1fc5a41561
 Directory: 4.4.alpha/php8.2/fpm
 
-Tags: 4.3.2, 4.3, 4, latest, 4.3.2-apache, 4.3-apache, 4-apache, apache, 4.3.2-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.2-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.3.3, 4.3, 4, latest, 4.3.3-apache, 4.3-apache, 4-apache, apache, 4.3.3-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.3-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.0/apache
 
-Tags: 4.3.2-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.3.3-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.0/fpm-alpine
 
-Tags: 4.3.2-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.3.3-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.0/fpm
 
-Tags: 4.3.2-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.3.3-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.1/apache
 
-Tags: 4.3.2-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.3.3-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.1/fpm-alpine
 
-Tags: 4.3.2-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.3.3-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eaf23042576d7fb02e6d4b34c5345a1bcd6531f1
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.1/fpm
 
-Tags: 4.3.2-php8.2-apache, 4.3-php8.2-apache, 4-php8.2-apache, php8.2-apache
+Tags: 4.3.3-php8.2-apache, 4.3-php8.2-apache, 4-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1f02139287395a0d5ccc3211cea4c6df184377b
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.2/apache
 
-Tags: 4.3.2-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 4.3.3-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1f02139287395a0d5ccc3211cea4c6df184377b
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.2/fpm-alpine
 
-Tags: 4.3.2-php8.2-fpm, 4.3-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
+Tags: 4.3.3-php8.2-fpm, 4.3-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1f02139287395a0d5ccc3211cea4c6df184377b
+GitCommit: 1a5f3a19ac30bddc212cb334d9a83ee0cbfda20c
 Directory: 4.3/php8.2/fpm
 
-Tags: 3.10.11, 3.10, 3, 3.10.11-apache, 3.10-apache, 3-apache, 3.10.11-php8.0, 3.10-php8.0, 3-php8.0, 3.10.11-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
+Tags: 3.10.12, 3.10, 3, 3.10.12-apache, 3.10-apache, 3-apache, 3.10.12-php8.0, 3.10-php8.0, 3-php8.0, 3.10.12-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5c118d93f57608d779ae61d75bf122f2f03d2d9b
+GitCommit: a125bc71e8e6cd67a1534384d03ba255756a73ac
 Directory: 3.10/php8.0/apache
 
-Tags: 3.10.11-php8.0-fpm-alpine, 3.10-php8.0-fpm-alpine, 3-php8.0-fpm-alpine
+Tags: 3.10.12-php8.0-fpm-alpine, 3.10-php8.0-fpm-alpine, 3-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5c118d93f57608d779ae61d75bf122f2f03d2d9b
+GitCommit: a125bc71e8e6cd67a1534384d03ba255756a73ac
 Directory: 3.10/php8.0/fpm-alpine
 
-Tags: 3.10.11-php8.0-fpm, 3.10-php8.0-fpm, 3-php8.0-fpm
+Tags: 3.10.12-php8.0-fpm, 3.10-php8.0-fpm, 3-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5c118d93f57608d779ae61d75bf122f2f03d2d9b
+GitCommit: a125bc71e8e6cd67a1534384d03ba255756a73ac
 Directory: 3.10/php8.0/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@1a5f3a1: Update Joomla 4.3.2 to 4.3.3 Images
- joomla-docker/docker-joomla@0505f68: Update Joomla 4.3.2 to 4.3.3 Version
- joomla-docker/docker-joomla@a125bc7: Update Joomla 3.10.11 to 3.10.12 Images
- joomla-docker/docker-joomla@567497a: Update Joomla 3.10.11 to 3.10.12 Version
- joomla-docker/docker-joomla@052a38d: Update Joomla 5.0 and 4.4 Alpha Images