### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.72.0, 5.72, 5, latest
+Tags: 5.72.1, 5.72, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c85ed82d808917fb5c6a593cde967d3e736da3d3
+GitCommit: 45d9e46166cd5a56cbd91776ebe773ff1bb23d47
 Directory: 5/debian
 
-Tags: 5.72.0-alpine, 5.72-alpine, 5-alpine, alpine
+Tags: 5.72.1-alpine, 5.72-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: c85ed82d808917fb5c6a593cde967d3e736da3d3
+GitCommit: 45d9e46166cd5a56cbd91776ebe773ff1bb23d47
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/45d9e46: Update to 5.72.1, ghost-cli 1.25.3