### PR TITLE
Almalinux auto-update - 161702

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,39 +1,39 @@
-# This file is generated using https://github.com/almalinux/docker-images/blob/0f287a463b6c372fb358d8f9f993c2c65361b6a7/gen_docker_official_library
+# This file is generated using https://github.com/almalinux/docker-images/blob/a95cef6a11ec939a6fa7b4f1a80cd1a0363b8cbc/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 
-Tags: 8, 8.8, 8.8-20230718
-GitFetch: refs/heads/al8-20230718-amd64
-GitCommit: a7e0d4c97e8c2ab80dfada8685b44831f7c8d6ad
+Tags: 8, 8.9, 8.9-20231122
+GitFetch: refs/heads/al8-20231122-amd64
+GitCommit: 2b55e461c04ed9a74c37e043f7657d5a457e9494
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20230718-arm64v8
-arm64v8-GitCommit: af89b951918bc59e0891dde2ecbcc38d64560c59
+arm64v8-GitFetch: refs/heads/al8-20231122-arm64v8
+arm64v8-GitCommit: 4fe18788750ad7efafd5239a1bb0b5799ce8e19b
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20230718-ppc64le
-ppc64le-GitCommit: 77ec120d5ee160cc72406c31dddb4a9e9ec5c809
+ppc64le-GitFetch: refs/heads/al8-20231122-ppc64le
+ppc64le-GitCommit: bd5fba172243873deb26fa9708ea03f9068908cd
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20230718-s390x
-s390x-GitCommit: 0d0bcc7dba2e66b6e360d77c6c16fb8217490ddd
+s390x-GitFetch: refs/heads/al8-20231122-s390x
+s390x-GitCommit: f3b8fdb7c42fd3df9a6d819572d07ecd3aaf493e
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 8-minimal, 8.8-minimal, 8.8-minimal-20230718
-GitFetch: refs/heads/al8-20230718-amd64
-GitCommit: a7e0d4c97e8c2ab80dfada8685b44831f7c8d6ad
+Tags: 8-minimal, 8.9-minimal, 8.9-minimal-20231122
+GitFetch: refs/heads/al8-20231122-amd64
+GitCommit: 2b55e461c04ed9a74c37e043f7657d5a457e9494
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20230718-arm64v8
-arm64v8-GitCommit: af89b951918bc59e0891dde2ecbcc38d64560c59
+arm64v8-GitFetch: refs/heads/al8-20231122-arm64v8
+arm64v8-GitCommit: 4fe18788750ad7efafd5239a1bb0b5799ce8e19b
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20230718-ppc64le
-ppc64le-GitCommit: 77ec120d5ee160cc72406c31dddb4a9e9ec5c809
+ppc64le-GitFetch: refs/heads/al8-20231122-ppc64le
+ppc64le-GitCommit: bd5fba172243873deb26fa9708ea03f9068908cd
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20230718-s390x
-s390x-GitCommit: 0d0bcc7dba2e66b6e360d77c6c16fb8217490ddd
+s390x-GitFetch: refs/heads/al8-20231122-s390x
+s390x-GitCommit: f3b8fdb7c42fd3df9a6d819572d07ecd3aaf493e
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: latest, 9, 9.2, 9.2-20230718
+Tags: latest, 9, 9.3, 9.3-20230718
 GitFetch: refs/heads/al9-20230718-amd64
 GitCommit: 764a53a590bc415278c977ad43f42f4a836b8c3f
 amd64-File: Dockerfile-x86_64-default
@@ -48,7 +48,7 @@ s390x-GitCommit: 5014341cc139ca7b70f2cc1440c3a35e693a60f9
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 9-minimal,  9.2-minimal, 9.2-minimal-20230718
+Tags: minimal, 9-minimal,  9.3-minimal, 9.3-minimal-20230718
 GitFetch: refs/heads/al9-20230718-amd64
 GitCommit: 764a53a590bc415278c977ad43f42f4a836b8c3f
 amd64-File: Dockerfile-x86_64-minimal


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @LKHN or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `almalinux-release` changed from 8.8-1.el8 to 8.9-1.el8
- `audit-libs` changed from 3.0.7-4.el8 to 3.0.7-5.el8
- `binutils` changed from 2.30-119.el8 to 2.30-123.el8
- `ca-certificates` changed from 2022.2.54-80.2.el8_6 to 2023.2.60_v7.0.306-80.0.el8_8
- `chkconfig` changed from 1.19.1-1.el8 to 1.19.2-1.el8
- `crypto-policies` changed from 20221215-1.gitece0092.el8 to 20230731-1.git3177e06.el8
- `cryptsetup-libs` changed from 2.3.7-5.el8 to 2.3.7-7.el8
- `curl` changed from 7.61.1-30.el8_8.2 to 7.61.1-33.el8
- `dbus` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-common` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-daemon` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-libs` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-tools` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `device-mapper` changed from 1.02.181-9.el8 to 1.02.181-13.el8_9
- `device-mapper-libs` changed from 1.02.181-9.el8 to 1.02.181-13.el8_9
- `dnf` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `dnf-data` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `elfutils-default-yama-scope` changed from 0.188-3.el8 to 0.189-3.el8
- `elfutils-libelf` changed from 0.188-3.el8 to 0.189-3.el8
- `elfutils-libs` changed from 0.188-3.el8 to 0.189-3.el8
- `file-libs` changed from 5.33-24.el8 to 5.33-25.el8
- `findutils` changed from 4.6.0-20.el8 to 4.6.0-21.el8
- `glibc` changed from 2.28-225.el8 to 2.28-236.el8.7
- `glibc-common` changed from 2.28-225.el8 to 2.28-236.el8.7
- `glibc-minimal-langpack` changed from 2.28-225.el8 to 2.28-236.el8.7
- `gnutls` changed from 3.6.16-6.el8_7 to 3.6.16-7.el8
- `iputils` changed from 20180629-10.el8 to 20180629-11.el8
- `krb5-libs` changed from 1.18.2-25.el8_8 to 1.18.2-26.el8_9
- `libblkid` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libcap` changed from 2.48-4.el8 to 2.48-5.el8_8
- `libcurl-minimal` changed from 7.61.1-30.el8_8.2 to 7.61.1-33.el8
- `libdnf` changed from 0.63.0-14.el8_8.alma to 0.63.0-17.el8_9.alma
- `libfdisk` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libgcc` changed from 8.5.0-18.el8.alma to 8.5.0-20.el8.alma
- `libmount` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libnghttp2` changed from 1.33.0-3.el8_2.1 to 1.33.0-5.el8_9
- `libsmartcols` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libsolv` changed from 0.7.20-4.el8_7 to 0.7.20-6.el8
- `libstdc++` changed from 8.5.0-18.el8.alma to 8.5.0-20.el8.alma
- `libuuid` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libxml2` changed from 2.9.7-16.el8 to 2.9.7-16.el8_8.1
- `ncurses-base` changed from 6.1-9.20180224.el8 to 6.1-10.20180224.el8
- `ncurses-libs` changed from 6.1-9.20180224.el8 to 6.1-10.20180224.el8
- `pam` changed from 1.3.1-25.el8 to 1.3.1-27.el8
- `platform-python` changed from 3.6.8-51.el8_8.1.alma to 3.6.8-56.el8_9.alma.1
- `python3-dnf` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `python3-hawkey` changed from 0.63.0-14.el8_8.alma to 0.63.0-17.el8_9.alma
- `python3-libdnf` changed from 0.63.0-14.el8_8.alma to 0.63.0-17.el8_9.alma
- `python3-libs` changed from 3.6.8-51.el8_8.1.alma to 3.6.8-56.el8_9.alma.1
- `python3-pip-wheel` changed from 9.0.3-22.el8 to 9.0.3-23.el8
- `shadow-utils` changed from 4.6-17.el8 to 4.6-19.el8
- `systemd` changed from 239-74.el8_8.2 to 239-78.el8
- `systemd-libs` changed from 239-74.el8_8.2 to 239-78.el8
- `systemd-pam` changed from 239-74.el8_8.2 to 239-78.el8
- `tpm2-tss` changed from 2.3.2-4.el8 to 2.3.2-5.el8
- `util-linux` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `yum` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `zlib` changed from 1.2.11-21.el8_7 to 1.2.11-25.el8


