### PR TITLE
[varnish] fix uid:gid in 7.4

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,4 +1,4 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/e6e52639c72df3c5f211d9f56534479819461c44/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/b9c04df300b4a9138c61debe495fbe56021f7550/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
@@ -15,12 +15,12 @@ GitCommit: e6e52639c72df3c5f211d9f56534479819461c44
 Tags: old, 7.3.0, 7.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: e6e52639c72df3c5f211d9f56534479819461c44
+GitCommit: b9c04df300b4a9138c61debe495fbe56021f7550
 
 Tags: old-alpine, 7.3.0-alpine, 7.3-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/alpine
-GitCommit: e6e52639c72df3c5f211d9f56534479819461c44
+GitCommit: b9c04df300b4a9138c61debe495fbe56021f7550
 
 Tags: stable, 6.0.11, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x

--- a/library/varnish
+++ b/library/varnish
@@ -1,16 +1,16 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/b9c04df300b4a9138c61debe495fbe56021f7550/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/61eab19ea5d87528d2c6a109dce7e355ac9965fc/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 7.4.0, 7.4, latest
+Tags: fresh, 7.4.1, 7.4, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: e6e52639c72df3c5f211d9f56534479819461c44
+GitCommit: 61eab19ea5d87528d2c6a109dce7e355ac9965fc
 
-Tags: fresh-alpine, 7.4.0-alpine, 7.4-alpine, alpine
+Tags: fresh-alpine, 7.4.1-alpine, 7.4-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: e6e52639c72df3c5f211d9f56534479819461c44
+GitCommit: 61eab19ea5d87528d2c6a109dce7e355ac9965fc
 
 Tags: old, 7.3.0, 7.3
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
I forgot that 7.3 introduced predictable uid:gid, and forgot to move a few things around, leading 7.3 to miss some setup code. This fixes it