### PR TITLE
Add support for PPC64LE for Ubuntu Jammy JRE images.

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -13,7 +13,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-8u372-b07-jdk-jammy, open-8-jdk-jammy
 SharedTags: open-8u372-b07-jdk, open-8-jdk
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -32,7 +32,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-8u372-b07-jre-jammy, open-8-jre-jammy
 SharedTags: open-8u372-b07-jre, open-8-jre
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -52,7 +52,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-11.0.19_7-jdk-jammy, open-11-jdk-jammy
 SharedTags: open-11.0.19_7-jdk, open-11-jdk
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -71,7 +71,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-11.0.19_7-jre-jammy, open-11-jre-jammy
 SharedTags: open-11.0.19_7-jre, open-11-jre
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -91,7 +91,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-17.0.7_7-jdk-jammy, open-17-jdk-jammy
 SharedTags: open-17.0.7_7-jdk, open-17-jdk
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -110,7 +110,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-17.0.7_7-jre-jammy, open-17-jre-jammy
 SharedTags: open-17.0.7_7-jre, open-17-jre
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -130,7 +130,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-20.0.1_9-jdk-jammy, open-20-jdk-jammy
 SharedTags: open-20.0.1_9-jdk, open-20-jdk
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 20/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
@@ -149,7 +149,7 @@ File: Dockerfile.open.releases.full
 
 Tags: open-20.0.1_9-jre-jammy, open-20-jre-jammy
 SharedTags: open-20.0.1_9-jre, open-20-jre
-Architectures: amd64, s390x, arm64v8
+Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
 Directory: 20/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full


### PR DESCRIPTION
PPC64LE support though enabled in the Dockerfiles, somehow it missed the entry in the semeru file. This PR updates the supported architecture list for Ubuntu Jammy JRE images. Please merge the same. Thanks !! 