### PR TITLE
Make 17-debian available

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -130,6 +130,10 @@ Tags: 17-alpine3.17, 17.0.7-alpine3.17, 17-alpine3.17-full, 17-alpine3.17-jdk, 1
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.17
 
+Tags: 17-debian
+Architectures: amd64, arm64v8
+Directory: 17/jdk/debian
+
 Tags: 20, 20.0.1, 20.0.1-al2, 20-al2-full, 20-al2-jdk, 20-al2-generic, 20.0.1-al2-generic, 20-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 20/jdk/al2-generic


### PR DESCRIPTION
Currently, there's no tag pushed for https://github.com/corretto/corretto-docker/blob/b3911c583ac27a9b5801eba2373a9dd8fe10a3a0/17/jdk/debian/Dockerfile
With this change, we can access the debian variant.