### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.3.1-apache, 6.3-apache, 6-apache, apache, 6.3.1, 6.3, 6, latest, 6.3.1-php8.0-apache, 6.3-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.3.1-php8.0, 6.3-php8.0, 6-php8.0, php8.0
+Tags: 6.3.2-apache, 6.3-apache, 6-apache, apache, 6.3.2, 6.3, 6, latest, 6.3.2-php8.0-apache, 6.3-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.3.2-php8.0, 6.3-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.0/apache
 
-Tags: 6.3.1-fpm, 6.3-fpm, 6-fpm, fpm, 6.3.1-php8.0-fpm, 6.3-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.3.2-fpm, 6.3-fpm, 6-fpm, fpm, 6.3.2-php8.0-fpm, 6.3-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.0/fpm
 
-Tags: 6.3.1-fpm-alpine, 6.3-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.3.1-php8.0-fpm-alpine, 6.3-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.3.2-fpm-alpine, 6.3-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.3.2-php8.0-fpm-alpine, 6.3-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.3.1-php8.1-apache, 6.3-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.3.1-php8.1, 6.3-php8.1, 6-php8.1, php8.1
+Tags: 6.3.2-php8.1-apache, 6.3-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.3.2-php8.1, 6.3-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.1/apache
 
-Tags: 6.3.1-php8.1-fpm, 6.3-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.3.2-php8.1-fpm, 6.3-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.1/fpm
 
-Tags: 6.3.1-php8.1-fpm-alpine, 6.3-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.3.2-php8.1-fpm-alpine, 6.3-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.3.1-php8.2-apache, 6.3-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.3.1-php8.2, 6.3-php8.2, 6-php8.2, php8.2
+Tags: 6.3.2-php8.2-apache, 6.3-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.3.2-php8.2, 6.3-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.2/apache
 
-Tags: 6.3.1-php8.2-fpm, 6.3-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.3.2-php8.2-fpm, 6.3-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.2/fpm
 
-Tags: 6.3.1-php8.2-fpm-alpine, 6.3-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.3.2-php8.2-fpm-alpine, 6.3-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 940a0d35951a0917622c35acc92b38b1db3c730f
+GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.8.1, cli-2.8, cli-2, cli, cli-2.8.1-php8.0, cli-2.8-php8.0, cli-2-php8.0, cli-php8.0
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
 Directory: cli/php8.2/alpine
 
-Tags: beta-6.4-beta3-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-beta3, beta-6.4, beta-6, beta, beta-6.4-beta3-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-beta3-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.4-beta4-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-beta4, beta-6.4, beta-6, beta, beta-6.4-beta4-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-beta4-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.0/apache
 
-Tags: beta-6.4-beta3-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-beta3-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.4-beta4-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-beta4-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.4-beta3-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-beta3-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.4-beta4-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-beta4-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.4-beta3-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-beta3-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.4-beta4-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-beta4-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.1/apache
 
-Tags: beta-6.4-beta3-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.4-beta4-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.4-beta3-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.4-beta4-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.4-beta3-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-beta3-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.4-beta4-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-beta4-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.2/apache
 
-Tags: beta-6.4-beta3-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.4-beta4-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.4-beta3-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.4-beta4-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b602aaa0dd911c3d2cdc794b7a839dda6ebc4ddc
+GitCommit: 4d8ac6a7f75692940380323c2e9e26eab5ccea8e
 Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/4d5bd0c: Update latest to 6.3.2
- https://github.com/docker-library/wordpress/commit/4d8ac6a: Update beta to 6.4-beta4