### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.1.20230719.0
+Tags: 2023, latest, 2023.1.20230725.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: ae2ef2f28d65c72f4ae6f5823066e80770d22f51
+amd64-GitCommit: 309a1ec082a5ea420a3801781f91a7796764143d
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 690585a92d0fc58af1f255d89f580561b718f602
+arm64v8-GitCommit: c6a5ca6c1fb14888aa39f502b242ebff3a03d3a2
 
-Tags: 2, 2.0.20230719.0
+Tags: 2, 2.0.20230727.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0f44358ef4b48bab8bdb26ffca3f58ca96f1f9f4
+amd64-GitCommit: 0270a0f82bb7e12190531be44d4516fd6274181a
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a2e27db0fd5eb2fb85bbdddfee2f73500d36f664
+arm64v8-GitCommit: a4753e780fbd1d2a844e38ad94d6964cd3f596f4
 
-Tags: 1, 2018.03, 2018.03.0.20230718.0
+Tags: 1, 2018.03, 2018.03.0.20230724.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 8095435c93108a9b7c69f482175eddd47b32dc8a
+amd64-GitCommit: 4000dd6f1d663b0609563b9662398f6d83d88475


### PR DESCRIPTION
Updated Packages for Amazon Linux 1:
- ncurses-5.7-4.20090207.15.amzn1
- ncurses-base-5.7-4.20090207.15.amzn1
- ncurses-libs-5.7-4.20090207.15.amzn1

Updated Packages for Amazon Linux 2:
- No updates

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.1.20230725-0.amzn2023
- libcurl-minimal-8.0.1-1.amzn2023.0.1
- curl-minimal-8.0.1-1.amzn2023.0.1
- system-release-2023.1.20230725-0.amzn2023
- sqlite-libs-3.40.0-1.amzn2023.0.3