### PR TITLE
Update Clear Linux OS to 39980

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 16638d1f7ac12f6271544ab07c58973609bd002a
-GitFetch: refs/heads/base-39960
+GitCommit: d0b0cab6c276fdea3d1ecb1278621080a4f0b525
+GitFetch: refs/heads/base-39980


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 39980

@bryteise @djklimes @bryteise