### PR TITLE
Update Clear Linux OS to 39670

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 927a55624e601b2e77516d0f01f93ca7ae2cfb2f
-GitFetch: refs/heads/base-39630
+GitCommit: 63416f6dc3b7c706804cedcd9d2d8e90d340b9f5
+GitFetch: refs/heads/base-39670


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39670

@bryteise @djklimes @bryteise