### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 955064939ae306088491856ff169b58319d619f9
 Directory: 4.0
 
-Tags: 3.11.15, 3.11, 3
+Tags: 3.11.16, 3.11, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 7f0ca5fd56b2397688f4de64cd5d15ef54b581ec
+GitCommit: 76e413ded2e5eb2c61d97296d01400d2fff2d6d5
 Directory: 3.11
 
 Tags: 3.0.29, 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/76e413d: Update 3.11 to 3.11.16