### PR TITLE
[security] Update Nextcloud

### DIFF
--- a/library/nextcloud
+++ b/library/nextcloud
@@ -3,47 +3,47 @@
 Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud)
 GitRepo: https://github.com/nextcloud/docker.git
 
-Tags: 25.0.8-apache, 25.0-apache, 25-apache, 25.0.8, 25.0, 25
+Tags: 25.0.9-apache, 25.0-apache, 25-apache, 25.0.9, 25.0, 25
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 25/apache
 
-Tags: 25.0.8-fpm, 25.0-fpm, 25-fpm
+Tags: 25.0.9-fpm, 25.0-fpm, 25-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 25/fpm
 
-Tags: 25.0.8-fpm-alpine, 25.0-fpm-alpine, 25-fpm-alpine
+Tags: 25.0.9-fpm-alpine, 25.0-fpm-alpine, 25-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 25/fpm-alpine
 
-Tags: 26.0.3-apache, 26.0-apache, 26-apache, stable-apache, production-apache, 26.0.3, 26.0, 26, stable, production
+Tags: 26.0.4-apache, 26.0-apache, 26-apache, 26.0.4, 26.0, 26
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 26/apache
 
-Tags: 26.0.3-fpm, 26.0-fpm, 26-fpm, stable-fpm, production-fpm
+Tags: 26.0.4-fpm, 26.0-fpm, 26-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 26/fpm
 
-Tags: 26.0.3-fpm-alpine, 26.0-fpm-alpine, 26-fpm-alpine, stable-fpm-alpine, production-fpm-alpine
+Tags: 26.0.4-fpm-alpine, 26.0-fpm-alpine, 26-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 26/fpm-alpine
 
-Tags: 27.0.0-apache, 27.0-apache, 27-apache, apache, 27.0.0, 27.0, 27, latest
+Tags: 27.0.1-apache, 27.0-apache, 27-apache, apache, 27.0.1, 27.0, 27, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 27/apache
 
-Tags: 27.0.0-fpm, 27.0-fpm, 27-fpm, fpm
+Tags: 27.0.1-fpm, 27.0-fpm, 27-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 27/fpm
 
-Tags: 27.0.0-fpm-alpine, 27.0-fpm-alpine, 27-fpm-alpine, fpm-alpine
+Tags: 27.0.1-fpm-alpine, 27.0-fpm-alpine, 27-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 040d8687a6eedf5490e3cea1aff189e73403a6ee
+GitCommit: 1b913eb0e9e6106c5ab58c8a0b1b01caeaab2ffa
 Directory: 27/fpm-alpine


### PR DESCRIPTION
production/stable tags are removed because the release is not yet available on https://github.com/nextcloud-releases/updater_server