### PR TITLE
Releasing Neo4j 4.4.27

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -25,12 +25,12 @@ Directory: 5.13.0/ubi8/enterprise
 
 
 
-Tags: 4.4.26, 4.4.26-community, 4.4, 4.4-community
+Tags: 4.4.27, 4.4.27-community, 4.4, 4.4-community
 Architectures: amd64, arm64v8
-GitCommit: 06d08eefe166a90662ea228cfbddce3438bd2732
-Directory: 4.4.26/bullseye/community
+GitCommit: 6c15231abd6294f0a736b4a46f59d258dea7f672
+Directory: 4.4.27/bullseye/community
 
-Tags: 4.4.26-enterprise, 4.4-enterprise
+Tags: 4.4.27-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
-GitCommit: 06d08eefe166a90662ea228cfbddce3438bd2732
-Directory: 4.4.26/bullseye/enterprise
+GitCommit: 6c15231abd6294f0a736b4a46f59d258dea7f672
+Directory: 4.4.27/bullseye/enterprise


### PR DESCRIPTION
Hi there, here's the newest Neo4j 4.4 release.

For our next release, I've been asked to replace `gosu` with `su-exec`. However, since su-exec does not provide a binary or a signature, I will have to update the Dockerfile to do a multi-part build. Is that allowed in official Dockerfiles?

The change would be to add this (or similar) to the top of the current Dockerfiles:

```
FROM debian:bullseye-slim as suexec-builder
# get su-exec source and checkout a known good version (current HEAD). Verify files contents are expected.
RUN apt update -q \
    && apt install -y gcc git make \
    && git clone https://github.com/ncopa/su-exec.git \
    && cd su-exec \
    && git checkout 4c3bb42b093f14da70d8ab924b487ccfbb1397af \
    && echo d6c40440609a23483f12eb6295b5191e94baf08298a856bab6e15b10c3b82891 su-exec.c | sha256sum -c \
    && echo 2a87af245eb125aca9305a0b1025525ac80825590800f047419dc57bba36b334 Makefile | sha256sum -c \
    && make \
    && rm -rf /var/lib/apt/lists/*


FROM debian:bullseye-slim
COPY --from=suexec-builder /su-exec/su-exec /usr/bin/su-exec
# the rest of the existing dockerfile
```

I've done my best to make the builder stage repeatable and secure.
Are these proposed change likely to get rejected?

Thanks for all your help :slightly_smiling_face: 