### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.0-beta.6, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 43525d5fe269be572c84516d855ca934ab26523b
+GitCommit: 687ece5f4db01a9a8925dbadb3dc872033627c16
 Directory: 3.13-rc/ubuntu
 
 Tags: 3.13.0-beta.6-management, 3.13-rc-management
@@ -17,7 +17,7 @@ Directory: 3.13-rc/ubuntu/management
 
 Tags: 3.13.0-beta.6-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 43525d5fe269be572c84516d855ca934ab26523b
+GitCommit: 687ece5f4db01a9a8925dbadb3dc872033627c16
 Directory: 3.13-rc/alpine
 
 Tags: 3.13.0-beta.6-management-alpine, 3.13-rc-management-alpine
@@ -25,22 +25,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/alpine/management
 
-Tags: 3.12.4, 3.12, 3, latest
+Tags: 3.12.5, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: af4b3006dd089278d45b5e925f54403314e50b18
+GitCommit: 5e5a04952e02dab153005a6e59d50deb99847e56
 Directory: 3.12/ubuntu
 
-Tags: 3.12.4-management, 3.12-management, 3-management, management
+Tags: 3.12.5-management, 3.12-management, 3-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: c30652127ae871535b7ec8ecda8046948a52ab79
 Directory: 3.12/ubuntu/management
 
-Tags: 3.12.4-alpine, 3.12-alpine, 3-alpine, alpine
+Tags: 3.12.5-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af4b3006dd089278d45b5e925f54403314e50b18
+GitCommit: 5e5a04952e02dab153005a6e59d50deb99847e56
 Directory: 3.12/alpine
 
-Tags: 3.12.4-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
+Tags: 3.12.5-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c30652127ae871535b7ec8ecda8046948a52ab79
 Directory: 3.12/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/5e5a049: Update 3.12 to 3.12.5
- https://github.com/docker-library/rabbitmq/commit/687ece5: Update 3.13-rc to otp 26.1