### PR TITLE
Add Maven with Correto 21 + AL2023

### DIFF
--- a/library/maven
+++ b/library/maven
@@ -123,6 +123,11 @@ Architectures: amd64, arm64v8
 GitCommit: 7741c2848c3ea3ad6b4180d94b90d669d419c893
 Directory: amazoncorretto-21
 
+Tags: 3.9.4-amazoncorretto-21-al2023, 3.9-amazoncorretto-21-al2023, 3-amazoncorretto-21-al2023
+Architectures: amd64, arm64v8
+GitCommit: 3a94e25bc22f4589addf7e50361a3e0c1af1c306
+Directory: amazoncorretto-21-al2023
+
 Tags: 3.9.4-amazoncorretto-21-debian, 3.9.4-amazoncorretto-21-debian-bookworm, 3.9-amazoncorretto-21-debian, 3.9-amazoncorretto-21-debian-bookworm, 3-amazoncorretto-21-debian, 3-amazoncorretto-21-debian-bookworm
 Architectures: amd64, arm64v8
 GitCommit: 61b5d8d7e9e5706522ff154315db185816d35891


### PR DESCRIPTION
[Per directions from carlossg](https://github.com/carlossg/docker-maven/issues/412#issuecomment-1738266140), I am creating this PR to add a new variant of the official Maven image that contains corretto 21 and Amazon Linux 2023.

The [original PR](https://github.com/carlossg/docker-maven/pull/413) to docker-maven