### PR TITLE
[oraclelinux] Updating 7-slim-fips and 8-slim-fips for latest errata.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 152a98886e04a749e31fe39060abc9452d37e4a6
+amd64-GitCommit: 91702b08932abe12cc2b31d41e2dc57070226a74
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e88a2bfad04e024687e0d17bc81862cb01b7a1eb
+arm64v8-GitCommit: 5c52d83ef000122a79bf2f11adf45578e9fe1e0b
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update Incorporates latest errata for the FIPS container images.

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>