### PR TITLE
Update SapMachine for July 2023 update cycle

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,62 +1,62 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Christian Halstrick <sapmachine@sap.com> (@chalstrick)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: jre-headless-ubuntu-11, jre-headless-ubuntu-11.0.19
+Tags: jre-headless-ubuntu-11, jre-headless-ubuntu-11.0.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 284381b712285fc3593a81284648ab1604f91c38
+GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
 Directory: dockerfiles/official/11/ubuntu/jre-headless
 
-Tags: jre-ubuntu-11, jre-ubuntu-11.0.19
+Tags: jre-ubuntu-11, jre-ubuntu-11.0.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 284381b712285fc3593a81284648ab1604f91c38
+GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
 Directory: dockerfiles/official/11/ubuntu/jre
 
-Tags: jdk-headless-ubuntu-11, jdk-headless-ubuntu-11.0.19
+Tags: jdk-headless-ubuntu-11, jdk-headless-ubuntu-11.0.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 284381b712285fc3593a81284648ab1604f91c38
+GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
 Directory: dockerfiles/official/11/ubuntu/jdk-headless
 
-Tags: jdk-ubuntu-11, jdk-ubuntu-11.0.19, 11, 11.0.19
+Tags: jdk-ubuntu-11, jdk-ubuntu-11.0.20, 11, 11.0.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 284381b712285fc3593a81284648ab1604f91c38
+GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
 Directory: dockerfiles/official/11/ubuntu/jdk
 
-Tags: jre-headless-ubuntu-17, jre-headless-ubuntu-17.0.7, jre-headless-ubuntu-lts
+Tags: jre-headless-ubuntu-17, jre-headless-ubuntu-17.0.8, jre-headless-ubuntu-lts
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ea273f4b64903125418a8b30ac55c6d9757634c8
+GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
 Directory: dockerfiles/official/17/ubuntu/jre-headless
 
-Tags: jre-ubuntu-17, jre-ubuntu-17.0.7, jre-ubuntu-lts
+Tags: jre-ubuntu-17, jre-ubuntu-17.0.8, jre-ubuntu-lts
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ea273f4b64903125418a8b30ac55c6d9757634c8
+GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
 Directory: dockerfiles/official/17/ubuntu/jre
 
-Tags: jdk-headless-ubuntu-17, jdk-headless-ubuntu-17.0.7, jdk-headless-ubuntu-lts
+Tags: jdk-headless-ubuntu-17, jdk-headless-ubuntu-17.0.8, jdk-headless-ubuntu-lts
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ea273f4b64903125418a8b30ac55c6d9757634c8
+GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
 Directory: dockerfiles/official/17/ubuntu/jdk-headless
 
-Tags: jdk-ubuntu-17, jdk-ubuntu-17.0.7, jdk-ubuntu-lts, 17, 17.0.7, lts
+Tags: jdk-ubuntu-17, jdk-ubuntu-17.0.8, jdk-ubuntu-lts, 17, 17.0.8, lts
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: ea273f4b64903125418a8b30ac55c6d9757634c8
+GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
 Directory: dockerfiles/official/17/ubuntu/jdk
 
-Tags: jre-headless-ubuntu-20, jre-headless-ubuntu-20.0.1, jre-headless-ubuntu
+Tags: jre-headless-ubuntu-20, jre-headless-ubuntu-20.0.2, jre-headless-ubuntu
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3d1d665c88254d2c3ae205ee47b6d924e0217893
+GitCommit: d8d71766093af433437a77900cba0839781f54c1
 Directory: dockerfiles/official/20/ubuntu/jre-headless
 
-Tags: jre-ubuntu-20, jre-ubuntu-20.0.1, jre-ubuntu
+Tags: jre-ubuntu-20, jre-ubuntu-20.0.2, jre-ubuntu
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3d1d665c88254d2c3ae205ee47b6d924e0217893
+GitCommit: d8d71766093af433437a77900cba0839781f54c1
 Directory: dockerfiles/official/20/ubuntu/jre
 
-Tags: jdk-headless-ubuntu-20, jdk-headless-ubuntu-20.0.1, jdk-headless-ubuntu
+Tags: jdk-headless-ubuntu-20, jdk-headless-ubuntu-20.0.2, jdk-headless-ubuntu
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3d1d665c88254d2c3ae205ee47b6d924e0217893
+GitCommit: d8d71766093af433437a77900cba0839781f54c1
 Directory: dockerfiles/official/20/ubuntu/jdk-headless
 
-Tags: jdk-ubuntu-20, jdk-ubuntu-20.0.1, jdk-ubuntu, 20, 20.0.1, latest
+Tags: jdk-ubuntu-20, jdk-ubuntu-20.0.2, jdk-ubuntu, 20, 20.0.2, latest
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3d1d665c88254d2c3ae205ee47b6d924e0217893
+GitCommit: d8d71766093af433437a77900cba0839781f54c1
 Directory: dockerfiles/official/20/ubuntu/jdk


### PR DESCRIPTION
The OpenJDK July 2023 updates for SapMachine.