### PR TITLE
archlinux: Release 20230921.0.180222

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230910.0.177821
-GitCommit: 8927543be41468cddf77a2fd4148bcdc5cf22e97
-GitFetch: refs/tags/v20230910.0.177821
+Tags: latest, base, base-20230921.0.180222
+GitCommit: a8bba69a7d928de88fcac7a7047b68bef542f73a
+GitFetch: refs/tags/v20230921.0.180222
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230910.0.177821
-GitCommit: 8927543be41468cddf77a2fd4148bcdc5cf22e97
-GitFetch: refs/tags/v20230910.0.177821
+Tags: base-devel, base-devel-20230921.0.180222
+GitCommit: a8bba69a7d928de88fcac7a7047b68bef542f73a
+GitFetch: refs/tags/v20230921.0.180222
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks