### PR TITLE
Add 20-al2023-generic for amazoncorretto

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -8,7 +8,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Victor Rudometov <vicrud@amazon.com> (@Rudometov)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: f379e16590ae6a8c15df6982aecbb0bab6b6fe38
+GitCommit: df7c548293c02db289dfe7de38c90e92a43e5fcf
 
 Tags: 8, 8u382, 8u382-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u382-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
@@ -149,6 +149,10 @@ Directory: 17/jdk/alpine/3.18
 Tags: 20, 20.0.2, 20.0.2-al2, 20-al2-full, 20-al2-jdk, 20-al2-generic, 20.0.2-al2-generic, 20-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 20/jdk/al2-generic
+
+Tags: 20-al2023-generic, 20.0.2-al2023-generic, 20-al2023-generic-jdk
+Architectures: amd64, arm64v8
+Directory: 20/jdk/al2023-generic
 
 Tags: 20-alpine3.15, 20.0.2-alpine3.15, 20-alpine3.15-full, 20-alpine3.15-jdk
 Architectures: amd64, arm64v8


### PR DESCRIPTION
### Notes

Add 20-al2023-generic for amazoncorretto. The Dockerfile is: https://github.com/corretto/corretto-docker/blob/main/20/jdk/al2023-generic/Dockerfile