### PR TITLE
Odoo: update 14.0-16.0 to release 20230825

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5a58ae093740b1d46bca77a09ec21907cbf25885
+GitCommit: 5a2479f0a2e1bdf387e520e8a7cc06b1148a7a74
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks.