### PR TITLE
[oraclelinux] Updating 7,7-slim, and 7-slim-fip for ELSA-2023-6885

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ef2ca8c5b8d9b95b21cb73ed042278f04b58b331
+amd64-GitCommit: 79225496d9d81baf338f4aa1bf5eab753292be2d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 279ddd2393dbfc1ceb9cec166f66b27222f1d17f
+arm64v8-GitCommit: 7d95c80b570fa22bafb12c7f44d5da7bf29e35ef
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-40217

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-6885.html


Signed-off-by: Alan Steinberg [alan.steinberg@oracle.com](mailto:alan.steinberg@oracle.com)