### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -5,100 +5,100 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Johan Euphrosine <proppy@google.com> (@proppy)
 GitRepo: https://github.com/docker-library/golang.git
 
-Tags: 1.21.3-bookworm, 1.21-bookworm, 1-bookworm, bookworm
-SharedTags: 1.21.3, 1.21, 1, latest
+Tags: 1.21.4-bookworm, 1.21-bookworm, 1-bookworm, bookworm
+SharedTags: 1.21.4, 1.21, 1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/bookworm
 
-Tags: 1.21.3-bullseye, 1.21-bullseye, 1-bullseye, bullseye
+Tags: 1.21.4-bullseye, 1.21-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/bullseye
 
-Tags: 1.21.3-alpine3.18, 1.21-alpine3.18, 1-alpine3.18, alpine3.18, 1.21.3-alpine, 1.21-alpine, 1-alpine, alpine
+Tags: 1.21.4-alpine3.18, 1.21-alpine3.18, 1-alpine3.18, alpine3.18, 1.21.4-alpine, 1.21-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/alpine3.18
 
-Tags: 1.21.3-alpine3.17, 1.21-alpine3.17, 1-alpine3.17, alpine3.17
+Tags: 1.21.4-alpine3.17, 1.21-alpine3.17, 1-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/alpine3.17
 
-Tags: 1.21.3-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.21.3-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.3, 1.21, 1, latest
+Tags: 1.21.4-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.21.4-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.4, 1.21, 1, latest
 Architectures: windows-amd64
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.21.3-windowsservercore-1809, 1.21-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.21.3-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.3, 1.21, 1, latest
+Tags: 1.21.4-windowsservercore-1809, 1.21-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.21.4-windowsservercore, 1.21-windowsservercore, 1-windowsservercore, windowsservercore, 1.21.4, 1.21, 1, latest
 Architectures: windows-amd64
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.21.3-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.21.3-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.21.4-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.21.4-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.21.3-nanoserver-1809, 1.21-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.21.3-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.21.4-nanoserver-1809, 1.21-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.21.4-nanoserver, 1.21-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 079c1fa6a2b011b1a81f902da6498d527f311dd5
+GitCommit: e787bff89247be4ce5a642335fd94e866a188902
 Directory: 1.21/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.20.10-bookworm, 1.20-bookworm
-SharedTags: 1.20.10, 1.20
+Tags: 1.20.11-bookworm, 1.20-bookworm
+SharedTags: 1.20.11, 1.20
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/bookworm
 
-Tags: 1.20.10-bullseye, 1.20-bullseye
+Tags: 1.20.11-bullseye, 1.20-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/bullseye
 
-Tags: 1.20.10-alpine3.18, 1.20-alpine3.18, 1.20.10-alpine, 1.20-alpine
+Tags: 1.20.11-alpine3.18, 1.20-alpine3.18, 1.20.11-alpine, 1.20-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/alpine3.18
 
-Tags: 1.20.10-alpine3.17, 1.20-alpine3.17
+Tags: 1.20.11-alpine3.17, 1.20-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/alpine3.17
 
-Tags: 1.20.10-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022
-SharedTags: 1.20.10-windowsservercore, 1.20-windowsservercore, 1.20.10, 1.20
+Tags: 1.20.11-windowsservercore-ltsc2022, 1.20-windowsservercore-ltsc2022
+SharedTags: 1.20.11-windowsservercore, 1.20-windowsservercore, 1.20.11, 1.20
 Architectures: windows-amd64
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.20.10-windowsservercore-1809, 1.20-windowsservercore-1809
-SharedTags: 1.20.10-windowsservercore, 1.20-windowsservercore, 1.20.10, 1.20
+Tags: 1.20.11-windowsservercore-1809, 1.20-windowsservercore-1809
+SharedTags: 1.20.11-windowsservercore, 1.20-windowsservercore, 1.20.11, 1.20
 Architectures: windows-amd64
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 1.20.10-nanoserver-ltsc2022, 1.20-nanoserver-ltsc2022
-SharedTags: 1.20.10-nanoserver, 1.20-nanoserver
+Tags: 1.20.11-nanoserver-ltsc2022, 1.20-nanoserver-ltsc2022
+SharedTags: 1.20.11-nanoserver, 1.20-nanoserver
 Architectures: windows-amd64
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.20.10-nanoserver-1809, 1.20-nanoserver-1809
-SharedTags: 1.20.10-nanoserver, 1.20-nanoserver
+Tags: 1.20.11-nanoserver-1809, 1.20-nanoserver-1809
+SharedTags: 1.20.11-nanoserver, 1.20-nanoserver
 Architectures: windows-amd64
-GitCommit: ef9079ff127908149138a53eef705046891fa120
+GitCommit: 345618568a127e06435ed46d0a6b01eecd714989
 Directory: 1.20/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/e787bff: Update 1.21 to 1.21.4
- https://github.com/docker-library/golang/commit/3456185: Update 1.20 to 1.20.11

https://groups.google.com/g/golang-announce/c/4tU8LZfBFkY: 
 - `CVE-2023-45283`, `CVE-2023-45284` and https://github.com/golang/go/issues/63713