### PR TITLE
Odoo: update 14.0-16.0 to release 20230807

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 80cde78131df9c17dc0c370ed8f8db1a33c54692
+GitCommit: bab3af70772ff02f799469f53a38a4a0e5003703
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks