### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.59.4, 5.59, 5, latest
+Tags: 5.60.0, 5.60, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d95bdb08e967f9f41c21c004ce916d4ac4973f28
+GitCommit: 2f6ba5c0a3ad636d981929af6553f133eaa8925e
 Directory: 5/debian
 
-Tags: 5.59.4-alpine, 5.59-alpine, 5-alpine, alpine
+Tags: 5.60.0-alpine, 5.60-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d95bdb08e967f9f41c21c004ce916d4ac4973f28
+GitCommit: 2f6ba5c0a3ad636d981929af6553f133eaa8925e
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/2f6ba5c: Update to 5.60.0, ghost-cli 1.24.2