### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.2.2-apache, 6.2-apache, 6-apache, apache, 6.2.2, 6.2, 6, latest, 6.2.2-php8.0-apache, 6.2-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.2.2-php8.0, 6.2-php8.0, 6-php8.0, php8.0
+Tags: 6.3.0-apache, 6.3-apache, 6-apache, apache, 6.3.0, 6.3, 6, latest, 6.3.0-php8.0-apache, 6.3-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.3.0-php8.0, 6.3-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7c79eeb7a24484fa9a5aca3161947c821b6b1e0e
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.0/apache
 
-Tags: 6.2.2-fpm, 6.2-fpm, 6-fpm, fpm, 6.2.2-php8.0-fpm, 6.2-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.3.0-fpm, 6.3-fpm, 6-fpm, fpm, 6.3.0-php8.0-fpm, 6.3-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7c79eeb7a24484fa9a5aca3161947c821b6b1e0e
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.0/fpm
 
-Tags: 6.2.2-fpm-alpine, 6.2-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.2.2-php8.0-fpm-alpine, 6.2-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.3.0-fpm-alpine, 6.3-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.3.0-php8.0-fpm-alpine, 6.3-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.2.2-php8.1-apache, 6.2-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.2.2-php8.1, 6.2-php8.1, 6-php8.1, php8.1
+Tags: 6.3.0-php8.1-apache, 6.3-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.3.0-php8.1, 6.3-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7c79eeb7a24484fa9a5aca3161947c821b6b1e0e
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.1/apache
 
-Tags: 6.2.2-php8.1-fpm, 6.2-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.3.0-php8.1-fpm, 6.3-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7c79eeb7a24484fa9a5aca3161947c821b6b1e0e
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.1/fpm
 
-Tags: 6.2.2-php8.1-fpm-alpine, 6.2-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.3.0-php8.1-fpm-alpine, 6.3-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.2.2-php8.2-apache, 6.2-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.2.2-php8.2, 6.2-php8.2, 6-php8.2, php8.2
+Tags: 6.3.0-php8.2-apache, 6.3-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.3.0-php8.2, 6.3-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7c79eeb7a24484fa9a5aca3161947c821b6b1e0e
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.2/apache
 
-Tags: 6.2.2-php8.2-fpm, 6.2-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.3.0-php8.2-fpm, 6.3-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7c79eeb7a24484fa9a5aca3161947c821b6b1e0e
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.2/fpm
 
-Tags: 6.2.2-php8.2-fpm-alpine, 6.2-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.3.0-php8.2-fpm-alpine, 6.3-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6fa05d9ba94e7cb48a53ff90878cc6fc777f7986
+GitCommit: f1704f65b98c2a903318b5bc775000b956f16300
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.8.1, cli-2.8, cli-2, cli, cli-2.8.1-php8.0, cli-2.8-php8.0, cli-2-php8.0, cli-php8.0
@@ -63,48 +63,3 @@ Tags: cli-2.8.1-php8.2, cli-2.8-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
 Directory: cli/php8.2/alpine
-
-Tags: beta-6.3-RC4-apache, beta-6.3-apache, beta-6-apache, beta-apache, beta-6.3-RC4, beta-6.3, beta-6, beta, beta-6.3-RC4-php8.0-apache, beta-6.3-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.3-RC4-php8.0, beta-6.3-php8.0, beta-6-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.0/apache
-
-Tags: beta-6.3-RC4-fpm, beta-6.3-fpm, beta-6-fpm, beta-fpm, beta-6.3-RC4-php8.0-fpm, beta-6.3-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.0/fpm
-
-Tags: beta-6.3-RC4-fpm-alpine, beta-6.3-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.3-RC4-php8.0-fpm-alpine, beta-6.3-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.0/fpm-alpine
-
-Tags: beta-6.3-RC4-php8.1-apache, beta-6.3-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.3-RC4-php8.1, beta-6.3-php8.1, beta-6-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.1/apache
-
-Tags: beta-6.3-RC4-php8.1-fpm, beta-6.3-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.1/fpm
-
-Tags: beta-6.3-RC4-php8.1-fpm-alpine, beta-6.3-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.1/fpm-alpine
-
-Tags: beta-6.3-RC4-php8.2-apache, beta-6.3-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.3-RC4-php8.2, beta-6.3-php8.2, beta-6-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.2/apache
-
-Tags: beta-6.3-RC4-php8.2-fpm, beta-6.3-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.2/fpm
-
-Tags: beta-6.3-RC4-php8.2-fpm-alpine, beta-6.3-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a348bf4d345ec7db894ac2ce4e72ff6ed393be31
-Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/f1704f6: Update latest to 6.3.0
- https://github.com/docker-library/wordpress/commit/0d6a1da: Update beta to 6.3.0