### PR TITLE
Update postgres (16.1, 15.5, 14.10, 12.7, 11.22)

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 16.0, 16, latest, 16.0-bookworm, 16-bookworm, bookworm
+Tags: 16.1, 16, latest, 16.1-bookworm, 16-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7442464585e3cd75554976cbe94819a42da10bbd
+GitCommit: f85674ce472bc78b8b8a0478dacd595e44cb9616
 Directory: 16/bookworm
 
-Tags: 16.0-bullseye, 16-bullseye, bullseye
+Tags: 16.1-bullseye, 16-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7442464585e3cd75554976cbe94819a42da10bbd
+GitCommit: f85674ce472bc78b8b8a0478dacd595e44cb9616
 Directory: 16/bullseye
 
-Tags: 16.0-alpine3.18, 16-alpine3.18, alpine3.18, 16.0-alpine, 16-alpine, alpine
+Tags: 16.1-alpine3.18, 16-alpine3.18, alpine3.18, 16.1-alpine, 16-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: f85674ce472bc78b8b8a0478dacd595e44cb9616
 Directory: 16/alpine3.18
 
-Tags: 16.0-alpine3.17, 16-alpine3.17, alpine3.17
+Tags: 16.1-alpine3.17, 16-alpine3.17, alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: f85674ce472bc78b8b8a0478dacd595e44cb9616
 Directory: 16/alpine3.17
 
-Tags: 15.4, 15, 15.4-bookworm, 15-bookworm
+Tags: 15.5, 15, 15.5-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8a631b939a0b4197cb6bef49b50b6c40c80ddf5b
+GitCommit: da624f9e2e26fd185c73532ec52203aa3683f4db
 Directory: 15/bookworm
 
-Tags: 15.4-bullseye, 15-bullseye
+Tags: 15.5-bullseye, 15-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8a631b939a0b4197cb6bef49b50b6c40c80ddf5b
+GitCommit: da624f9e2e26fd185c73532ec52203aa3683f4db
 Directory: 15/bullseye
 
-Tags: 15.4-alpine3.18, 15-alpine3.18, 15.4-alpine, 15-alpine
+Tags: 15.5-alpine3.18, 15-alpine3.18, 15.5-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: da624f9e2e26fd185c73532ec52203aa3683f4db
 Directory: 15/alpine3.18
 
-Tags: 15.4-alpine3.17, 15-alpine3.17
+Tags: 15.5-alpine3.17, 15-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: da624f9e2e26fd185c73532ec52203aa3683f4db
 Directory: 15/alpine3.17
 
-Tags: 14.9, 14, 14.9-bookworm, 14-bookworm
+Tags: 14.10, 14, 14.10-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05f691067b29d8fb4211a47da37a381d58d36691
+GitCommit: d7660ac1e7417041e5197861d7d8c3d0954c83c4
 Directory: 14/bookworm
 
-Tags: 14.9-bullseye, 14-bullseye
+Tags: 14.10-bullseye, 14-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 05f691067b29d8fb4211a47da37a381d58d36691
+GitCommit: d7660ac1e7417041e5197861d7d8c3d0954c83c4
 Directory: 14/bullseye
 
-Tags: 14.9-alpine3.18, 14-alpine3.18, 14.9-alpine, 14-alpine
+Tags: 14.10-alpine3.18, 14-alpine3.18, 14.10-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: d7660ac1e7417041e5197861d7d8c3d0954c83c4
 Directory: 14/alpine3.18
 
-Tags: 14.9-alpine3.17, 14-alpine3.17
+Tags: 14.10-alpine3.17, 14-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: d7660ac1e7417041e5197861d7d8c3d0954c83c4
 Directory: 14/alpine3.17
 
-Tags: 13.12, 13, 13.12-bookworm, 13-bookworm
+Tags: 13.13, 13, 13.13-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 69cf8b8aac63224380f943bd6428f088ddfb3435
+GitCommit: ce930677d59d780645e69fa2fe68d4ac391b6d2e
 Directory: 13/bookworm
 
-Tags: 13.12-bullseye, 13-bullseye
+Tags: 13.13-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 69cf8b8aac63224380f943bd6428f088ddfb3435
+GitCommit: ce930677d59d780645e69fa2fe68d4ac391b6d2e
 Directory: 13/bullseye
 
-Tags: 13.12-alpine3.18, 13-alpine3.18, 13.12-alpine, 13-alpine
+Tags: 13.13-alpine3.18, 13-alpine3.18, 13.13-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: ce930677d59d780645e69fa2fe68d4ac391b6d2e
 Directory: 13/alpine3.18
 
-Tags: 13.12-alpine3.17, 13-alpine3.17
+Tags: 13.13-alpine3.17, 13-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: ce930677d59d780645e69fa2fe68d4ac391b6d2e
 Directory: 13/alpine3.17
 
-Tags: 12.16, 12, 12.16-bookworm, 12-bookworm
+Tags: 12.17, 12, 12.17-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9061f74afc30391adb6a1a35d4f7b605ecaa09b9
+GitCommit: 038c4c577a3c58dddf9ec2ccaa643009b8ba414b
 Directory: 12/bookworm
 
-Tags: 12.16-bullseye, 12-bullseye
+Tags: 12.17-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9061f74afc30391adb6a1a35d4f7b605ecaa09b9
+GitCommit: 038c4c577a3c58dddf9ec2ccaa643009b8ba414b
 Directory: 12/bullseye
 
-Tags: 12.16-alpine3.18, 12-alpine3.18, 12.16-alpine, 12-alpine
+Tags: 12.17-alpine3.18, 12-alpine3.18, 12.17-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: 038c4c577a3c58dddf9ec2ccaa643009b8ba414b
 Directory: 12/alpine3.18
 
-Tags: 12.16-alpine3.17, 12-alpine3.17
+Tags: 12.17-alpine3.17, 12-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: 038c4c577a3c58dddf9ec2ccaa643009b8ba414b
 Directory: 12/alpine3.17
 
-Tags: 11.21-bookworm, 11-bookworm
+Tags: 11.22-bookworm, 11-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 16fa0f1d18f7c46f7dcac1e250b680fcb1a2e051
+GitCommit: f2860f3faf8d0f3993389f529f8833778b08eba4
 Directory: 11/bookworm
 
-Tags: 11.21-bullseye, 11-bullseye
+Tags: 11.22-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 16fa0f1d18f7c46f7dcac1e250b680fcb1a2e051
+GitCommit: f2860f3faf8d0f3993389f529f8833778b08eba4
 Directory: 11/bullseye
 
-Tags: 11.21-alpine3.18, 11-alpine3.18, 11.21-alpine, 11-alpine
+Tags: 11.22-alpine3.18, 11-alpine3.18, 11.22-alpine, 11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: f2860f3faf8d0f3993389f529f8833778b08eba4
 Directory: 11/alpine3.18
 
-Tags: 11.21-alpine3.17, 11-alpine3.17
+Tags: 11.22-alpine3.17, 11-alpine3.17
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6f4ae836406b010948f01fbcb400a31dca4fdf52
+GitCommit: f2860f3faf8d0f3993389f529f8833778b08eba4
 Directory: 11/alpine3.17


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/f85674c: Update 16 to 16.1, bookworm 16.1-1.pgdg120+1, bullseye 16.1-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/da624f9: Update 15 to 15.5, bookworm 15.5-1.pgdg120+1, bullseye 15.5-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/d7660ac: Update 14 to 14.10, bookworm 14.10-1.pgdg120+1, bullseye 14.10-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/ce93067: Update 13 to 13.13, bookworm 13.13-1.pgdg120+1, bullseye 13.13-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/038c4c5: Update 12 to 12.17, bookworm 12.17-1.pgdg120+1, bullseye 12.17-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/f2860f3: Update 11 to 11.22, bookworm 11.22-1.pgdg120+1, bullseye 11.22-1.pgdg110+1