### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,122 +4,122 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.0.0-rc1-php8.1-apache, 5.0-php8.1-apache, 5.0.rc-php8.1-apache, 5.0.0-rc-php8.1-apache
+Tags: 5.0.0-php8.1-apache, 5.0-php8.1-apache, 5-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 5.0.rc/php8.1/apache
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 5.0/php8.1/apache
 
-Tags: 5.0.0-rc1-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5.0.rc-php8.1-fpm-alpine, 5.0.0-rc-php8.1-fpm-alpine
+Tags: 5.0.0-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 5.0.rc/php8.1/fpm-alpine
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 5.0/php8.1/fpm-alpine
 
-Tags: 5.0.0-rc1-php8.1-fpm, 5.0-php8.1-fpm, 5.0.rc-php8.1-fpm, 5.0.0-rc-php8.1-fpm
+Tags: 5.0.0-php8.1-fpm, 5.0-php8.1-fpm, 5-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 5.0.rc/php8.1/fpm
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 5.0/php8.1/fpm
 
-Tags: 5.0.0-rc1, 5.0, 5.0.rc, 5.0.0-rc, 5.0.0-rc1-apache, 5.0-apache, 5.0.rc-apache, 5.0.0-rc-apache, 5.0.0-rc1-php8.2, 5.0-php8.2, 5.0.rc-php8.2, 5.0.0-rc-php8.2, 5.0.0-rc1-php8.2-apache, 5.0-php8.2-apache, 5.0.rc-php8.2-apache, 5.0.0-rc-php8.2-apache
+Tags: 5.0.0, 5.0, 5, 5.0.0-apache, 5.0-apache, 5-apache, 5.0.0-php8.2, 5.0-php8.2, 5-php8.2, 5.0.0-php8.2-apache, 5.0-php8.2-apache, 5-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 5.0.rc/php8.2/apache
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 5.0/php8.2/apache
 
-Tags: 5.0.0-rc1-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5.0.rc-php8.2-fpm-alpine, 5.0.0-rc-php8.2-fpm-alpine
+Tags: 5.0.0-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 5.0.rc/php8.2/fpm-alpine
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 5.0/php8.2/fpm-alpine
 
-Tags: 5.0.0-rc1-php8.2-fpm, 5.0-php8.2-fpm, 5.0.rc-php8.2-fpm, 5.0.0-rc-php8.2-fpm
+Tags: 5.0.0-php8.2-fpm, 5.0-php8.2-fpm, 5-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 5.0.rc/php8.2/fpm
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 5.0/php8.2/fpm
 
-Tags: 4.4.0-rc1-php8.0-apache, 4.4-php8.0-apache, 4.4.rc-php8.0-apache, 4.4.0-rc-php8.0-apache
+Tags: 4.4.0-php8.0-apache, 4.4-php8.0-apache, 4-php8.0-apache, php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.0/apache
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.0/apache
 
-Tags: 4.4.0-rc1-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4.4.rc-php8.0-fpm-alpine, 4.4.0-rc-php8.0-fpm-alpine
+Tags: 4.4.0-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.0/fpm-alpine
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.0/fpm-alpine
 
-Tags: 4.4.0-rc1-php8.0-fpm, 4.4-php8.0-fpm, 4.4.rc-php8.0-fpm, 4.4.0-rc-php8.0-fpm
+Tags: 4.4.0-php8.0-fpm, 4.4-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.0/fpm
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.0/fpm
 
-Tags: 4.4.0-rc1, 4.4, 4.4.rc, 4.4.0-rc, 4.4.0-rc1-apache, 4.4-apache, 4.4.rc-apache, 4.4.0-rc-apache, 4.4.0-rc1-php8.1, 4.4-php8.1, 4.4.rc-php8.1, 4.4.0-rc-php8.1, 4.4.0-rc1-php8.1-apache, 4.4-php8.1-apache, 4.4.rc-php8.1-apache, 4.4.0-rc-php8.1-apache
+Tags: 4.4.0, 4.4, 4, latest, 4.4.0-apache, 4.4-apache, 4-apache, apache, 4.4.0-php8.1, 4.4-php8.1, 4-php8.1, php8.1, 4.4.0-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.1/apache
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.1/apache
 
-Tags: 4.4.0-rc1-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4.4.rc-php8.1-fpm-alpine, 4.4.0-rc-php8.1-fpm-alpine
+Tags: 4.4.0-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.1/fpm-alpine
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.1/fpm-alpine
 
-Tags: 4.4.0-rc1-php8.1-fpm, 4.4-php8.1-fpm, 4.4.rc-php8.1-fpm, 4.4.0-rc-php8.1-fpm
+Tags: 4.4.0-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.1/fpm
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.1/fpm
 
-Tags: 4.4.0-rc1-php8.2-apache, 4.4-php8.2-apache, 4.4.rc-php8.2-apache, 4.4.0-rc-php8.2-apache
+Tags: 4.4.0-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.2/apache
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.2/apache
 
-Tags: 4.4.0-rc1-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4.4.rc-php8.2-fpm-alpine, 4.4.0-rc-php8.2-fpm-alpine
+Tags: 4.4.0-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.2/fpm-alpine
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.2/fpm-alpine
 
-Tags: 4.4.0-rc1-php8.2-fpm, 4.4-php8.2-fpm, 4.4.rc-php8.2-fpm, 4.4.0-rc-php8.2-fpm
+Tags: 4.4.0-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5b2b8442758fb72964f534614f69e84ba9aef5
-Directory: 4.4.rc/php8.2/fpm
+GitCommit: 8cac4ff7ae88b9274870a95f5e22ea3c32f01fd7
+Directory: 4.4/php8.2/fpm
 
-Tags: 4.3.4, 4.3, 4, latest, 4.3.4-apache, 4.3-apache, 4-apache, apache, 4.3.4-php8.0, 4.3-php8.0, 4-php8.0, php8.0, 4.3.4-php8.0-apache, 4.3-php8.0-apache, 4-php8.0-apache, php8.0-apache
+Tags: 4.3.4-php8.0-apache, 4.3-php8.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.0/apache
 
-Tags: 4.3.4-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 4.3.4-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.0/fpm-alpine
 
-Tags: 4.3.4-php8.0-fpm, 4.3-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
+Tags: 4.3.4-php8.0-fpm, 4.3-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.0/fpm
 
-Tags: 4.3.4-php8.1-apache, 4.3-php8.1-apache, 4-php8.1-apache, php8.1-apache
+Tags: 4.3.4, 4.3, 4.3.4-apache, 4.3-apache, 4.3.4-php8.1, 4.3-php8.1, 4.3.4-php8.1-apache, 4.3-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.1/apache
 
-Tags: 4.3.4-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 4.3.4-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.1/fpm-alpine
 
-Tags: 4.3.4-php8.1-fpm, 4.3-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
+Tags: 4.3.4-php8.1-fpm, 4.3-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.1/fpm
 
-Tags: 4.3.4-php8.2-apache, 4.3-php8.2-apache, 4-php8.2-apache, php8.2-apache
+Tags: 4.3.4-php8.2-apache, 4.3-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.2/apache
 
-Tags: 4.3.4-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 4.3.4-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.2/fpm-alpine
 
-Tags: 4.3.4-php8.2-fpm, 4.3-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
+Tags: 4.3.4-php8.2-fpm, 4.3-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98ed77593ebf9a2d6687fe68460832e82d412991
 Directory: 4.3/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@05096f8 Fixed aliases
- joomla-docker/docker-joomla@8cac4ff Adds Joomla 5.0.0 and 4.4.0 Removes Joomla 5.0.beta and 4.4.beta.