### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,52 +5,52 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.21rc3-bookworm, 1.21-rc-bookworm
-SharedTags: 1.21rc3, 1.21-rc
+Tags: 1.21rc4-bookworm, 1.21-rc-bookworm
+SharedTags: 1.21rc4, 1.21-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/bookworm
 
-Tags: 1.21rc3-bullseye, 1.21-rc-bullseye
+Tags: 1.21rc4-bullseye, 1.21-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/bullseye
 
-Tags: 1.21rc3-alpine3.18, 1.21-rc-alpine3.18, 1.21rc3-alpine, 1.21-rc-alpine
+Tags: 1.21rc4-alpine3.18, 1.21-rc-alpine3.18, 1.21rc4-alpine, 1.21-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/alpine3.18
 
-Tags: 1.21rc3-alpine3.17, 1.21-rc-alpine3.17
+Tags: 1.21rc4-alpine3.17, 1.21-rc-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/alpine3.17
 
-Tags: 1.21rc3-windowsservercore-ltsc2022, 1.21-rc-windowsservercore-ltsc2022
-SharedTags: 1.21rc3-windowsservercore, 1.21-rc-windowsservercore, 1.21rc3, 1.21-rc
+Tags: 1.21rc4-windowsservercore-ltsc2022, 1.21-rc-windowsservercore-ltsc2022
+SharedTags: 1.21rc4-windowsservercore, 1.21-rc-windowsservercore, 1.21rc4, 1.21-rc
 Architectures: windows-amd64
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.21rc3-windowsservercore-1809, 1.21-rc-windowsservercore-1809
-SharedTags: 1.21rc3-windowsservercore, 1.21-rc-windowsservercore, 1.21rc3, 1.21-rc
+Tags: 1.21rc4-windowsservercore-1809, 1.21-rc-windowsservercore-1809
+SharedTags: 1.21rc4-windowsservercore, 1.21-rc-windowsservercore, 1.21rc4, 1.21-rc
 Architectures: windows-amd64
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.21rc3-nanoserver-ltsc2022, 1.21-rc-nanoserver-ltsc2022
-SharedTags: 1.21rc3-nanoserver, 1.21-rc-nanoserver
+Tags: 1.21rc4-nanoserver-ltsc2022, 1.21-rc-nanoserver-ltsc2022
+SharedTags: 1.21rc4-nanoserver, 1.21-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.21rc3-nanoserver-1809, 1.21-rc-nanoserver-1809
-SharedTags: 1.21rc3-nanoserver, 1.21-rc-nanoserver
+Tags: 1.21rc4-nanoserver-1809, 1.21-rc-nanoserver-1809
+SharedTags: 1.21rc4-nanoserver, 1.21-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 105ef084889a9bd607fbc97aaded37a91a125787
+GitCommit: 3a7d300a26ad7a99245232f49cad9d871df60fb5
 Directory: 1.21-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/3a7d300: Update 1.21-rc to 1.21rc4