### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,10 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
+Tags: 8.9.0
+Architectures: amd64, arm64v8
+GitCommit: ae7c373dd5eed001b3b9b3676a1897bad7a4a846
+Directory: 8.9.0
+
+Tags: 8.8.2
+Architectures: amd64, arm64v8
+GitCommit: ae7c373dd5eed001b3b9b3676a1897bad7a4a846
+Directory: 8.8.2
+
 Tags: 8.9.1
 Architectures: amd64, arm64v8
 GitCommit: eae769ae918ec760e5d21385d22298003914bd33
 Directory: 8
+
+Tags: 7.17.11
+Architectures: amd64, arm64v8
+GitCommit: ae7c373dd5eed001b3b9b3676a1897bad7a4a846
+Directory: 7.17.11
 
 Tags: 7.17.12
 Architectures: amd64, arm64v8

--- a/library/kibana
+++ b/library/kibana
@@ -4,10 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
+Tags: 8.9.0
+Architectures: amd64, arm64v8
+GitCommit: 52950fea8dd5b2466d327f62b4e6a7d8bbb0f865
+Directory: 8.9.0
+
+Tags: 8.8.2
+Architectures: amd64, arm64v8
+GitCommit: 52950fea8dd5b2466d327f62b4e6a7d8bbb0f865
+Directory: 8.8.2
+
 Tags: 8.9.1
 Architectures: amd64, arm64v8
 GitCommit: bc464499de24fd857521ba25fcb8d58f23516d3d
 Directory: 8
+
+Tags: 7.17.11
+Architectures: amd64, arm64v8
+GitCommit: 52950fea8dd5b2466d327f62b4e6a7d8bbb0f865
+Directory: 7.17.11
 
 Tags: 7.17.12
 Architectures: amd64, arm64v8

--- a/library/logstash
+++ b/library/logstash
@@ -4,10 +4,25 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
+Tags: 8.9.0
+Architectures: amd64, arm64v8
+GitCommit: 2105c9b1b6afcef578a932a55ad6625a196254ab
+Directory: 8.9.0
+
+Tags: 8.8.2
+Architectures: amd64, arm64v8
+GitCommit: 2105c9b1b6afcef578a932a55ad6625a196254ab
+Directory: 8.8.2
+
 Tags: 8.9.1
 Architectures: amd64, arm64v8
 GitCommit: 2ff314dcb3ed7b4bb812ca9fa3cdf72ca958e99f
 Directory: 8
+
+Tags: 7.17.11
+Architectures: amd64, arm64v8
+GitCommit: 2105c9b1b6afcef578a932a55ad6625a196254ab
+Directory: 7.17.11
 
 Tags: 7.17.12
 Architectures: amd64, arm64v8


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/80be985: Merge pull request https://github.com/docker-library/elasticsearch/pull/208 from infosiftr/backfill
- https://github.com/docker-library/elasticsearch/commit/ae7c373: Temporary backfill of missed versions

logstash:
- https://github.com/docker-library/logstash/commit/def5ab2: Merge pull request https://github.com/docker-library/logstash/pull/106 from infosiftr/backfill
- https://github.com/docker-library/logstash/commit/2105c9b: Temporary backfill of missed versions

kibana:
- https://github.com/docker-library/kibana/commit/9fc570c: Merge pull request https://github.com/docker-library/kibana/pull/100 from infosiftr/backfill
- https://github.com/docker-library/kibana/commit/52950fe: Temporary backfill of missed versions

Fixes https://github.com/docker-library/official-images/issues/15091