### PR TITLE
eclipse-temurin: Add 11.0.20.1 and 17.0.8.1

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -134,256 +134,256 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.20_8-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.20.1_1-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jdk-focal, 11-jdk-focal, 11-focal
+Tags: 11.0.20.1_1-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jdk-jammy, 11-jdk-jammy, 11-jammy
-SharedTags: 11.0.20_8-jdk, 11-jdk, 11
+Tags: 11.0.20.1_1-jdk-jammy, 11-jdk-jammy, 11-jammy
+SharedTags: 11.0.20.1_1-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jdk-centos7, 11-jdk-centos7, 11-centos7
+Tags: 11.0.20.1_1-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Tags: 11.0.20.1_1-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.20_8-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20_8-jdk, 11-jdk, 11
+Tags: 11.0.20.1_1-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.20.1_1-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20.1_1-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.20_8-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.20_8-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.20.1_1-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.20.1_1-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.20_8-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.20_8-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20_8-jdk, 11-jdk, 11
+Tags: 11.0.20.1_1-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.20.1_1-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20.1_1-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.20_8-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.20_8-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.20.1_1-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.20.1_1-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.20_8-jre-alpine, 11-jre-alpine
+Tags: 11.0.20.1_1-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jre-focal, 11-jre-focal
+Tags: 11.0.20.1_1-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jre-jammy, 11-jre-jammy
-SharedTags: 11.0.20_8-jre, 11-jre
+Tags: 11.0.20.1_1-jre-jammy, 11-jre-jammy
+SharedTags: 11.0.20.1_1-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jre-centos7, 11-jre-centos7
+Tags: 11.0.20.1_1-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Tags: 11.0.20.1_1-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 11.0.20_8-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.20_8-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20_8-jre, 11-jre
+Tags: 11.0.20.1_1-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.20.1_1-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20.1_1-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.20_8-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.20_8-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.20.1_1-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.20.1_1-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.20_8-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.20_8-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20_8-jre, 11-jre
+Tags: 11.0.20.1_1-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.20.1_1-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20.1_1-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.20_8-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.20_8-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.20.1_1-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.20.1_1-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 7b6ee5b8da666343ab1169d6019833a94ef6eb6d
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 11/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.8_7-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.8.1_1-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/alpine
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jdk-focal, 17-jdk-focal, 17-focal
+Tags: 17.0.8.1_1-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.8_7-jdk, 17-jdk, 17
+Tags: 17.0.8.1_1-jdk-jammy, 17-jdk-jammy, 17-jammy
+SharedTags: 17.0.8.1_1-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jdk-centos7, 17-jdk-centos7, 17-centos7
+Tags: 17.0.8.1_1-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/centos
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.8.1_1-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.8_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.8_7-jdk, 17-jdk, 17
+Tags: 17.0.8.1_1-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.8.1_1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.8.1_1-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.8_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.8_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.8.1_1-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.8.1_1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.8_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.8_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.8_7-jdk, 17-jdk, 17
+Tags: 17.0.8.1_1-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.8.1_1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.8.1_1-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.8_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.8_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.8.1_1-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.8.1_1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jdk/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17.0.8_7-jre-alpine, 17-jre-alpine
+Tags: 17.0.8.1_1-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/alpine
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jre-focal, 17-jre-focal
+Tags: 17.0.8.1_1-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.8_7-jre, 17-jre
+Tags: 17.0.8.1_1-jre-jammy, 17-jre-jammy
+SharedTags: 17.0.8.1_1-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jre-centos7, 17-jre-centos7
+Tags: 17.0.8.1_1-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/centos
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.8.1_1-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f308aa1a9dc0ac8775662e4c4d71840088ab076c
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/ubi/ubi9-minimal
 File: Dockerfile.releases.full
 
-Tags: 17.0.8_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.8_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.8_7-jre, 17-jre
+Tags: 17.0.8.1_1-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.8.1_1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.8.1_1-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.8_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.8_7-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.8.1_1-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.8.1_1-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/windows/nanoserver-ltsc2022
 File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.8_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.8_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.8_7-jre, 17-jre
+Tags: 17.0.8.1_1-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.8.1_1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.8.1_1-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/windows/windowsservercore-1809
 File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.8_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.8_7-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.8.1_1-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.8.1_1-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 2eabe3e4525f57d9d4e85af796fca2a2748fe907
+GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
 Directory: 17/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -491,4 +491,3 @@ GitCommit: 22734cf4688ad791769df55353dfb15bba9abca5
 Directory: 20/jre/windows/nanoserver-1809
 File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
-


### PR DESCRIPTION
Updates for the bug-fix release of OpenJDK 11 and 17