### PR TITLE
Removing Neo4j 4.1.13 entries

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -34,13 +34,3 @@ Tags: 4.4.25-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
 GitCommit: ff223b3ef8e89fb2ef0fa6116e59f05abd28d9e4
 Directory: 4.4.25/bullseye/enterprise
-
-Tags: 4.1.13, 4.1.13-community, 4.1, 4.1-community
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e96abe5736714a37ed22ed00c02718232eb9a15c
-Directory: 4.1.13/community
-
-Tags: 4.1.13-enterprise, 4.1-enterprise
-GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
-GitCommit: e96abe5736714a37ed22ed00c02718232eb9a15c
-Directory: 4.1.13/enterprise


### PR DESCRIPTION
As promised earlier to avoid unnecessary updates