### PR TITLE
Upgrades SonarQube to 10.2.1

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -1,8 +1,9 @@
 Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassallo),
-             Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU)
+             Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU),
+             Davi Koscianski Vidal <davi.koscianski-vidal@sonarsource.com> (@davividal)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: 485f918a718960a87c940a66c6a32a4f8f55f3da
+GitCommit: a1a383e82d4b8b273c8b9237714fc9c700b71dc7
 
 Tags: 9.9.2-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8
@@ -24,22 +25,22 @@ Tags: 9.9.2-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-d
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/search
 
-Tags: 10.2.0-community, 10.2-community, 10-community, community, latest
+Tags: 10.2.1-community, 10.2-community, 10-community, community, latest
 Architectures: amd64, arm64v8
 Directory: 10/community
 
-Tags: 10.2.0-developer, 10.2-developer, 10-developer, developer
+Tags: 10.2.1-developer, 10.2-developer, 10-developer, developer
 Architectures: amd64, arm64v8
 Directory: 10/developer
 
-Tags: 10.2.0-enterprise, 10.2-enterprise, 10-enterprise, enterprise
+Tags: 10.2.1-enterprise, 10.2-enterprise, 10-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: 10/enterprise
 
-Tags: 10.2.0-datacenter-app, 10.2-datacenter-app, 10-datacenter-app, datacenter-app
+Tags: 10.2.1-datacenter-app, 10.2-datacenter-app, 10-datacenter-app, datacenter-app
 Architectures: amd64, arm64v8
 Directory: 10/datacenter/app
 
-Tags: 10.2.0-datacenter-search, 10.2-datacenter-search, 10-datacenter-search, datacenter-search
+Tags: 10.2.1-datacenter-search, 10.2-datacenter-search, 10-datacenter-search, datacenter-search
 Architectures: amd64, arm64v8
 Directory: 10/datacenter/search


### PR DESCRIPTION
Dear team,

We just released SonarQube 10.2.1. Please merge this PR to have it released as a Docker image.