### PR TITLE
caddy: v2.7.3 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,51 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/a82cbc5b1bf43757f718d8b21adcca6a0df560c7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/a05143ab31c83c6a0385a40e570c00779e8e9c0f/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/de2643dd4c0251e14791e01c3619cff6ebee5162/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.7.2-alpine, 2.7-alpine, 2-alpine, alpine
-SharedTags: 2.7.2, 2.7, 2, latest
+Tags: 2.7.3-alpine, 2.7-alpine, 2-alpine, alpine
+SharedTags: 2.7.3, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/alpine
-GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
+GitCommit: de2643dd4c0251e14791e01c3619cff6ebee5162
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.7.2-builder-alpine, 2.7-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.7.2-builder, 2.7-builder, 2-builder, builder
+Tags: 2.7.3-builder-alpine, 2.7-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.7.3-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/builder
-GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
+GitCommit: de2643dd4c0251e14791e01c3619cff6ebee5162
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.7.2-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.7.2-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.2, 2.7, 2, latest
+Tags: 2.7.3-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.7.3-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.3, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows/1809
-GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
+GitCommit: de2643dd4c0251e14791e01c3619cff6ebee5162
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.7.2-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.7.2-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.2, 2.7, 2, latest
+Tags: 2.7.3-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.7.3-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.3, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows/ltsc2022
-GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
+GitCommit: de2643dd4c0251e14791e01c3619cff6ebee5162
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.7.2-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.7.2-builder, 2.7-builder, 2-builder, builder
+Tags: 2.7.3-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.7.3-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows-builder/1809
-GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
+GitCommit: de2643dd4c0251e14791e01c3619cff6ebee5162
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.7.2-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.7.2-builder, 2.7-builder, 2-builder, builder
+Tags: 2.7.3-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.7.3-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows-builder/ltsc2022
-GitCommit: a05143ab31c83c6a0385a40e570c00779e8e9c0f
+GitCommit: de2643dd4c0251e14791e01c3619cff6ebee5162
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
Bumps Caddy to [v2.7.3](https://github.com/caddyserver/caddy/releases/tag/v2.7.3) and xcaddy to [v0.3.5](https://github.com/caddyserver/xcaddy/releases/tag/v0.3.5)