### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev6, 2.9-dev, 2.9-dev6-bullseye, 2.9-dev-bullseye
+Tags: 2.9-dev7, 2.9-dev, 2.9-dev7-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40db7d102d0b5ac819985b7c7ee68e7dd4edd21a
+GitCommit: c95674c9a4c5a77b035a05de2ae3097dcb71abe3
 Directory: 2.9
 
-Tags: 2.9-dev6-alpine, 2.9-dev-alpine, 2.9-dev6-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9-dev7-alpine, 2.9-dev-alpine, 2.9-dev7-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 40db7d102d0b5ac819985b7c7ee68e7dd4edd21a
+GitCommit: c95674c9a4c5a77b035a05de2ae3097dcb71abe3
 Directory: 2.9/alpine
 
 Tags: 2.8.3, 2.8, lts, latest, 2.8.3-bullseye, 2.8-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c95674c: Update 2.9 to 2.9-dev7