### PR TITLE
Odoo: Add Odoo 17.0

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 3864188c94c33dace7d4b5f6767e00a4328fe08c
+GitCommit: 37a68eedff8ad776107bd51f0494514d4e4fb7be
 
-Tags: 16.0, 16, latest
+Tags: 17.0, 17, latest
+Architectures: amd64, arm64v8, ppc64le
+Directory: 17.0
+
+Tags: 16.0, 16
 Architectures: amd64, arm64v8, ppc64le
 Directory: 16.0
 
 Tags: 15.0, 15
 Architectures: amd64
 Directory: 15.0
-
-Tags: 14.0, 14
-Architectures: amd64
-Directory: 14.0
 


### PR DESCRIPTION
Hello,

- new version 17.0 of Odoo
- remove deprecated 14.0
- update 15.0 and 16.0 to 20231113

Thanks

