### PR TITLE
Update spark version to 3.5.0

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -1,17 +1,37 @@
 Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 3.4.1-scala2.12-java11-python3-ubuntu, 3.4.1-python3, python3, 3.4.1, latest
+Tags: 3.5.0-scala2.12-java11-python3-ubuntu, 3.5.0-python3, 3.5.0, python3, latest
+Architectures: amd64, arm64v8
+GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
+Directory: ./3.5.0/scala2.12-java11-python3-ubuntu
+
+Tags: 3.5.0-scala2.12-java11-r-ubuntu, 3.5.0-r, r
+Architectures: amd64, arm64v8
+GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
+Directory: ./3.5.0/scala2.12-java11-r-ubuntu
+
+Tags: 3.5.0-scala2.12-java11-ubuntu, 3.5.0-scala, scala
+Architectures: amd64, arm64v8
+GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
+Directory: ./3.5.0/scala2.12-java11-ubuntu
+
+Tags: 3.5.0-scala2.12-java11-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
+Directory: ./3.5.0/scala2.12-java11-python3-r-ubuntu
+
+Tags: 3.4.1-scala2.12-java11-python3-ubuntu, 3.4.1-python3, 3.4.1
 Architectures: amd64,arm64v8
 GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
 Directory: ./3.4.1/scala2.12-java11-python3-ubuntu
 
-Tags: 3.4.1-scala2.12-java11-r-ubuntu, 3.4.1-r, r
+Tags: 3.4.1-scala2.12-java11-r-ubuntu, 3.4.1-r
 Architectures: amd64,arm64v8
 GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
 Directory: ./3.4.1/scala2.12-java11-r-ubuntu
 
-Tags: 3.4.1-scala2.12-java11-ubuntu, 3.4.1-scala, scala
+Tags: 3.4.1-scala2.12-java11-ubuntu, 3.4.1-scala
 Architectures: amd64,arm64v8
 GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
 Directory: ./3.4.1/scala2.12-java11-ubuntu


### PR DESCRIPTION
This patch add 3.5.0 version for Apache Spark https://spark.apache.org/docs/3.5.0/ [1]

[1] https://github.com/apache/spark-website/pull/476
[2] https://github.com/apache/spark-docker/pull/55
