### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.65.1, 5.65, 5, latest
+Tags: 5.66.0, 5.66, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1719f39e02b47a9bf5878aa48eb9201017678cd9
+GitCommit: d8381ef467ab303a4fcb70aeb855af1c5bcbe749
 Directory: 5/debian
 
-Tags: 5.65.1-alpine, 5.65-alpine, 5-alpine, alpine
+Tags: 5.66.0-alpine, 5.66-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 404e37b66bf1d908fba92a06e01a6d7fbc18b6bb
+GitCommit: d8381ef467ab303a4fcb70aeb855af1c5bcbe749
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/d8381ef: Update to 5.66.0, ghost-cli 1.24.2