### PR TITLE
archlinux: Release 20231112.0.191179

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,13 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20231105.0.189722
-GitCommit: 1ec02e22e80a5f701bfc8edfac17219dd1ea5da8
-GitFetch: refs/tags/v20231105.0.189722
+Tags: latest, base, base-20231112.0.191179
+GitCommit: 9e3e5066b444021f47836449f6a9d89d0cf5861a
+GitFetch: refs/tags/v20231112.0.191179
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20231105.0.189722
-GitCommit: 1ec02e22e80a5f701bfc8edfac17219dd1ea5da8
-GitFetch: refs/tags/v20231105.0.189722
+Tags: base-devel, base-devel-20231112.0.191179
+GitCommit: 9e3e5066b444021f47836449f6a9d89d0cf5861a
+GitFetch: refs/tags/v20231112.0.191179
 File: Dockerfile.base-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks