### PR TITLE
Update bonita, add 2023.2

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -2,23 +2,23 @@ Maintainers: Danila Mazour <danila.mazour@bonitasoft.org> (@danila-m),
              Emmanuel Duchastenier <emmanuel.duchastenier@bonitasoft.org> (@educhastenier),
              Pascal Garcia <pascal.garcia@bonitasoft.org> (@passga),
              Anthony Birembaut <anthony.birembaut@bonitasoft.org> (@abirembaut),
-             Dumitru Corini <dumitru.corini@bonitasoft.org> (@DumitruCorini)
+             Romain Bioteau <romain.bioteau@bonitasoft.org> (@rbioteau)
 Architectures: amd64, arm64v8, ppc64le
 GitRepo: https://github.com/bonitasoft/bonita-distrib.git
 Directory: docker
 
-Tags: 2021.2-u0, 2021.2, 7.13.0, 7.13
-GitFetch: refs/heads/docker/2021.2
-GitCommit: a1d9ee5e31d38958aa553cc7f9d465f1151d902f
-
 Tags: 2022.1-u0, 2022.1, 7.14.0, 7.14
-GitFetch: refs/heads/master
-GitCommit: 694bf79347add872f8c6a4c0a7f5c3ef12c31dc8
+GitFetch: refs/heads/docker/2022.1
+GitCommit: 4cdeb1c385b981e7074ce19cc685c08028d7149d
 
 Tags: 2022.2-u0, 2022.2, 7.15.0, 7.15
-GitFetch: refs/heads/master
-GitCommit: 21c0e51634e836feaf910e8e3d6e95de200e1814
+GitFetch: refs/heads/docker/2022.2
+GitCommit: 607a6a3885df35979e0946611af4f7c858f9c989
 
-Tags: 2023.1-u0, 2023.1, 8.0.0, 8.0, latest
-GitFetch: refs/heads/master
-GitCommit: 0848e9716e3ff36a15f03e8ffe5bfd25c273cc5b
+Tags: 2023.1-u0, 2023.1, 8.0.0, 8.0
+GitFetch: refs/heads/docker/2023.1
+GitCommit: 814cc8cc0a6e8b02c827cb1dfeabb1bb4569a865
+
+Tags: 2023.2-u0, 2023.2, 9.0.0, 9.0, latest
+GitFetch: refs/heads/docker/2023.2
+GitCommit: a8f0abf47fa8f7b96cb010e7d80b032ae96720ca


### PR DESCRIPTION
* Add 2023.2 version
* Update maintainers
* Update fetch reference branch
* Remove old unsupported version