### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,124 +4,124 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.0.0-beta2-php8.1-apache, 5.0-php8.1-apache, 5.0.beta-php8.1-apache, 5.0.0-beta-php8.1-apache
+Tags: 5.0.0-rc1-php8.1-apache, 5.0-php8.1-apache, 5.0.rc-php8.1-apache, 5.0.0-rc-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 5.0.beta/php8.1/apache
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 5.0.rc/php8.1/apache
 
-Tags: 5.0.0-beta2-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.beta-php8.1-fpm-alpine, 5.0.0-beta-php8.1-fpm-alpine
+Tags: 5.0.0-rc1-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.rc-php8.1-fpm-alpine, 5.0.0-rc-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 5.0.beta/php8.1/fpm-alpine
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 5.0.rc/php8.1/fpm-alpine
 
-Tags: 5.0.0-beta2-php8.1-fpm, 5.0-php8.1-fpm, 5.0.beta-php8.1-fpm, 5.0.0-beta-php8.1-fpm
+Tags: 5.0.0-rc1-php8.1-fpm, 5.0-php8.1-fpm, 5.0.rc-php8.1-fpm, 5.0.0-rc-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 5.0.beta/php8.1/fpm
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 5.0.rc/php8.1/fpm
 
-Tags: 5.0.0-beta2, 5.0, 5.0.beta, 5.0.0-beta, 5.0.0-beta2-apache, 5.0-apache, 5.0.beta-apache, 5.0.0-beta-apache, 5.0.0-beta2-php8.2, 5.0-php8.2, 5.0.beta-php8.2, 5.0.0-beta-php8.2, 5.0.0-beta2-php8.2-apache, 5.0-php8.2-apache, 5.0.beta-php8.2-apache, 5.0.0-beta-php8.2-apache
+Tags: 5.0.0-rc1, 5.0, 5.0.rc, 5.0.0-rc, 5.0.0-rc1-apache, 5.0-apache, 5.0.rc-apache, 5.0.0-rc-apache, 5.0.0-rc1-php8.2, 5.0-php8.2, 5.0.rc-php8.2, 5.0.0-rc-php8.2, 5.0.0-rc1-php8.2-apache, 5.0-php8.2-apache, 5.0.rc-php8.2-apache, 5.0.0-rc-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 5.0.beta/php8.2/apache
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 5.0.rc/php8.2/apache
 
-Tags: 5.0.0-beta2-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.beta-php8.2-fpm-alpine, 5.0.0-beta-php8.2-fpm-alpine
+Tags: 5.0.0-rc1-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.rc-php8.2-fpm-alpine, 5.0.0-rc-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 5.0.beta/php8.2/fpm-alpine
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 5.0.rc/php8.2/fpm-alpine
 
-Tags: 5.0.0-beta2-php8.2-fpm, 5.0-php8.2-fpm, 5.0.beta-php8.2-fpm, 5.0.0-beta-php8.2-fpm
+Tags: 5.0.0-rc1-php8.2-fpm, 5.0-php8.2-fpm, 5.0.rc-php8.2-fpm, 5.0.0-rc-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 5.0.beta/php8.2/fpm
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 5.0.rc/php8.2/fpm
 
-Tags: 4.4.0-beta2-php8.0-apache, 4.4-php8.0-apache, 4.4.beta-php8.0-apache, 4.4.0-beta-php8.0-apache
+Tags: 4.4.0-rc1-php8.0-apache, 4.4-php8.0-apache, 4.4.rc-php8.0-apache, 4.4.0-rc-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.0/apache
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.0/apache
 
-Tags: 4.4.0-beta2-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.beta-php8.0-fpm-alpine, 4.4.0-beta-php8.0-fpm-alpine
+Tags: 4.4.0-rc1-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.rc-php8.0-fpm-alpine, 4.4.0-rc-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.0/fpm-alpine
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.0/fpm-alpine
 
-Tags: 4.4.0-beta2-php8.0-fpm, 4.4-php8.0-fpm, 4.4.beta-php8.0-fpm, 4.4.0-beta-php8.0-fpm
+Tags: 4.4.0-rc1-php8.0-fpm, 4.4-php8.0-fpm, 4.4.rc-php8.0-fpm, 4.4.0-rc-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.0/fpm
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.0/fpm
 
-Tags: 4.4.0-beta2, 4.4, 4.4.beta, 4.4.0-beta, 4.4.0-beta2-apache, 4.4-apache, 4.4.beta-apache, 4.4.0-beta-apache, 4.4.0-beta2-php8.1, 4.4-php8.1, 4.4.beta-php8.1, 4.4.0-beta-php8.1, 4.4.0-beta2-php8.1-apache, 4.4-php8.1-apache, 4.4.beta-php8.1-apache, 4.4.0-beta-php8.1-apache
+Tags: 4.4.0-rc1, 4.4, 4.4.rc, 4.4.0-rc, 4.4.0-rc1-apache, 4.4-apache, 4.4.rc-apache, 4.4.0-rc-apache, 4.4.0-rc1-php8.1, 4.4-php8.1, 4.4.rc-php8.1, 4.4.0-rc-php8.1, 4.4.0-rc1-php8.1-apache, 4.4-php8.1-apache, 4.4.rc-php8.1-apache, 4.4.0-rc-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.1/apache
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.1/apache
 
-Tags: 4.4.0-beta2-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.beta-php8.1-fpm-alpine, 4.4.0-beta-php8.1-fpm-alpine
+Tags: 4.4.0-rc1-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.rc-php8.1-fpm-alpine, 4.4.0-rc-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.1/fpm-alpine
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.1/fpm-alpine
 
-Tags: 4.4.0-beta2-php8.1-fpm, 4.4-php8.1-fpm, 4.4.beta-php8.1-fpm, 4.4.0-beta-php8.1-fpm
+Tags: 4.4.0-rc1-php8.1-fpm, 4.4-php8.1-fpm, 4.4.rc-php8.1-fpm, 4.4.0-rc-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.1/fpm
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.1/fpm
 
-Tags: 4.4.0-beta2-php8.2-apache, 4.4-php8.2-apache, 4.4.beta-php8.2-apache, 4.4.0-beta-php8.2-apache
+Tags: 4.4.0-rc1-php8.2-apache, 4.4-php8.2-apache, 4.4.rc-php8.2-apache, 4.4.0-rc-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.2/apache
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.2/apache
 
-Tags: 4.4.0-beta2-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.beta-php8.2-fpm-alpine, 4.4.0-beta-php8.2-fpm-alpine
+Tags: 4.4.0-rc1-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.rc-php8.2-fpm-alpine, 4.4.0-rc-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.2/fpm-alpine
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.2/fpm-alpine
 
-Tags: 4.4.0-beta2-php8.2-fpm, 4.4-php8.2-fpm, 4.4.beta-php8.2-fpm, 4.4.0-beta-php8.2-fpm
+Tags: 4.4.0-rc1-php8.2-fpm, 4.4-php8.2-fpm, 4.4.rc-php8.2-fpm, 4.4.0-rc-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 32a8ac51fa8885f858e5716f57b0502f23812169
-Directory: 4.4.beta/php8.2/fpm
+GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
+Directory: 4.4.rc/php8.2/fpm
 
 Tags: 4.3.4, 4.3, 4, latest, 4.3.4-apache, 4.3-apache, 4-apache, apache, 4.3.4-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.4-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.0/apache
 
 Tags: 4.3.4-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.0/fpm-alpine
 
 Tags: 4.3.4-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.0/fpm
 
 Tags: 4.3.4-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.1/apache
 
 Tags: 4.3.4-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.1/fpm-alpine
 
 Tags: 4.3.4-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.1/fpm
 
 Tags: 4.3.4-php8.2-apache, 4.3-php8.2-apache, 4-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.2/apache
 
 Tags: 4.3.4-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.2/fpm-alpine
 
 Tags: 4.3.4-php8.2-fpm, 4.3-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f9a16bcbd8cc90ddcac5c7f8223e18d306a45825
+GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.2/fpm
 
 Tags: 3.10.12, 3.10, 3, 3.10.12-apache, 3.10-apache, 3-apache, 3.10.12-php8.0, 3.10-php8.0, 3-php8.0, 3.10.12-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@dc5b2b8: Adds Joomla 5.0.rc and 4.4.rc. Removes Joomla 5.0.beta and 4.4.beta.
- joomla-docker/docker-joomla@98ed775: Adds auto deploy of the official images.