### PR TITLE
eclipse-temurin: Support the use system cacerts as an option

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -8,32 +8,32 @@ GitFetch: refs/heads/main
 #------------------------------v8 images---------------------------------
 Tags: 8u382-b05-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u382-b05-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
@@ -71,32 +71,32 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u382-b05-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jre-jammy, 8-jre-jammy
 SharedTags: 8u382-b05-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jre/centos
 File: Dockerfile.releases.full
 
 Tags: 8u382-b05-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a076df4eb8dd8a60f52fbb60d9adc8e5f86c8b1a
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 8/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
@@ -136,32 +136,32 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.20_8-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.20_8-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
@@ -199,32 +199,32 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.20_8-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.20_8-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
 Tags: 11.0.20_8-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 11/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
@@ -264,32 +264,32 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.8_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jdk/alpine
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jdk-jammy, 17-jdk-jammy, 17-jammy
 SharedTags: 17.0.8_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jdk/centos
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
@@ -327,32 +327,32 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.8_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jre/alpine
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jre-jammy, 17-jre-jammy
 SharedTags: 17.0.8_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jre/centos
 File: Dockerfile.releases.full
 
 Tags: 17.0.8_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 05b7f082746228466ceacf43dd0c21e9a0ba2b84
 Directory: 17/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 


### PR DESCRIPTION
Pushing out for the remaining versions