### PR TITLE
Update Clear Linux OS to 39780

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 1f9fe34b371c8097482b4a03bc3fbdb07cc701ff
-GitFetch: refs/heads/base-39710
+GitCommit: f0092b51ee5211ce19e02c6d73247f7316ad2711
+GitFetch: refs/heads/base-39780


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39780

@bryteise @djklimes @bryteise