### PR TITLE
MariaDB stable releases for 2023 Q4

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,46 +1,46 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/5169d8f1961786986c7c5be8e3e86147352b7d14/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/5e35bb00051a81ca9369583b79c180f47a745c4f/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
              Faustin Lammler <faustin@mariadb.org> (@fauust)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 11.1.2-jammy, 11.1-jammy, 11-jammy, jammy, 11.1.2, 11.1, 11, latest
+Tags: 11.2.1-rc-jammy, 11.2-rc-jammy, 11.2.1-rc, 11.2-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 70d8c97f486055689e9f5a6a133f8bfb0806632a
+GitCommit: 6852b71f228e3d003dd7ce6db3627c5b10cfc1a0
+Directory: 11.2
+
+Tags: 11.1.3-jammy, 11.1-jammy, 11-jammy, jammy, 11.1.3, 11.1, 11, latest
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 11.1
 
-Tags: 11.0.3-jammy, 11.0-jammy, 11.0.3, 11.0
+Tags: 11.0.4-jammy, 11.0-jammy, 11.0.4, 11.0
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 11.0
 
-Tags: 10.11.5-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.5, 10.11, 10, lts
+Tags: 10.11.6-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.6, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 10.11
 
-Tags: 10.10.6-jammy, 10.10-jammy, 10.10.6, 10.10
+Tags: 10.10.7-jammy, 10.10-jammy, 10.10.7, 10.10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 10.10
 
-Tags: 10.9.8-jammy, 10.9-jammy, 10.9.8, 10.9
+Tags: 10.6.16-focal, 10.6-focal, 10.6.16, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
-Directory: 10.9
-
-Tags: 10.6.15-focal, 10.6-focal, 10.6.15, 10.6
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 10.6
 
-Tags: 10.5.22-focal, 10.5-focal, 10.5.22, 10.5
+Tags: 10.5.23-focal, 10.5-focal, 10.5.23, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 10.5
 
-Tags: 10.4.31-focal, 10.4-focal, 10.4.31, 10.4
+Tags: 10.4.32-focal, 10.4-focal, 10.4.32, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73a6fc045e12961287d2f41a6473bbf4e0eddeba
+GitCommit: 38b234791e8fe1939a805d35509088933049284d
 Directory: 10.4


### PR DESCRIPTION
First stable release changes of 2023 Q3.

Changes:

- Invert single and double quotes for sql command definitions in [healthcheck.sh](https://mariadb.com/kb/en/using-healthcheck-sh-script/) due to failure under [sql_mode=ANSI_QUOTES](https://mariadb.com/kb/en/sql-mode/#ansi_quotes) - contribution by Dominik Häckel
-  [healthcheck.sh](https://mariadb.com/kb/en/using-healthcheck-sh-script/) --no-defaults behaviour was corrected - reported by Dominik Häckel-  Added backup/restore from [mariadb-backup](https://mariadb.com/kb/en/mariadb-backup/) - [instructions](https://mariadb.com/kb/en/docker-official-image-frequently-asked-questions/#how-do-i-create-a-mariadb-backup-of-the-data)
-  Refactor docker_mariadb_init in the entrypoint for extending the MariaDB image
- CIS failure due to world-writable directory /var/run/mysqld, added sticky bit - reported by @ollie1
-  Add [PROXY privileges](https://mariadb.com/kb/en/grant/#proxy-privileges) for root@MARIADB_ROOT_HOST - reported by Matthieu Gusmini
-  [healthcheck.sh](https://mariadb.com/kb/en/using-healthcheck-sh-script/) added --galera_online test, to match what the [mariadb-operator](https://github.com/mariadb-operator/mariadb-operator) does.