### PR TITLE
Odoo: update 14.0-16.0 to release 20230925

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 61148a86eed7fb5452dc7705b479988e1f49f9a6
+GitCommit: d04d885eea6b8f60ada727fcc498f5a8fd44da51
 
 Tags: 16.0, 16, latest
 Architectures: amd64


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks.