### PR TITLE
eclipse-temurin: Add support for custom CA Certificates

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -392,20 +392,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v20 images---------------------------------
 Tags: 20.0.2_9-jdk-alpine, 20-jdk-alpine, 20-alpine
 Architectures: amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 20/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 20.0.2_9-jdk-jammy, 20-jdk-jammy, 20-jammy
 SharedTags: 20.0.2_9-jdk, 20-jdk, 20, latest
 Architectures: amd64, arm64v8
-GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 20/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 20.0.2_9-jdk-ubi9-minimal, 20-jdk-ubi9-minimal, 20-ubi9-minimal
 Architectures: amd64, arm64v8
-GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 20/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
@@ -443,20 +443,20 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 20.0.2_9-jre-alpine, 20-jre-alpine
 Architectures: amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 20/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 20.0.2_9-jre-jammy, 20-jre-jammy
 SharedTags: 20.0.2_9-jre, 20-jre
 Architectures: amd64, arm64v8
-GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 20/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 20.0.2_9-jre-ubi9-minimal, 20-jre-ubi9-minimal
 Architectures: amd64, arm64v8
-GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 20/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 


### PR DESCRIPTION
We're rolling out JDK20 first and will update 8, 11 and 17 in the next week or two