### PR TITLE
Update Clear Linux OS to 40330

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 5a2ae74342e6528e27d9f5e089d55fd489a33d69
-GitFetch: refs/heads/base-40310
+GitCommit: 6fac7bf7d1a9173050938b94b9cb59b24d3402c2
+GitFetch: refs/heads/base-40330


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 40330

@bryteise @djklimes @bryteise