### PR TITLE
[oraclelinux] Update 8/8-slim/8-slim-fips for amd64/arm64v8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: db0a252eb2321be71848abcceb92fa31be918332
+amd64-GitCommit: 2f1a9736a0ec1895a67191dbf222e8ae838b3f83
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cbf9229aca97e62c5bb4299aa43fda9a4ab18a53
+arm64v8-GitCommit: 023c68f238c1ac7d36f4bf3ec4a1070433c645c2
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Fixes issue with oraclelinux:8 aarch64.