### PR TITLE
arangodb 3.11.4

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,17 +2,12 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.9, 3.9.12
-Architectures: amd64
-GitCommit: 53f958f87211657b217169c7e00847034a708cd4
-Directory: alpine/3.9.12
-
 Tags: 3.10, 3.10.10
 Architectures: amd64, arm64v8
 GitCommit: 5e1e58d2e5a985fe21b0747909d39eb3ccc434e2
 Directory: alpine/3.10.10
 
-Tags: 3.11, 3.11.3, latest
+Tags: 3.11, 3.11.4, latest
 Architectures: amd64, arm64v8
-GitCommit: a2086d378d6c439d95b6900c6429709e57c6f24d
-Directory: alpine/3.11.3
+GitCommit: 8bb5a2e1077cf575d91c05246f9317b2bb9713bb
+Directory: alpine/3.11.4


### PR DESCRIPTION
Updated ArangoDB 3.11 to 3.11.4 and removed 3.9 (EoL).