### PR TITLE
Add Amazon Linux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,19 +13,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.2.20231011.0
+Tags: 2023, latest, 2023.2.20231018.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: af8bdafe241daebe9bd3ef2b864084a60ff022af
+amd64-GitCommit: ba9fd7ed5735a8ed7c01406726debd4386eb81c9
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 7f794b5a5fd2edfaf5f9acd623cf21cd5c7b16f3
+arm64v8-GitCommit: dbb1e74204f4cf1b1735bbd9c67e81d1930a6900
 
-Tags: 2, 2.0.20230926.0
+Tags: 2, 2.0.20231020.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 293ef6f41163e4d22700ffda8e8c032593e13215
+amd64-GitCommit: da6f3f58f5d173ca4b7fc8c2665c2e63b4e4880f
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: ef5e6e6ed98e10c02b4d9f47df6903bc26043a96
+arm64v8-GitCommit: aef37a741bae05a33f527db19ebc14577697c36c
 
 Tags: 1, 2018.03, 2018.03.0.20231002.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
    - amazon-linux-repo-cdn-2023.2.20231018-0.amzn2023
    - openssl-libs-3.0.8-1.amzn2023.0.8
    - system-release-2023.2.20231018-0.amzn2023
    - libnghttp2-1.57.0-1.amzn2023.0.1 ([CVE-2023-44487](https://alas.aws.amazon.com/cve/html/CVE-2023-44487.html))

Updated Packages for Amazon Linux 2:
    - libnghttp2-1.41.0-1.amzn2.0.4 ([CVE-2023-44487](https://alas.aws.amazon.com/cve/html/CVE-2023-44487.html))
    - vim-minimal-9.0.1882-1.amzn2.0.2 ([CVE-2023-5344](https://alas.aws.amazon.com/cve/html/CVE-2023-5344.html))
    - vim-data-9.0.1882-1.amzn2.0.2
    - yum-3.4.3-158.amzn2.0.7
    - libsepol-2.5-10.amzn2.0.1 ([CVE-2021-36084](https://alas.aws.amazon.com/cve/html/CVE-2021-36084.html), [CVE-2021-36085](https://alas.aws.amazon.com/cve/html/CVE-2021-36085.html), [CVE-2021-36086](https://alas.aws.amazon.com/cve/html/CVE-2021-36086.html), [CVE-2021-36087](https://alas.aws.amazon.com/cve/html/CVE-2021-36087.html))