### PR TITLE
Update amazoncorretto for Q3 2023 patch release

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -8,7 +8,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Victor Rudometov <vicrud@amazon.com> (@Rudometov)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: df7c548293c02db289dfe7de38c90e92a43e5fcf
+GitCommit: c48e6824bfc3d8b04e94fc8c16cee8f023183e2d
 
 Tags: 8, 8u382, 8u382-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u382-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updates to the latest Q3 patch releases, see [coretto-docker#176](https://github.com/corretto/corretto-docker/pull/176) for more info.