### PR TITLE
archlinux: Release 20230716.0.165339

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230709.0.163418
-GitCommit: e7997e3798b056648f0424e97dd3c78698d319f0
-GitFetch: refs/tags/v20230709.0.163418
+Tags: latest, base, base-20230716.0.165339
+GitCommit: 193965519a6b830b07627eaa784c4ab636fb4a41
+GitFetch: refs/tags/v20230716.0.165339
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230709.0.163418
-GitCommit: e7997e3798b056648f0424e97dd3c78698d319f0
-GitFetch: refs/tags/v20230709.0.163418
+Tags: base-devel, base-devel-20230716.0.165339
+GitCommit: 193965519a6b830b07627eaa784c4ab636fb4a41
+GitFetch: refs/tags/v20230716.0.165339
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks