### PR TITLE
Upgrade SonarQube to 10.2

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -2,7 +2,7 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: 9b79d014844155923673ca1fbe72ecc0d9ff361c
+GitCommit: 8d14b48e708adc136578db90cd201d2da92dcc76
 
 Tags: 9.9.1-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8
@@ -24,22 +24,22 @@ Tags: 9.9.1-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-d
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/search
 
-Tags: 10.1.0-community, 10.1-community, 10-community, community, latest
+Tags: 10.2.0-community, 10.2-community, 10-community, community, latest
 Architectures: amd64, arm64v8
 Directory: 10/community
 
-Tags: 10.1.0-developer, 10.1-developer, 10-developer, developer
+Tags: 10.2.0-developer, 10.2-developer, 10-developer, developer
 Architectures: amd64, arm64v8
 Directory: 10/developer
 
-Tags: 10.1.0-enterprise, 10.1-enterprise, 10-enterprise, enterprise
+Tags: 10.2.0-enterprise, 10.2-enterprise, 10-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: 10/enterprise
 
-Tags: 10.1.0-datacenter-app, 10.1-datacenter-app, 10-datacenter-app, datacenter-app
+Tags: 10.2.0-datacenter-app, 10.2-datacenter-app, 10-datacenter-app, datacenter-app
 Architectures: amd64, arm64v8
 Directory: 10/datacenter/app
 
-Tags: 10.1.0-datacenter-search, 10.1-datacenter-search, 10-datacenter-search, datacenter-search
+Tags: 10.2.0-datacenter-search, 10.2-datacenter-search, 10-datacenter-search, datacenter-search
 Architectures: amd64, arm64v8
 Directory: 10/datacenter/search


### PR DESCRIPTION
Hello team,

we just released SonarQube 10.2.
Please merge this PR to have it released as Docker image.