### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.1.20230725.0
+Tags: 2023, latest, 2023.1.20230809.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 309a1ec082a5ea420a3801781f91a7796764143d
+amd64-GitCommit: 0a5000d4f70e7fb5ce45918b5b06942bb350574b
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: c6a5ca6c1fb14888aa39f502b242ebff3a03d3a2
+arm64v8-GitCommit: f2453ff12994b956ca06c53a74b01d50e1368fe3
 
-Tags: 2, 2.0.20230727.0
+Tags: 2, 2.0.20230808.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0270a0f82bb7e12190531be44d4516fd6274181a
+amd64-GitCommit: a4879e934010e5d34e9cc46c65695c1b75ac4c57
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a4753e780fbd1d2a844e38ad94d6964cd3f596f4
+arm64v8-GitCommit: be8873625a1ff6610b5c69eee98b54969c83dffe
 
-Tags: 1, 2018.03, 2018.03.0.20230724.0
+Tags: 1, 2018.03, 2018.03.0.20230807.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 4000dd6f1d663b0609563b9662398f6d83d88475
+amd64-GitCommit: 5139ae655ef520ac44dea179c16f93d9e9650998


### PR DESCRIPTION
Updated Packages for Amazon Linux 1:
- libnghttp2-1.33.0-1.1.7.amzn1

Updated Packages for Amazon Linux 2:
- openldap-2.4.44-25.amzn2.0.7
- elfutils-libelf-0.176-2.amzn2.0.1
- libnghttp2-1.41.0-1.amzn2.0.1

Updated Packages for Amazon Linux 2023:
- pcre2-syntax-10.40-1.amzn2023.0.3
- pcre2-10.40-1.amzn2023.0.3
- libnghttp2-1.55.1-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.1.20230809-0.amzn2023
- system-release-2023.1.20230809-0.amzn2023