### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -51,15 +51,15 @@ Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.8.1, cli-2.8, cli-2, cli, cli-2.8.1-php8.0, cli-2.8-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
+GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
 Directory: cli/php8.0/alpine
 
 Tags: cli-2.8.1-php8.1, cli-2.8-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
+GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
 Directory: cli/php8.1/alpine
 
 Tags: cli-2.8.1-php8.2, cli-2.8-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 68ba8edcf61e8fd4748614510ebec96ef17806c0
+GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
 Directory: cli/php8.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/6e0d5ac: Update cli to 2.8.1
- https://github.com/docker-library/wordpress/commit/141b55c: Update cli to 2.8.0