### PR TITLE
Releasing Neo4j 5.10.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -4,15 +4,15 @@ Maintainers: Jenny Owen <jenny.owen@neo4j.com> (@jennyowen),
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 
-Tags: 5.9.0, 5.9.0-community, 5.9, 5.9-community, 5, 5-community, community, latest
+Tags: 5.10.0, 5.10.0-community, 5.10, 5.10-community, 5, 5-community, community, latest
 Architectures: amd64, arm64v8
-GitCommit: 9d7a9047bb1b1b736c01e50bf5d38c0a4d3d1697
-Directory: 5.9.0/community
+GitCommit: 53020c7673630cd8a216a4731096f08ebb8a4e30
+Directory: 5.10.0/debian/community
 
-Tags: 5.9.0-enterprise, 5.9-enterprise, 5-enterprise, enterprise
+Tags: 5.10.0-enterprise, 5.10-enterprise, 5-enterprise, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 9d7a9047bb1b1b736c01e50bf5d38c0a4d3d1697
-Directory: 5.9.0/enterprise
+GitCommit: 53020c7673630cd8a216a4731096f08ebb8a4e30
+Directory: 5.10.0/debian/enterprise
 
 
 Tags: 4.4.23, 4.4.23-community, 4.4, 4.4-community


### PR DESCRIPTION
I also have some exciting redhat versions of Neo4j 5.10.0 waiting to be released, but I'll include those in a separate PR after this one so that they don't block the usual stuff from being released.
Thanks!