### PR TITLE
Update Apache Flink to 1.18.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -1,13 +1,29 @@
 # this file is generated via https://github.com/apache/flink-docker/blob/187238c6b444457d9b57279715fa16b37fe59e45/generate-stackbrew-library.sh
+
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.17.1-scala_2.12-java8, 1.17-scala_2.12-java8, scala_2.12-java8, 1.17.1-java8, 1.17-java8, java8
+Tags: 1.18.0-scala_2.12-java8, 1.18-scala_2.12-java8, scala_2.12-java8, 1.18.0-java8, 1.18-java8, java8
+Architectures: amd64,arm64v8
+GitCommit: 3154e4800c2aa8f183ac4b03dcdc90b14a6404a1
+Directory: ./1.18/scala_2.12-java8-ubuntu
+
+Tags: 1.18.0-scala_2.12-java17, 1.18-scala_2.12-java17, scala_2.12-java17, 1.18.0-java17, 1.18-java17, java17
+Architectures: amd64,arm64v8
+GitCommit: 3154e4800c2aa8f183ac4b03dcdc90b14a6404a1
+Directory: ./1.18/scala_2.12-java17-ubuntu
+
+Tags: 1.18.0-scala_2.12-java11, 1.18-scala_2.12-java11, scala_2.12-java11, 1.18.0-scala_2.12, 1.18-scala_2.12, scala_2.12, 1.18.0-java11, 1.18-java11, java11, 1.18.0, 1.18, latest
+Architectures: amd64,arm64v8
+GitCommit: 3154e4800c2aa8f183ac4b03dcdc90b14a6404a1
+Directory: ./1.18/scala_2.12-java11-ubuntu
+
+Tags: 1.17.1-scala_2.12-java8, 1.17-scala_2.12-java8, 1.17.1-java8, 1.17-java8
 Architectures: amd64,arm64v8
 GitCommit: abc36dd88483a221c0f5495c742bd95c349e9ac2
 Directory: ./1.17/scala_2.12-java8-ubuntu
 
-Tags: 1.17.1-scala_2.12-java11, 1.17-scala_2.12-java11, scala_2.12-java11, 1.17.1-scala_2.12, 1.17-scala_2.12, scala_2.12, 1.17.1-java11, 1.17-java11, java11, 1.17.1, 1.17, latest
+Tags: 1.17.1-scala_2.12-java11, 1.17-scala_2.12-java11, 1.17.1-scala_2.12, 1.17-scala_2.12, 1.17.1-java11, 1.17-java11, 1.17.1, 1.17
 Architectures: amd64,arm64v8
 GitCommit: abc36dd88483a221c0f5495c742bd95c349e9ac2
 Directory: ./1.17/scala_2.12-java11-ubuntu


### PR DESCRIPTION
This adds the new Flink 1.18.0 release: https://flink.apache.org/2023/10/24/announcing-the-release-of-apache-flink-1.18/

and updates the tags on the 1.17 images accordingly.