### PR TITLE
[Security] Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.0-rc.1, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 991fa32b267f44c9069ec5414fee6f24e1729177
+GitCommit: e4305ffb6bb437ce9e67e5590d467efd6890d216
 Directory: 3.13-rc/ubuntu
 
 Tags: 3.13.0-rc.1-management, 3.13-rc-management
@@ -17,7 +17,7 @@ Directory: 3.13-rc/ubuntu/management
 
 Tags: 3.13.0-rc.1-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 991fa32b267f44c9069ec5414fee6f24e1729177
+GitCommit: e4305ffb6bb437ce9e67e5590d467efd6890d216
 Directory: 3.13-rc/alpine
 
 Tags: 3.13.0-rc.1-management-alpine, 3.13-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 3.13-rc/alpine/management
 
 Tags: 3.12.7, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f634e692a19d4e3efd10785c3800f7d21b8a8b00
+GitCommit: 7352e3888be20533a303cb0d2972a226d4615900
 Directory: 3.12/ubuntu
 
 Tags: 3.12.7-management, 3.12-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.7-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f634e692a19d4e3efd10785c3800f7d21b8a8b00
+GitCommit: 7352e3888be20533a303cb0d2972a226d4615900
 Directory: 3.12/alpine
 
 Tags: 3.12.7-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.12/alpine/management
 
 Tags: 3.11.24, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1f2cd450abe5f2b15e0e5844d94390c4bd7cceea
+GitCommit: 527cc3568a67533fc10a294b9814053f6412e083
 Directory: 3.11/ubuntu
 
 Tags: 3.11.24-management, 3.11-management
@@ -57,7 +57,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.24-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1f2cd450abe5f2b15e0e5844d94390c4bd7cceea
+GitCommit: 527cc3568a67533fc10a294b9814053f6412e083
 Directory: 3.11/alpine
 
 Tags: 3.11.24-management-alpine, 3.11-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.25, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5551ce78936a1bcac482f5b4792686c456db6845
+GitCommit: 0e547c0d4ef0a09238c1b0f514835f3733f69148
 Directory: 3.10/ubuntu
 
 Tags: 3.10.25-management, 3.10-management
@@ -77,7 +77,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.25-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5551ce78936a1bcac482f5b4792686c456db6845
+GitCommit: 0e547c0d4ef0a09238c1b0f514835f3733f69148
 Directory: 3.10/alpine
 
 Tags: 3.10.25-management-alpine, 3.10-management-alpine
@@ -87,7 +87,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9cac94018c00eb881e382afd2337d85970c890c2
+GitCommit: 4ef39c16217ca65831d0a997f60e54c916244a3c
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -97,7 +97,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9cac94018c00eb881e382afd2337d85970c890c2
+GitCommit: 4ef39c16217ca65831d0a997f60e54c916244a3c
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7352e38: Update 3.12 to openssl 3.1.4
- https://github.com/docker-library/rabbitmq/commit/527cc35: Update 3.11 to openssl 3.1.4
- https://github.com/docker-library/rabbitmq/commit/4ef39c1: Update 3.9 to openssl 3.1.4
- https://github.com/docker-library/rabbitmq/commit/e4305ff: Update 3.13-rc to openssl 3.1.4
- https://github.com/docker-library/rabbitmq/commit/0e547c0: Update 3.10 to openssl 3.1.4

Fixes `CVE-2023-5363` for `rabbitmq` images (https://www.openssl.org/news/secadv/20231024.txt).