### PR TITLE
mediawiki: Update maintainers

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -1,6 +1,6 @@
-Maintainers: David Barratt <dbarratt@wikimedia.org> (@davidbarratt),
-             Kunal Mehta <legoktm@debian.org> (@legoktm),
-             addshore <addshorewiki@gmail.com> (@addshore)
+Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
+             addshore <addshorewiki@gmail.com> (@addshore),
+             Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
 GitCommit: fdf347f62615dad789d0e703fc2f6d628c43d4e1


### PR DESCRIPTION
David had asked to be replaced earlier in the year and recently, Christian stepped up, performing the most recent update and volunteering to be a maintainer.

Thanks to David for originally kicking off this project!

See <https://phabricator.wikimedia.org/T330367> for related discussion.