### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -27,7 +27,7 @@ Directory: 3.13-rc/alpine/management
 
 Tags: 3.12.4, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: cad64a21990ac10bee474e8cf102f17ec57fd821
+GitCommit: 1a91aecbf477ff0609f9478ea559921569647414
 Directory: 3.12/ubuntu
 
 Tags: 3.12.4-management, 3.12-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.4-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cad64a21990ac10bee474e8cf102f17ec57fd821
+GitCommit: 1a91aecbf477ff0609f9478ea559921569647414
 Directory: 3.12/alpine
 
 Tags: 3.12.4-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.12/alpine/management
 
 Tags: 3.11.22, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: cad64a21990ac10bee474e8cf102f17ec57fd821
+GitCommit: 24bfe1c0303506838e7b9c6d50ac42c1655c6473
 Directory: 3.11/ubuntu
 
 Tags: 3.11.22-management, 3.11-management
@@ -57,7 +57,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.22-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cad64a21990ac10bee474e8cf102f17ec57fd821
+GitCommit: 24bfe1c0303506838e7b9c6d50ac42c1655c6473
 Directory: 3.11/alpine
 
 Tags: 3.11.22-management-alpine, 3.11-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.25, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: daf0c85adf02108dda23c62d5e18b739f58f2c89
+GitCommit: ac7ec5f309ce53e69fdbcf4c245086d63ed2b7ed
 Directory: 3.10/ubuntu
 
 Tags: 3.10.25-management, 3.10-management
@@ -77,7 +77,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.25-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: daf0c85adf02108dda23c62d5e18b739f58f2c89
+GitCommit: ac7ec5f309ce53e69fdbcf4c245086d63ed2b7ed
 Directory: 3.10/alpine
 
 Tags: 3.10.25-management-alpine, 3.10-management-alpine
@@ -87,7 +87,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: daf0c85adf02108dda23c62d5e18b739f58f2c89
+GitCommit: 974b154bfcf4d21c021f8d94d2cb21a2081c7f24
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -97,7 +97,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: daf0c85adf02108dda23c62d5e18b739f58f2c89
+GitCommit: 974b154bfcf4d21c021f8d94d2cb21a2081c7f24
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/974b154: Update 3.9 to otp 25.3.2.6
- https://github.com/docker-library/rabbitmq/commit/1a91aec: Update 3.12 to otp 25.3.2.6
- https://github.com/docker-library/rabbitmq/commit/24bfe1c: Update 3.11 to otp 25.3.2.6
- https://github.com/docker-library/rabbitmq/commit/ac7ec5f: Update 3.10 to otp 25.3.2.6