### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev3, 2.9-dev, 2.9-dev3-bullseye, 2.9-dev-bullseye
+Tags: 2.9-dev4, 2.9-dev, 2.9-dev4-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c8e1d6ffde3f934abf19d538df687f5a2f19c63c
+GitCommit: e29365c13e500cc30a45a4e900780c484af5cf62
 Directory: 2.9
 
-Tags: 2.9-dev3-alpine, 2.9-dev-alpine, 2.9-dev3-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9-dev4-alpine, 2.9-dev-alpine, 2.9-dev4-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c8e1d6ffde3f934abf19d538df687f5a2f19c63c
+GitCommit: e29365c13e500cc30a45a4e900780c484af5cf62
 Directory: 2.9/alpine
 
 Tags: 2.8.2, 2.8, lts, latest, 2.8.2-bullseye, 2.8-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e29365c: Update 2.9 to 2.9-dev4