### PR TITLE
archlinux: Release 20231105.0.189722

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20231029.0.188123
-GitCommit: 270e7d427498806277f0e487441bccb012f696fc
-GitFetch: refs/tags/v20231029.0.188123
+Tags: latest, base, base-20231105.0.189722
+GitCommit: 1ec02e22e80a5f701bfc8edfac17219dd1ea5da8
+GitFetch: refs/tags/v20231105.0.189722
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20231029.0.188123
-GitCommit: 270e7d427498806277f0e487441bccb012f696fc
-GitFetch: refs/tags/v20231029.0.188123
+Tags: base-devel, base-devel-20231105.0.189722
+GitCommit: 1ec02e22e80a5f701bfc8edfac17219dd1ea5da8
+GitFetch: refs/tags/v20231105.0.189722
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks