### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 16beta2, 16beta2-bookworm
+Tags: 16beta3, 16beta3-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cba2a05c03706daf5f9a66b93a447540b62df063
+GitCommit: ee530cc079f232f9b1045db43d8c501ee2057d6d
 Directory: 16/bookworm
 
-Tags: 16beta2-bullseye
+Tags: 16beta3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cba2a05c03706daf5f9a66b93a447540b62df063
+GitCommit: ee530cc079f232f9b1045db43d8c501ee2057d6d
 Directory: 16/bullseye
 
-Tags: 16beta2-alpine3.18, 16beta2-alpine
+Tags: 16beta3-alpine3.18, 16beta3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cba2a05c03706daf5f9a66b93a447540b62df063
+GitCommit: ee530cc079f232f9b1045db43d8c501ee2057d6d
 Directory: 16/alpine3.18
 
-Tags: 16beta2-alpine3.17
+Tags: 16beta3-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cba2a05c03706daf5f9a66b93a447540b62df063
+GitCommit: ee530cc079f232f9b1045db43d8c501ee2057d6d
 Directory: 16/alpine3.17
 
-Tags: 15.3, 15, latest, 15.3-bookworm, 15-bookworm, bookworm
+Tags: 15.4, 15, latest, 15.4-bookworm, 15-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fda89cc5c2e588f46ae4f1ac117114c8e6814f1
+GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
 Directory: 15/bookworm
 
-Tags: 15.3-bullseye, 15-bullseye, bullseye
+Tags: 15.4-bullseye, 15-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a23c0e97980edae5be2cd4eb68ff1f0762d031cd
+GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
 Directory: 15/bullseye
 
-Tags: 15.3-alpine3.18, 15-alpine3.18, alpine3.18, 15.3-alpine, 15-alpine, alpine
+Tags: 15.4-alpine3.18, 15-alpine3.18, alpine3.18, 15.4-alpine, 15-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
 Directory: 15/alpine3.18
 
-Tags: 15.3-alpine3.17, 15-alpine3.17, alpine3.17
+Tags: 15.4-alpine3.17, 15-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 1a73ab671b5f0f18313726e734c76bf171385c32
 Directory: 15/alpine3.17
 
-Tags: 14.8, 14, 14.8-bookworm, 14-bookworm
+Tags: 14.9, 14, 14.9-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fda89cc5c2e588f46ae4f1ac117114c8e6814f1
+GitCommit: 05f691067b29d8fb4211a47da37a381d58d36691
 Directory: 14/bookworm
 
-Tags: 14.8-bullseye, 14-bullseye
+Tags: 14.9-bullseye, 14-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8ff11cd5ae43e73fd84d0b2bc8aa88537fe18649
+GitCommit: 05f691067b29d8fb4211a47da37a381d58d36691
 Directory: 14/bullseye
 
-Tags: 14.8-alpine3.18, 14-alpine3.18, 14.8-alpine, 14-alpine
+Tags: 14.9-alpine3.18, 14-alpine3.18, 14.9-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 05f691067b29d8fb4211a47da37a381d58d36691
 Directory: 14/alpine3.18
 
-Tags: 14.8-alpine3.17, 14-alpine3.17
+Tags: 14.9-alpine3.17, 14-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 05f691067b29d8fb4211a47da37a381d58d36691
 Directory: 14/alpine3.17
 
-Tags: 13.11, 13, 13.11-bookworm, 13-bookworm
+Tags: 13.12, 13, 13.12-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fda89cc5c2e588f46ae4f1ac117114c8e6814f1
+GitCommit: 69cf8b8aac63224380f943bd6428f088ddfb3435
 Directory: 13/bookworm
 
-Tags: 13.11-bullseye, 13-bullseye
+Tags: 13.12-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 43d17d5ced92f230fa8c196e746f2e2aa288e5e8
+GitCommit: 69cf8b8aac63224380f943bd6428f088ddfb3435
 Directory: 13/bullseye
 
-Tags: 13.11-alpine3.18, 13-alpine3.18, 13.11-alpine, 13-alpine
+Tags: 13.12-alpine3.18, 13-alpine3.18, 13.12-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 69cf8b8aac63224380f943bd6428f088ddfb3435
 Directory: 13/alpine3.18
 
-Tags: 13.11-alpine3.17, 13-alpine3.17
+Tags: 13.12-alpine3.17, 13-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 69cf8b8aac63224380f943bd6428f088ddfb3435
 Directory: 13/alpine3.17
 
-Tags: 12.15, 12, 12.15-bookworm, 12-bookworm
+Tags: 12.16, 12, 12.16-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fda89cc5c2e588f46ae4f1ac117114c8e6814f1
+GitCommit: 9061f74afc30391adb6a1a35d4f7b605ecaa09b9
 Directory: 12/bookworm
 
-Tags: 12.15-bullseye, 12-bullseye
+Tags: 12.16-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d681c1da2faebccc790fffd3e71514548b458d50
+GitCommit: 9061f74afc30391adb6a1a35d4f7b605ecaa09b9
 Directory: 12/bullseye
 
-Tags: 12.15-alpine3.18, 12-alpine3.18, 12.15-alpine, 12-alpine
+Tags: 12.16-alpine3.18, 12-alpine3.18, 12.16-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 9061f74afc30391adb6a1a35d4f7b605ecaa09b9
 Directory: 12/alpine3.18
 
-Tags: 12.15-alpine3.17, 12-alpine3.17
+Tags: 12.16-alpine3.17, 12-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 9061f74afc30391adb6a1a35d4f7b605ecaa09b9
 Directory: 12/alpine3.17
 
-Tags: 11.20-bookworm, 11-bookworm
+Tags: 11.21-bookworm, 11-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fda89cc5c2e588f46ae4f1ac117114c8e6814f1
+GitCommit: 16fa0f1d18f7c46f7dcac1e250b680fcb1a2e051
 Directory: 11/bookworm
 
-Tags: 11.20-bullseye, 11-bullseye
+Tags: 11.21-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ee629b1e31754d3aeed529a1a3610ac180f20e0b
+GitCommit: 16fa0f1d18f7c46f7dcac1e250b680fcb1a2e051
 Directory: 11/bullseye
 
-Tags: 11.20-alpine3.18, 11-alpine3.18, 11.20-alpine, 11-alpine
+Tags: 11.21-alpine3.18, 11-alpine3.18, 11.21-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 16fa0f1d18f7c46f7dcac1e250b680fcb1a2e051
 Directory: 11/alpine3.18
 
-Tags: 11.20-alpine3.17, 11-alpine3.17
+Tags: 11.21-alpine3.17, 11-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5ea98fe00be95fbbe642732d62af3b4dbc83f442
+GitCommit: 16fa0f1d18f7c46f7dcac1e250b680fcb1a2e051
 Directory: 11/alpine3.17


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/ee530cc: Update 16 to 16beta3, bookworm 16\~beta3-1.pgdg120+2, bullseye 16~beta3-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/1a73ab6: Update 15 to 15.4, bookworm 15.4-1.pgdg120+1, bullseye 15.4-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/05f6910: Update 14 to 14.9, bookworm 14.9-1.pgdg120+1, bullseye 14.9-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/69cf8b8: Update 13 to 13.12, bookworm 13.12-1.pgdg120+1, bullseye 13.12-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/9061f74: Update 12 to 12.16, bookworm 12.16-1.pgdg120+1, bullseye 12.16-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/16fa0f1: Update 11 to 11.21, bookworm 11.21-1.pgdg120+1, bullseye 11.21-1.pgdg110+1