### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -49,62 +49,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
 Directory: latest/php8.2/fpm-alpine
 
-Tags: cli-2.8.1, cli-2.8, cli-2, cli, cli-2.8.1-php8.0, cli-2.8-php8.0, cli-2-php8.0, cli-php8.0
+Tags: cli-2.9.0, cli-2.9, cli-2, cli, cli-2.9.0-php8.0, cli-2.9-php8.0, cli-2-php8.0, cli-php8.0
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
+GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.0/alpine
 
-Tags: cli-2.8.1-php8.1, cli-2.8-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.9.0-php8.1, cli-2.9-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
+GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.8.1-php8.2, cli-2.8-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.9.0-php8.2, cli-2.9-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6e0d5acfc84bef260c85110da4b94d763ad5086c
+GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.2/alpine
 
-Tags: beta-6.4-RC1-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-RC1, beta-6.4, beta-6, beta, beta-6.4-RC1-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-RC1-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.4-RC2-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-RC2, beta-6.4, beta-6, beta, beta-6.4-RC2-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-RC2-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.0/apache
 
-Tags: beta-6.4-RC1-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-RC1-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.4-RC2-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-RC2-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.4-RC1-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-RC1-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.4-RC2-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-RC2-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.4-RC1-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-RC1-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.4-RC2-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-RC2-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.1/apache
 
-Tags: beta-6.4-RC1-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.4-RC2-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.4-RC1-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.4-RC2-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.4-RC1-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-RC1-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.4-RC2-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-RC2-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.2/apache
 
-Tags: beta-6.4-RC1-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.4-RC2-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.4-RC1-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.4-RC2-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4fdbb1b7f399af62672598a2ab34ec6d508a5c75
+GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
 Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/480b5c3: Update cli to 2.9.0
- https://github.com/docker-library/wordpress/commit/3ed0c9a: Update beta to 6.4-RC2