### PR TITLE
[nats-streaming] Release v0.25.6

### DIFF
--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -2,25 +2,25 @@ Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
 GitFetch: refs/heads/main
-GitCommit: d8dd9e2f5f7943f6a4d08de304f2bce513cc6735
+GitCommit: b58b5957ac6c7e2349e52a01ec61fb0afb376ac5
 
-Tags: 0.25.5-alpine3.18, 0.25-alpine3.18, alpine3.18, 0.25.5-alpine, 0.25-alpine, alpine
+Tags: 0.25.6-alpine3.18, 0.25-alpine3.18, alpine3.18, 0.25.6-alpine, 0.25-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.25.5/alpine3.18
+Directory: 0.25.6/alpine3.18
 
-Tags: 0.25.5-scratch, 0.25-scratch, scratch, 0.25.5-linux, 0.25-linux, linux
-SharedTags: 0.25.5, 0.25, latest
+Tags: 0.25.6-scratch, 0.25-scratch, scratch, 0.25.6-linux, 0.25-linux, linux
+SharedTags: 0.25.6, 0.25, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.25.5/scratch
+Directory: 0.25.6/scratch
 
-Tags: 0.25.5-windowsservercore-1809, 0.25-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.25.5-windowsservercore, 0.25-windowsservercore, windowsservercore
+Tags: 0.25.6-windowsservercore-1809, 0.25-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.25.6-windowsservercore, 0.25-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 0.25.5/windowsservercore-1809
+Directory: 0.25.6/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 0.25.5-nanoserver-1809, 0.25-nanoserver-1809, nanoserver-1809
-SharedTags: 0.25.5-nanoserver, 0.25-nanoserver, nanoserver, 0.25.5, 0.25, latest
+Tags: 0.25.6-nanoserver-1809, 0.25-nanoserver-1809, nanoserver-1809
+SharedTags: 0.25.6-nanoserver, 0.25-nanoserver, nanoserver, 0.25.6, 0.25, latest
 Architectures: windows-amd64
-Directory: 0.25.5/nanoserver-1809
+Directory: 0.25.6/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-streaming-server/releases/tag/v0.25.6)

Signed-off-by: Ivan Kozlovic <ivan@synadia.com>