### PR TITLE
[nats] Release v2.10.4

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: dec4f4419f9d420c080d33508490c1804618a526
+GitCommit: 527dad8cfc64d7afba2993351697cc0b44b03854
 GitFetch: refs/heads/main
 
-Tags: 2.10.3-alpine3.18, 2.10-alpine3.18, 2-alpine3.18, alpine3.18, 2.10.3-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.10.4-alpine3.18, 2.10-alpine3.18, 2-alpine3.18, alpine3.18, 2.10.4-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 Directory: 2.10.x/alpine3.18
 
-Tags: 2.10.3-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.3-linux, 2.10-linux, 2-linux, linux
-SharedTags: 2.10.3, 2.10, 2, latest
+Tags: 2.10.4-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.4-linux, 2.10-linux, 2-linux, linux
+SharedTags: 2.10.4, 2.10, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 Directory: 2.10.x/scratch
 
-Tags: 2.10.3-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.10.3-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.10.4-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.10.4-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.3-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.10.3-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.3, 2.10, 2, latest
+Tags: 2.10.4-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.10.4-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.4, 2.10, 2, latest
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.10.4)