### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.2.20231026.0
+Tags: 2023, latest, 2023.2.20231113.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: a91cdfe045001e6c564070f467a5ddc21bbaaad3
+amd64-GitCommit: bb26f34bf58219b9c2833ddfc550edf24dc5d2b1
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 5e5a3900055739617f9d839822fbb2d785fd573a
+arm64v8-GitCommit: 8ad82e04839d21d355f530f64b80a66109bdb839
 
-Tags: 2, 2.0.20231101.0
+Tags: 2, 2.0.20231116.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 75d8ec841d42a12103774b888bf14a4b8bb7752b
+amd64-GitCommit: e513900321398ab144fa1c8c422035e04d5f22d4
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 7064869a72e6440253229420c3eb7ca180820ed0
+arm64v8-GitCommit: 8fedb973d1887194b817560609f54171b40f4dd1
 
-Tags: 1, 2018.03, 2018.03.0.20231024.0
+Tags: 1, 2018.03, 2018.03.0.20231106.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 2c8d2ccf663a8e07e8a87b7e98049c69956d05c7
+amd64-GitCommit: 4e00ac2c097d0ed30dbcd4e7a9cce4d3dee18a9b


### PR DESCRIPTION
Updated Packages for Amazon Linux 1:
- ca-certificates-2023.2.62-1.32.amzn1
- libxml2-2.9.1-6.6.44.amzn1, libxml2-python27-2.9.1-6.6.44.amzn1
  - [CVE-2023-45322](https://alas.aws.amazon.com/cve/html/CVE-2023-45322.html)
- expat-2.1.0-15.34.amzn1
  - [CVE-2022-23990](https://alas.aws.amazon.com/cve/html/CVE-2022-23990.html)
- python27-2.7.18-2.149.amzn1, python27-libs-2.7.18-2.149.amzn1
  - [CVE-2022-48565](https://alas.aws.amazon.com/cve/html/CVE-2022-48565.html)

Updated Packages for Amazon Linux 2:
- nss-3.90.0-2.amzn2.0.1
- nss-util-3.90.0-1.amzn2
- nss-softokn-3.90.0-6.amzn2
- nss-sysinit-3.90.0-2.amzn2.0.1
- nss-softokn-freebl-3.90.0-6.amzn2
- nss-tools-3.90.0-2.amzn2.0.1
- vim-minimal-9.0.2081-1.amzn2.0.1, vim-data-9.0.2081-1.amzn2.0.1
  - [CVE-2023-46246](https://alas.aws.amazon.com/cve/html/CVE-2023-46246.html)
- nspr-4.35.0-1.amzn2
  - [CVE-2021-43527](https://alas.aws.amazon.com/cve/html/CVE-2021-43527.html)
  - [CVE-2021-43527](https://alas.aws.amazon.com/cve/html/CVE-2021-43527.html)

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.2.20231113-1.amzn2023
- system-release-2023.2.20231113-1.amzn2023