### PR TITLE
Ignore value of `.RegistryConfig.Mirrors` when it is not a list

### DIFF
--- a/.bin/docker-buildx-ensure.sh
+++ b/.bin/docker-buildx-ensure.sh
@@ -25,7 +25,7 @@ fi
 platform="$(bashbrew cat --format '{{ ociPlatform arch }}' <(echo 'Maintainers: empty hack (@example)'))"
 
 hubMirrors="$(docker info --format '{{ json .RegistryConfig.Mirrors }}' | jq -c '
-	[ env.DOCKERHUB_PUBLIC_PROXY // empty, .[] ]
+	[ env.DOCKERHUB_PUBLIC_PROXY // empty, .[]? ]
 	| map(select(startswith("https://")) | ltrimstr("https://") | rtrimstr("/") | select(contains("/") | not))
 	| reduce .[] as $item ( # "unique" but order-preserving (we want DOCKERHUB_PUBLIC_PROXY first followed by everything else set in the dockerd mirrors config without duplication)
 		[];


### PR DESCRIPTION
On newer versions of Docker (23.0+), `docker info --format '{{ json .RegistryConfig.Mirrors }}'` returns the value `null` instead of an empty list.


I think https://github.com/moby/moby/pull/43298 was the change, particularly this:
```diff
-		Mirrors:                                 make([]string, 0),
...
- servConfig.Mirrors = append(servConfig.Mirrors, s.config.ServiceConfig.Mirrors...)

+		Mirrors:                                 append([]string(nil), config.Mirrors...),
```