### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 22-ea-21-jdk-oraclelinux8, 22-ea-21-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-21-jdk-oracle, 22-ea-21-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-21-jdk, 22-ea-21, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-22-jdk-oraclelinux8, 22-ea-22-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-22-jdk-oracle, 22-ea-22-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-22-jdk, 22-ea-22, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-21-jdk-oraclelinux7, 22-ea-21-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-22-jdk-oraclelinux7, 22-ea-22-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-21-jdk-bookworm, 22-ea-21-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-22-jdk-bookworm, 22-ea-22-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-21-jdk-slim-bookworm, 22-ea-21-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-21-jdk-slim, 22-ea-21-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-22-jdk-slim-bookworm, 22-ea-22-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-22-jdk-slim, 22-ea-22-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-21-jdk-bullseye, 22-ea-21-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-22-jdk-bullseye, 22-ea-22-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-21-jdk-slim-bullseye, 22-ea-21-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-22-jdk-slim-bullseye, 22-ea-22-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-21-jdk-windowsservercore-ltsc2022, 22-ea-21-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-21-jdk-windowsservercore, 22-ea-21-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-21-jdk, 22-ea-21, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-22-jdk-windowsservercore-ltsc2022, 22-ea-22-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-22-jdk-windowsservercore, 22-ea-22-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-22-jdk, 22-ea-22, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-21-jdk-windowsservercore-1809, 22-ea-21-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-21-jdk-windowsservercore, 22-ea-21-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-21-jdk, 22-ea-21, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-22-jdk-windowsservercore-1809, 22-ea-22-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-22-jdk-windowsservercore, 22-ea-22-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-22-jdk, 22-ea-22, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-21-jdk-nanoserver-1809, 22-ea-21-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-21-jdk-nanoserver, 22-ea-21-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-22-jdk-nanoserver-1809, 22-ea-22-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-22-jdk-nanoserver, 22-ea-22-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: b8677ffe605a897650dc98a86e6827501bacdd59
+GitCommit: 16f3c445b8092aebcdc1cfbdb4b0c2786cacf5cc
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/16f3c44: Update 22 to 22-ea+22