### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.55.0, 5.55, 5, latest
+Tags: 5.55.2, 5.55, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0bd4a5b4a525e89242c2f7291705584c718056c4
+GitCommit: 66c255ce097b60998ff7540ca9be179b75826415
 Directory: 5/debian
 
-Tags: 5.55.0-alpine, 5.55-alpine, 5-alpine, alpine
+Tags: 5.55.2-alpine, 5.55-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 0bd4a5b4a525e89242c2f7291705584c718056c4
+GitCommit: 66c255ce097b60998ff7540ca9be179b75826415
 Directory: 5/alpine


### PR DESCRIPTION
hanges:

- https://github.com/docker-library/ghost/commit/66c255c: Update to 5.55.2, ghost-cli 1.24.2
- https://github.com/docker-library/ghost/commit/b35b373: Update to 5.55.1, ghost-cli 1.24.2