### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.0-beta.6, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 687ece5f4db01a9a8925dbadb3dc872033627c16
+GitCommit: ced055dcc013310157788d8e5a710f231bb7cdba
 Directory: 3.13-rc/ubuntu
 
 Tags: 3.13.0-beta.6-management, 3.13-rc-management
@@ -17,7 +17,7 @@ Directory: 3.13-rc/ubuntu/management
 
 Tags: 3.13.0-beta.6-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 687ece5f4db01a9a8925dbadb3dc872033627c16
+GitCommit: ced055dcc013310157788d8e5a710f231bb7cdba
 Directory: 3.13-rc/alpine
 
 Tags: 3.13.0-beta.6-management-alpine, 3.13-rc-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/ced055d: Update 3.13-rc to otp 26.1.1