### PR TITLE
[oraclelinux] Updating 8/8-slim/8-fips/9/9-slim for ELSA-2023-5837, ELSA-2023-5838, ELSA-2023-5763,ELSA-2023-5462

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 27c114bdedfaf42464804fe198b8cf4dcafd0bd8
+amd64-GitCommit: 6c5531adf48feee7f9ac11d963ca0ecc695743f4
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0fe93d2573f36d7adf52eab0a27d9897b0bb6684
+arm64v8-GitCommit: 7f7f2e3312abe74857e4f5d830effc39aef5462f
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-40217,CVE-2023-44487,CVE-2023-38545,CVE-2023-38546

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-5462.html
https://linux.oracle.com/errata/ELSA-2023-5838.html
https://linux.oracle.com/errata/ELSA-2023-5837.html
https://linux.oracle.com/errata/ELSA-2023-5763.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>