### PR TITLE
Updated swipl devel to 9.1.14

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: e3851850186cded44b986da8095df36f5d87f0df
+GitCommit: 367d4601846856eaa2468bef93715919512a1a69
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 9.1.13
-Directory: 9.1.13/bullseye
+Tags: latest, 9.1.14
+Directory: 9.1.14/bullseye
 
 Tags: stable, 9.0.4
 Directory: 9.0.4/bullseye


### PR DESCRIPTION
Updates add-ons rocksdb and hdt as well.  These are now based on the
much more portable new C++ interface and will probably compile on the
arm platforms.   I do not have the facilities to verify the build on these
platforms.