### PR TITLE
archlinux: Release 20231029.0.188123

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20231015.0.185077
-GitCommit: 686bf22e2b94c89feb1a7e05ee03402404d7d3e7
-GitFetch: refs/tags/v20231015.0.185077
+Tags: latest, base, base-20231029.0.188123
+GitCommit: 270e7d427498806277f0e487441bccb012f696fc
+GitFetch: refs/tags/v20231029.0.188123
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20231015.0.185077
-GitCommit: 686bf22e2b94c89feb1a7e05ee03402404d7d3e7
-GitFetch: refs/tags/v20231015.0.185077
+Tags: base-devel, base-devel-20231029.0.188123
+GitCommit: 270e7d427498806277f0e487441bccb012f696fc
+GitFetch: refs/tags/v20231029.0.188123
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks