### PR TITLE
[oraclelinux] Updating 7,8 and 9-slim for ELSA-2023-4347 ELSA-2023-4349 ELSA-2023-4412 ELSA-2023-4354 ELSA-2023-4419 ELSA-2023-4382

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 23954d8c46127085cd6dbdb8b8a10f2beca7ba94
+amd64-GitCommit: 99900d09aa0e41d686a3b4e36fc5ef40b60c4337
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 024ea58b2fcb6151ddde018e66d536288d46f7bb
+arm64v8-GitCommit: ecb715453790260dc958e16c0d7b2d2d552b2563
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-22652, CVE-2023-28484, CVE-2023-29469, CVE-2023-38408, CVE-2023-28321, CVE-2023-28322.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-4347.html
https://linux.oracle.com/errata/ELSA-2023-4349.html
https://linux.oracle.com/errata/ELSA-2023-4412.html
https://linux.oracle.com/errata/ELSA-2023-4354.html
https://linux.oracle.com/errata/ELSA-2023-4419.html
https://linux.oracle.com/errata/ELSA-2023-4382.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>