### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.2/alpine
 
-Tags: beta-6.4-RC2-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-RC2, beta-6.4, beta-6, beta, beta-6.4-RC2-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-RC2-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
+Tags: beta-6.4-RC3-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-RC3, beta-6.4, beta-6, beta, beta-6.4-RC3-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-RC3-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.0/apache
 
-Tags: beta-6.4-RC2-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-RC2-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
+Tags: beta-6.4-RC3-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-RC3-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.0/fpm
 
-Tags: beta-6.4-RC2-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-RC2-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
+Tags: beta-6.4-RC3-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-RC3-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.0/fpm-alpine
 
-Tags: beta-6.4-RC2-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-RC2-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.4-RC3-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-RC3-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.1/apache
 
-Tags: beta-6.4-RC2-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.4-RC3-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.4-RC2-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.4-RC3-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.4-RC2-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-RC2-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.4-RC3-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-RC3-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.2/apache
 
-Tags: beta-6.4-RC2-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.4-RC3-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.4-RC2-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.4-RC3-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3ed0c9ad0dccfaaf7d815637fad262e6c04b3a22
+GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
 Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/f6015e3: Update beta to 6.4-RC3