### PR TITLE
fix arguments for terminating commands in Jetty

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -7,234 +7,234 @@ GitRepo: https://github.com/eclipse/jetty.docker.git
 Tags: 9.4.51-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.51-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre8-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jre8, 9.4-jre8, 9-jre8, 9.4.51-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre8
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.51-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jre17, 9.4-jre17, 9-jre17, 9.4.51-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.51-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jre11, 9.4-jre11, 9-jre11, 9.4.51-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk8, 9.4-jdk8, 9-jdk8, 9.4.51-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.51-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51, 9.4, 9, 9.4.51-jdk17, 9.4-jdk17, 9-jdk17, 9.4.51-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.51-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.51-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk11, 9.4-jdk11, 9-jdk11, 9.4.51-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 12.0.0-jre17-alpine, 12.0-jre17-alpine, 12.0.0-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 12.0.0-jre17, 12.0-jre17, 12.0.0-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 12.0.0-jdk17-alpine, 12.0-jdk17-alpine, 12.0.0-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 12.0.0, 12.0, 12.0.0-jdk17, 12.0-jdk17, 12.0.0-eclipse-temurin, 12.0-eclipse-temurin, 12.0.0-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.15-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jre17, 11.0-jre17, 11-jre17, 11.0.15-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.15-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jre11, 11.0-jre11, 11-jre11, 11.0.15-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.15-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15, 11.0, 11, 11.0.15-jdk17, 11.0-jdk17, 11-jdk17, 11.0.15-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.15-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin, latest, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.15-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jdk11, 11.0-jdk11, 11-jdk11, 11.0.15-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.15-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jre17, 10.0-jre17, 10-jre17, 10.0.15-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.15-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jre11, 10.0-jre11, 10-jre11, 10.0.15-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.15-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15, 10.0, 10, 10.0.15-jdk17, 10.0-jdk17, 10-jdk17, 10.0.15-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.15-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.15-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jdk11, 10.0-jdk11, 10-jdk11, 10.0.15-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.51-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 9.4.51-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 12.0.0-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 12.0.0-amazoncorretto, 12.0-amazoncorretto, 12.0.0-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.15-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 11.0.15-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.15-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948
 
 Tags: 10.0.15-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: 03c0b9d1d494f6f8b39f1e2046e680f2d3dd2604
+GitCommit: 0cc0c51a10e6d7b99ae0593c27d4f79304a5d948


### PR DESCRIPTION
Fix issue with `docker-entrypoint.sh` which causes issues during startup for several users. 

See https://github.com/eclipse/jetty.docker/issues/153