### PR TITLE
Update Clear Linux OS to 39840

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: f0092b51ee5211ce19e02c6d73247f7316ad2711
-GitFetch: refs/heads/base-39780
+GitCommit: 5557000f5b1e8cb62576aa05d6847e551375d458
+GitFetch: refs/heads/base-39840


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39840

@bryteise @djklimes @bryteise