### PR TITLE
Update Clear Linux OS to 39930

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 19a5a350b1f3651a50a4ce34619faa48d3b7091c
-GitFetch: refs/heads/base-39890
+GitCommit: ad57d95c60d48299c689dfe4aed4af2a96fed475
+GitFetch: refs/heads/base-39930


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39930

@bryteise @djklimes @bryteise