### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,80 +4,80 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.0.0-alpha4, 5.0, 5.0.alpha, 5.0.0-alpha, 5.0.0-alpha4-apache, 5.0-apache, 5.0.alpha-apache, 5.0.0-alpha-apache, 5.0.0-alpha4-php8.1, 5.0-php8.1, 5.0.alpha-php8.1, 5.0.0-alpha-php8.1, 5.0.0-alpha4-php8.1-apache, 5.0-php8.1-apache, 5.0.alpha-php8.1-apache, 5.0.0-alpha-php8.1-apache
+Tags: 5.0.0-beta1-php8.1-apache, 5.0-php8.1-apache, 5.0.beta-php8.1-apache, 5.0.0-beta-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 5.0.alpha/php8.1/apache
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 5.0.beta/php8.1/apache
 
-Tags: 5.0.0-alpha4-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.alpha-php8.1-fpm-alpine, 5.0.0-alpha-php8.1-fpm-alpine
+Tags: 5.0.0-beta1-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.beta-php8.1-fpm-alpine, 5.0.0-beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 5.0.alpha/php8.1/fpm-alpine
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 5.0.beta/php8.1/fpm-alpine
 
-Tags: 5.0.0-alpha4-php8.1-fpm, 5.0-php8.1-fpm, 5.0.alpha-php8.1-fpm, 5.0.0-alpha-php8.1-fpm
+Tags: 5.0.0-beta1-php8.1-fpm, 5.0-php8.1-fpm, 5.0.beta-php8.1-fpm, 5.0.0-beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 5.0.alpha/php8.1/fpm
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 5.0.beta/php8.1/fpm
 
-Tags: 5.0.0-alpha4-php8.2-apache, 5.0-php8.2-apache, 5.0.alpha-php8.2-apache, 5.0.0-alpha-php8.2-apache
+Tags: 5.0.0-beta1, 5.0, 5.0.beta, 5.0.0-beta, 5.0.0-beta1-apache, 5.0-apache, 5.0.beta-apache, 5.0.0-beta-apache, 5.0.0-beta1-php8.2, 5.0-php8.2, 5.0.beta-php8.2, 5.0.0-beta-php8.2, 5.0.0-beta1-php8.2-apache, 5.0-php8.2-apache, 5.0.beta-php8.2-apache, 5.0.0-beta-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 5.0.alpha/php8.2/apache
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 5.0.beta/php8.2/apache
 
-Tags: 5.0.0-alpha4-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.alpha-php8.2-fpm-alpine, 5.0.0-alpha-php8.2-fpm-alpine
+Tags: 5.0.0-beta1-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.beta-php8.2-fpm-alpine, 5.0.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 5.0.alpha/php8.2/fpm-alpine
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 5.0.beta/php8.2/fpm-alpine
 
-Tags: 5.0.0-alpha4-php8.2-fpm, 5.0-php8.2-fpm, 5.0.alpha-php8.2-fpm, 5.0.0-alpha-php8.2-fpm
+Tags: 5.0.0-beta1-php8.2-fpm, 5.0-php8.2-fpm, 5.0.beta-php8.2-fpm, 5.0.0-beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 5.0.alpha/php8.2/fpm
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 5.0.beta/php8.2/fpm
 
-Tags: 4.4.0-alpha4-php8.0-apache, 4.4-php8.0-apache, 4.4.alpha-php8.0-apache, 4.4.0-alpha-php8.0-apache
+Tags: 4.4.0-beta1-php8.0-apache, 4.4-php8.0-apache, 4.4.beta-php8.0-apache, 4.4.0-beta-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.0/apache
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.0/apache
 
-Tags: 4.4.0-alpha4-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.alpha-php8.0-fpm-alpine, 4.4.0-alpha-php8.0-fpm-alpine
+Tags: 4.4.0-beta1-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.beta-php8.0-fpm-alpine, 4.4.0-beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.0/fpm-alpine
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.0/fpm-alpine
 
-Tags: 4.4.0-alpha4-php8.0-fpm, 4.4-php8.0-fpm, 4.4.alpha-php8.0-fpm, 4.4.0-alpha-php8.0-fpm
+Tags: 4.4.0-beta1-php8.0-fpm, 4.4-php8.0-fpm, 4.4.beta-php8.0-fpm, 4.4.0-beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.0/fpm
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.0/fpm
 
-Tags: 4.4.0-alpha4, 4.4, 4.4.alpha, 4.4.0-alpha, 4.4.0-alpha4-apache, 4.4-apache, 4.4.alpha-apache, 4.4.0-alpha-apache, 4.4.0-alpha4-php8.1, 4.4-php8.1, 4.4.alpha-php8.1, 4.4.0-alpha-php8.1, 4.4.0-alpha4-php8.1-apache, 4.4-php8.1-apache, 4.4.alpha-php8.1-apache, 4.4.0-alpha-php8.1-apache
+Tags: 4.4.0-beta1, 4.4, 4.4.beta, 4.4.0-beta, 4.4.0-beta1-apache, 4.4-apache, 4.4.beta-apache, 4.4.0-beta-apache, 4.4.0-beta1-php8.1, 4.4-php8.1, 4.4.beta-php8.1, 4.4.0-beta-php8.1, 4.4.0-beta1-php8.1-apache, 4.4-php8.1-apache, 4.4.beta-php8.1-apache, 4.4.0-beta-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.1/apache
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.1/apache
 
-Tags: 4.4.0-alpha4-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.alpha-php8.1-fpm-alpine, 4.4.0-alpha-php8.1-fpm-alpine
+Tags: 4.4.0-beta1-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.beta-php8.1-fpm-alpine, 4.4.0-beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.1/fpm-alpine
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.1/fpm-alpine
 
-Tags: 4.4.0-alpha4-php8.1-fpm, 4.4-php8.1-fpm, 4.4.alpha-php8.1-fpm, 4.4.0-alpha-php8.1-fpm
+Tags: 4.4.0-beta1-php8.1-fpm, 4.4-php8.1-fpm, 4.4.beta-php8.1-fpm, 4.4.0-beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.1/fpm
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.1/fpm
 
-Tags: 4.4.0-alpha4-php8.2-apache, 4.4-php8.2-apache, 4.4.alpha-php8.2-apache, 4.4.0-alpha-php8.2-apache
+Tags: 4.4.0-beta1-php8.2-apache, 4.4-php8.2-apache, 4.4.beta-php8.2-apache, 4.4.0-beta-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.2/apache
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.2/apache
 
-Tags: 4.4.0-alpha4-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.alpha-php8.2-fpm-alpine, 4.4.0-alpha-php8.2-fpm-alpine
+Tags: 4.4.0-beta1-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.beta-php8.2-fpm-alpine, 4.4.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.2/fpm-alpine
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.2/fpm-alpine
 
-Tags: 4.4.0-alpha4-php8.2-fpm, 4.4-php8.2-fpm, 4.4.alpha-php8.2-fpm, 4.4.0-alpha-php8.2-fpm
+Tags: 4.4.0-beta1-php8.2-fpm, 4.4-php8.2-fpm, 4.4.beta-php8.2-fpm, 4.4.0-beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0e00ac6f0b2c81a9627eea72f991494c3028b853
-Directory: 4.4.alpha/php8.2/fpm
+GitCommit: dc4fd864b32eda5c1794d0fb89573167d3a2d422
+Directory: 4.4.beta/php8.2/fpm
 
 Tags: 4.3.4, 4.3, 4, latest, 4.3.4-apache, 4.3-apache, 4-apache, apache, 4.3.4-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.4-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@dc4fd86: Adds Joomla 5.0.beta and 4.4.beta. Removes Joomla 5.0.alpha and 4.4.alpha.