### PR TITLE
Update registry to v2.8.3 release

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -2,7 +2,7 @@ Maintainers: Milos Gajdos (@milosgajdos),
              Sebastiaan van Stijn (@thajeztah)
 GitRepo: https://github.com/docker/distribution-library-image.git
 GitFetch: refs/heads/master
-GitCommit: e42103a5670538e10ac42f5284e2a25912f17973
+GitCommit: 39dd72feaab7066334829d6945c54bc51a0aee98
 
-Tags: 2.8.2, 2.8, 2, latest
+Tags: 2.8.3, 2.8, 2, latest
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x


### PR DESCRIPTION
References:
* https://github.com/distribution/distribution/releases/tag/v2.8.3
* https://github.com/docker/distribution-library-image/pull/151