### PR TITLE
eclipse-temurin: bump JDK11 to jdk-11.0.20+8

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -134,128 +134,128 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.19_7-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.20_8-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 15919f7dd6a903f0f966f484461954dcf7e28620
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jdk-focal, 11-jdk-focal, 11-focal
+Tags: 11.0.20_8-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jdk-jammy, 11-jdk-jammy, 11-jammy
-SharedTags: 11.0.19_7-jdk, 11-jdk, 11
+Tags: 11.0.20_8-jdk-jammy, 11-jdk-jammy, 11-jammy
+SharedTags: 11.0.20_8-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jdk-centos7, 11-jdk-centos7, 11-centos7
+Tags: 11.0.20_8-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Tags: 11.0.20_8-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.19_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.19_7-jdk, 11-jdk, 11
+Tags: 11.0.20_8-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.20_8-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20_8-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.19_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.19_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.20_8-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.20_8-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.19_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.19_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.19_7-jdk, 11-jdk, 11
+Tags: 11.0.20_8-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.20_8-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20_8-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.19_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.19_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.20_8-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.20_8-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.19_7-jre-alpine, 11-jre-alpine
+Tags: 11.0.20_8-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 15919f7dd6a903f0f966f484461954dcf7e28620
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jre-focal, 11-jre-focal
+Tags: 11.0.20_8-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jre-jammy, 11-jre-jammy
-SharedTags: 11.0.19_7-jre, 11-jre
+Tags: 11.0.20_8-jre-jammy, 11-jre-jammy
+SharedTags: 11.0.20_8-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jre-centos7, 11-jre-centos7
+Tags: 11.0.20_8-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Tags: 11.0.20_8-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 11.0.19_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.19_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.19_7-jre, 11-jre
+Tags: 11.0.20_8-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.20_8-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20_8-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.19_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.19_7-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.20_8-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.20_8-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.19_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.19_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.19_7-jre, 11-jre
+Tags: 11.0.20_8-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.20_8-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20_8-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.19_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.19_7-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.20_8-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.20_8-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 920efae8fe37e2b8f2b288b5f7f9e67134ecad1d
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 11/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -390,9 +390,9 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v20 images---------------------------------
-Tags: 20.0.1_9-jdk-alpine, 20-jdk-alpine, 20-alpine
+Tags: 20.0.2_9-jdk-alpine, 20-jdk-alpine, 20-alpine
 Architectures: amd64
-GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 20/jdk/alpine
 File: Dockerfile.releases.full
 
@@ -441,9 +441,9 @@ Directory: 20/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 20.0.1_9-jre-alpine, 20-jre-alpine
+Tags: 20.0.2_9-jre-alpine, 20-jre-alpine
 Architectures: amd64
-GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
+GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
 Directory: 20/jre/alpine
 File: Dockerfile.releases.full
 


### PR DESCRIPTION
also adds the JDK20 alpine updates