### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.9.1
+Tags: 8.9.2
 Architectures: amd64, arm64v8
-GitCommit: eae769ae918ec760e5d21385d22298003914bd33
+GitCommit: 51a1c0836b7c50e452fa036a496f97ed2d3324c3
 Directory: 8
 
-Tags: 7.17.12
+Tags: 7.17.13
 Architectures: amd64, arm64v8
-GitCommit: 5fe5a426ca33ac9869500cf87e6e4a14d7b1f9e5
+GitCommit: 91b35e027265ce33d16bb0f88884f5897a11328e
 Directory: 7

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.9.1
+Tags: 8.9.2
 Architectures: amd64, arm64v8
-GitCommit: bc464499de24fd857521ba25fcb8d58f23516d3d
+GitCommit: 3dcda6bebb142ecbd9b9c0fd21dee8879847bd06
 Directory: 8
 
-Tags: 7.17.12
+Tags: 7.17.13
 Architectures: amd64, arm64v8
-GitCommit: c2cb4e05003784aaa811f1c2ec8df9bdfb8d46e5
+GitCommit: e79be1ed96f3a741881bbd741c5816aa9273ac2f
 Directory: 7

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.9.1
+Tags: 8.9.2
 Architectures: amd64, arm64v8
-GitCommit: 2ff314dcb3ed7b4bb812ca9fa3cdf72ca958e99f
+GitCommit: 7ff963996f280d51ea274c9ddbf84fa02c30ef26
 Directory: 8
 
-Tags: 7.17.12
+Tags: 7.17.13
 Architectures: amd64, arm64v8
-GitCommit: d94032bc7db1f3b62922a15f9e0eab7401fe479b
+GitCommit: a6039d10cfa0f21d86c08f473b9a18c6b94be352
 Directory: 7


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/51a1c08: Update to 8.9.2
- https://github.com/docker-library/elasticsearch/commit/91b35e0: Update to 7.17.13

logstash:
- https://github.com/docker-library/logstash/commit/7ff9639: Update to 8.9.2
- https://github.com/docker-library/logstash/commit/a6039d1: Update to 7.17.13

kibana:
- https://github.com/docker-library/kibana/commit/3dcda6b: Update to 8.9.2
- https://github.com/docker-library/kibana/commit/e79be1e: Update to 7.17.13