### PR TITLE
eclipse-temurin: bump JDK11, JDK17 and JDK21

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -134,260 +134,223 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.20.1_1-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.21_9-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/alpine
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jdk-focal, 11-jdk-focal, 11-focal
+Tags: 11.0.21_9-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/ubuntu/focal
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jdk-jammy, 11-jdk-jammy, 11-jammy
-SharedTags: 11.0.20.1_1-jdk, 11-jdk, 11
+Tags: 11.0.21_9-jdk-jammy, 11-jdk-jammy, 11-jammy
+SharedTags: 11.0.21_9-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/ubuntu/jammy
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jdk-centos7, 11-jdk-centos7, 11-centos7
+Tags: 11.0.21_9-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/centos
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Tags: 11.0.21_9-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/ubi/ubi9-minimal
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.20.1_1-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20.1_1-jdk, 11-jdk, 11
+Tags: 11.0.21_9-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.21_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.21_9-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
-File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.20.1_1-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.20.1_1-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.21_9-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.21_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/windows/nanoserver-ltsc2022
-File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.20.1_1-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.20.1_1-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.20.1_1-jdk, 11-jdk, 11
+Tags: 11.0.21_9-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.21_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.21_9-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/windows/windowsservercore-1809
-File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.20.1_1-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.20.1_1-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.21_9-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.21_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jdk/windows/nanoserver-1809
-File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.20.1_1-jre-alpine, 11-jre-alpine
+Tags: 11.0.21_9-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/alpine
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jre-focal, 11-jre-focal
+Tags: 11.0.21_9-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/ubuntu/focal
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jre-jammy, 11-jre-jammy
-SharedTags: 11.0.20.1_1-jre, 11-jre
+Tags: 11.0.21_9-jre-jammy, 11-jre-jammy
+SharedTags: 11.0.21_9-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/ubuntu/jammy
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jre-centos7, 11-jre-centos7
+Tags: 11.0.21_9-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/centos
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Tags: 11.0.21_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/ubi/ubi9-minimal
-File: Dockerfile.releases.full
 
-Tags: 11.0.20.1_1-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.20.1_1-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20.1_1-jre, 11-jre
+Tags: 11.0.21_9-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.21_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.21_9-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/windows/windowsservercore-ltsc2022
-File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.20.1_1-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.20.1_1-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.21_9-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.21_9-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/windows/nanoserver-ltsc2022
-File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.20.1_1-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.20.1_1-jre-windowsservercore, 11-jre-windowsservercore, 11.0.20.1_1-jre, 11-jre
+Tags: 11.0.21_9-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.21_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.21_9-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/windows/windowsservercore-1809
-File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 11.0.20.1_1-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.20.1_1-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.21_9-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.21_9-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 11/jre/windows/nanoserver-1809
-File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.8.1_1-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.9_9-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/alpine
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jdk-focal, 17-jdk-focal, 17-focal
+Tags: 17.0.9_9-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/ubuntu/focal
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.8.1_1-jdk, 17-jdk, 17
+Tags: 17.0.9_9-jdk-jammy, 17-jdk-jammy, 17-jammy
+SharedTags: 17.0.9_9-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/ubuntu/jammy
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jdk-centos7, 17-jdk-centos7, 17-centos7
+Tags: 17.0.9_9-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/centos
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.9_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/ubi/ubi9-minimal
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.8.1_1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.8.1_1-jdk, 17-jdk, 17
+Tags: 17.0.9_9.1-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.9_9.1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9.1-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
-File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.8.1_1-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.8.1_1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.9_9.1-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.9_9.1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/windows/nanoserver-ltsc2022
-File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.8.1_1-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.8.1_1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.8.1_1-jdk, 17-jdk, 17
+Tags: 17.0.9_9.1-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.9_9.1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9.1-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/windows/windowsservercore-1809
-File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.8.1_1-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.8.1_1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.9_9.1-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.9_9.1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jdk/windows/nanoserver-1809
-File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17.0.8.1_1-jre-alpine, 17-jre-alpine
+Tags: 17.0.9_9-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/alpine
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jre-focal, 17-jre-focal
+Tags: 17.0.9_9-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/ubuntu/focal
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.8.1_1-jre, 17-jre
+Tags: 17.0.9_9-jre-jammy, 17-jre-jammy
+SharedTags: 17.0.9_9-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/ubuntu/jammy
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jre-centos7, 17-jre-centos7
+Tags: 17.0.9_9-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/centos
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.9_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/ubi/ubi9-minimal
-File: Dockerfile.releases.full
 
-Tags: 17.0.8.1_1-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.8.1_1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.8.1_1-jre, 17-jre
+Tags: 17.0.9_9.1-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.9_9.1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9.1-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/windows/windowsservercore-ltsc2022
-File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.8.1_1-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.8.1_1-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.9_9.1-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.9_9.1-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/windows/nanoserver-ltsc2022
-File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.8.1_1-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.8.1_1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.8.1_1-jre, 17-jre
+Tags: 17.0.9_9.1-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.9_9.1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9.1-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/windows/windowsservercore-1809
-File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 17.0.8.1_1-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.8.1_1-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.9_9.1-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.9_9.1-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 25f458a0991f58bb7ed0ec9817e026a40d559c38
+GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
 Directory: 17/jre/windows/nanoserver-1809
-File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
-
 
 #------------------------------v21 images---------------------------------
 Tags: 21_35-jdk-alpine, 21-jdk-alpine, 21-alpine

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -136,109 +136,109 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.21_9-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/alpine
 
 Tags: 11.0.21_9-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.21_9-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.21_9-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.21_9-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/centos
 
 Tags: 11.0.21_9-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.21_9-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
 SharedTags: 11.0.21_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.21_9-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.21_9-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
 SharedTags: 11.0.21_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.21_9-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.21_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.21_9-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.21_9-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.21_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.21_9-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/alpine
 
 Tags: 11.0.21_9-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.21_9-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.21_9-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.21_9-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/centos
 
 Tags: 11.0.21_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.21_9-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
 SharedTags: 11.0.21_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.21_9-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.21_9-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
 SharedTags: 11.0.21_9-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.21_9-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.21_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.21_9-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.21_9-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.21_9-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -246,212 +246,199 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.9_9-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/alpine
 
 Tags: 17.0.9_9-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/ubuntu/focal
 
 Tags: 17.0.9_9-jdk-jammy, 17-jdk-jammy, 17-jammy
 SharedTags: 17.0.9_9-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/ubuntu/jammy
 
 Tags: 17.0.9_9-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/centos
 
 Tags: 17.0.9_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.9_9.1-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.9_9.1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9.1-jdk, 17-jdk, 17
+Tags: 17.0.9_9-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.9_9.1-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.9_9.1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.9_9-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.9_9.1-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.9_9.1-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9.1-jdk, 17-jdk, 17
+Tags: 17.0.9_9-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.9_9.1-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.9_9.1-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.9_9-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.9_9-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/alpine
 
 Tags: 17.0.9_9-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.9_9-jre-jammy, 17-jre-jammy
 SharedTags: 17.0.9_9-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/ubuntu/jammy
 
 Tags: 17.0.9_9-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/centos
 
 Tags: 17.0.9_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.9_9.1-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.9_9.1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9.1-jre, 17-jre
+Tags: 17.0.9_9-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.9_9.1-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.9_9.1-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.9_9-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.9_9.1-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.9_9.1-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9.1-jre, 17-jre
+Tags: 17.0.9_9-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.9_9.1-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.9_9.1-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.9_9-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 305dacd0cb9d4d45b2234a32928e5708e32f4362
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
+
 #------------------------------v21 images---------------------------------
-Tags: 21_35-jdk-alpine, 21-jdk-alpine, 21-alpine
+Tags: 21.0.1_12-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/alpine
-File: Dockerfile.releases.full
 
-Tags: 21_35-jdk-jammy, 21-jdk-jammy, 21-jammy
-SharedTags: 21_35-jdk, 21-jdk, 21, latest
-Architectures: amd64, arm64v8
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+Tags: 21.0.1_12-jdk-jammy, 21-jdk-jammy, 21-jammy
+SharedTags: 21.0.1_12-jdk, 21-jdk, 21, latest
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/ubuntu/jammy
-File: Dockerfile.releases.full
 
-Tags: 21_35-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
-Architectures: amd64, arm64v8
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+Tags: 21.0.1_12-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/ubi/ubi9-minimal
-File: Dockerfile.releases.full
 
-Tags: 21_35-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21_35-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21_35-jdk, 21-jdk, 21, latest
+Tags: 21.0.1_12-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21.0.1_12-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.1_12-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
-File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21_35-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
-SharedTags: 21_35-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.1_12-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
+SharedTags: 21.0.1_12-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/windows/nanoserver-ltsc2022
-File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21_35-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21_35-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21_35-jdk, 21-jdk, 21, latest
+Tags: 21.0.1_12-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21.0.1_12-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.1_12-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/windows/windowsservercore-1809
-File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 21_35-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21_35-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.1_12-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21.0.1_12-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jdk/windows/nanoserver-1809
-File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 21_35-jre-alpine, 21-jre-alpine
+Tags: 21.0.1_12-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/alpine
-File: Dockerfile.releases.full
 
-Tags: 21_35-jre-jammy, 21-jre-jammy
-SharedTags: 21_35-jre, 21-jre
-Architectures: amd64, arm64v8
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+Tags: 21.0.1_12-jre-jammy, 21-jre-jammy
+SharedTags: 21.0.1_12-jre, 21-jre
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/ubuntu/jammy
-File: Dockerfile.releases.full
 
-Tags: 21_35-jre-ubi9-minimal, 21-jre-ubi9-minimal
-Architectures: amd64, arm64v8
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+Tags: 21.0.1_12-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/ubi/ubi9-minimal
-File: Dockerfile.releases.full
 
-Tags: 21_35-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
-SharedTags: 21_35-jre-windowsservercore, 21-jre-windowsservercore, 21_35-jre, 21-jre
+Tags: 21.0.1_12-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
+SharedTags: 21.0.1_12-jre-windowsservercore, 21-jre-windowsservercore, 21.0.1_12-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/windows/windowsservercore-ltsc2022
-File: Dockerfile.releases.full
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21_35-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
-SharedTags: 21_35-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.1_12-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
+SharedTags: 21.0.1_12-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/windows/nanoserver-ltsc2022
-File: Dockerfile.releases.full
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21_35-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
-SharedTags: 21_35-jre-windowsservercore, 21-jre-windowsservercore, 21_35-jre, 21-jre
+Tags: 21.0.1_12-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
+SharedTags: 21.0.1_12-jre-windowsservercore, 21-jre-windowsservercore, 21.0.1_12-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/windows/windowsservercore-1809
-File: Dockerfile.releases.full
 Constraints: windowsservercore-1809
 
-Tags: 21_35-jre-nanoserver-1809, 21-jre-nanoserver-1809
-SharedTags: 21_35-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.1_12-jre-nanoserver-1809, 21-jre-nanoserver-1809
+SharedTags: 21.0.1_12-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 7360285847f9a281dfb23682be1351482a5ebe58
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 21/jre/windows/nanoserver-1809
-File: Dockerfile.releases.full
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
8 may be a few days later so lets merge this for now