### PR TITLE
caddy: v2.7.2 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,97 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/a82cbc5b1bf43757f718d8b21adcca6a0df560c7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/21f00011fb6126d6ff94e938fb091da8e7ea69df/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/a05143ab31c83c6a0385a40e570c00779e8e9c0f/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.6.4-alpine, 2.6-alpine, 2-alpine, alpine
-SharedTags: 2.6.4, 2.6, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.6/alpine
-GitCommit: 6e5a266c6839d6f84eb84f8430ce13a49c1b0aae
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.6.4-builder-alpine, 2.6-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.6.4-builder, 2.6-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.6/builder
-GitCommit: 38f8d57b19ce4ebcd46f214c69bf0c932a4a409e
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-
-Tags: 2.6.4-windowsservercore-1809, 2.6-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.6.4-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.4, 2.6, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.6/windows/1809
-GitCommit: 968a9e779660c4e0711021103eebf610c7979a7e
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
-Tags: 2.6.4-windowsservercore-ltsc2022, 2.6-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.6.4-windowsservercore, 2.6-windowsservercore, 2-windowsservercore, windowsservercore, 2.6.4, 2.6, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.6/windows/ltsc2022
-GitCommit: 968a9e779660c4e0711021103eebf610c7979a7e
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 2.6.4-builder-windowsservercore-1809, 2.6-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.6.4-builder, 2.6-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.6/windows-builder/1809
-GitCommit: 38f8d57b19ce4ebcd46f214c69bf0c932a4a409e
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
-Tags: 2.6.4-builder-windowsservercore-ltsc2022, 2.6-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.6.4-builder, 2.6-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.6/windows-builder/ltsc2022
-GitCommit: 38f8d57b19ce4ebcd46f214c69bf0c932a4a409e
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 2.7.0-beta.2-alpine, 2.7-alpine
-SharedTags: 2.7.0-beta.2, 2.7
+Tags: 2.7.2-alpine, 2.7-alpine, 2-alpine, alpine
+SharedTags: 2.7.2, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/alpine
-GitCommit: 21f00011fb6126d6ff94e938fb091da8e7ea69df
+GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.7.0-beta.2-builder-alpine, 2.7-builder-alpine
-SharedTags: 2.7.0-beta.2-builder, 2.7-builder
+Tags: 2.7.2-builder-alpine, 2.7-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.7.2-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/builder
-GitCommit: 21f00011fb6126d6ff94e938fb091da8e7ea69df
+GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.7.0-beta.2-windowsservercore-1809, 2.7-windowsservercore-1809
-SharedTags: 2.7.0-beta.2-windowsservercore, 2.7-windowsservercore, 2.7.0-beta.2, 2.7
+Tags: 2.7.2-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.7.2-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.2, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows/1809
-GitCommit: 21f00011fb6126d6ff94e938fb091da8e7ea69df
+GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.7.0-beta.2-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022
-SharedTags: 2.7.0-beta.2-windowsservercore, 2.7-windowsservercore, 2.7.0-beta.2, 2.7
+Tags: 2.7.2-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.7.2-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.2, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows/ltsc2022
-GitCommit: 21f00011fb6126d6ff94e938fb091da8e7ea69df
+GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.7.0-beta.2-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809
-SharedTags: 2.7.0-beta.2-builder, 2.7-builder
+Tags: 2.7.2-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.7.2-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows-builder/1809
-GitCommit: 21f00011fb6126d6ff94e938fb091da8e7ea69df
+GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.7.0-beta.2-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022
-SharedTags: 2.7.0-beta.2-builder, 2.7-builder
+Tags: 2.7.2-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.7.2-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows-builder/ltsc2022
-GitCommit: 21f00011fb6126d6ff94e938fb091da8e7ea69df
+GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.7.2