### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 22-ea-14-jdk-oraclelinux8, 22-ea-14-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-14-jdk-oracle, 22-ea-14-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-14-jdk, 22-ea-14, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-15-jdk-oraclelinux8, 22-ea-15-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-15-jdk-oracle, 22-ea-15-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-15-jdk, 22-ea-15, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-14-jdk-oraclelinux7, 22-ea-14-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-15-jdk-oraclelinux7, 22-ea-15-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-14-jdk-bookworm, 22-ea-14-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-15-jdk-bookworm, 22-ea-15-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-14-jdk-slim-bookworm, 22-ea-14-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-14-jdk-slim, 22-ea-14-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-15-jdk-slim-bookworm, 22-ea-15-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-15-jdk-slim, 22-ea-15-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-14-jdk-bullseye, 22-ea-14-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-15-jdk-bullseye, 22-ea-15-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-14-jdk-slim-bullseye, 22-ea-14-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-15-jdk-slim-bullseye, 22-ea-15-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-14-jdk-windowsservercore-ltsc2022, 22-ea-14-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-14-jdk-windowsservercore, 22-ea-14-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-14-jdk, 22-ea-14, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-15-jdk-windowsservercore-ltsc2022, 22-ea-15-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-15-jdk-windowsservercore, 22-ea-15-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-15-jdk, 22-ea-15, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-14-jdk-windowsservercore-1809, 22-ea-14-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-14-jdk-windowsservercore, 22-ea-14-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-14-jdk, 22-ea-14, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-15-jdk-windowsservercore-1809, 22-ea-15-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-15-jdk-windowsservercore, 22-ea-15-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-15-jdk, 22-ea-15, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-14-jdk-nanoserver-1809, 22-ea-14-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-14-jdk-nanoserver, 22-ea-14-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-15-jdk-nanoserver-1809, 22-ea-15-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-15-jdk-nanoserver, 22-ea-15-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: f84b156e86a330d5000fe11f1813dd72fd00920b
+GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/a2e23b0: Update 22 to 22-ea+15