### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.13.0-beta.3, 3.13-rc
+Tags: 3.13.0-beta.4, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2a34299995bd94fa478bb688ec6ea1ca0dfb3f76
+GitCommit: 05bc72cdc91d9c85319d917ea749ae7f82792adc
 Directory: 3.13-rc/ubuntu
 
-Tags: 3.13.0-beta.3-management, 3.13-rc-management
+Tags: 3.13.0-beta.4-management, 3.13-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/ubuntu/management
 
-Tags: 3.13.0-beta.3-alpine, 3.13-rc-alpine
+Tags: 3.13.0-beta.4-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a34299995bd94fa478bb688ec6ea1ca0dfb3f76
+GitCommit: 05bc72cdc91d9c85319d917ea749ae7f82792adc
 Directory: 3.13-rc/alpine
 
-Tags: 3.13.0-beta.3-management-alpine, 3.13-rc-management-alpine
+Tags: 3.13.0-beta.4-management-alpine, 3.13-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/05bc72c: Update 3.13-rc to 3.13.0-beta.4