### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.1.20230705.0
+Tags: 2023, latest, 2023.1.20230719.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: e2a12edeb2149ac97b854b43676c4117ced6fb70
+amd64-GitCommit: ae2ef2f28d65c72f4ae6f5823066e80770d22f51
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2bcbd7ca7b1be3b85d210ae0052943e64a44eb70
+arm64v8-GitCommit: 690585a92d0fc58af1f255d89f580561b718f602
 
-Tags: 2, 2.0.20230628.0
+Tags: 2, 2.0.20230719.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0df7bde196fbf207d36ade9bdbbf1b8ed493051f
+amd64-GitCommit: 0f44358ef4b48bab8bdb26ffca3f58ca96f1f9f4
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 4254b1296ebebb8c458d6dea704f6f3c47fe4090
+arm64v8-GitCommit: a2e27db0fd5eb2fb85bbdddfee2f73500d36f664
 
-Tags: 1, 2018.03, 2018.03.0.20230628.0
+Tags: 1, 2018.03, 2018.03.0.20230718.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 18405b44cfe8a9e24a023ea3ccecd7b41cba827f
+amd64-GitCommit: 8095435c93108a9b7c69f482175eddd47b32dc8a


### PR DESCRIPTION
### Updated Packages for Amazon Linux 1:
- ncurses-5.7-4.20090207.15.amzn1
- ncurses-base-5.7-4.20090207.15.amzn1
- ncurses-libs-5.7-4.20090207.15.amzn1
#### Packages addressing CVES:
- ncurses-5.7-4.20090207.15.amzn1, ncurses-base-5.7-4.20090207.15.amzn1, ncurses-libs-5.7-4.20090207.15.amzn1
  - [CVE-2023-29491](https://alas.aws.amazon.com/cve/html/CVE-2023-29491.html)

### Updated Packages for Amazon Linux 2:
- libcap-2.54-1.amzn2.0.2
#### Packages addressing CVES:
- libcap-2.54-1.amzn2.0.2
  - [CVE-2023-2602](https://alas.aws.amazon.com/cve/html/CVE-2023-2602.html)

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.1.20230719-0.amzn2023
- libzstd-1.5.2-1.amzn2023.0.3
- python3-setuptools-wheel-59.6.0-2.amzn2023.0.4
- system-release-2023.1.20230719-0.amzn2023
- libarchive-3.5.3-2.amzn2023.0.3
#### Packages addressing CVES:
- libzstd-1.5.2-1.amzn2023.0.3
  - [CVE-2022-4899](https://alas.aws.amazon.com/cve/html/CVE-2022-4899.html)
- python3-setuptools-wheel-59.6.0-2.amzn2023.0.4
  - [CVE-2022-40897](https://alas.aws.amazon.com/cve/html/CVE-2022-40897.html)
- libarchive-3.5.3-2.amzn2023.0.3
  - [CVE-2022-36227](https://alas.aws.amazon.com/cve/html/CVE-2022-36227.html)