### PR TITLE
Update Jetty versions to 10.0.18, 11.0.18 & 12.0.3

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -59,105 +59,105 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 12.0.2-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.2-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.3-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.3-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 12.0.2-jre17, 12.0-jre17, 12-jre17, 12.0.2-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.3-jre17, 12.0-jre17, 12-jre17, 12.0.3-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 12.0.2-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.2-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.3-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.3-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 12.0.2, 12.0, 12, 12.0.2-jdk17, 12.0-jdk17, 12-jdk17, 12.0.2-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.2-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, latest, jdk17
+Tags: 12.0.3, 12.0, 12, 12.0.3-jdk17, 12.0-jdk17, 12-jdk17, 12.0.3-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.3-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, latest, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.17-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
+Tags: 11.0.18-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.18-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jre17, 11.0-jre17, 11-jre17, 11.0.17-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
+Tags: 11.0.18-jre17, 11.0-jre17, 11-jre17, 11.0.18-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.17-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
+Tags: 11.0.18-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.18-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jre11, 11.0-jre11, 11-jre11, 11.0.17-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
+Tags: 11.0.18-jre11, 11.0-jre11, 11-jre11, 11.0.18-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.17-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.18-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.18-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17, 11.0, 11, 11.0.17-jdk17, 11.0-jdk17, 11-jdk17, 11.0.17-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.17-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.18, 11.0, 11, 11.0.18-jdk17, 11.0-jdk17, 11-jdk17, 11.0.18-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.18-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.17-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.18-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.18-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jdk11, 11.0-jdk11, 11-jdk11, 11.0.17-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.18-jdk11, 11.0-jdk11, 11-jdk11, 11.0.18-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.17-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
+Tags: 10.0.18-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.18-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jre17, 10.0-jre17, 10-jre17, 10.0.17-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
+Tags: 10.0.18-jre17, 10.0-jre17, 10-jre17, 10.0.18-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.17-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
+Tags: 10.0.18-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.18-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jre11, 10.0-jre11, 10-jre11, 10.0.17-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
+Tags: 10.0.18-jre11, 10.0-jre11, 10-jre11, 10.0.18-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.17-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.18-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.18-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17, 10.0, 10, 10.0.17-jdk17, 10.0-jdk17, 10-jdk17, 10.0.17-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.17-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.18, 10.0, 10, 10.0.18-jdk17, 10.0-jdk17, 10-jdk17, 10.0.18-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.18-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.17-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.18-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.18-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jdk11, 10.0-jdk11, 10-jdk11, 10.0.17-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.18-jdk11, 10.0-jdk11, 10-jdk11, 10.0.18-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
 Tags: 9.4.53-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -189,52 +189,52 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 12.0.2-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.3-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 12.0.2-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.2-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.3-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.3-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.18-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.17-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.18-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.18-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.18-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.17-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.18-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.18-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.17-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.18-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.18-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.18-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.17-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.18-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16


### PR DESCRIPTION
## Update Jetty Versions

`10.0.17` -> `10.0.18`
`11.0.17`  -> `11.0.18`
`12.0.2` -> `12.0.3`