### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.2.20230920.1
+Tags: 2023, latest, 2023.2.20231011.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 414b5d5f6254ca8a674e04cc2f5e0e334ac77f14
+amd64-GitCommit: af8bdafe241daebe9bd3ef2b864084a60ff022af
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: da06108429da71749dfb1ed777d0bf4e066585e5
+arm64v8-GitCommit: 7f794b5a5fd2edfaf5f9acd623cf21cd5c7b16f3
 
-Tags: 2, 2.0.20230912.0
+Tags: 2, 2.0.20230926.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 758d8663f71fe6d9c26dc42a366eabdf024458ca
+amd64-GitCommit: 293ef6f41163e4d22700ffda8e8c032593e13215
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 66a3740f12f9671b39bfa26501317e1b4ae48fb5
+arm64v8-GitCommit: ef5e6e6ed98e10c02b4d9f47df6903bc26043a96
 
-Tags: 1, 2018.03, 2018.03.0.20230905.0
+Tags: 1, 2018.03, 2018.03.0.20231002.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: bb33672fcca36770bfe1536b7773b19ca43df8da
+amd64-GitCommit: a71cd32b94ea6e1f8a5fad33f9614695e34ae1a8


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.2.20231011-0.amzn2023
- curl-minimal-8.3.0-1.amzn2023.0.2
- gpg-pubkey-d832c631-6515c85e
- libcurl-minimal-8.3.0-1.amzn2023.0.2
- system-release-2023.2.20231011-0.amzn2023

Updated Packages for Amazon Linux 1:
- libxml2-2.9.1-6.6.43.amzn1
- libxml2-python27-2.9.1-6.6.43.amzn1
- openssl-1.0.2k-16.164.amzn1

Updated Packages for Amazon Linux 2:
- elfutils-libelf-0.176-2.amzn2.0.2
- system-release-2-15.amzn2
- libssh2-1.4.3-12.amzn2.2.6