### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2023-04-26
-Tags: 13.1.0, 13.1, 13, latest, 13.1.0-bookworm, 13.1-bookworm, 13-bookworm, bookworm
+# Last Modified: 2023-07-27
+Tags: 13.2.0, 13.2, 13, latest, 13.2.0-bookworm, 13.2-bookworm, 13-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
+GitCommit: af458ec8254ef7ca3344f12631e2356b20b4a7f1
 Directory: 13
-# Docker EOL: 2024-10-26
+# Docker EOL: 2025-01-27
 
 # Last Modified: 2023-05-08
 Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/af458ec: Update 13 to 13.2.0