### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/julia/blob/e7b78511fdae10bb6bb32737be3e8503c8a1b87a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/julia/blob/2686258cc9fc54364a0db841321e969c161f4aef/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -31,6 +31,7 @@ Architectures: windows-amd64
 GitCommit: b079ad40685c641e9ff6b880e6dc3ba311a2baf7
 Directory: 1.10-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
+Builder: classic
 
 Tags: 1.10.0-beta3-windowsservercore-1809, 1.10-rc-windowsservercore-1809, rc-windowsservercore-1809
 SharedTags: 1.10.0-beta3, 1.10-rc, rc, 1.10.0-beta3-windowsservercore, 1.10-rc-windowsservercore, rc-windowsservercore
@@ -38,6 +39,7 @@ Architectures: windows-amd64
 GitCommit: b079ad40685c641e9ff6b880e6dc3ba311a2baf7
 Directory: 1.10-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
+Builder: classic
 
 Tags: 1.9.3-bookworm, 1.9-bookworm, 1-bookworm, bookworm
 SharedTags: 1.9.3, 1.9, 1, latest
@@ -66,6 +68,7 @@ Architectures: windows-amd64
 GitCommit: d50ed8b3f1ef3c76d9be2647c7151ab0a539d2a8
 Directory: 1.9/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
+Builder: classic
 
 Tags: 1.9.3-windowsservercore-1809, 1.9-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
 SharedTags: 1.9.3, 1.9, 1, latest, 1.9.3-windowsservercore, 1.9-windowsservercore, 1-windowsservercore, windowsservercore
@@ -73,6 +76,7 @@ Architectures: windows-amd64
 GitCommit: d50ed8b3f1ef3c76d9be2647c7151ab0a539d2a8
 Directory: 1.9/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
+Builder: classic
 
 Tags: 1.6.7-bookworm, 1.6-bookworm
 SharedTags: 1.6.7, 1.6
@@ -101,6 +105,7 @@ Architectures: windows-amd64
 GitCommit: e0d0364c90b544d2d6de097e324ff7cc538613e8
 Directory: 1.6/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
+Builder: classic
 
 Tags: 1.6.7-windowsservercore-1809, 1.6-windowsservercore-1809
 SharedTags: 1.6.7, 1.6, 1.6.7-windowsservercore, 1.6-windowsservercore
@@ -108,3 +113,4 @@ Architectures: windows-amd64
 GitCommit: e0d0364c90b544d2d6de097e324ff7cc538613e8
 Directory: 1.6/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
+Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/24a467d: Merge pull request https://github.com/docker-library/julia/pull/85 from LaurentGoderre/no-buildkit-for-win
- https://github.com/docker-library/julia/commit/2686258: Prevent using BuildKit variant for Windows variants