### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,11 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.10.3
-Architectures: amd64, arm64v8
-GitCommit: 2d1506e4c1ad26c8e180b33e84feefa179cdac22
-Directory: 8.10.3
-
 Tags: 8.10.4
 Architectures: amd64, arm64v8
 GitCommit: d1265e69805eeea34ef3986b87f1361826510b02

--- a/library/kibana
+++ b/library/kibana
@@ -4,11 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.10.3
-Architectures: amd64, arm64v8
-GitCommit: fc439ccc2255a47957081ece0cb32b05a203d888
-Directory: 8.10.3
-
 Tags: 8.10.4
 Architectures: amd64, arm64v8
 GitCommit: 80b2a8744c168da3b7227e2cf34c9d09f1287077

--- a/library/logstash
+++ b/library/logstash
@@ -4,11 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.10.3
-Architectures: amd64, arm64v8
-GitCommit: 0e1075e50d8a5bff32fe66e3be3115003bdc3b02
-Directory: 8.10.3
-
 Tags: 8.10.4
 Architectures: amd64, arm64v8
 GitCommit: b7f90bae4346f5e5ad82e1d55660e5c24f253697


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/b54351c: Merge pull request https://github.com/docker-library/elasticsearch/pull/211 from docker-library/revert-210-8.10.3
- https://github.com/docker-library/elasticsearch/commit/4706496: Revert "Temporary backfill of missed versions"

logstash:
- https://github.com/docker-library/logstash/commit/7212dc7: Merge pull request https://github.com/docker-library/logstash/pull/109 from docker-library/revert-108-8.10.3
- https://github.com/docker-library/logstash/commit/94ed412: Revert "Temporary backfill of missed versions"

kibana:
- https://github.com/docker-library/kibana/commit/61221e7: Merge pull request https://github.com/docker-library/kibana/pull/103 from docker-library/revert-102-8.10.3
- https://github.com/docker-library/kibana/commit/cc4d55d: Revert "Temporary backfill of missed versions"