### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,34 +14,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a98384bac2cec72f9a434e3fbf9559f55a959f97
 Directory: 2.9/alpine
 
-Tags: 2.8.1, 2.8, lts, latest, 2.8.1-bullseye, 2.8-bullseye, lts-bullseye, bullseye
+Tags: 2.8.2, 2.8, lts, latest, 2.8.2-bullseye, 2.8-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fe74fe536642ccfe90c0753767a7f344f820047
+GitCommit: c2acd7ee546c724135e38dd46ad683823edaf3cd
 Directory: 2.8
 
-Tags: 2.8.1-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.1-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
+Tags: 2.8.2-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.2-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fe74fe536642ccfe90c0753767a7f344f820047
+GitCommit: c2acd7ee546c724135e38dd46ad683823edaf3cd
 Directory: 2.8/alpine
 
-Tags: 2.7.9, 2.7, 2.7.9-bullseye, 2.7-bullseye
+Tags: 2.7.10, 2.7, 2.7.10-bullseye, 2.7-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 078ca80d6479126a48c24c8ada4b174241bccea3
+GitCommit: 6ac34139426d79e07ec76ff9a8b9948dc85e34b3
 Directory: 2.7
 
-Tags: 2.7.9-alpine, 2.7-alpine, 2.7.9-alpine3.18, 2.7-alpine3.18
+Tags: 2.7.10-alpine, 2.7-alpine, 2.7.10-alpine3.18, 2.7-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 078ca80d6479126a48c24c8ada4b174241bccea3
+GitCommit: 6ac34139426d79e07ec76ff9a8b9948dc85e34b3
 Directory: 2.7/alpine
 
-Tags: 2.6.14, 2.6, 2.6.14-bullseye, 2.6-bullseye
+Tags: 2.6.15, 2.6, 2.6.15-bullseye, 2.6-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3eeba1e19f5660c9584b378e93ec9115f590ccfb
+GitCommit: fc50ce81390257a9702f3ea74237a73c658a1789
 Directory: 2.6
 
-Tags: 2.6.14-alpine, 2.6-alpine, 2.6.14-alpine3.18, 2.6-alpine3.18
+Tags: 2.6.15-alpine, 2.6-alpine, 2.6.15-alpine3.18, 2.6-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3eeba1e19f5660c9584b378e93ec9115f590ccfb
+GitCommit: fc50ce81390257a9702f3ea74237a73c658a1789
 Directory: 2.6/alpine
 
 Tags: 2.4.23, 2.4, 2.4.23-bullseye, 2.4-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c2acd7e: Update 2.8 to 2.8.2
- https://github.com/docker-library/haproxy/commit/6ac3413: Update 2.7 to 2.7.10
- https://github.com/docker-library/haproxy/commit/fc50ce8: Update 2.6 to 2.6.15