### PR TITLE
Bump Traefik to v2.10.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,15 +13,15 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: d9507badace6c064417d852daeea402d29ec0707
 Directory: alpine
 
-Tags: v2.10.3-windowsservercore-1809, 2.10.3-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.10.4-windowsservercore-1809, 2.10.4-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 45ebd782ec472b47b90058b27253874297242a26
+GitCommit: 03f1cd9c3350bdf9090136b01acc0e3fd2616600
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.10.3, 2.10.3, v2.10, 2.10, saintmarcelin, latest
+Tags: v2.10.4, 2.10.4, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 45ebd782ec472b47b90058b27253874297242a26
+GitCommit: 03f1cd9c3350bdf9090136b01acc0e3fd2616600
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.10.4](https://github.com/traefik/traefik/releases/tag/v2.10.4).

/cc @mmatur @rtribotte

Cheers
