### PR TITLE
[oraclelinux] Updating 8 for ELSA-2023-5997

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6c5531adf48feee7f9ac11d963ca0ecc695743f4
+amd64-GitCommit: ef2ca8c5b8d9b95b21cb73ed042278f04b58b331
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7f7f2e3312abe74857e4f5d830effc39aef5462f
+arm64v8-GitCommit: 279ddd2393dbfc1ceb9cec166f66b27222f1d17f
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-40217

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-5997.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
