### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.70.1, 5.70, 5, latest
+Tags: 5.70.2, 5.70, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 23c550666021939b447e26d8b00f021e2fb3f00d
+GitCommit: 18272e470c7c88bf03aee901c404c724fe072852
 Directory: 5/debian
 
-Tags: 5.70.1-alpine, 5.70-alpine, 5-alpine, alpine
+Tags: 5.70.2-alpine, 5.70-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 23c550666021939b447e26d8b00f021e2fb3f00d
+GitCommit: 18272e470c7c88bf03aee901c404c724fe072852
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/18272e4: Update to 5.70.2, ghost-cli 1.25.3