### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.67.0, 5.67, 5, latest
+Tags: 5.68.0, 5.68, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fae9e5a5222553c1a2746dd31779df1ea1277785
+GitCommit: 64f729bc386d8fe074677adca8d71e1b35d08d5e
 Directory: 5/debian
 
-Tags: 5.67.0-alpine, 5.67-alpine, 5-alpine, alpine
+Tags: 5.68.0-alpine, 5.68-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: fae9e5a5222553c1a2746dd31779df1ea1277785
+GitCommit: 64f729bc386d8fe074677adca8d71e1b35d08d5e
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/64f729b: Update to 5.68.0, ghost-cli 1.25.2