### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,6 +4,11 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
+Tags: 5.0-alpha1, 5.0
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 01dffce9d5d205f61733cbffaaf8973cc586219b
+Directory: 5.0
+
 Tags: 4.1.3, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 44614387cda4278e477056c24cde3070f679a32a
@@ -11,7 +16,7 @@ Directory: 4.1
 
 Tags: 4.0.11, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 955064939ae306088491856ff169b58319d619f9
+GitCommit: b57fae57e886db7b46c0851ed761b6b0a260f065
 Directory: 4.0
 
 Tags: 3.11.16, 3.11, 3


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/9b936f9: Merge pull request https://github.com/docker-library/cassandra/pull/268 from infosiftr/5.0-alpha
- https://github.com/docker-library/cassandra/commit/b57fae5: Update 4.0 to 4.0.11
- https://github.com/docker-library/cassandra/commit/b989966: Update 4.0 to 4.0.9
- https://github.com/docker-library/cassandra/commit/01dffce: Add 5.0-alpha release