### PR TITLE
arangodb 3.11.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -12,7 +12,7 @@ Architectures: amd64, arm64v8
 GitCommit: bdd1fadac33809b6344b6ce1adceef73717e576e
 Directory: alpine/3.10.9
 
-Tags: 3.11, 3.11.1, latest
+Tags: 3.11, 3.11.2, latest
 Architectures: amd64, arm64v8
-GitCommit: 5c926a243d7c952a58f97488781f5eaf6d6704b9
-Directory: alpine/3.11.1
+GitCommit: b2fcf01f639bebe80a8563c2d67b2866331f13c2
+Directory: alpine/3.11.2


### PR DESCRIPTION
Updated ArangoDB 3.11 to 3.11.2.