### PR TITLE
Update to R 4.3.2 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.3.1, latest
+Tags: 4.3.2, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 697411900789ece481e6a24be01e1ab3a3857b7d
-Directory: r-base/4.3.1
+GitCommit: fc5974d0cd04e4e281323a52251d8976239ea071
+Directory: r-base/4.3.2
 


### PR DESCRIPTION
Standard update of r-base to the new upstream release 4.3.2 made this morning via the updated Debian binaries. 

No code changes.