### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.61.2, 5.61, 5, latest
+Tags: 5.61.3, 5.61, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c7cbc993d201e5cb1f7dd6f8c5f3ab437eeb3b41
+GitCommit: 12e4dad661b22d7a3a042b2b815ce96eec47b010
 Directory: 5/debian
 
-Tags: 5.61.2-alpine, 5.61-alpine, 5-alpine, alpine
+Tags: 5.61.3-alpine, 5.61-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: c7cbc993d201e5cb1f7dd6f8c5f3ab437eeb3b41
+GitCommit: 12e4dad661b22d7a3a042b2b815ce96eec47b010
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/12e4dad: Merge pull request https://github.com/docker-library/ghost/pull/390 from infosiftr/node-bump
- https://github.com/docker-library/ghost/commit/a023271: Update to 5.61.3, ghost-cli 1.24.2
- https://github.com/docker-library/ghost/commit/e7e76fa: Bump node to 18 since 16 is EOL later this month