### PR TITLE
New docker image for Silverpeas 6.3.1

### DIFF
--- a/library/silverpeas
+++ b/library/silverpeas
@@ -6,6 +6,6 @@ Tags: 6.3.1, latest
 GitCommit: c1fa483e14efa07680009a9f177b94072ab24827
 GitFetch: refs/heads/6.3.x
 
-Tags: 6.2.3
-GitCommit: 899560a46feaddb077f0ec93b5da3e01be7abbe0
+Tags: 6.2.3-b1
+GitCommit: 9714dcc94eb558508f085835a329a44f5c3cb52e
 GitFetch: refs/heads/6.2.x

--- a/library/silverpeas
+++ b/library/silverpeas
@@ -2,10 +2,10 @@
 Maintainers: Miguel Moquillon <miguel.moquillon@silverpeas.org> (@mmoqui)
 GitRepo: https://github.com/Silverpeas/docker-silverpeas-prod.git
 
-Tags: 6.3, latest
-GitCommit: cab21d1a3a25bf15d24f27a156d3df894123bb10
+Tags: 6.3.1, latest
+GitCommit: c1fa483e14efa07680009a9f177b94072ab24827
 GitFetch: refs/heads/6.3.x
 
-Tags: 6.2.3-b1
-GitCommit: 9714dcc94eb558508f085835a329a44f5c3cb52e
+Tags: 6.2.3
+GitCommit: 899560a46feaddb077f0ec93b5da3e01be7abbe0
 GitFetch: refs/heads/6.2.x


### PR DESCRIPTION
Update 'silverpeas' Docker library to take into account Silverpeas 6.3.1