### PR TITLE
MariaDB new stable + rc release for 2023 Q4

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,46 +1,51 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/5e35bb00051a81ca9369583b79c180f47a745c4f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/4834a866d899619a38de15cce392e26241b20c36/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
              Faustin Lammler <faustin@mariadb.org> (@fauust)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 11.2.1-rc-jammy, 11.2-rc-jammy, 11.2.1-rc, 11.2-rc
+Tags: 11.3.1-rc-jammy, 11.3-rc-jammy, 11.3.1-rc, 11.3-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6852b71f228e3d003dd7ce6db3627c5b10cfc1a0
+GitCommit: 54a8a7fb16e45d3414b575e5d9d95e2972cf1f70
+Directory: 11.3
+
+Tags: 11.2.2-jammy, 11.2-jammy, 11-jammy, jammy, 11.2.2, 11.2, 11, latest
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 54a8a7fb16e45d3414b575e5d9d95e2972cf1f70
 Directory: 11.2
 
-Tags: 11.1.3-jammy, 11.1-jammy, 11-jammy, jammy, 11.1.3, 11.1, 11, latest
+Tags: 11.1.3-jammy, 11.1-jammy, 11.1.3, 11.1
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 11.1
 
 Tags: 11.0.4-jammy, 11.0-jammy, 11.0.4, 11.0
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 11.0
 
 Tags: 10.11.6-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.6, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 10.11
 
 Tags: 10.10.7-jammy, 10.10-jammy, 10.10.7, 10.10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 10.10
 
 Tags: 10.6.16-focal, 10.6-focal, 10.6.16, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 10.6
 
 Tags: 10.5.23-focal, 10.5-focal, 10.5.23, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 10.5
 
 Tags: 10.4.32-focal, 10.4-focal, 10.4.32, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 38b234791e8fe1939a805d35509088933049284d
+GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
 Directory: 10.4


### PR DESCRIPTION
Also bump gosu to 1.17

Closes: https://github.com/MariaDB/mariadb-docker/issues/546