### PR TITLE
Updated Packages for Amazon Linux 1:

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.1.20230809.0
+Tags: 2023, latest, 2023.1.20230825.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 0a5000d4f70e7fb5ce45918b5b06942bb350574b
+amd64-GitCommit: 068827c218fcfd1494a296edca29a9ae1c5fafa7
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: f2453ff12994b956ca06c53a74b01d50e1368fe3
+arm64v8-GitCommit: 8abc047b4fd20289d889ac876b085af4d2b30ae7
 
-Tags: 2, 2.0.20230808.0
+Tags: 2, 2.0.20230822.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: a4879e934010e5d34e9cc46c65695c1b75ac4c57
+amd64-GitCommit: 81483ce21289e23fcdd3644eeed17c94c4077f64
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: be8873625a1ff6610b5c69eee98b54969c83dffe
+arm64v8-GitCommit: a5a1860c1df5ff3e270e4063484afb25079e4b0b
 
-Tags: 1, 2018.03, 2018.03.0.20230807.0
+Tags: 1, 2018.03, 2018.03.0.20230821.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 5139ae655ef520ac44dea179c16f93d9e9650998
+amd64-GitCommit: ce19335809fc05b4e4b451a70c9bc6a1ca518ae5


### PR DESCRIPTION
Updated Packages for Amazon Linux 1:
- openldap-2.4.40-16.37.amzn1

Updated Packages for Amazon Linux 2:
- No updates for AL2

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.1.20230825-0.amzn2023
- openssl-libs-3.0.8-1.amzn2023.0.4
- system-release-2023.1.20230825-0.amzn2023
- gawk-5.1.0-3.amzn2023.0.3
- ca-certificates-2023.2.60-1.0.amzn2023.0.3