### PR TITLE
[Security] Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.57, 2.4, 2, latest, 2.4.57-bookworm, 2.4-bookworm, 2-bookworm, bookworm
+Tags: 2.4.58, 2.4, 2, latest, 2.4.58-bookworm, 2.4-bookworm, 2-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 242f3c62ba1ceee0a3633045fc4fd9277cb86cd3
+GitCommit: 338f9a4b1e36e09ad2733f36f19e31157f5c959c
 Directory: 2.4
 
-Tags: 2.4.57-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.57-alpine3.18, 2.4-alpine3.18, 2-alpine3.18, alpine3.18
+Tags: 2.4.58-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.58-alpine3.18, 2.4-alpine3.18, 2-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c87146e71508462f0ebd5de9890a0f8bb3b98c8f
+GitCommit: 338f9a4b1e36e09ad2733f36f19e31157f5c959c
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/338f9a4: Update to 2.4.58

https://downloads.apache.org/httpd/CHANGES_2.4.58