### PR TITLE
Update Clear Linux OS to 39710

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 63416f6dc3b7c706804cedcd9d2d8e90d340b9f5
-GitFetch: refs/heads/base-39670
+GitCommit: 1f9fe34b371c8097482b4a03bc3fbdb07cc701ff
+GitFetch: refs/heads/base-39710


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39710

@bryteise @djklimes @bryteise