### PR TITLE
SapMachine: Add missing JRE images

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,6 +1,16 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Christian Halstrick <sapmachine@sap.com> (@chalstrick)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
+Tags: 11-jre-headless-ubuntu, 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.20.1-jre-headless-ubuntu, 11.0.20.1-jre-headless-ubuntu-jammy, 11.0.20.1-jre-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c1723a87e4227704b879bc0153969ee497b188c2
+Directory: dockerfiles/official/11/ubuntu/jre-headless
+
+Tags: 11-jre-ubuntu, 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.20.1-jre-ubuntu, 11.0.20.1-jre-ubuntu-jammy, 11.0.20.1-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c1723a87e4227704b879bc0153969ee497b188c2
+Directory: dockerfiles/official/11/ubuntu/jre
+
 Tags: 11-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.20.1-jdk-headless-ubuntu, 11.0.20.1-jdk-headless-ubuntu-jammy, 11.0.20.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: c1723a87e4227704b879bc0153969ee497b188c2
@@ -10,6 +20,16 @@ Tags: 11-jdk-ubuntu, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.20.1-jdk-ubu
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: c1723a87e4227704b879bc0153969ee497b188c2
 Directory: dockerfiles/official/11/ubuntu/jdk
+
+Tags: 17-jre-headless-ubuntu, 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.8.1-jre-headless-ubuntu, 17.0.8.1-jre-headless-ubuntu-jammy, 17.0.8.1-jre-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: b2502288737bc565d44b9399c552bfebae112174
+Directory: dockerfiles/official/17/ubuntu/jre-headless
+
+Tags: 17-jre-ubuntu, 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.8.1-jre-ubuntu, 17.0.8.1-jre-ubuntu-jammy, 17.0.8.1-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: b2502288737bc565d44b9399c552bfebae112174
+Directory: dockerfiles/official/17/ubuntu/jre
 
 Tags: 17-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.8.1-jdk-headless-ubuntu, 17.0.8.1-jdk-headless-ubuntu-jammy, 17.0.8.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
This adds the missing JRE images. Hopefully tests are all green now.