### PR TITLE
GHC 9.6.2 -> 9.6.3

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,14 +2,14 @@ Maintainers: Alistair Burrowes <afburrowes@gmail.com> (@AlistairB),
              Albert Krewinkel <albert+docker@tarleb.com> (@tarleb)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.6.2-buster, 9.6-buster, 9-buster, buster, 9.6.2, 9.6, 9, latest
+Tags: 9.6.3-buster, 9.6-buster, 9-buster, buster, 9.6.3, 9.6, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: d33bf51b985814e1d38b5d3fd301531ff16d7d21
+GitCommit: 9bf57e9b736ce1d32fbccbc30f88a48c9e221225
 Directory: 9.6/buster
 
-Tags: 9.6.2-slim-buster, 9.6-slim-buster, 9-slim-buster, slim-buster, 9.6.2-slim, 9.6-slim, 9-slim, slim
+Tags: 9.6.3-slim-buster, 9.6-slim-buster, 9-slim-buster, slim-buster, 9.6.3-slim, 9.6-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: d33bf51b985814e1d38b5d3fd301531ff16d7d21
+GitCommit: 9bf57e9b736ce1d32fbccbc30f88a48c9e221225
 Directory: 9.6/slim-buster
 
 Tags: 9.4.7-buster, 9.4-buster, 9.4.7, 9.4


### PR DESCRIPTION
Bumping GHC 9.6.2 to 9.6.3.

Relevant PR: https://github.com/haskell/docker-haskell/pull/112
Merge commit with complete changeset: https://github.com/haskell/docker-haskell/commit/9bf57e9b736ce1d32fbccbc30f88a48c9e221225