### PR TITLE
mariadb 2023 August release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -7,40 +7,40 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 11.1.1-rc-jammy, 11.1-rc-jammy, 11.1.1-rc, 11.1-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 28adeb9071427d1e18aa9317f41d62fa4a0f3769
 Directory: 11.1
 
-Tags: 11.0.2-jammy, 11.0-jammy, 11-jammy, jammy, 11.0.2, 11.0, 11, latest
+Tags: 11.0.3-jammy, 11.0-jammy, 11-jammy, jammy, 11.0.3, 11.0, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 11.0
 
-Tags: 10.11.4-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.4, 10.11, 10, lts
+Tags: 10.11.5-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.5, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 10.11
 
-Tags: 10.10.5-jammy, 10.10-jammy, 10.10.5, 10.10
+Tags: 10.10.6-jammy, 10.10-jammy, 10.10.6, 10.10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 10.10
 
-Tags: 10.9.7-jammy, 10.9-jammy, 10.9.7, 10.9
+Tags: 10.9.8-jammy, 10.9-jammy, 10.9.8, 10.9
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 10.9
 
-Tags: 10.6.14-focal, 10.6-focal, 10.6.14, 10.6
+Tags: 10.6.15-focal, 10.6-focal, 10.6.15, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 10.6
 
-Tags: 10.5.21-focal, 10.5-focal, 10.5.21, 10.5
+Tags: 10.5.22-focal, 10.5-focal, 10.5.22, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 10.5
 
-Tags: 10.4.30-focal, 10.4-focal, 10.4.30, 10.4
+Tags: 10.4.31-focal, 10.4-focal, 10.4.31, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 51c2b915a19573f233424635627355bcf14057d4
+GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
 Directory: 10.4


### PR DESCRIPTION
Just [another release](https://lists.mariadb.org/hyperkitty/list/announce@lists.mariadb.org/thread/WGSLJJ46CF624HDCBM36CESRZUVSPT2I/).

Added debug repo url for those that want to enhance with debug info packages.

removed mysqld/mariadb_safe.cnf file as its syslog setting where picked up by galera.