### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.4.0-apache, 6.4-apache, 6-apache, apache, 6.4.0, 6.4, 6, latest, 6.4.0-php8.0-apache, 6.4-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.4.0-php8.0, 6.4-php8.0, 6-php8.0, php8.0
+Tags: 6.4.1-apache, 6.4-apache, 6-apache, apache, 6.4.1, 6.4, 6, latest, 6.4.1-php8.0-apache, 6.4-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.4.1-php8.0, 6.4-php8.0, 6-php8.0, php8.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.0/apache
 
-Tags: 6.4.0-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.0-php8.0-fpm, 6.4-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
+Tags: 6.4.1-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.1-php8.0-fpm, 6.4-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.0/fpm
 
-Tags: 6.4.0-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.0-php8.0-fpm-alpine, 6.4-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
+Tags: 6.4.1-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.1-php8.0-fpm-alpine, 6.4-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.0/fpm-alpine
 
-Tags: 6.4.0-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.0-php8.1, 6.4-php8.1, 6-php8.1, php8.1
+Tags: 6.4.1-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.1-php8.1, 6.4-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.1/apache
 
-Tags: 6.4.0-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.4.1-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.1/fpm
 
-Tags: 6.4.0-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.4.1-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.4.0-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.0-php8.2, 6.4-php8.2, 6-php8.2, php8.2
+Tags: 6.4.1-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.1-php8.2, 6.4-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.2/apache
 
-Tags: 6.4.0-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.4.1-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.2/fpm
 
-Tags: 6.4.0-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.4.1-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f40b7ed87e2f08941630e823ebcd9fd4ac7af6d2
+GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
 Directory: latest/php8.2/fpm-alpine
 
 Tags: cli-2.9.0, cli-2.9, cli-2, cli, cli-2.9.0-php8.0, cli-2.9-php8.0, cli-2-php8.0, cli-php8.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/4b49662: Update latest to 6.4.1
- https://github.com/docker-library/wordpress/commit/91884ed: Update beta to 6.4.1