### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
 Directory: cli/php8.2/alpine
 
-Tags: beta-6.4-beta2-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-beta2, beta-6.4, beta-6, beta, beta-6.4-beta2-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-beta2-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.4-beta3-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-beta3, beta-6.4, beta-6, beta, beta-6.4-beta3-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-beta3-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.0/apache
 
-Tags: beta-6.4-beta2-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-beta2-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.4-beta3-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-beta3-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.4-beta2-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-beta2-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.4-beta3-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-beta3-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.4-beta2-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-beta2-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.4-beta3-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-beta3-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.1/apache
 
-Tags: beta-6.4-beta2-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.4-beta3-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.4-beta2-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.4-beta3-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.4-beta2-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-beta2-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.4-beta3-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-beta3-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.2/apache
 
-Tags: beta-6.4-beta2-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.4-beta3-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.4-beta2-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.4-beta3-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1273e4ed4235ed8522d0a874ff7adb655764cf91
+GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
 Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/b602aaa: Update beta to 6.4-beta3