### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.2.20231018.2
+Tags: 2023, latest, 2023.2.20231026.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: ba9fd7ed5735a8ed7c01406726debd4386eb81c9
+amd64-GitCommit: a91cdfe045001e6c564070f467a5ddc21bbaaad3
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: dbb1e74204f4cf1b1735bbd9c67e81d1930a6900
+arm64v8-GitCommit: 5e5a3900055739617f9d839822fbb2d785fd573a
 
-Tags: 2, 2.0.20231020.1
+Tags: 2, 2.0.20231101.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: da6f3f58f5d173ca4b7fc8c2665c2e63b4e4880f
+amd64-GitCommit: 75d8ec841d42a12103774b888bf14a4b8bb7752b
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: aef37a741bae05a33f527db19ebc14577697c36c
+arm64v8-GitCommit: 7064869a72e6440253229420c3eb7ca180820ed0
 
-Tags: 1, 2018.03, 2018.03.0.20231002.0
+Tags: 1, 2018.03, 2018.03.0.20231024.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: a71cd32b94ea6e1f8a5fad33f9614695e34ae1a8
+amd64-GitCommit: 2c8d2ccf663a8e07e8a87b7e98049c69956d05c7


### PR DESCRIPTION
Updated Packages for Amazon Linux 1:
- nss-softokn-freebl-3.53.1-6.48.amzn1, nss-softokn-3.53.1-6.48.amzn1
  - [CVE-2023-4421](https://alas.aws.amazon.com/cve/html/CVE-2023-4421.html)
- libnghttp2-1.33.0-1.1.8.amzn1
  - [CVE-2023-44487](https://alas.aws.amazon.com/cve/html/CVE-2023-44487.html)

Updated Packages for Amazon Linux 2:
- ca-certificates-2023.2.62-1.amzn2.0.1
- openssl-libs-1.0.2k-24.amzn2.0.10
- libxml2-2.9.1-6.amzn2.5.13
  - [CVE-2023-45322](https://alas.aws.amazon.com/cve/html/CVE-2023-45322.html)
- python-2.7.18-1.amzn2.0.7, python-libs-2.7.18-1.amzn2.0.7
  - [CVE-2022-48565](https://alas.aws.amazon.com/cve/html/CVE-2022-48565.html)
- vim-minimal-9.0.1882-1.amzn2.0.3, vim-data-9.0.1882-1.amzn2.0.3
  - [CVE-2023-5441](https://alas.aws.amazon.com/cve/html/CVE-2023-5441.html)
  - [CVE-2023-5535](https://alas.aws.amazon.com/cve/html/CVE-2023-5535.html)
- zlib-1.2.7-19.amzn2.0.3
  - [CVE-2023-45853](https://alas.aws.amazon.com/cve/html/CVE-2023-45853.html)

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.2.20231026-0.amzn2023
- system-release-2023.2.20231026-0.amzn2023