### PR TITLE
[oraclelinux] Updating 8, 8-slim, and 9 for ELSA-2023-4569 ELSA-2023-4523 ELSA-2023-4524 ELSA-2023-4529 ELSA-2023-4498

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 98f8372b0349f3e011fd42828dd6272c74f3c10d
+amd64-GitCommit: 152a98886e04a749e31fe39060abc9452d37e4a6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8fd5e8fcc52c980dea58a225af377b3c7de75347
+arm64v8-GitCommit: e88a2bfad04e024687e0d17bc81862cb01b7a1eb
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-27536, CVE-2023-28321, CVE-2023-2602, CVE-2023-2603, CVE-2023-28484, CVE-2023-29469, CVE-2023-34969.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-4523.html
https://linux.oracle.com/errata/ELSA-2023-4524.html
https://linux.oracle.com/errata/ELSA-2023-4529.html
https://linux.oracle.com/errata/ELSA-2023-4498.html
https://linux.oracle.com/errata/ELSA-2023-4569.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
