### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.3.2-apache, 6.3-apache, 6-apache, apache, 6.3.2, 6.3, 6, latest, 6.3.2-php8.0-apache, 6.3-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.3.2-php8.0, 6.3-php8.0, 6-php8.0, php8.0
+Tags: 6.4.0-apache, 6.4-apache, 6-apache, apache, 6.4.0, 6.4, 6, latest, 6.4.0-php8.0-apache, 6.4-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.4.0-php8.0, 6.4-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.0/apache
 
-Tags: 6.3.2-fpm, 6.3-fpm, 6-fpm, fpm, 6.3.2-php8.0-fpm, 6.3-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.4.0-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.0-php8.0-fpm, 6.4-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.0/fpm
 
-Tags: 6.3.2-fpm-alpine, 6.3-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.3.2-php8.0-fpm-alpine, 6.3-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.4.0-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.0-php8.0-fpm-alpine, 6.4-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.3.2-php8.1-apache, 6.3-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.3.2-php8.1, 6.3-php8.1, 6-php8.1, php8.1
+Tags: 6.4.0-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.0-php8.1, 6.4-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.1/apache
 
-Tags: 6.3.2-php8.1-fpm, 6.3-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.4.0-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.1/fpm
 
-Tags: 6.3.2-php8.1-fpm-alpine, 6.3-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.4.0-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.3.2-php8.2-apache, 6.3-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.3.2-php8.2, 6.3-php8.2, 6-php8.2, php8.2
+Tags: 6.4.0-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.0-php8.2, 6.4-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.2/apache
 
-Tags: 6.3.2-php8.2-fpm, 6.3-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.4.0-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.2/fpm
 
-Tags: 6.3.2-php8.2-fpm-alpine, 6.3-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.4.0-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4d5bd0cc496f7e3976a8535dd670ca6d3763af1d
+GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.9.0, cli-2.9, cli-2, cli, cli-2.9.0-php8.0, cli-2.9-php8.0, cli-2-php8.0, cli-php8.0
@@ -63,48 +63,3 @@ Tags: cli-2.9.0-php8.2, cli-2.9-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.2/alpine
-
-Tags: beta-6.4-RC3-apache, beta-6.4-apache, beta-6-apache, beta-apache, beta-6.4-RC3, beta-6.4, beta-6, beta, beta-6.4-RC3-php8.0-apache, beta-6.4-php8.0-apache, beta-6-php8.0-apache, beta-php8.0-apache, beta-6.4-RC3-php8.0, beta-6.4-php8.0, beta-6-php8.0, beta-php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.0/apache
-
-Tags: beta-6.4-RC3-fpm, beta-6.4-fpm, beta-6-fpm, beta-fpm, beta-6.4-RC3-php8.0-fpm, beta-6.4-php8.0-fpm, beta-6-php8.0-fpm, beta-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.0/fpm
-
-Tags: beta-6.4-RC3-fpm-alpine, beta-6.4-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.4-RC3-php8.0-fpm-alpine, beta-6.4-php8.0-fpm-alpine, beta-6-php8.0-fpm-alpine, beta-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.0/fpm-alpine
-
-Tags: beta-6.4-RC3-php8.1-apache, beta-6.4-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.4-RC3-php8.1, beta-6.4-php8.1, beta-6-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.1/apache
-
-Tags: beta-6.4-RC3-php8.1-fpm, beta-6.4-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.1/fpm
-
-Tags: beta-6.4-RC3-php8.1-fpm-alpine, beta-6.4-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.1/fpm-alpine
-
-Tags: beta-6.4-RC3-php8.2-apache, beta-6.4-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.4-RC3-php8.2, beta-6.4-php8.2, beta-6-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.2/apache
-
-Tags: beta-6.4-RC3-php8.2-fpm, beta-6.4-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.2/fpm
-
-Tags: beta-6.4-RC3-php8.2-fpm-alpine, beta-6.4-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6015e3f57f8285ee77acf56f8a86405b7308f95
-Directory: beta/php8.2/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/f40b7ed: Update latest to 6.4.0
- https://github.com/docker-library/wordpress/commit/6893437: Update beta to 6.4.0
- https://github.com/docker-library/wordpress/commit/f82e2eb: Update beta to 6.4-RC4