### PR TITLE
Updated Unit to 1.31.0.

### DIFF
--- a/library/unit
+++ b/library/unit
@@ -1,60 +1,88 @@
-# this file is generated via https://github.com/nginx/unit/blob/92ffcb89f8e145299e837438f0a0de93d73ffede/pkg/docker/Makefile
+# this file is generated via https://github.com/nginx/unit/blob/8c4425ccb9a413e8d0506e0254f0e84bd89a32a6/pkg/docker/Makefile
 
 Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/unit.git
 
-Tags: 1.30.0-go1.20, go1.20, go1, go
+Tags: 1.31.0-go1.21, go1.21, go1, go
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
+Directory: pkg/docker
+File: Dockerfile.go1.21
+
+Tags: 1.31.0-go1.20, go1.20
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.go1.20
 
-Tags: 1.30.0-jsc11, jsc11, jsc
+Tags: 1.31.0-jsc11, jsc11, jsc
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.jsc11
 
-Tags: 1.30.0-node18, node18, node
+Tags: 1.31.0-node20, node20, node
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
+Directory: pkg/docker
+File: Dockerfile.node20
+
+Tags: 1.31.0-node18, node18
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.node18
 
-Tags: 1.30.0-perl5.36, perl5.36, perl5, perl
+Tags: 1.31.0-perl5.38, perl5.38, perl5, perl
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
+Directory: pkg/docker
+File: Dockerfile.perl5.38
+
+Tags: 1.31.0-perl5.36, perl5.36
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.perl5.36
 
-Tags: 1.30.0-php8.2, php8.2, php8, php
+Tags: 1.31.0-php8.2, php8.2, php8, php
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.php8.2
 
-Tags: 1.30.0-python3.11, python3.11, python3, python
+Tags: 1.31.0-python3.11, python3.11, python3, python
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.python3.11
 
-Tags: 1.30.0-ruby3.2, ruby3.2, ruby3, ruby
+Tags: 1.31.0-ruby3.2, ruby3.2, ruby3, ruby
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.ruby3.2
 
-Tags: 1.30.0-minimal, minimal, latest
+Tags: 1.31.0-wasm, wasm
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: 92ffcb89f8e145299e837438f0a0de93d73ffede
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
+Directory: pkg/docker
+File: Dockerfile.wasm
+
+Tags: 1.31.0-minimal, minimal, latest
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: 8c4425ccb9a413e8d0506e0254f0e84bd89a32a6
 Directory: pkg/docker
 File: Dockerfile.minimal


### PR DESCRIPTION
Notable Dockerfile changes include:
- new variants based on node 20, go 1.21, perl 5.38
- new variant with wasm module
- cleaned up cache leftovers in multiple images