### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.13.0-beta.5, 3.13-rc
+Tags: 3.13.0-beta.6, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: cad64a21990ac10bee474e8cf102f17ec57fd821
+GitCommit: 03543b13c22cf5b1304d5889c9fd14b14b4cf3fd
 Directory: 3.13-rc/ubuntu
 
-Tags: 3.13.0-beta.5-management, 3.13-rc-management
+Tags: 3.13.0-beta.6-management, 3.13-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/ubuntu/management
 
-Tags: 3.13.0-beta.5-alpine, 3.13-rc-alpine
+Tags: 3.13.0-beta.6-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cad64a21990ac10bee474e8cf102f17ec57fd821
+GitCommit: 03543b13c22cf5b1304d5889c9fd14b14b4cf3fd
 Directory: 3.13-rc/alpine
 
-Tags: 3.13.0-beta.5-management-alpine, 3.13-rc-management-alpine
+Tags: 3.13.0-beta.6-management-alpine, 3.13-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/03543b1: Update 3.13-rc to 3.13.0-beta.6