### PR TITLE
Update bashbrew action to 0.1.9

### DIFF
--- a/.github/workflows/.bashbrew/action.yml
+++ b/.github/workflows/.bashbrew/action.yml
@@ -10,8 +10,8 @@ runs:
 
     # these two version numbers are intentionally as close together as I could possibly get them because no matter what I tried, GitHub will not allow me to DRY them (can't have any useful variables in `uses:` and can't even have YAML references to steal it in `env:` or something)
     - shell: 'bash -Eeuo pipefail -x {0}'
-      run:    echo BASHBREW_VERSION=v0.1.8 >> "$GITHUB_ENV"
-    - uses: docker-library/bashbrew@v0.1.8
+      run:    echo BASHBREW_VERSION=v0.1.9 >> "$GITHUB_ENV"
+    - uses: docker-library/bashbrew@v0.1.9
       if: inputs.build == 'host'
 
     - run: docker build --pull --tag oisupport/bashbrew:base "https://github.com/docker-library/bashbrew.git#$BASHBREW_VERSION"


### PR DESCRIPTION
This release disables cgo during the `bashbrew.sh` build script which will fix the `windows-2022` build failures on GitHub actions:

<details>
<summary>sample error:</summary>

```console
C:\hostedtoolcache\windows\go\1.18.10\x64\pkg\tool\windows_amd64\link.exe: running gcc failed: exit status 1
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-2177102903\000008.o: in function `_cgo_preinit_init':
\\_\_\runtime\cgo/gcc_libinit_windows.c:30: undefined reference to `__imp___iob_func'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-2177102903\000008.o: in function `x_cgo_sys_thread_create':
\\_\_\runtime\cgo/gcc_libinit_windows.c:60: undefined reference to `__imp___iob_func'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-2177102903\000008.o: in function `x_cgo_notify_runtime_init_done':
\\_\_\runtime\cgo/gcc_libinit_windows.c:101: undefined reference to `__imp___iob_func'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-2177102903\000009.o: in function `x_cgo_thread_start':
\\_\_\runtime\cgo/gcc_util.c:18: undefined reference to `__imp___iob_func'
C:/mingw64/bin/../lib/gcc/x86_64-w64-mingw32/12.2.0/../../../../x86_64-w64-mingw32/bin/ld.exe: C:\Users\RUNNER~1\AppData\Local\Temp\go-link-2177102903\000010.o: in function `_cgo_sys_thread_start':
\\_\_\runtime\cgo/gcc_windows_amd64.c:31: undefined reference to `__imp___iob_func'
collect2.exe: error: ld returned 1 exit status
```

</details>