### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 22-ea-15-jdk-oraclelinux8, 22-ea-15-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-15-jdk-oracle, 22-ea-15-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-15-jdk, 22-ea-15, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-16-jdk-oraclelinux8, 22-ea-16-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-16-jdk-oracle, 22-ea-16-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-16-jdk, 22-ea-16, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-15-jdk-oraclelinux7, 22-ea-15-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-16-jdk-oraclelinux7, 22-ea-16-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-15-jdk-bookworm, 22-ea-15-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-16-jdk-bookworm, 22-ea-16-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-15-jdk-slim-bookworm, 22-ea-15-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-15-jdk-slim, 22-ea-15-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-16-jdk-slim-bookworm, 22-ea-16-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-16-jdk-slim, 22-ea-16-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-15-jdk-bullseye, 22-ea-15-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-16-jdk-bullseye, 22-ea-16-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-15-jdk-slim-bullseye, 22-ea-15-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-16-jdk-slim-bullseye, 22-ea-16-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-15-jdk-windowsservercore-ltsc2022, 22-ea-15-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-15-jdk-windowsservercore, 22-ea-15-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-15-jdk, 22-ea-15, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-16-jdk-windowsservercore-ltsc2022, 22-ea-16-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-16-jdk-windowsservercore, 22-ea-16-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-16-jdk, 22-ea-16, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-15-jdk-windowsservercore-1809, 22-ea-15-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-15-jdk-windowsservercore, 22-ea-15-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-15-jdk, 22-ea-15, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-16-jdk-windowsservercore-1809, 22-ea-16-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-16-jdk-windowsservercore, 22-ea-16-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-16-jdk, 22-ea-16, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-15-jdk-nanoserver-1809, 22-ea-15-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-15-jdk-nanoserver, 22-ea-15-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-16-jdk-nanoserver-1809, 22-ea-16-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-16-jdk-nanoserver, 22-ea-16-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: a2e23b0f73aed49ce0126379603d25222e43d64d
+GitCommit: 35d7a4f2a7cb30b5283facd578027abfb74de8fc
 Directory: 22/jdk/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 21-rc-jdk-oraclelinux8, 21-rc-oraclelinux8, 21-jdk-oraclelinux8, 21-oraclelinux8, 21-rc-jdk-oracle, 21-rc-oracle, 21-jdk-oracle, 21-oracle
-SharedTags: 21-rc-jdk, 21-rc, 21-jdk, 21
-Architectures: amd64, arm64v8
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/oraclelinux8
-
-Tags: 21-rc-jdk-oraclelinux7, 21-rc-oraclelinux7, 21-jdk-oraclelinux7, 21-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/oraclelinux7
-
-Tags: 21-rc-jdk-bookworm, 21-rc-bookworm, 21-jdk-bookworm, 21-bookworm
-Architectures: amd64, arm64v8
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/bookworm
-
-Tags: 21-rc-jdk-slim-bookworm, 21-rc-slim-bookworm, 21-jdk-slim-bookworm, 21-slim-bookworm, 21-rc-jdk-slim, 21-rc-slim, 21-jdk-slim, 21-slim
-Architectures: amd64, arm64v8
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/slim-bookworm
-
-Tags: 21-rc-jdk-bullseye, 21-rc-bullseye, 21-jdk-bullseye, 21-bullseye
-Architectures: amd64, arm64v8
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/bullseye
-
-Tags: 21-rc-jdk-slim-bullseye, 21-rc-slim-bullseye, 21-jdk-slim-bullseye, 21-slim-bullseye
-Architectures: amd64, arm64v8
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/slim-bullseye
-
-Tags: 21-rc-jdk-windowsservercore-ltsc2022, 21-rc-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21-rc-jdk-windowsservercore, 21-rc-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-rc-jdk, 21-rc, 21-jdk, 21
-Architectures: windows-amd64
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 21-rc-jdk-windowsservercore-1809, 21-rc-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21-rc-jdk-windowsservercore, 21-rc-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21-rc-jdk, 21-rc, 21-jdk, 21
-Architectures: windows-amd64
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 21-rc-jdk-nanoserver-1809, 21-rc-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21-rc-jdk-nanoserver, 21-rc-nanoserver, 21-jdk-nanoserver, 21-nanoserver
-Architectures: windows-amd64
-GitCommit: 4c2b1a57869e24c5fcfbea6a17e558c710d4f6bd
-Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0b6f2be: Merge pull request https://github.com/docker-library/openjdk/pull/531 from infosiftr/ga-21
- https://github.com/docker-library/openjdk/commit/35d7a4f: Update 22 to 22-ea+16
- https://github.com/docker-library/openjdk/commit/1dabc03: Remove version 21 (now GA)