### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.0-beta.6, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 656ee2332a740807b5024a8190967eb12aeb5b09
 Directory: 3.13-rc/ubuntu
 
 Tags: 3.13.0-beta.6-management, 3.13-rc-management
@@ -17,7 +17,7 @@ Directory: 3.13-rc/ubuntu/management
 
 Tags: 3.13.0-beta.6-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 656ee2332a740807b5024a8190967eb12aeb5b09
 Directory: 3.13-rc/alpine
 
 Tags: 3.13.0-beta.6-management-alpine, 3.13-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 3.13-rc/alpine/management
 
 Tags: 3.12.6, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: b2f298d2826fe5ca8e2e7e0984d8405708c7171e
 Directory: 3.12/ubuntu
 
 Tags: 3.12.6-management, 3.12-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.6-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: b2f298d2826fe5ca8e2e7e0984d8405708c7171e
 Directory: 3.12/alpine
 
 Tags: 3.12.6-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.12/alpine/management
 
 Tags: 3.11.23, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 2a04889d18742699c69b01b1154946eb16ec28c0
 Directory: 3.11/ubuntu
 
 Tags: 3.11.23-management, 3.11-management
@@ -57,7 +57,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.23-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 2a04889d18742699c69b01b1154946eb16ec28c0
 Directory: 3.11/alpine
 
 Tags: 3.11.23-management-alpine, 3.11-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.25, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 5551ce78936a1bcac482f5b4792686c456db6845
 Directory: 3.10/ubuntu
 
 Tags: 3.10.25-management, 3.10-management
@@ -77,7 +77,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.25-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 5551ce78936a1bcac482f5b4792686c456db6845
 Directory: 3.10/alpine
 
 Tags: 3.10.25-management-alpine, 3.10-management-alpine
@@ -87,7 +87,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 9cac94018c00eb881e382afd2337d85970c890c2
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -97,7 +97,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e5870068747ebef1d00134c52bd9a8e41cb2b4b
+GitCommit: 9cac94018c00eb881e382afd2337d85970c890c2
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/b2f298d: Update 3.12 to otp 25.3.2.7
- https://github.com/docker-library/rabbitmq/commit/2a04889: Update 3.11 to otp 25.3.2.7
- https://github.com/docker-library/rabbitmq/commit/5551ce7: Update 3.10 to otp 25.3.2.7
- https://github.com/docker-library/rabbitmq/commit/9cac940: Update 3.9 to otp 25.3.2.7
- https://github.com/docker-library/rabbitmq/commit/656ee23: Update 3.13-rc to otp 26.1.2