### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,21 +4,21 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.33, 8.0, 8, latest, 8.0.33-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.0.34, 8.0, 8, latest, 8.0.34-oracle, 8.0-oracle, 8-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 1bfa4724fe112b4246672ed2b3c42142f17d5636
+GitCommit: f4030aebf6a63d640f7085fb3e4601b4e70313c8
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.33-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.34-debian, 8.0-debian, 8-debian, debian
 Architectures: amd64
-GitCommit: 611aa464a96f69e5d4d4172b14ca829ded162b42
+GitCommit: f4030aebf6a63d640f7085fb3e4601b4e70313c8
 Directory: 8.0
 File: Dockerfile.debian
 
 Tags: 5.7.42, 5.7, 5, 5.7.42-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: e4bdff20153e6a05364a8fe80356dcfd502445bd
+GitCommit: 2baf92d30620d7d123141b98988b0d42d2156351
 Directory: 5.7
 File: Dockerfile.oracle
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/2baf92d: Update 5.7 to mysql-shell 8.0.34-1.el7
- https://github.com/docker-library/mysql/commit/f4030ae: Update 8.0 to 8.0.34, debian 8.0.34-1debian11, mysql-shell 8.0.34-1.el8, oracle 8.0.34-1.el8