### PR TITLE
Almalinux auto-update - 170938

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,64 +1,64 @@
-# This file is generated using https://github.com/almalinux/docker-images/blob/0f287a463b6c372fb358d8f9f993c2c65361b6a7/gen_docker_official_library
+# This file is generated using https://github.com/almalinux/docker-images/blob/a95cef6a11ec939a6fa7b4f1a80cd1a0363b8cbc/gen_docker_official_library
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
 GitRepo: https://github.com/AlmaLinux/docker-images.git
 
 
-Tags: 8, 8.8, 8.8-20230718
-GitFetch: refs/heads/al8-20230718-amd64
-GitCommit: a7e0d4c97e8c2ab80dfada8685b44831f7c8d6ad
+Tags: 8, 8.9, 8.9-20231122
+GitFetch: refs/heads/al8-20231122-amd64
+GitCommit: 2b55e461c04ed9a74c37e043f7657d5a457e9494
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20230718-arm64v8
-arm64v8-GitCommit: af89b951918bc59e0891dde2ecbcc38d64560c59
+arm64v8-GitFetch: refs/heads/al8-20231122-arm64v8
+arm64v8-GitCommit: 4fe18788750ad7efafd5239a1bb0b5799ce8e19b
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20230718-ppc64le
-ppc64le-GitCommit: 77ec120d5ee160cc72406c31dddb4a9e9ec5c809
+ppc64le-GitFetch: refs/heads/al8-20231122-ppc64le
+ppc64le-GitCommit: bd5fba172243873deb26fa9708ea03f9068908cd
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20230718-s390x
-s390x-GitCommit: 0d0bcc7dba2e66b6e360d77c6c16fb8217490ddd
+s390x-GitFetch: refs/heads/al8-20231122-s390x
+s390x-GitCommit: f3b8fdb7c42fd3df9a6d819572d07ecd3aaf493e
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 8-minimal, 8.8-minimal, 8.8-minimal-20230718
-GitFetch: refs/heads/al8-20230718-amd64
-GitCommit: a7e0d4c97e8c2ab80dfada8685b44831f7c8d6ad
+Tags: 8-minimal, 8.9-minimal, 8.9-minimal-20231122
+GitFetch: refs/heads/al8-20231122-amd64
+GitCommit: 2b55e461c04ed9a74c37e043f7657d5a457e9494
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20230718-arm64v8
-arm64v8-GitCommit: af89b951918bc59e0891dde2ecbcc38d64560c59
+arm64v8-GitFetch: refs/heads/al8-20231122-arm64v8
+arm64v8-GitCommit: 4fe18788750ad7efafd5239a1bb0b5799ce8e19b
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20230718-ppc64le
-ppc64le-GitCommit: 77ec120d5ee160cc72406c31dddb4a9e9ec5c809
+ppc64le-GitFetch: refs/heads/al8-20231122-ppc64le
+ppc64le-GitCommit: bd5fba172243873deb26fa9708ea03f9068908cd
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20230718-s390x
-s390x-GitCommit: 0d0bcc7dba2e66b6e360d77c6c16fb8217490ddd
+s390x-GitFetch: refs/heads/al8-20231122-s390x
+s390x-GitCommit: f3b8fdb7c42fd3df9a6d819572d07ecd3aaf493e
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: latest, 9, 9.2, 9.2-20230718
-GitFetch: refs/heads/al9-20230718-amd64
-GitCommit: 764a53a590bc415278c977ad43f42f4a836b8c3f
+Tags: latest, 9, 9.3, 9.3-20231122
+GitFetch: refs/heads/al9-20231122-amd64
+GitCommit: fe2a97c5db0765c328ad806792866e60b14596ee
 amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20230718-arm64v8
-arm64v8-GitCommit: 8812e025bed7bf8b231f8cdbc2a67880f1fd03e0
+arm64v8-GitFetch: refs/heads/al9-20231122-arm64v8
+arm64v8-GitCommit: 15a35229e19f81fcd8c1c2d1a30e4d46a9690fa4
 arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20230718-ppc64le
-ppc64le-GitCommit: 7167d334fcc163577422e74f364f652481f5cd97
+ppc64le-GitFetch: refs/heads/al9-20231122-ppc64le
+ppc64le-GitCommit: da1ed3b1643a8741646e20f73eef1ba3afbbd24a
 ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20230718-s390x
-s390x-GitCommit: 5014341cc139ca7b70f2cc1440c3a35e693a60f9
+s390x-GitFetch: refs/heads/al9-20231122-s390x
+s390x-GitCommit: 0ca81f035791f349604b65f8187b478d70c632c8
 s390x-File: Dockerfile-s390x-default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 9-minimal,  9.2-minimal, 9.2-minimal-20230718
-GitFetch: refs/heads/al9-20230718-amd64
-GitCommit: 764a53a590bc415278c977ad43f42f4a836b8c3f
+Tags: minimal, 9-minimal,  9.3-minimal, 9.3-minimal-20231122
+GitFetch: refs/heads/al9-20231122-amd64
+GitCommit: fe2a97c5db0765c328ad806792866e60b14596ee
 amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20230718-arm64v8
-arm64v8-GitCommit: 8812e025bed7bf8b231f8cdbc2a67880f1fd03e0
+arm64v8-GitFetch: refs/heads/al9-20231122-arm64v8
+arm64v8-GitCommit: 15a35229e19f81fcd8c1c2d1a30e4d46a9690fa4
 arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20230718-ppc64le
-ppc64le-GitCommit: 7167d334fcc163577422e74f364f652481f5cd97
+ppc64le-GitFetch: refs/heads/al9-20231122-ppc64le
+ppc64le-GitCommit: da1ed3b1643a8741646e20f73eef1ba3afbbd24a
 ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20230718-s390x
-s390x-GitCommit: 5014341cc139ca7b70f2cc1440c3a35e693a60f9
+s390x-GitFetch: refs/heads/al9-20231122-s390x
+s390x-GitCommit: 0ca81f035791f349604b65f8187b478d70c632c8
 s390x-File: Dockerfile-s390x-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @LKHN or email to AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)

### AlmaLinux 8 change log

- `almalinux-release` changed from 8.8-1.el8 to 8.9-1.el8
- `audit-libs` changed from 3.0.7-4.el8 to 3.0.7-5.el8
- `binutils` changed from 2.30-119.el8 to 2.30-123.el8
- `ca-certificates` changed from 2022.2.54-80.2.el8_6 to 2023.2.60_v7.0.306-80.0.el8_8
- `chkconfig` changed from 1.19.1-1.el8 to 1.19.2-1.el8
- `crypto-policies` changed from 20221215-1.gitece0092.el8 to 20230731-1.git3177e06.el8
- `cryptsetup-libs` changed from 2.3.7-5.el8 to 2.3.7-7.el8
- `curl` changed from 7.61.1-30.el8_8.2 to 7.61.1-33.el8
- `dbus` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-common` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-daemon` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-libs` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `dbus-tools` changed from 1.12.8-24.el8 to 1.12.8-26.el8
- `device-mapper` changed from 1.02.181-9.el8 to 1.02.181-13.el8_9
- `device-mapper-libs` changed from 1.02.181-9.el8 to 1.02.181-13.el8_9
- `dnf` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `dnf-data` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `elfutils-default-yama-scope` changed from 0.188-3.el8 to 0.189-3.el8
- `elfutils-libelf` changed from 0.188-3.el8 to 0.189-3.el8
- `elfutils-libs` changed from 0.188-3.el8 to 0.189-3.el8
- `file-libs` changed from 5.33-24.el8 to 5.33-25.el8
- `findutils` changed from 4.6.0-20.el8 to 4.6.0-21.el8
- `glibc` changed from 2.28-225.el8 to 2.28-236.el8.7
- `glibc-common` changed from 2.28-225.el8 to 2.28-236.el8.7
- `glibc-minimal-langpack` changed from 2.28-225.el8 to 2.28-236.el8.7
- `gnutls` changed from 3.6.16-6.el8_7 to 3.6.16-7.el8
- `iputils` changed from 20180629-10.el8 to 20180629-11.el8
- `krb5-libs` changed from 1.18.2-25.el8_8 to 1.18.2-26.el8_9
- `libblkid` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libcap` changed from 2.48-4.el8 to 2.48-5.el8_8
- `libcurl-minimal` changed from 7.61.1-30.el8_8.2 to 7.61.1-33.el8
- `libdnf` changed from 0.63.0-14.el8_8.alma to 0.63.0-17.el8_9.alma
- `libfdisk` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libgcc` changed from 8.5.0-18.el8.alma to 8.5.0-20.el8.alma
- `libmount` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libnghttp2` changed from 1.33.0-3.el8_2.1 to 1.33.0-5.el8_9
- `libsmartcols` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libsolv` changed from 0.7.20-4.el8_7 to 0.7.20-6.el8
- `libstdc++` changed from 8.5.0-18.el8.alma to 8.5.0-20.el8.alma
- `libuuid` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `libxml2` changed from 2.9.7-16.el8 to 2.9.7-16.el8_8.1
- `ncurses-base` changed from 6.1-9.20180224.el8 to 6.1-10.20180224.el8
- `ncurses-libs` changed from 6.1-9.20180224.el8 to 6.1-10.20180224.el8
- `pam` changed from 1.3.1-25.el8 to 1.3.1-27.el8
- `platform-python` changed from 3.6.8-51.el8_8.1.alma to 3.6.8-56.el8_9.alma.1
- `python3-dnf` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `python3-hawkey` changed from 0.63.0-14.el8_8.alma to 0.63.0-17.el8_9.alma
- `python3-libdnf` changed from 0.63.0-14.el8_8.alma to 0.63.0-17.el8_9.alma
- `python3-libs` changed from 3.6.8-51.el8_8.1.alma to 3.6.8-56.el8_9.alma.1
- `python3-pip-wheel` changed from 9.0.3-22.el8 to 9.0.3-23.el8
- `shadow-utils` changed from 4.6-17.el8 to 4.6-19.el8
- `systemd` changed from 239-74.el8_8.2 to 239-78.el8
- `systemd-libs` changed from 239-74.el8_8.2 to 239-78.el8
- `systemd-pam` changed from 239-74.el8_8.2 to 239-78.el8
- `tpm2-tss` changed from 2.3.2-4.el8 to 2.3.2-5.el8
- `util-linux` changed from 2.32.1-42.el8_8 to 2.32.1-43.el8
- `yum` changed from 4.7.0-16.el8_8.alma to 4.7.0-19.el8.alma
- `zlib` changed from 1.2.11-21.el8_7 to 1.2.11-25.el8

### AlmaLinux 9 change log

- `almalinux-gpg-keys` changed from 9.2-1.el9 to 9.3-1.el9
- `almalinux-release` changed from 9.2-1.el9 to 9.3-1.el9
- `almalinux-repos` changed from 9.2-1.el9 to 9.3-1.el9
- `alternatives` changed from 1.20-2.el9 to 1.24-1.el9
- `audit-libs` changed from 3.0.7-103.el9 to 3.0.7-104.el9
- `binutils` changed from 2.35.2-37.el9 to 2.35.2-42.el9
- `binutils-gold` changed from 2.35.2-37.el9 to 2.35.2-42.el9
- `ca-certificates` changed from 2022.2.54-90.2.el9_0 to 2023.2.60_v7.0.306-90.1.el9_2
- `crypto-policies` changed from 20221215-1.git9a18988.el9 to 20230731-1.git94f0e2c.el9_3.1
- `crypto-policies-scripts` changed from 20221215-1.git9a18988.el9 to 20230731-1.git94f0e2c.el9_3.1
- `curl-minimal` changed from 7.76.1-23.el9_2.1 to 7.76.1-26.el9_3.2
- `dbus` changed from 1.12.20-7.el9_1 to 1.12.20-8.el9
- `dbus-common` changed from 1.12.20-7.el9_1 to 1.12.20-8.el9
- `dnf` changed from 4.14.0-5.el9_2.alma to 4.14.0-8.el9.alma.1
- `dnf-data` changed from 4.14.0-5.el9_2.alma to 4.14.0-8.el9.alma.1
- `elfutils-debuginfod-client` changed from 0.188-3.el9 to 0.189-3.el9
- `elfutils-default-yama-scope` changed from 0.188-3.el9 to 0.189-3.el9
- `elfutils-libelf` changed from 0.188-3.el9 to 0.189-3.el9
- `elfutils-libs` changed from 0.188-3.el9 to 0.189-3.el9
- `file-libs` changed from 5.39-12.el9 to 5.39-14.el9
- `findutils` changed from 4.8.0-5.el9 to 4.8.0-6.el9
- `glib2` changed from 2.68.4-6.el9 to 2.68.4-11.el9
- `glibc` changed from 2.34-60.el9 to 2.34-83.el9_3.7
- `glibc-common` changed from 2.34-60.el9 to 2.34-83.el9_3.7
- `glibc-minimal-langpack` changed from 2.34-60.el9 to 2.34-83.el9_3.7
- `gmp` changed from 6.2.0-10.el9 to 6.2.0-13.el9
- `gnupg2` changed from 2.3.3-2.el9_0 to 2.3.3-4.el9
- `gnutls` changed from 3.7.6-20.el9_2 to 3.7.6-23.el9
- `iputils` changed from 20210202-8.el9_1.1 to 20210202-9.el9
- `kmod-libs` changed from 28-7.el9 to 28-9.el9
- `krb5-libs` changed from 1.20.1-9.el9_2 to 1.21.1-1.el9
- `libblkid` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `libcap` changed from 2.48-8.el9 to 2.48-9.el9_2
- `libcurl-minimal` changed from 7.76.1-23.el9_2.1 to 7.76.1-26.el9_3.2
- `libdnf` changed from 0.69.0-3.el9_2.alma to 0.69.0-6.el9_3.alma.1
- `libeconf` changed from 0.4.1-2.el9 to 0.4.1-3.el9_2
- `libfdisk` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `libffi` changed from 3.4.2-7.el9 to 3.4.2-8.el9
- `libgcc` changed from 11.3.1-4.3.el9.alma to 11.4.1-2.1.el9.alma
- `libgomp` changed from 11.3.1-4.3.el9.alma to 11.4.1-2.1.el9.alma
- `libmount` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `libnghttp2` changed from 1.43.0-5.el9 to 1.43.0-5.el9_3.1
- `libsemanage` changed from 3.5-1.el9 to 3.5-2.el9
- `libsmartcols` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `libsolv` changed from 0.7.22-4.el9 to 0.7.24-2.el9
- `libstdc++` changed from 11.3.1-4.3.el9.alma to 11.4.1-2.1.el9.alma
- `libuuid` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `libxml2` changed from 2.9.13-3.el9_1 to 2.9.13-4.el9
- `lua-libs` changed from 5.4.4-3.el9 to 5.4.4-4.el9
- `ncurses-base` changed from 6.2-8.20210508.el9 to 6.2-10.20210508.el9
- `ncurses-libs` changed from 6.2-8.20210508.el9 to 6.2-10.20210508.el9
- `openldap` changed from 2.6.2-3.el9 to 2.6.3-1.el9
- `openldap-compat-2.6.2-3.el9` package removed
- `openssl` changed from 3.0.7-16.el9_2 to 3.0.7-24.el9
- `openssl-libs` changed from 3.0.7-16.el9_2 to 3.0.7-24.el9
- `pam` changed from 1.5.1-14.el9 to 1.5.1-15.el9
- `python3` changed from 3.9.16-1.el9_2.1 to 3.9.18-1.el9_3
- `python3-dnf` changed from 4.14.0-5.el9_2.alma to 4.14.0-8.el9.alma.1
- `python3-hawkey` changed from 0.69.0-3.el9_2.alma to 0.69.0-6.el9_3.alma.1
- `python3-libdnf` changed from 0.69.0-3.el9_2.alma to 0.69.0-6.el9_3.alma.1
- `python3-libs` changed from 3.9.16-1.el9_2.1 to 3.9.18-1.el9_3
- `python3-pip-wheel` changed from 21.2.3-6.el9 to 21.2.3-7.el9
- `python3-rpm` changed from 4.16.1.3-22.el9 to 4.16.1.3-25.el9
- `rpm` changed from 4.16.1.3-22.el9 to 4.16.1.3-25.el9
- `rpm-build-libs` changed from 4.16.1.3-22.el9 to 4.16.1.3-25.el9
- `rpm-libs` changed from 4.16.1.3-22.el9 to 4.16.1.3-25.el9
- `rpm-sign-libs` changed from 4.16.1.3-22.el9 to 4.16.1.3-25.el9
- `shadow-utils` changed from 4.9-6.el9 to 4.9-8.el9
- `systemd` changed from 252-14.el9_2.1 to 252-18.el9
- `systemd-libs` changed from 252-14.el9_2.1 to 252-18.el9
- `systemd-pam` changed from 252-14.el9_2.1 to 252-18.el9
- `systemd-rpm-macros` changed from 252-14.el9_2.1 to 252-18.el9
- `tpm2-tss` changed from 3.0.3-8.el9 to 3.2.2-2.el9
- `util-linux` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `util-linux-core` changed from 2.37.4-11.el9_2 to 2.37.4-15.el9
- `yum` changed from 4.14.0-5.el9_2.alma to 4.14.0-8.el9.alma.1
- `zlib` changed from 1.2.11-39.el9 to 1.2.11-40.el9

