### PR TITLE
SapMachine: New versions and release specific ubuntu tags

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,62 +1,42 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Christian Halstrick <sapmachine@sap.com> (@chalstrick)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: jre-headless-ubuntu-11, jre-headless-ubuntu-11.0.20
+Tags: 11-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.20.1-jdk-headless-ubuntu, 11.0.20.1-jdk-headless-ubuntu-jammy, 11.0.20.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
-Directory: dockerfiles/official/11/ubuntu/jre-headless
-
-Tags: jre-ubuntu-11, jre-ubuntu-11.0.20
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
-Directory: dockerfiles/official/11/ubuntu/jre
-
-Tags: jdk-headless-ubuntu-11, jdk-headless-ubuntu-11.0.20
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
+GitCommit: c1723a87e4227704b879bc0153969ee497b188c2
 Directory: dockerfiles/official/11/ubuntu/jdk-headless
 
-Tags: jdk-ubuntu-11, jdk-ubuntu-11.0.20, 11, 11.0.20
+Tags: 11-jdk-ubuntu, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.20.1-jdk-ubuntu, 11.0.20.1-jdk-ubuntu-jammy, 11.0.20.1-jdk-ubuntu-22.04, 11, 11-ubuntu-jammy, 11-ubuntu-22.04, 11.0.20.1, 11.0.20.1-ubuntu-jammy, 11.0.20.1-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 03a69c14ccf4cdb173bb67823d779770bcb44d72
+GitCommit: c1723a87e4227704b879bc0153969ee497b188c2
 Directory: dockerfiles/official/11/ubuntu/jdk
 
-Tags: jre-headless-ubuntu-17, jre-headless-ubuntu-17.0.8, jre-headless-ubuntu-lts
+Tags: 17-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.8.1-jdk-headless-ubuntu, 17.0.8.1-jdk-headless-ubuntu-jammy, 17.0.8.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
-Directory: dockerfiles/official/17/ubuntu/jre-headless
-
-Tags: jre-ubuntu-17, jre-ubuntu-17.0.8, jre-ubuntu-lts
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
-Directory: dockerfiles/official/17/ubuntu/jre
-
-Tags: jdk-headless-ubuntu-17, jdk-headless-ubuntu-17.0.8, jdk-headless-ubuntu-lts
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
+GitCommit: b2502288737bc565d44b9399c552bfebae112174
 Directory: dockerfiles/official/17/ubuntu/jdk-headless
 
-Tags: jdk-ubuntu-17, jdk-ubuntu-17.0.8, jdk-ubuntu-lts, 17, 17.0.8, lts
+Tags: 17-jdk-ubuntu, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.8.1-jdk-ubuntu, 17.0.8.1-jdk-ubuntu-jammy, 17.0.8.1-jdk-ubuntu-22.04, 17, 17-ubuntu-jammy, 17-ubuntu-22.04, 17.0.8.1, 17.0.8.1-ubuntu-jammy, 17.0.8.1-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2d4f3b8850a40a6ab8ea0322f05cc05ed19d0f4e
+GitCommit: b2502288737bc565d44b9399c552bfebae112174
 Directory: dockerfiles/official/17/ubuntu/jdk
 
-Tags: jre-headless-ubuntu-20, jre-headless-ubuntu-20.0.2, jre-headless-ubuntu
+Tags: 21-jre-headless-ubuntu, 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, jre-headless-ubuntu, jre-headless-ubuntu-jammy, jre-headless-ubuntu-jammy-22.04, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: d8d71766093af433437a77900cba0839781f54c1
-Directory: dockerfiles/official/20/ubuntu/jre-headless
+GitCommit: a9fe2dafdcc3e4f728431d147ce3a3950153b4a9
+Directory: dockerfiles/official/21/ubuntu/jre-headless
 
-Tags: jre-ubuntu-20, jre-ubuntu-20.0.2, jre-ubuntu
+Tags: 21-jre-ubuntu, 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, jre-ubuntu, jre-ubuntu-jammy, jre-ubuntu-jammy-22.04, lts-jre-ubuntu, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: d8d71766093af433437a77900cba0839781f54c1
-Directory: dockerfiles/official/20/ubuntu/jre
+GitCommit: a9fe2dafdcc3e4f728431d147ce3a3950153b4a9
+Directory: dockerfiles/official/21/ubuntu/jre
 
-Tags: jdk-headless-ubuntu-20, jdk-headless-ubuntu-20.0.2, jdk-headless-ubuntu
+Tags: 21-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, jdk-headless-ubuntu, jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-jammy-22.04, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: d8d71766093af433437a77900cba0839781f54c1
-Directory: dockerfiles/official/20/ubuntu/jdk-headless
+GitCommit: a9fe2dafdcc3e4f728431d147ce3a3950153b4a9
+Directory: dockerfiles/official/21/ubuntu/jdk-headless
 
-Tags: jdk-ubuntu-20, jdk-ubuntu-20.0.2, jdk-ubuntu, 20, 20.0.2, latest
+Tags: 21-jdk-ubuntu, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, jdk-ubuntu, jdk-ubuntu-jammy, jdk-ubuntu-jammy-22.04, lts-jdk-ubuntu, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 21, 21-ubuntu-jammy, 21-ubuntu-22.04, latest, ubuntu-jammy, ubuntu-22.04, lts, lts-ubuntu-jammy, lts-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: d8d71766093af433437a77900cba0839781f54c1
-Directory: dockerfiles/official/20/ubuntu/jdk
+GitCommit: a9fe2dafdcc3e4f728431d147ce3a3950153b4a9
+Directory: dockerfiles/official/21/ubuntu/jdk


### PR DESCRIPTION
This PR adds release specific Ubuntu tags to enable support for multiple Ubuntu versions.

Furthermore it updates to the recent SapMachine versions.