### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -94,21 +94,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: e2fc735283ba4e96efc3e4acf2b74bc3eccbf327
 Directory: ubuntu/jammy
 
-Tags: kinetic-curl, 22.10-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3e18c3af1f5dce6a48abf036857f9097b6bd79cc
-Directory: ubuntu/kinetic/curl
-
-Tags: kinetic-scm, 22.10-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
-Directory: ubuntu/kinetic/scm
-
-Tags: kinetic, 22.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c96f4f3e1d5bc19fba5c652f57af0a35bb929718
-Directory: ubuntu/kinetic
-
 Tags: lunar-curl, 23.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 3e18c3af1f5dce6a48abf036857f9097b6bd79cc


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/7d128d1: Merge pull request https://github.com/docker-library/buildpack-deps/pull/147 from infosiftr/kinetic-eol
- https://github.com/docker-library/buildpack-deps/commit/9c6da3b: Remove Ubuntu Kinetic (EOL)