### PR TITLE
[oraclelinux] Updating 7,7-slim,7-slim-fips,8, 8-slim and 8-slim-fips for ELSA-2023-5474,ELSA-2023-5455,ELBA-2023-5615,ELBA-2023-5623

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a6899fe3d6752118cfa1d57210e4de317f617891
+amd64-GitCommit: 27c114bdedfaf42464804fe198b8cf4dcafd0bd8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 21bab0b84259a0082fdcf71f744f5f106ea376a2
+arm64v8-GitCommit: 0fe93d2573f36d7adf52eab0a27d9897b0bb6684
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-3341, CVE-2023-4911, CVE-2023-4806, CVE-2023-4813, CVE-2023-4527, CVE-2020-22218 and ca-certificates.



See the following for details:

https://linux.oracle.com/errata/ELSA-2023-5474.html
https://linux.oracle.com/errata/ELSA-2023-5455.html
https://linux.oracle.com/errata/ELBA-2023-5615.html
https://linux.oracle.com/errata/ELBA-2023-5623.html

Signed-off-by: Alan Steinberg alan.steinberg@oracle.com