### PR TITLE
[nats] Release V2.9.20

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -5,25 +5,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 80858aeed571549ac03ad6ba9cd3aa61725ed040
+GitCommit: 6ee3723373975f65c7b446e20d4a938a5c5a5567
 
-Tags: 2.9.19-alpine3.18, 2.9-alpine3.18, 2-alpine3.18, alpine3.18, 2.9.19-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.20-alpine3.18, 2.9-alpine3.18, 2-alpine3.18, alpine3.18, 2.9.20-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.19/alpine3.18
+Directory: 2.9.20/alpine3.18
 
-Tags: 2.9.19-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.19-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.19, 2.9, 2, latest
+Tags: 2.9.20-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.20-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.20, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.19/scratch
+Directory: 2.9.20/scratch
 
-Tags: 2.9.19-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.19-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.20-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.20-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.19/windowsservercore-1809
+Directory: 2.9.20/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.19-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.19-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.19, 2.9, 2, latest
+Tags: 2.9.20-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.20-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.20, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.19/nanoserver-1809
+Directory: 2.9.20/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.20)