### PR TITLE
Odoo: update 14.0-16.0 to release 20231024

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,9 +1,9 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: d04d885eea6b8f60ada727fcc498f5a8fd44da51
+GitCommit: 3864188c94c33dace7d4b5f6767e00a4328fe08c
 
 Tags: 16.0, 16, latest
-Architectures: amd64
+Architectures: amd64, arm64v8, ppc64le
 Directory: 16.0
 
 Tags: 15.0, 15


### PR DESCRIPTION
Hello,

Here are the latest updates of Odoo supported versions.
Also, this adds support of ppc64le and arm64 for  Odoo 16.0.

Thanks