### PR TITLE
Upgrade Zookeeper to 3.7.2, 3.8.3 and 3.9.1

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -2,14 +2,14 @@ Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 Architectures: amd64, arm64v8, s390x, ppc64le
 
-Tags: 3.7.1-temurin, 3.7-temurin
-GitCommit: 5cf119d9c5d61024fdba66f7be707413513a8b0d
-Directory: 3.7.1
+Tags: 3.7.2-temurin, 3.7-temurin
+GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
+Directory: 3.7.2
 
-Tags: 3.8.2, 3.8, 3.8.2-temurin, 3.8-temurin
-GitCommit: 952b2f523f4f9a829d77114ddbe08ab9249d820b
-Directory: 3.8.2
+Tags: 3.8.3, 3.8, 3.8.3-temurin, 3.8-temurin
+GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
+Directory: 3.8.3
 
-Tags: 3.9.0, 3.9, latest
-GitCommit: 47955764fa33b1cfa547786f5ea0a2ded4e971b9
-Directory: 3.9.0
+Tags: 3.9.1, 3.9, latest
+GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
+Directory: 3.9.1

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -2,14 +2,26 @@ Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 Architectures: amd64, arm64v8, s390x, ppc64le
 
-Tags: 3.7.2-temurin, 3.7-temurin
+Tags: 3.7.2, 3.7, 3.7.2-jre-11, 3.7-jre-11
 GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
 Directory: 3.7.2
 
-Tags: 3.8.3, 3.8, 3.8.3-temurin, 3.8-temurin
+Tags: 3.8.3, 3.8, 3.8.3-jre-11, 3.8-jre-11
 GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
 Directory: 3.8.3
 
-Tags: 3.9.1, 3.9, latest
+Tags: 3.9.1, 3.9, 3.9.1-jre-11, 3.9-jre-11
 GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
+Directory: 3.9.1
+
+Tags: 3.7.2-jre-17, 3.7-jre-17
+GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
+Directory: 3.7.2
+
+Tags: 3.8.3-jre-17, 3.8-jre-17
+GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
+Directory: 3.8.3
+
+Tags: 3.9.1-jre-17, 3.9-jre-17, latest
+GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
 Directory: 3.9.1


### PR DESCRIPTION
* I removed the last `temurin` tag according to the plan described here: https://github.com/docker-library/official-images/pull/12949#issuecomment-1383656252
* I introduced `jre` tags to help users migrate to JRE 17. JRE 11 is EoL so `3.7.2`, `3.8.3` and `3.9.1` will be the last tags to support it.