### PR TITLE
Update ELK images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/elasticsearch.git
 
-Tags: 8.11.0
+Tags: 8.11.1
 Architectures: amd64, arm64v8
-GitCommit: d4d6ab49e6fb9bdc82adb84014035f4892d1b092
+GitCommit: 84a62adaf958d51f39376ed636a7d59f2e92ca69
 Directory: 8
 
-Tags: 7.17.14
+Tags: 7.17.15
 Architectures: amd64, arm64v8
-GitCommit: 59d22a26ecf5dd91403608437300f297953d57d1
+GitCommit: 917e6014bd129e3e2193e2ec52245c9f599e1e84
 Directory: 7

--- a/library/kibana
+++ b/library/kibana
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/kibana.git
 
-Tags: 8.11.0
+Tags: 8.11.1
 Architectures: amd64, arm64v8
-GitCommit: 25daf858f68ac38906ab83243bdfc8f4f79962f1
+GitCommit: d86e69a854eb6bb1c4b4b33d629b784eb6ca539d
 Directory: 8
 
-Tags: 7.17.14
+Tags: 7.17.15
 Architectures: amd64, arm64v8
-GitCommit: a19c898e1c1c78025376bb5cbcab4a6244f39ddc
+GitCommit: 9c6a9d1c949c08a7254e2ff66594e25c4be54da7
 Directory: 7

--- a/library/logstash
+++ b/library/logstash
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/logstash.git
 
-Tags: 8.11.0
+Tags: 8.11.1
 Architectures: amd64, arm64v8
-GitCommit: 0abad0b071d05a8959f6741841b8f7d307e649e7
+GitCommit: 7866ca9dec9586e2e4a1a8d19a2958dfac93cede
 Directory: 8
 
-Tags: 7.17.14
+Tags: 7.17.15
 Architectures: amd64, arm64v8
-GitCommit: d9df987bd398bf87b134970ab93f5a46dbe8638a
+GitCommit: e8bb7b091d72d4592901eb24379c9dde4975775f
 Directory: 7


### PR DESCRIPTION
elasticsearch:
- https://github.com/docker-library/elasticsearch/commit/84a62ad: Update to 8.11.1
- https://github.com/docker-library/elasticsearch/commit/917e601: Update to 7.17.15

logstash:
- https://github.com/docker-library/logstash/commit/7866ca9: Update to 8.11.1
- https://github.com/docker-library/logstash/commit/e8bb7b0: Update to 7.17.15

kibana:
- https://github.com/docker-library/kibana/commit/d86e69a: Update to 8.11.1
- https://github.com/docker-library/kibana/commit/9c6a9d1: Update to 7.17.15