### PR TITLE
Update neo4j to include 4.1.13

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -34,3 +34,13 @@ Tags: 4.4.25-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
 GitCommit: ff223b3ef8e89fb2ef0fa6116e59f05abd28d9e4
 Directory: 4.4.25/bullseye/enterprise
+
+Tags: 4.1.13, 4.1.13-community, 4.1, 4.1-community
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 162d06aa7dc5c6f0df6b21f8e3b774221610d353
+Directory: 4.1.13/community
+
+Tags: 4.1.13-enterprise, 4.1-enterprise
+GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
+GitCommit: 162d06aa7dc5c6f0df6b21f8e3b774221610d353
+Directory: 4.1.13/enterprise

--- a/library/neo4j
+++ b/library/neo4j
@@ -37,10 +37,10 @@ Directory: 4.4.25/bullseye/enterprise
 
 Tags: 4.1.13, 4.1.13-community, 4.1, 4.1-community
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 162d06aa7dc5c6f0df6b21f8e3b774221610d353
+GitCommit: e96abe5736714a37ed22ed00c02718232eb9a15c
 Directory: 4.1.13/community
 
 Tags: 4.1.13-enterprise, 4.1-enterprise
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: 162d06aa7dc5c6f0df6b21f8e3b774221610d353
+GitCommit: e96abe5736714a37ed22ed00c02718232eb9a15c
 Directory: 4.1.13/enterprise


### PR DESCRIPTION
We have to make a bug fix to an old version of neo4j. We will delete this entry in a few days so it does not have to get security updates in the future. cc @jennyowen 