### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev8, 2.9-dev, 2.9-dev8-bullseye, 2.9-dev-bullseye
+Tags: 2.9-dev9, 2.9-dev, 2.9-dev9-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5d74ee5acfe35f75fe3a814ad77f0ceee92af260
+GitCommit: a86b78650d7054ebd03deb668c299c8cf5e14f3b
 Directory: 2.9
 
-Tags: 2.9-dev8-alpine, 2.9-dev-alpine, 2.9-dev8-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9-dev9-alpine, 2.9-dev-alpine, 2.9-dev9-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d74ee5acfe35f75fe3a814ad77f0ceee92af260
+GitCommit: a86b78650d7054ebd03deb668c299c8cf5e14f3b
 Directory: 2.9/alpine
 
 Tags: 2.8.3, 2.8, lts, latest, 2.8.3-bullseye, 2.8-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a86b786: Update 2.9 to 2.9-dev9