### PR TITLE
Update Clear Linux OS to 39960

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ad57d95c60d48299c689dfe4aed4af2a96fed475
-GitFetch: refs/heads/base-39930
+GitCommit: 16638d1f7ac12f6271544ab07c58973609bd002a
+GitFetch: refs/heads/base-39960


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39960

@bryteise @djklimes @bryteise