### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.21, 1.6, 1, latest, 1.6.21-bookworm, 1.6-bookworm, 1-bookworm, bookworm
+Tags: 1.6.22, 1.6, 1, latest, 1.6.22-bookworm, 1.6-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d3a51632e123ddcbf1b1e06e6cefdaa65f27b29a
+GitCommit: b8a7264e4fc952fd71f2fe325908d6ba06e8e061
 Directory: debian
 
-Tags: 1.6.21-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.21-alpine3.18, 1.6-alpine3.18, 1-alpine3.18, alpine3.18
+Tags: 1.6.22-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.22-alpine3.18, 1.6-alpine3.18, 1-alpine3.18, alpine3.18
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d3a51632e123ddcbf1b1e06e6cefdaa65f27b29a
+GitCommit: b8a7264e4fc952fd71f2fe325908d6ba06e8e061
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/b8a7264: Update to 1.6.22