### PR TITLE
Odoo: update 14.0-16.0 to release 20230816

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: bab3af70772ff02f799469f53a38a4a0e5003703
+GitCommit: 5a58ae093740b1d46bca77a09ec21907cbf25885
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks