### PR TITLE
[oraclelinux] Updating 9 for RPM correction.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 99900d09aa0e41d686a3b4e36fc5ef40b60c4337
+amd64-GitCommit: 98f8372b0349f3e011fd42828dd6272c74f3c10d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ecb715453790260dc958e16c0d7b2d2d552b2563
+arm64v8-GitCommit: 8fd5e8fcc52c980dea58a225af377b3c7de75347
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Rebuilt to remove a pre-release errata package.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
