### PR TITLE
Updated Packages for Amazon Linux 1:

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.1.20230825.0
+Tags: 2023, latest, 2023.2.20230920.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 068827c218fcfd1494a296edca29a9ae1c5fafa7
+amd64-GitCommit: 414b5d5f6254ca8a674e04cc2f5e0e334ac77f14
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 8abc047b4fd20289d889ac876b085af4d2b30ae7
+arm64v8-GitCommit: da06108429da71749dfb1ed777d0bf4e066585e5
 
-Tags: 2, 2.0.20230822.0
+Tags: 2, 2.0.20230912.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 81483ce21289e23fcdd3644eeed17c94c4077f64
+amd64-GitCommit: 758d8663f71fe6d9c26dc42a366eabdf024458ca
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a5a1860c1df5ff3e270e4063484afb25079e4b0b
+arm64v8-GitCommit: 66a3740f12f9671b39bfa26501317e1b4ae48fb5
 
-Tags: 1, 2018.03, 2018.03.0.20230821.0
+Tags: 1, 2018.03, 2018.03.0.20230905.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: ce19335809fc05b4e4b451a70c9bc6a1ca518ae5
+amd64-GitCommit: bb33672fcca36770bfe1536b7773b19ca43df8da


### PR DESCRIPTION
### Updated Packages for Amazon Linux 1:
- krb5-libs-1.15.1-55.52.amzn1
- ca-certificates-2018.2.22-65.1.31.amzn1
#### Packages addressing CVES:
- krb5-libs-1.15.1-55.52.amzn1
  - [CVE-2023-36054](https://alas.aws.amazon.com/cve/html/CVE-2023-36054.html)
- ca-certificates-2018.2.22-65.1.31.amzn1
  - [CVE-2023-37920](https://alas.aws.amazon.com/cve/html/CVE-2023-37920.html)

### Updated Packages for Amazon Linux 2:
- glibc-common-2.26-63.amzn2.0.1
- libxml2-2.9.1-6.amzn2.5.12
- libcrypt-2.26-63.amzn2.0.1
- libnghttp2-1.41.0-1.amzn2.0.3
- libidn2-2.3.0-1.amzn2.0.3
- libtasn1-4.10-1.amzn2.0.6
- glibc-minimal-langpack-2.26-63.amzn2.0.1
- libstdc++-7.3.1-17.amzn2
- libcurl-8.2.1-1.amzn2.0.3
- libgcc-7.3.1-17.amzn2
- glibc-2.26-63.amzn2.0.1
- openssl-libs-1.0.2k-24.amzn2.0.9
- libssh2-1.4.3-12.amzn2.2.5
- curl-8.2.1-1.amzn2.0.3
- glibc-langpack-en-2.26-63.amzn2.0.1
#### Packages addressing CVES:
- libstdc++-7.3.1-17.amzn2, libgcc-7.3.1-17.amzn2
  - [CVE-2023-4039](https://alas.aws.amazon.com/cve/html/CVE-2023-4039.html)
- openssl-libs-1.0.2k-24.amzn2.0.9
  - [CVE-2023-3446](https://alas.aws.amazon.com/cve/html/CVE-2023-3446.html)
  - [CVE-2023-3817](https://alas.aws.amazon.com/cve/html/CVE-2023-3817.html)

### Updated Packages for Amazon Linux 2023:
- libffi-3.4.4-1.amzn2023.0.1
- libgcrypt-1.10.2-1.amzn2023.0.1
- python3-libs-3.9.16-1.amzn2023.0.6
- amazon-linux-repo-cdn-2023.2.20230920-0.amzn2023
- system-release-2023.2.20230920-0.amzn2023
- p11-kit-0.24.1-2.amzn2023.0.3
- p11-kit-trust-0.24.1-2.amzn2023.0.3
- glib2-2.74.7-689.amzn2023.0.2
- python3-3.9.16-1.amzn2023.0.6
#### Packages addressing CVES: