### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e29365c13e500cc30a45a4e900780c484af5cf62
 Directory: 2.9/alpine
 
-Tags: 2.8.2, 2.8, lts, latest, 2.8.2-bullseye, 2.8-bullseye, lts-bullseye, bullseye
+Tags: 2.8.3, 2.8, lts, latest, 2.8.3-bullseye, 2.8-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2acd7ee546c724135e38dd46ad683823edaf3cd
+GitCommit: 97bab51de2c27f86ce61bf5ef3f605997a7b98a6
 Directory: 2.8
 
-Tags: 2.8.2-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.2-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
+Tags: 2.8.3-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.3-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2acd7ee546c724135e38dd46ad683823edaf3cd
+GitCommit: 97bab51de2c27f86ce61bf5ef3f605997a7b98a6
 Directory: 2.8/alpine
 
 Tags: 2.7.10, 2.7, 2.7.10-bullseye, 2.7-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/97bab51: Update 2.8 to 2.8.3