### PR TITLE
archlinux: Release 20231015.0.185077

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20231001.0.182270
-GitCommit: a8c000a0752f90e436cc96e097bcc3750f961164
-GitFetch: refs/tags/v20231001.0.182270
+Tags: latest, base, base-20231015.0.185077
+GitCommit: 686bf22e2b94c89feb1a7e05ee03402404d7d3e7
+GitFetch: refs/tags/v20231015.0.185077
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20231001.0.182270
-GitCommit: a8c000a0752f90e436cc96e097bcc3750f961164
-GitFetch: refs/tags/v20231001.0.182270
+Tags: base-devel, base-devel-20231015.0.185077
+GitCommit: 686bf22e2b94c89feb1a7e05ee03402404d7d3e7
+GitFetch: refs/tags/v20231015.0.185077
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks