### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -18,12 +18,12 @@ Directory: 1.21-rc/bullseye
 
 Tags: 1.21rc2-alpine3.18, 1.21-rc-alpine3.18, 1.21rc2-alpine, 1.21-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ab26fd7f52d0cd35223b82e79774a4a3aa24a1b
+GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
 Directory: 1.21-rc/alpine3.18
 
 Tags: 1.21rc2-alpine3.17, 1.21-rc-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1ab26fd7f52d0cd35223b82e79774a4a3aa24a1b
+GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
 Directory: 1.21-rc/alpine3.17
 
 Tags: 1.21rc2-windowsservercore-ltsc2022, 1.21-rc-windowsservercore-ltsc2022
@@ -67,12 +67,12 @@ Directory: 1.20/bullseye
 
 Tags: 1.20.6-alpine3.18, 1.20-alpine3.18, 1-alpine3.18, alpine3.18, 1.20.6-alpine, 1.20-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bba543aacac120bf09b371bd1b41496f3d2ea89d
+GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
 Directory: 1.20/alpine3.18
 
 Tags: 1.20.6-alpine3.17, 1.20-alpine3.17, 1-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bba543aacac120bf09b371bd1b41496f3d2ea89d
+GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
 Directory: 1.20/alpine3.17
 
 Tags: 1.20.6-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
@@ -116,12 +116,12 @@ Directory: 1.19/bullseye
 
 Tags: 1.19.11-alpine3.18, 1.19-alpine3.18, 1.19.11-alpine, 1.19-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0238356ccf448c8d4cbd3a6008ab05708ac77b0c
+GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
 Directory: 1.19/alpine3.18
 
 Tags: 1.19.11-alpine3.17, 1.19-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0238356ccf448c8d4cbd3a6008ab05708ac77b0c
+GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
 Directory: 1.19/alpine3.17
 
 Tags: 1.19.11-windowsservercore-ltsc2022, 1.19-windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/431c08f: Update architectures lists with more references
- https://github.com/docker-library/golang/commit/5eca4a0: Merge pull request https://github.com/docker-library/golang/pull/474 from infosiftr/alpine-1.21-upstream
- https://github.com/docker-library/golang/commit/0ac27a1: Use upstream binaries for Alpine in 1.21+