### PR TITLE
Almalinux auto-update - 160622

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -3,62 +3,62 @@ Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 
-Tags: 8, 8.8, 8.8-20230524
-GitFetch: refs/heads/al8-20230524-amd64
-GitCommit: 96c180e154599cb2831d58f8ef290967ee12e3b9
+Tags: 8, 8.8, 8.8-20230718
+GitFetch: refs/heads/al8-20230718-amd64
+GitCommit: a7e0d4c97e8c2ab80dfada8685b44831f7c8d6ad
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20230524-arm64v8
-arm64v8-GitCommit: bc59c2d99f415aa962aa55ec3bbd14ca54c71b3b
+arm64v8-GitFetch: refs/heads/al8-20230718-arm64v8
+arm64v8-GitCommit: af89b951918bc59e0891dde2ecbcc38d64560c59
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20230524-ppc64le
-ppc64le-GitCommit: b45dd35e03d4a5d858be83ba373d04f56202b481
+ppc64le-GitFetch: refs/heads/al8-20230718-ppc64le
+ppc64le-GitCommit: 77ec120d5ee160cc72406c31dddb4a9e9ec5c809
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20230524-s390x
-s390x-GitCommit: 2ff040417aab732196030265a9bc3844ec19b74d
+s390x-GitFetch: refs/heads/al8-20230718-s390x
+s390x-GitCommit: 0d0bcc7dba2e66b6e360d77c6c16fb8217490ddd
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 8-minimal, 8.8-minimal, 8.8-minimal-20230524
-GitFetch: refs/heads/al8-20230524-amd64
-GitCommit: 96c180e154599cb2831d58f8ef290967ee12e3b9
+Tags: 8-minimal, 8.8-minimal, 8.8-minimal-20230718
+GitFetch: refs/heads/al8-20230718-amd64
+GitCommit: a7e0d4c97e8c2ab80dfada8685b44831f7c8d6ad
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20230524-arm64v8
-arm64v8-GitCommit: bc59c2d99f415aa962aa55ec3bbd14ca54c71b3b
+arm64v8-GitFetch: refs/heads/al8-20230718-arm64v8
+arm64v8-GitCommit: af89b951918bc59e0891dde2ecbcc38d64560c59
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20230524-ppc64le
-ppc64le-GitCommit: b45dd35e03d4a5d858be83ba373d04f56202b481
+ppc64le-GitFetch: refs/heads/al8-20230718-ppc64le
+ppc64le-GitCommit: 77ec120d5ee160cc72406c31dddb4a9e9ec5c809
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20230524-s390x
-s390x-GitCommit: 2ff040417aab732196030265a9bc3844ec19b74d
+s390x-GitFetch: refs/heads/al8-20230718-s390x
+s390x-GitCommit: 0d0bcc7dba2e66b6e360d77c6c16fb8217490ddd
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: latest, 9, 9.2, 9.2-20230512
-GitFetch: refs/heads/al9-20230512-amd64
-GitCommit: 600467393dc75d3768196215ea1c122b552b9728
+Tags: latest, 9, 9.2, 9.2-20230718
+GitFetch: refs/heads/al9-20230718-amd64
+GitCommit: 764a53a590bc415278c977ad43f42f4a836b8c3f
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20230512-arm64v8
-arm64v8-GitCommit: 1b341d33f81c8402ef8d9532277495f92e4414b8
+arm64v8-GitFetch: refs/heads/al9-20230718-arm64v8
+arm64v8-GitCommit: 8812e025bed7bf8b231f8cdbc2a67880f1fd03e0
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20230512-ppc64le
-ppc64le-GitCommit: 7fc5ec9ff0146d00072a3185fa00f2972c804b93
+ppc64le-GitFetch: refs/heads/al9-20230718-ppc64le
+ppc64le-GitCommit: 7167d334fcc163577422e74f364f652481f5cd97
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20230512-s390x
-s390x-GitCommit: c1d1785d246bad9715a5d3f290443d1ab5b086e8
+s390x-GitFetch: refs/heads/al9-20230718-s390x
+s390x-GitCommit: 5014341cc139ca7b70f2cc1440c3a35e693a60f9
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 9-minimal,  9.2-minimal, 9.2-minimal-20230512
-GitFetch: refs/heads/al9-20230512-amd64
-GitCommit: 600467393dc75d3768196215ea1c122b552b9728
+Tags: minimal, 9-minimal,  9.2-minimal, 9.2-minimal-20230718
+GitFetch: refs/heads/al9-20230718-amd64
+GitCommit: 764a53a590bc415278c977ad43f42f4a836b8c3f
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20230512-arm64v8
-arm64v8-GitCommit: 1b341d33f81c8402ef8d9532277495f92e4414b8
+arm64v8-GitFetch: refs/heads/al9-20230718-arm64v8
+arm64v8-GitCommit: 8812e025bed7bf8b231f8cdbc2a67880f1fd03e0
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20230512-ppc64le
-ppc64le-GitCommit: 7fc5ec9ff0146d00072a3185fa00f2972c804b93
+ppc64le-GitFetch: refs/heads/al9-20230718-ppc64le
+ppc64le-GitCommit: 7167d334fcc163577422e74f364f652481f5cd97
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20230512-s390x
-s390x-GitCommit: c1d1785d246bad9715a5d3f290443d1ab5b086e8
+s390x-GitFetch: refs/heads/al9-20230718-s390x
+s390x-GitCommit: 5014341cc139ca7b70f2cc1440c3a35e693a60f9
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @LKHN or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `krb5-libs` changed from 1.18.2-22.el8_7 to 1.18.2-25.el8_8
- `platform-python` changed from 3.6.8-51.el8.alma to 3.6.8-51.el8_8.1.alma
- `python3-libs` changed from 3.6.8-51.el8.alma to 3.6.8-51.el8_8.1.alma
- `sqlite-libs` changed from 3.26.0-17.el8_7 to 3.26.0-18.el8_8
- `systemd` changed from 239-74.el8_8 to 239-74.el8_8.2
- `systemd-libs` changed from 239-74.el8_8 to 239-74.el8_8.2
- `systemd-pam` changed from 239-74.el8_8 to 239-74.el8_8.2

### AlmaLinux 9 change log

- `krb5-libs` changed from 1.20.1-8.el9 to 1.20.1-9.el9_2
- `less` changed from 590-1.el9_0 to 590-2.el9_2
- `openssl` changed from 3.0.7-6.el9_2 to 3.0.7-16.el9_2
- `openssl-libs` changed from 3.0.7-6.el9_2 to 3.0.7-16.el9_2
- `python3` changed from 3.9.16-1.el9 to 3.9.16-1.el9_2.1
- `python3-libs` changed from 3.9.16-1.el9 to 3.9.16-1.el9_2.1
- `systemd` changed from 252-13.el9_2 to 252-14.el9_2.1
- `systemd-libs` changed from 252-13.el9_2 to 252-14.el9_2.1
- `systemd-pam` changed from 252-13.el9_2 to 252-14.el9_2.1
- `systemd-rpm-macros` changed from 252-13.el9_2 to 252-14.el9_2.1

