### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.1.0, 8.1, 8, innovation, latest, 8.1.0-oracle, 8.1-oracle, 8-oracle, innovation-oracle, oracle
+Tags: 8.2.0, 8.2, 8, innovation, latest, 8.2.0-oracle, 8.2-oracle, 8-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: eb1850601849ef7ef77a23f017a20debc95d597c
+GitCommit: 76806cdd0acee2dec39b1b66e9c8015ef75be196
 Directory: innovation
 File: Dockerfile.oracle
 
-Tags: 8.0.34, 8.0, 8.0.34-oracle, 8.0-oracle
+Tags: 8.0.35, 8.0, 8.0.35-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: f4030aebf6a63d640f7085fb3e4601b4e70313c8
+GitCommit: 84ba05eaa75e1f0e1d33185e23f95a9cdc607b51
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.34-debian, 8.0-debian
+Tags: 8.0.35-debian, 8.0-debian
 Architectures: amd64
-GitCommit: f4030aebf6a63d640f7085fb3e4601b4e70313c8
+GitCommit: 84ba05eaa75e1f0e1d33185e23f95a9cdc607b51
 Directory: 8.0
 File: Dockerfile.debian
 
-Tags: 5.7.43, 5.7, 5, 5.7.43-oracle, 5.7-oracle, 5-oracle
+Tags: 5.7.44, 5.7, 5, 5.7.44-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: c13cda9c2c9d836af9b3331e8681f8cc8e0a7803
+GitCommit: 9678ed1d27794ae9529c43b4411e30f981ce39ea
 Directory: 5.7
 File: Dockerfile.oracle


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/76806cd: Update innovation to 8.2.0, mysql-shell 8.0.35-1.el8, oracle 8.2.0-1.el8
- https://github.com/docker-library/mysql/commit/84ba05e: Update 8.0 to 8.0.35, debian 8.0.35-1debian11, mysql-shell 8.0.35-1.el8, oracle 8.0.35-1.el8
- https://github.com/docker-library/mysql/commit/9678ed1: Update 5.7 to 5.7.44, mysql-shell 8.0.35-1.el7, oracle 5.7.44-1.el7