### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 22-ea-9-jdk-oraclelinux8, 22-ea-9-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-9-jdk-oracle, 22-ea-9-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-9-jdk, 22-ea-9, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-10-jdk-oraclelinux8, 22-ea-10-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-10-jdk-oracle, 22-ea-10-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-10-jdk, 22-ea-10, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-9-jdk-oraclelinux7, 22-ea-9-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-10-jdk-oraclelinux7, 22-ea-10-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-9-jdk-bookworm, 22-ea-9-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-10-jdk-bookworm, 22-ea-10-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-9-jdk-slim-bookworm, 22-ea-9-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-9-jdk-slim, 22-ea-9-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-10-jdk-slim-bookworm, 22-ea-10-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-10-jdk-slim, 22-ea-10-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-9-jdk-bullseye, 22-ea-9-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-10-jdk-bullseye, 22-ea-10-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-9-jdk-slim-bullseye, 22-ea-9-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-10-jdk-slim-bullseye, 22-ea-10-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-9-jdk-windowsservercore-ltsc2022, 22-ea-9-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-9-jdk-windowsservercore, 22-ea-9-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-9-jdk, 22-ea-9, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-10-jdk-windowsservercore-ltsc2022, 22-ea-10-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-10-jdk-windowsservercore, 22-ea-10-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-10-jdk, 22-ea-10, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-9-jdk-windowsservercore-1809, 22-ea-9-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-9-jdk-windowsservercore, 22-ea-9-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-9-jdk, 22-ea-9, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-10-jdk-windowsservercore-1809, 22-ea-10-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-10-jdk-windowsservercore, 22-ea-10-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-10-jdk, 22-ea-10, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-9-jdk-nanoserver-1809, 22-ea-9-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-9-jdk-nanoserver, 22-ea-9-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-10-jdk-nanoserver-1809, 22-ea-10-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-10-jdk-nanoserver, 22-ea-10-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: 33bf62688dea0a2858659dbb3f97772d4a568a4b
+GitCommit: 1b03ec590df92c6876a354403f3659edfd0d7139
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 21-ea-34-jdk-oraclelinux8, 21-ea-34-oraclelinux8, 21-ea-jdk-oraclelinux8, 21-ea-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-ea-34-jdk-oracle, 21-ea-34-oracle, 21-ea-jdk-oracle, 21-ea-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-ea-34-jdk, 21-ea-34, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-rc-jdk-oraclelinux8, 21-rc-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-rc-jdk-oracle, 21-rc-oracle, 21-jdk-oracle, 21-oracle
+SharedTags: 21-rc-jdk, 21-rc, 21-jdk, 21
 Architectures: amd64, arm64v8
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/oraclelinux8
 
-Tags: 21-ea-34-jdk-oraclelinux7, 21-ea-34-oraclelinux7, 21-ea-jdk-oraclelinux7, 21-ea-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
+Tags: 21-rc-jdk-oraclelinux7, 21-rc-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/oraclelinux7
 
-Tags: 21-ea-34-jdk-bookworm, 21-ea-34-bookworm, 21-ea-jdk-bookworm, 21-ea-bookworm, 21-jdk-bookworm, 21-bookworm
+Tags: 21-rc-jdk-bookworm, 21-rc-bookworm, 21-jdk-bookworm, 21-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/bookworm
 
-Tags: 21-ea-34-jdk-slim-bookworm, 21-ea-34-slim-bookworm, 21-ea-jdk-slim-bookworm, 21-ea-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-ea-34-jdk-slim, 21-ea-34-slim, 21-ea-jdk-slim, 21-ea-slim, 21-jdk-slim, 21-slim
+Tags: 21-rc-jdk-slim-bookworm, 21-rc-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-rc-jdk-slim, 21-rc-slim, 21-jdk-slim, 21-slim
 Architectures: amd64, arm64v8
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/slim-bookworm
 
-Tags: 21-ea-34-jdk-bullseye, 21-ea-34-bullseye, 21-ea-jdk-bullseye, 21-ea-bullseye, 21-jdk-bullseye, 21-bullseye
+Tags: 21-rc-jdk-bullseye, 21-rc-bullseye, 21-jdk-bullseye, 21-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/bullseye
 
-Tags: 21-ea-34-jdk-slim-bullseye, 21-ea-34-slim-bullseye, 21-ea-jdk-slim-bullseye, 21-ea-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
+Tags: 21-rc-jdk-slim-bullseye, 21-rc-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/slim-bullseye
 
-Tags: 21-ea-34-jdk-windowsservercore-ltsc2022, 21-ea-34-windowsservercore-ltsc2022, 21-ea-jdk-windowsservercore-ltsc2022, 21-ea-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-ea-34-jdk-windowsservercore, 21-ea-34-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-34-jdk, 21-ea-34, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-rc-jdk-windowsservercore-ltsc2022, 21-rc-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21-rc-jdk-windowsservercore, 21-rc-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-rc-jdk, 21-rc, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21-ea-34-jdk-windowsservercore-1809, 21-ea-34-windowsservercore-1809, 21-ea-jdk-windowsservercore-1809, 21-ea-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-ea-34-jdk-windowsservercore, 21-ea-34-windowsservercore, 21-ea-jdk-windowsservercore, 21-ea-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-ea-34-jdk, 21-ea-34, 21-ea-jdk, 21-ea, 21-jdk, 21
+Tags: 21-rc-jdk-windowsservercore-1809, 21-rc-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21-rc-jdk-windowsservercore, 21-rc-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-rc-jdk, 21-rc, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21-ea-34-jdk-nanoserver-1809, 21-ea-34-nanoserver-1809, 21-ea-jdk-nanoserver-1809, 21-ea-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-ea-34-jdk-nanoserver, 21-ea-34-nanoserver, 21-ea-jdk-nanoserver, 21-ea-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21-rc-jdk-nanoserver-1809, 21-rc-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21-rc-jdk-nanoserver, 21-rc-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f45e65c50b0945bca7710b790799adad18526b8
+GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/1b03ec5: Update 22 to 22-ea+10
- https://github.com/docker-library/openjdk/commit/4c2b1a5: Update 21 to 21