### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 22-ea-6-jdk-oraclelinux8, 22-ea-6-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-6-jdk-oracle, 22-ea-6-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-6-jdk, 22-ea-6, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-7-jdk-oraclelinux8, 22-ea-7-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-7-jdk-oracle, 22-ea-7-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-7-jdk, 22-ea-7, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-6-jdk-oraclelinux7, 22-ea-6-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-7-jdk-oraclelinux7, 22-ea-7-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-6-jdk-bookworm, 22-ea-6-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-7-jdk-bookworm, 22-ea-7-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-6-jdk-slim-bookworm, 22-ea-6-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-6-jdk-slim, 22-ea-6-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-7-jdk-slim-bookworm, 22-ea-7-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-7-jdk-slim, 22-ea-7-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-6-jdk-bullseye, 22-ea-6-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-7-jdk-bullseye, 22-ea-7-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-6-jdk-slim-bullseye, 22-ea-6-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-7-jdk-slim-bullseye, 22-ea-7-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-6-jdk-windowsservercore-ltsc2022, 22-ea-6-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-6-jdk-windowsservercore, 22-ea-6-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-6-jdk, 22-ea-6, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-7-jdk-windowsservercore-ltsc2022, 22-ea-7-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-7-jdk-windowsservercore, 22-ea-7-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-7-jdk, 22-ea-7, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-6-jdk-windowsservercore-1809, 22-ea-6-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-6-jdk-windowsservercore, 22-ea-6-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-6-jdk, 22-ea-6, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-7-jdk-windowsservercore-1809, 22-ea-7-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-7-jdk-windowsservercore, 22-ea-7-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-7-jdk, 22-ea-7, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-6-jdk-nanoserver-1809, 22-ea-6-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-6-jdk-nanoserver, 22-ea-6-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-7-jdk-nanoserver-1809, 22-ea-7-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-7-jdk-nanoserver, 22-ea-7-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: ed439b105fbc90c048c6da0b3ecf3d83e3c88155
+GitCommit: 2845bbf34dc65f4723e7f2f08f4df50928d7d6fe
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 21-ea-31-jdk-oraclelinux8, 21-ea-31-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-31-jdk-oracle, 21-ea-31-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-31-jdk, 21-ea-31, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-32-jdk-oraclelinux8, 21-ea-32-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-32-jdk-oracle, 21-ea-32-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-ea-32-jdk, 21-ea-32, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-31-jdk-oraclelinux7, 21-ea-31-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-ea-32-jdk-oraclelinux7, 21-ea-32-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-31-jdk-bookworm, 21-ea-31-bookworm, 21-ea-jdk-bookworm, 21-ea-bookworm, 21-jdk-bookworm, 21-bookworm
+Tags: 21-ea-32-jdk-bookworm, 21-ea-32-bookworm, 21-ea-jdk-bookworm, 21-ea-bookworm, 21-jdk-bookworm, 21-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/bookworm
 
-Tags: 21-ea-31-jdk-slim-bookworm, 21-ea-31-slim-bookworm, 21-ea-jdk-slim-bookworm, 21-ea-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-ea-31-jdk-slim, 21-ea-31-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-ea-32-jdk-slim-bookworm, 21-ea-32-slim-bookworm, 21-ea-jdk-slim-bookworm, 21-ea-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-ea-32-jdk-slim, 21-ea-32-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/slim-bookworm
 
-Tags: 21-ea-31-jdk-bullseye, 21-ea-31-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-ea-32-jdk-bullseye, 21-ea-32-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-31-jdk-slim-bullseye, 21-ea-31-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
+Tags: 21-ea-32-jdk-slim-bullseye, 21-ea-32-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-31-jdk-windowsservercore-ltsc2022, 21-ea-31-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-31-jdk-windowsservercore, 21-ea-31-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-31-jdk, 21-ea-31, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-32-jdk-windowsservercore-ltsc2022, 21-ea-32-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-ea-32-jdk-windowsservercore, 21-ea-32-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-32-jdk, 21-ea-32, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-31-jdk-windowsservercore-1809, 21-ea-31-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-31-jdk-windowsservercore, 21-ea-31-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-31-jdk, 21-ea-31, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-ea-32-jdk-windowsservercore-1809, 21-ea-32-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-ea-32-jdk-windowsservercore, 21-ea-32-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-32-jdk, 21-ea-32, 21-ea-jdk, 21-ea, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-31-jdk-nanoserver-1809, 21-ea-31-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-31-jdk-nanoserver, 21-ea-31-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-ea-32-jdk-nanoserver-1809, 21-ea-32-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-ea-32-jdk-nanoserver, 21-ea-32-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 13174bcf6c9eb30d7274a16f869ced38c6af8fe8
+GitCommit: 6642f6693fe16dad08e91cbb7ee2391959bb68c4
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/2845bbf: Update 22 to 22-ea+7
- https://github.com/docker-library/openjdk/commit/6642f66: Update 21 to 21-ea+32