### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev9, 2.9-dev, 2.9-dev9-bullseye, 2.9-dev-bullseye
+Tags: 2.9-dev10, 2.9-dev, 2.9-dev10-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a86b78650d7054ebd03deb668c299c8cf5e14f3b
+GitCommit: fdb46d56e1f9512e05b4f5acf63d2ffa2044b5bf
 Directory: 2.9
 
-Tags: 2.9-dev9-alpine, 2.9-dev-alpine, 2.9-dev9-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9-dev10-alpine, 2.9-dev-alpine, 2.9-dev10-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a86b78650d7054ebd03deb668c299c8cf5e14f3b
+GitCommit: fdb46d56e1f9512e05b4f5acf63d2ffa2044b5bf
 Directory: 2.9/alpine
 
-Tags: 2.8.3, 2.8, lts, latest, 2.8.3-bullseye, 2.8-bullseye, lts-bullseye, bullseye
+Tags: 2.8.4, 2.8, lts, latest, 2.8.4-bullseye, 2.8-bullseye, lts-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 97bab51de2c27f86ce61bf5ef3f605997a7b98a6
+GitCommit: 3b21ae1e4abb804305fcda315a390ef27f8e2caa
 Directory: 2.8
 
-Tags: 2.8.3-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.3-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
+Tags: 2.8.4-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.4-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97bab51de2c27f86ce61bf5ef3f605997a7b98a6
+GitCommit: 3b21ae1e4abb804305fcda315a390ef27f8e2caa
 Directory: 2.8/alpine
 
 Tags: 2.7.10, 2.7, 2.7.10-bullseye, 2.7-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3b21ae1: Update 2.8 to 2.8.4