### PR TITLE
Update backdrop to latest version 1.26.1

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.25.1, 1.25, 1, 1.25.1-apache, 1.25-apache, 1-apache, apache, latest
+Tags: 1.26.1, 1.26, 1, 1.26.1-apache, 1.26-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 37aae82be48457f524a3cd475ea55d7c1ce0ef2c
+GitCommit: 95902d6610b2474ca88ff8faae40ed30e7d3318a
 Directory: 1/apache
 
-Tags: 1.25.1-fpm, 1.25-fpm, 1-fpm, fpm
+Tags: 1.26.1-fpm, 1.26-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 37aae82be48457f524a3cd475ea55d7c1ce0ef2c
+GitCommit: 95902d6610b2474ca88ff8faae40ed30e7d3318a
 Directory: 1/fpm


### PR DESCRIPTION
Update backdrop to 1.26.1
    
Here's the latest release of Backdrop:
https://github.com/backdrop/backdrop/releases/tag/1.26.1
    
Here's the latest commit to backdrop-docker repo
https://github.com/backdrop-ops/backdrop-docker/commits/master
