### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,52 +5,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.21rc2-bookworm, 1.21-rc-bookworm
-SharedTags: 1.21rc2, 1.21-rc
+Tags: 1.21rc3-bookworm, 1.21-rc-bookworm
+SharedTags: 1.21rc3, 1.21-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 72bc141d781ae54ef20f71aa1105449cb6c2edc4
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/bookworm
 
-Tags: 1.21rc2-bullseye, 1.21-rc-bullseye
+Tags: 1.21rc3-bullseye, 1.21-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 72bc141d781ae54ef20f71aa1105449cb6c2edc4
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/bullseye
 
-Tags: 1.21rc2-alpine3.18, 1.21-rc-alpine3.18, 1.21rc2-alpine, 1.21-rc-alpine
+Tags: 1.21rc3-alpine3.18, 1.21-rc-alpine3.18, 1.21rc3-alpine, 1.21-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/alpine3.18
 
-Tags: 1.21rc2-alpine3.17, 1.21-rc-alpine3.17
+Tags: 1.21rc3-alpine3.17, 1.21-rc-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 431c08ffa8fdcb3dd1a1e1d6fd48b8788570a7cc
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/alpine3.17
 
-Tags: 1.21rc2-windowsservercore-ltsc2022, 1.21-rc-windowsservercore-ltsc2022
-SharedTags: 1.21rc2-windowsservercore, 1.21-rc-windowsservercore, 1.21rc2, 1.21-rc
+Tags: 1.21rc3-windowsservercore-ltsc2022, 1.21-rc-windowsservercore-ltsc2022
+SharedTags: 1.21rc3-windowsservercore, 1.21-rc-windowsservercore, 1.21rc3, 1.21-rc
 Architectures: windows-amd64
-GitCommit: 1ab26fd7f52d0cd35223b82e79774a4a3aa24a1b
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.21rc2-windowsservercore-1809, 1.21-rc-windowsservercore-1809
-SharedTags: 1.21rc2-windowsservercore, 1.21-rc-windowsservercore, 1.21rc2, 1.21-rc
+Tags: 1.21rc3-windowsservercore-1809, 1.21-rc-windowsservercore-1809
+SharedTags: 1.21rc3-windowsservercore, 1.21-rc-windowsservercore, 1.21rc3, 1.21-rc
 Architectures: windows-amd64
-GitCommit: 1ab26fd7f52d0cd35223b82e79774a4a3aa24a1b
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.21rc2-nanoserver-ltsc2022, 1.21-rc-nanoserver-ltsc2022
-SharedTags: 1.21rc2-nanoserver, 1.21-rc-nanoserver
+Tags: 1.21rc3-nanoserver-ltsc2022, 1.21-rc-nanoserver-ltsc2022
+SharedTags: 1.21rc3-nanoserver, 1.21-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 1ab26fd7f52d0cd35223b82e79774a4a3aa24a1b
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.21rc2-nanoserver-1809, 1.21-rc-nanoserver-1809
-SharedTags: 1.21rc2-nanoserver, 1.21-rc-nanoserver
+Tags: 1.21rc3-nanoserver-1809, 1.21-rc-nanoserver-1809
+SharedTags: 1.21rc3-nanoserver, 1.21-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 1ab26fd7f52d0cd35223b82e79774a4a3aa24a1b
+GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
 Directory: 1.21-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/105ef08: Update 1.21-rc to 1.21rc3
- https://github.com/docker-library/golang/commit/3c5b74f: Merge pull request https://github.com/docker-library/golang/pull/475 from infosiftr/versions-arches
- https://github.com/docker-library/golang/commit/34cdec3: Move "arches normalization" code down so it happens more consistently (for both "supported" and "missing" arches)