### PR TITLE
Update Clear Linux OS to 39890

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: b33e9cb059d62aab30acf0a6d4d34ef0c7ce4419
-GitFetch: refs/heads/base-39860
+GitCommit: 19a5a350b1f3651a50a4ce34619faa48d3b7091c
+GitFetch: refs/heads/base-39890


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39890

@bryteise @djklimes @bryteise