### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.61.3, 5.61, 5, latest
+Tags: 5.62.0, 5.62, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 12e4dad661b22d7a3a042b2b815ce96eec47b010
+GitCommit: 4b9927f15a4c469fb2d00aeeda143be8a0356f48
 Directory: 5/debian
 
-Tags: 5.61.3-alpine, 5.61-alpine, 5-alpine, alpine
+Tags: 5.62.0-alpine, 5.62-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 12e4dad661b22d7a3a042b2b815ce96eec47b010
+GitCommit: 4b9927f15a4c469fb2d00aeeda143be8a0356f48
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4b9927f: Update to 5.62.0, ghost-cli 1.24.2