### PR TITLE
Update Clear Linux OS to 39860

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 5557000f5b1e8cb62576aa05d6847e551375d458
-GitFetch: refs/heads/base-39840
+GitCommit: b33e9cb059d62aab30acf0a6d4d34ef0c7ce4419
+GitFetch: refs/heads/base-39860


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39860

@bryteise @djklimes @bryteise