### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.66.0, 5.66, 5, latest
+Tags: 5.66.1, 5.66, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d8381ef467ab303a4fcb70aeb855af1c5bcbe749
+GitCommit: f494e8c84e73c1c816eb8876e1ab6a02e1fa500e
 Directory: 5/debian
 
-Tags: 5.66.0-alpine, 5.66-alpine, 5-alpine, alpine
+Tags: 5.66.1-alpine, 5.66-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d8381ef467ab303a4fcb70aeb855af1c5bcbe749
+GitCommit: f494e8c84e73c1c816eb8876e1ab6a02e1fa500e
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/f494e8c: Update to 5.66.1, ghost-cli 1.24.2