### PR TITLE
mediawiki: Add 1.40, remove 1.38

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -2,28 +2,28 @@ Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
              Kunal Mehta <legoktm@debian.org> (@legoktm),
              addshore <addshorewiki@gmail.com> (@addshore)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
-GitCommit: 1baa2905a338f333ca3f48176bca13f34329bf6b
+GitCommit: d81c6d202933880f4e2ebebe691be34e8b991c61
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
-Tags: 1.39.4, 1.39, stable, lts, latest
+Tags: 1.40.0, 1.40, stable, latest
+Directory: 1.40/apache
+
+Tags: 1.40.0-fpm, 1.40-fpm, stable-fpm
+Directory: 1.40/fpm
+
+Tags: 1.40.0-fpm-alpine, 1.40-fpm-alpine, stable-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Directory: 1.40/fpm-alpine
+
+Tags: 1.39.4, 1.39, lts, legacy
 Directory: 1.39/apache
 
-Tags: 1.39.4-fpm, 1.39-fpm, stable-fpm, lts-fpm
+Tags: 1.39.4-fpm, 1.39-fpm, legacy-fpm, lts-fpm
 Directory: 1.39/fpm
 
-Tags: 1.39.4-fpm-alpine, 1.39-fpm-alpine, stable-fpm-alpine, lts-fpm-alpine
+Tags: 1.39.4-fpm-alpine, 1.39-fpm-alpine, legacy-fpm-alpine, lts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.39/fpm-alpine
-
-Tags: 1.38.7, 1.38, legacy
-Directory: 1.38/apache
-
-Tags: 1.38.7-fpm, 1.38-fpm, legacy-fpm
-Directory: 1.38/fpm
-
-Tags: 1.38.7-fpm-alpine, 1.38-fpm-alpine, legacy-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
-Directory: 1.38/fpm-alpine
 
 Tags: 1.35.11, 1.35, legacylts
 Directory: 1.35/apache


### PR DESCRIPTION
1.40 is the new stable release, shifting 1.39 to legacy.

1.38 is EOL and removed.

Refs https://github.com/wikimedia/mediawiki-docker/pull/124