### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2023-5249 and ELBA-2023-5248

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2f1a9736a0ec1895a67191dbf222e8ae838b3f83
+amd64-GitCommit: a6899fe3d6752118cfa1d57210e4de317f617891
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 023c68f238c1ac7d36f4bf3ec4a1070433c645c2
+arm64v8-GitCommit: 21bab0b84259a0082fdcf71f744f5f106ea376a2
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-29491 and ca-certificates.

See the following for details:

https://linux.oracle.com/errata/ELBA-2023-5248.html
https://linux.oracle.com/errata/ELSA-2023-5249.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
