### PR TITLE
[oraclelinux] Updating 7, 8 and 8-slim for ELSA-2023-4102 ELSA-2023-4152 ELSA-2023-3837

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: dbd5f24abbe089f39db8a1e4eceb4d754d9ed976
+amd64-GitCommit: 23954d8c46127085cd6dbdb8b8a10f2beca7ba94
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8f1d929b0000e53d2f7e13af930eea9e3523f8ff
+arm64v8-GitCommit: 024ea58b2fcb6151ddde018e66d536288d46f7bb
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-2828, CVE-2023-26604

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-4102.html
https://linux.oracle.com/errata/ELSA-2023-4152.html
https://linux.oracle.com/errata/ELSA-2023-3837.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>