### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -66,7 +66,7 @@ Directory: debian/sid
 
 Tags: trixie-curl, testing-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4fae1079681a664db5a84c0b83621dd7c115996
+GitCommit: 6b4838ad208cd3447d2c8d6535827e0dfc74a145
 Directory: debian/trixie/curl
 
 Tags: trixie-scm, testing-scm
@@ -126,7 +126,7 @@ Directory: ubuntu/lunar
 
 Tags: mantic-curl, 23.10-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ba367c3a52946cee45274b62f7f8b27e07807289
+GitCommit: 6b4838ad208cd3447d2c8d6535827e0dfc74a145
 Directory: ubuntu/mantic/curl
 
 Tags: mantic-scm, 23.10-scm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/c376415: Merge pull request https://github.com/docker-library/buildpack-deps/pull/150 from infosiftr/sq
- https://github.com/docker-library/buildpack-deps/commit/6b4838a: Update "sq" availability matrix (yes trixie, no mantic)