### PR TITLE
archlinux: Release 20231001.0.182270

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20230921.0.180222
-GitCommit: a8bba69a7d928de88fcac7a7047b68bef542f73a
-GitFetch: refs/tags/v20230921.0.180222
+Tags: latest, base, base-20231001.0.182270
+GitCommit: a8c000a0752f90e436cc96e097bcc3750f961164
+GitFetch: refs/tags/v20231001.0.182270
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20230921.0.180222
-GitCommit: a8bba69a7d928de88fcac7a7047b68bef542f73a
-GitFetch: refs/tags/v20230921.0.180222
+Tags: base-devel, base-devel-20231001.0.182270
+GitCommit: a8c000a0752f90e436cc96e097bcc3750f961164
+GitFetch: refs/tags/v20231001.0.182270
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks