### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,32 +44,32 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: fc50ce81390257a9702f3ea74237a73c658a1789
 Directory: 2.6/alpine
 
-Tags: 2.4.23, 2.4, 2.4.23-bullseye, 2.4-bullseye
+Tags: 2.4.24, 2.4, 2.4.24-bullseye, 2.4-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7acb59e8fbc48dabf3d7b06bae1387ac9f2ac5ce
+GitCommit: 4c041fe042121e9f30046440f12cf0d2747a5061
 Directory: 2.4
 
-Tags: 2.4.23-alpine, 2.4-alpine, 2.4.23-alpine3.18, 2.4-alpine3.18
+Tags: 2.4.24-alpine, 2.4-alpine, 2.4.24-alpine3.18, 2.4-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7acb59e8fbc48dabf3d7b06bae1387ac9f2ac5ce
+GitCommit: 4c041fe042121e9f30046440f12cf0d2747a5061
 Directory: 2.4/alpine
 
-Tags: 2.2.30, 2.2, 2.2.30-bullseye, 2.2-bullseye
+Tags: 2.2.31, 2.2, 2.2.31-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e3884218d34cd77b8b59145d05e058be227b334
+GitCommit: ad34487167b0bb727cb56000f26d8ea37449c590
 Directory: 2.2
 
-Tags: 2.2.30-alpine, 2.2-alpine, 2.2.30-alpine3.18, 2.2-alpine3.18
+Tags: 2.2.31-alpine, 2.2-alpine, 2.2.31-alpine3.18, 2.2-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e3884218d34cd77b8b59145d05e058be227b334
+GitCommit: ad34487167b0bb727cb56000f26d8ea37449c590
 Directory: 2.2/alpine
 
-Tags: 2.0.32, 2.0, 2.0.32-buster, 2.0-buster
+Tags: 2.0.33, 2.0, 2.0.33-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 51e072f624e35ba473bb69e6d2815cb1dae0c7cc
+GitCommit: 9c85db58f62beefbcbc4fabc5697ddaeb9ff3ff2
 Directory: 2.0
 
-Tags: 2.0.32-alpine, 2.0-alpine, 2.0.32-alpine3.16, 2.0-alpine3.16
+Tags: 2.0.33-alpine, 2.0-alpine, 2.0.33-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 51e072f624e35ba473bb69e6d2815cb1dae0c7cc
+GitCommit: 9c85db58f62beefbcbc4fabc5697ddaeb9ff3ff2
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4c041fe: Update 2.4 to 2.4.24
- https://github.com/docker-library/haproxy/commit/ad34487: Update 2.2 to 2.2.31
- https://github.com/docker-library/haproxy/commit/9c85db5: Update 2.0 to 2.0.33