### PR TITLE
Bump Haskell ghc 9.4.5 -> 9.4.6

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -12,14 +12,14 @@ Architectures: amd64, arm64v8
 GitCommit: d33bf51b985814e1d38b5d3fd301531ff16d7d21
 Directory: 9.6/slim-buster
 
-Tags: 9.4.5-buster, 9.4-buster, 9.4.5, 9.4
+Tags: 9.4.6-buster, 9.4-buster, 9.4.6, 9.4
 Architectures: amd64, arm64v8
-GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
+GitCommit: 8d518f4f5eb5d0949e0b6d3086e6c1d1e05ed85b
 Directory: 9.4/buster
 
-Tags: 9.4.5-slim-buster, 9.4-slim-buster, 9.4.5-slim, 9.4-slim
+Tags: 9.4.6-slim-buster, 9.4-slim-buster, 9.4.6-slim, 9.4-slim
 Architectures: amd64, arm64v8
-GitCommit: 13262afb82e457645a9b9f3f3eadb8e5acd4b5c1
+GitCommit: 8d518f4f5eb5d0949e0b6d3086e6c1d1e05ed85b
 Directory: 9.4/slim-buster
 
 Tags: 9.2.8-buster, 9.2-buster, 9.2.8, 9.2


### PR DESCRIPTION
Includes changes from https://github.com/haskell/docker-haskell/pull/110