### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 4.1.2, 4.1, 4, latest
+Tags: 4.1.3, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 676c7fb1737244ff736edc56064af335cf9d466f
+GitCommit: 44614387cda4278e477056c24cde3070f679a32a
 Directory: 4.1
 
 Tags: 4.0.11, 4.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/4461438: Update 4.1 to 4.1.3