### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -64,6 +64,21 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv6
 GitCommit: 65d69325ad741cea6dee20781c1faaab2e003d87
 Directory: debian/sid
 
+Tags: trixie-curl, testing-curl
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: f4fae1079681a664db5a84c0b83621dd7c115996
+Directory: debian/trixie/curl
+
+Tags: trixie-scm, testing-scm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 443a8d3c6e53dbd17c55070de7de850f865ba6eb
+Directory: debian/trixie/scm
+
+Tags: trixie, testing
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 443a8d3c6e53dbd17c55070de7de850f865ba6eb
+Directory: debian/trixie
+
 Tags: focal-curl, 20.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 93d6db0797f91ab674535553b7e0e762941a02d0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/fdfe65e: Merge pull request https://github.com/docker-library/buildpack-deps/pull/149 from kristof-mattei/add-debian-trixie
- https://github.com/docker-library/buildpack-deps/commit/f4fae10: Regenerate templates
- https://github.com/docker-library/buildpack-deps/commit/6839bc3: Prevent sq from installing on Trixie
- https://github.com/docker-library/buildpack-deps/commit/443a8d3: Add Debian Trixie (testing)