### PR TITLE
Update Semeru OE releases to latest versions.

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -5,158 +5,158 @@ GitRepo: https://github.com/ibmruntimes/semeru-containers.git
 GitFetch: refs/heads/ibm
 
 #-----------------------------openj9 v8 images---------------------------------
-Tags: open-8u372-b07-jdk-focal, open-8-jdk-focal
+Tags: open-8u382-b05-jdk-focal, open-8-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-8u372-b07-jdk-jammy, open-8-jdk-jammy
-SharedTags: open-8u372-b07-jdk, open-8-jdk
+Tags: open-8u382-b05-jdk-jammy, open-8-jdk-jammy
+SharedTags: open-8u382-b05-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u372-b07-jdk-centos7, open-8-jdk-centos7
+Tags: open-8u382-b05-jdk-centos7, open-8-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 8/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-8u372-b07-jre-focal, open-8-jre-focal
+Tags: open-8u382-b05-jre-focal, open-8-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-8u372-b07-jre-jammy, open-8-jre-jammy
-SharedTags: open-8u372-b07-jre, open-8-jre
+Tags: open-8u382-b05-jre-jammy, open-8-jre-jammy
+SharedTags: open-8u382-b05-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u372-b07-jre-centos7, open-8-jre-centos7
+Tags: open-8u382-b05-jre-centos7, open-8-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 8/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
-Tags: open-11.0.19_7-jdk-focal, open-11-jdk-focal
+Tags: open-11.0.20_8-jdk-focal, open-11-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.19_7-jdk-jammy, open-11-jdk-jammy
-SharedTags: open-11.0.19_7-jdk, open-11-jdk
+Tags: open-11.0.20_8-jdk-jammy, open-11-jdk-jammy
+SharedTags: open-11.0.20_8-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.19_7-jdk-centos7, open-11-jdk-centos7
+Tags: open-11.0.20_8-jdk-centos7, open-11-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 11/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.19_7-jre-focal, open-11-jre-focal
+Tags: open-11.0.20_8-jre-focal, open-11-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.19_7-jre-jammy, open-11-jre-jammy
-SharedTags: open-11.0.19_7-jre, open-11-jre
+Tags: open-11.0.20_8-jre-jammy, open-11-jre-jammy
+SharedTags: open-11.0.20_8-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.19_7-jre-centos7, open-11-jre-centos7
+Tags: open-11.0.20_8-jre-centos7, open-11-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 11/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
-Tags: open-17.0.7_7-jdk-focal, open-17-jdk-focal
+Tags: open-17.0.8_7-jdk-focal, open-17-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.7_7-jdk-jammy, open-17-jdk-jammy
-SharedTags: open-17.0.7_7-jdk, open-17-jdk
+Tags: open-17.0.8_7-jdk-jammy, open-17-jdk-jammy
+SharedTags: open-17.0.8_7-jdk, open-17-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.7_7-jdk-centos7, open-17-jdk-centos7
+Tags: open-17.0.8_7-jdk-centos7, open-17-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 17/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.7_7-jre-focal, open-17-jre-focal
+Tags: open-17.0.8_7-jre-focal, open-17-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.7_7-jre-jammy, open-17-jre-jammy
-SharedTags: open-17.0.7_7-jre, open-17-jre
+Tags: open-17.0.8_7-jre-jammy, open-17-jre-jammy
+SharedTags: open-17.0.8_7-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.7_7-jre-centos7, open-17-jre-centos7
+Tags: open-17.0.8_7-jre-centos7, open-17-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 17/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v20 images---------------------------------
-Tags: open-20.0.1_9-jdk-focal, open-20-jdk-focal
+Tags: open-20.0.2_9-jdk-focal, open-20-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 20/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-20.0.1_9-jdk-jammy, open-20-jdk-jammy
-SharedTags: open-20.0.1_9-jdk, open-20-jdk
+Tags: open-20.0.2_9-jdk-jammy, open-20-jdk-jammy
+SharedTags: open-20.0.2_9-jdk, open-20-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 20/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-20.0.1_9-jdk-centos7, open-20-jdk-centos7
+Tags: open-20.0.2_9-jdk-centos7, open-20-jdk-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 20/jdk/centos
 File: Dockerfile.open.releases.full
 
-Tags: open-20.0.1_9-jre-focal, open-20-jre-focal
+Tags: open-20.0.2_9-jre-focal, open-20-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 20/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-20.0.1_9-jre-jammy, open-20-jre-jammy
-SharedTags: open-20.0.1_9-jre, open-20-jre
+Tags: open-20.0.2_9-jre-jammy, open-20-jre-jammy
+SharedTags: open-20.0.2_9-jre, open-20-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 20/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-20.0.1_9-jre-centos7, open-20-jre-centos7
+Tags: open-20.0.2_9-jre-centos7, open-20-jre-centos7
 Architectures: amd64, ppc64le, arm64v8
-GitCommit: ee3e910142ce63e8065c4528c59072d6f3292219
+GitCommit: fb3c496391b231595e921c4d3b5fcec948e025c4
 Directory: 20/jre/centos
 File: Dockerfile.open.releases.full
 


### PR DESCRIPTION
Updating the releases to latest version (11.0.20, 17.0.8, 8u382b05 and 20.0.2)