### PR TITLE
Odoo: update 14.0-16.0 to release 20230908

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 84abbabfd74959c2a6bde08a482a05418e2647e9
+GitCommit: 61148a86eed7fb5452dc7705b479988e1f49f9a6
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo supported versions.

Thanks