### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,100 +5,100 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.21.1-bookworm, 1.21-bookworm, 1-bookworm, bookworm
-SharedTags: 1.21.1, 1.21, 1, latest
+Tags: 1.21.2-bookworm, 1.21-bookworm, 1-bookworm, bookworm
+SharedTags: 1.21.2, 1.21, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b643595f97209e0e67f0cf62e13d4fb6c609451b
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/bookworm
 
-Tags: 1.21.1-bullseye, 1.21-bullseye, 1-bullseye, bullseye
+Tags: 1.21.2-bullseye, 1.21-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b643595f97209e0e67f0cf62e13d4fb6c609451b
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/bullseye
 
-Tags: 1.21.1-alpine3.18, 1.21-alpine3.18, 1-alpine3.18, alpine3.18, 1.21.1-alpine, 1.21-alpine, 1-alpine, alpine
+Tags: 1.21.2-alpine3.18, 1.21-alpine3.18, 1-alpine3.18, alpine3.18, 1.21.2-alpine, 1.21-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b643595f97209e0e67f0cf62e13d4fb6c609451b
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/alpine3.18
 
-Tags: 1.21.1-alpine3.17, 1.21-alpine3.17, 1-alpine3.17, alpine3.17
+Tags: 1.21.2-alpine3.17, 1.21-alpine3.17, 1-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b643595f97209e0e67f0cf62e13d4fb6c609451b
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/alpine3.17
 
-Tags: 1.21.1-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.21.1-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.1, 1.21, 1, latest
+Tags: 1.21.2-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.21.2-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.2, 1.21, 1, latest
 Architectures: windows-amd64
-GitCommit: 585c8c1e705a7a458455f0629922a4f90628ce08
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.21.1-windowsservercore-1809, 1.21-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.21.1-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.1, 1.21, 1, latest
+Tags: 1.21.2-windowsservercore-1809, 1.21-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.21.2-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.2, 1.21, 1, latest
 Architectures: windows-amd64
-GitCommit: 585c8c1e705a7a458455f0629922a4f90628ce08
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.21.1-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.21.1-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.21.2-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.21.2-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 585c8c1e705a7a458455f0629922a4f90628ce08
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.21.1-nanoserver-1809, 1.21-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.21.1-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.21.2-nanoserver-1809, 1.21-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.21.2-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 585c8c1e705a7a458455f0629922a4f90628ce08
+GitCommit: f0d301c385958888968d6ab8f8510c3cd5cce704
 Directory: 1.21/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.20.8-bookworm, 1.20-bookworm
-SharedTags: 1.20.8, 1.20
+Tags: 1.20.9-bookworm, 1.20-bookworm
+SharedTags: 1.20.9, 1.20
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/bookworm
 
-Tags: 1.20.8-bullseye, 1.20-bullseye
+Tags: 1.20.9-bullseye, 1.20-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/bullseye
 
-Tags: 1.20.8-alpine3.18, 1.20-alpine3.18, 1.20.8-alpine, 1.20-alpine
+Tags: 1.20.9-alpine3.18, 1.20-alpine3.18, 1.20.9-alpine, 1.20-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/alpine3.18
 
-Tags: 1.20.8-alpine3.17, 1.20-alpine3.17
+Tags: 1.20.9-alpine3.17, 1.20-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/alpine3.17
 
-Tags: 1.20.8-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022
-SharedTags: 1.20.8-windowsservercore, 1.20-windowsservercore, 1.20.8, 1.20
+Tags: 1.20.9-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022
+SharedTags: 1.20.9-windowsservercore, 1.20-windowsservercore, 1.20.9, 1.20
 Architectures: windows-amd64
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.20.8-windowsservercore-1809, 1.20-windowsservercore-1809
-SharedTags: 1.20.8-windowsservercore, 1.20-windowsservercore, 1.20.8, 1.20
+Tags: 1.20.9-windowsservercore-1809, 1.20-windowsservercore-1809
+SharedTags: 1.20.9-windowsservercore, 1.20-windowsservercore, 1.20.9, 1.20
 Architectures: windows-amd64
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.20.8-nanoserver-ltsc2022, 1.20-nanoserver-ltsc2022
-SharedTags: 1.20.8-nanoserver, 1.20-nanoserver
+Tags: 1.20.9-nanoserver-ltsc2022, 1.20-nanoserver-ltsc2022
+SharedTags: 1.20.9-nanoserver, 1.20-nanoserver
 Architectures: windows-amd64
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.20.8-nanoserver-1809, 1.20-nanoserver-1809
-SharedTags: 1.20.8-nanoserver, 1.20-nanoserver
+Tags: 1.20.9-nanoserver-1809, 1.20-nanoserver-1809
+SharedTags: 1.20.9-nanoserver, 1.20-nanoserver
 Architectures: windows-amd64
-GitCommit: 24115a7612dfca330632a04604cd72f673085e8a
+GitCommit: d47076e3070196e128f769ca0720009aacc86e65
 Directory: 1.20/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/d47076e: Update 1.20 to 1.20.9
- https://github.com/docker-library/golang/commit/f0d301c: Update 1.21 to 1.21.2

These releases contain fixes for `CVE-2023-39323`, https://github.com/golang/go/issues/63211