### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,12 +1,12 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/f3414c2a8296f199b5a23b5c716cbe65d3856a1c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/a735f1a91518f379a1279a543744e797fabedde4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0-alpha1, 5.0
+Tags: 5.0-alpha2, 5.0, 5
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 01dffce9d5d205f61733cbffaaf8973cc586219b
+GitCommit: 12ee728efc59b4aa6cc02c637396c8460ee1e3cd
 Directory: 5.0
 
 Tags: 4.1.3, 4.1, 4, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/a735f1a: Add version alias for version 5
- https://github.com/docker-library/cassandra/commit/12ee728: Update 5.0 to 5.0-alpha2