### PR TITLE
Update Clear Linux OS to 39630

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 11a8acec1e58aab06d40c35dad429daa6518d532
-GitFetch: refs/heads/base-39590
+GitCommit: 927a55624e601b2e77516d0f01f93ca7ae2cfb2f
+GitFetch: refs/heads/base-39630


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39630

@bryteise @djklimes @bryteise