### PR TITLE
[nats] Release v2.9.22

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -5,25 +5,25 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
 GitFetch: refs/heads/main
-GitCommit: 36c73754f3d7b2b2e69a0c4680a48636929012cc
+GitCommit: 876a6fdd56caf60d791ad82dd6e9e0287b2924d4
 
-Tags: 2.9.21-alpine3.18, 2.9-alpine3.18, 2-alpine3.18, alpine3.18, 2.9.21-alpine, 2.9-alpine, 2-alpine, alpine
+Tags: 2.9.22-alpine3.18, 2.9-alpine3.18, 2-alpine3.18, alpine3.18, 2.9.22-alpine, 2.9-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.21/alpine3.18
+Directory: 2.9.22/alpine3.18
 
-Tags: 2.9.21-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.21-linux, 2.9-linux, 2-linux, linux
-SharedTags: 2.9.21, 2.9, 2, latest
+Tags: 2.9.22-scratch, 2.9-scratch, 2-scratch, scratch, 2.9.22-linux, 2.9-linux, 2-linux, linux
+SharedTags: 2.9.22, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 2.9.21/scratch
+Directory: 2.9.22/scratch
 
-Tags: 2.9.21-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.9.21-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.9.22-windowsservercore-1809, 2.9-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.9.22-windowsservercore, 2.9-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.9.21/windowsservercore-1809
+Directory: 2.9.22/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.21-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.9.21-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.21, 2.9, 2, latest
+Tags: 2.9.22-nanoserver-1809, 2.9-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.9.22-nanoserver, 2.9-nanoserver, 2-nanoserver, nanoserver, 2.9.22, 2.9, 2, latest
 Architectures: windows-amd64
-Directory: 2.9.21/nanoserver-1809
+Directory: 2.9.22/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.22)