### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -1,29 +1,29 @@
-# this file is generated via https://github.com/docker-library/mysql/blob/9ed73fdd2f2fd77591d0020e13c37602a0600eb8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mysql/blob/eb1850601849ef7ef77a23f017a20debc95d597c/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.0.34, 8.0, 8, latest, 8.0.34-oracle, 8.0-oracle, 8-oracle, oracle
+Tags: 8.1.0, 8.1, 8, innovation, latest, 8.1.0-oracle, 8.1-oracle, 8-oracle, innovation-oracle, oracle
+Architectures: amd64, arm64v8
+GitCommit: eb1850601849ef7ef77a23f017a20debc95d597c
+Directory: innovation
+File: Dockerfile.oracle
+
+Tags: 8.0.34, 8.0, 8.0.34-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
 GitCommit: f4030aebf6a63d640f7085fb3e4601b4e70313c8
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.34-debian, 8.0-debian, 8-debian, debian
+Tags: 8.0.34-debian, 8.0-debian
 Architectures: amd64
 GitCommit: f4030aebf6a63d640f7085fb3e4601b4e70313c8
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.42, 5.7, 5, 5.7.42-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.43, 5.7, 5, 5.7.43-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: 2baf92d30620d7d123141b98988b0d42d2156351
+GitCommit: c13cda9c2c9d836af9b3331e8681f8cc8e0a7803
 Directory: 5.7
 File: Dockerfile.oracle
-
-Tags: 5.7.42-debian, 5.7-debian, 5-debian
-Architectures: amd64
-GitCommit: 611aa464a96f69e5d4d4172b14ca829ded162b42
-Directory: 5.7
-File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/e83b98d: Merge pull request https://github.com/docker-library/mysql/pull/987 from infosiftr/repomd
- https://github.com/docker-library/mysql/commit/c13cda9: Update 5.7 to 5.7.43, dropping Debian support
- https://github.com/docker-library/mysql/commit/eb18506: Add innovation (8.1.0)
- https://github.com/docker-library/mysql/commit/18afafd: Add very crude parsing of "repomd.xml"