### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.57.3, 5.57, 5, latest
+Tags: 5.58.0, 5.58, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 58ec9a3f50429c20df8c9c5583e6583039926229
+GitCommit: 3253874ab556131adb078ee57e521be6462e3a81
 Directory: 5/debian
 
-Tags: 5.57.3-alpine, 5.57-alpine, 5-alpine, alpine
+Tags: 5.58.0-alpine, 5.58-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 58ec9a3f50429c20df8c9c5583e6583039926229
+GitCommit: 3253874ab556131adb078ee57e521be6462e3a81
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3253874: Update to 5.58.0, ghost-cli 1.24.2