### PR TITLE
[Draft DO-NOT-MERGE] Add sonar-scanner-cli as official docker image

### DIFF
--- a/library/sonar-scanner-cli
+++ b/library/sonar-scanner-cli
@@ -1,0 +1,10 @@
+Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassallo),
+             Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU),
+             Davi Koscianski-vidal <davi.koscianski-vidal@sonarsource.com> (@davividal)
+GitRepo: https://github.com/SonarSource/sonar-scanner-cli-docker
+Architectures: amd64, arm64v8
+GitCommit: dc6c344d32f09e905665d2463e3a0de9c7f8c948
+
+Tags: 5.0.1.3006, 5.0.1, 5.0, 5, latest
+Architectures: amd64, arm64v8
+Directory: 5


### PR DESCRIPTION
Hello everyone, we would like to add a new official image for the tool called sonar-scanner-cli.

This is the tool used to interact with SonarQube product (which is already an official image).

Here is the related [doc PR](https://github.com/docker-library/docs/pull/2366)

Those PR will stay in draft while gathering your feedback on the [ongoing Dockerfile here](https://github.com/SonarSource/sonar-scanner-cli-docker/blob/master/5/Dockerfile)

Thanks a lot in advance