### PR TITLE
[nats] Release v2.9.24

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,7 +4,7 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 527dad8cfc64d7afba2993351697cc0b44b03854
+GitCommit: 2e80fecdcb58ce995cd7bb9d8af66499ca023e44
 GitFetch: refs/heads/main
 
 Tags: 2.10.4-alpine3.18, 2.10-alpine3.18, 2-alpine3.18, alpine3.18, 2.10.4-alpine, 2.10-alpine, 2-alpine, alpine
@@ -28,23 +28,23 @@ Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.9.23-alpine3.18, 2.9-alpine3.18, 2.9.23-alpine, 2.9-alpine
+Tags: 2.9.24-alpine3.18, 2.9-alpine3.18, 2.9.24-alpine, 2.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 Directory: 2.9.x/alpine3.18
 
-Tags: 2.9.23-scratch, 2.9-scratch, 2.9.23-linux, 2.9-linux
-SharedTags: 2.9.23, 2.9, 2, latest
+Tags: 2.9.24-scratch, 2.9-scratch, 2.9.24-linux, 2.9-linux
+SharedTags: 2.9.24, 2.9, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 Directory: 2.9.x/scratch
 
-Tags: 2.9.23-windowsservercore-1809, 2.9-windowsservercore-1809
-SharedTags: 2.9.23-windowsservercore, 2.9-windowsservercore
+Tags: 2.9.24-windowsservercore-1809, 2.9-windowsservercore-1809
+SharedTags: 2.9.24-windowsservercore, 2.9-windowsservercore
 Architectures: windows-amd64
 Directory: 2.9.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.9.23-nanoserver-1809, 2.9-nanoserver-1809
-SharedTags: 2.9.23-nanoserver, 2.9-nanoserver
+Tags: 2.9.24-nanoserver-1809, 2.9-nanoserver-1809
+SharedTags: 2.9.24-nanoserver, 2.9-nanoserver
 Architectures: windows-amd64
 Directory: 2.9.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.9.24)