### PR TITLE
archlinux: Release 20231126.0.194797

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20231112.0.191179
-GitCommit: 9e3e5066b444021f47836449f6a9d89d0cf5861a
-GitFetch: refs/tags/v20231112.0.191179
+Tags: latest, base, base-20231126.0.194797
+GitCommit: 52e6c79506dd9e5dd372939b4798831f448a0b3e
+GitFetch: refs/tags/v20231126.0.194797
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20231112.0.191179
-GitCommit: 9e3e5066b444021f47836449f6a9d89d0cf5861a
-GitFetch: refs/tags/v20231112.0.191179
+Tags: base-devel, base-devel-20231126.0.194797
+GitCommit: 52e6c79506dd9e5dd372939b4798831f448a0b3e
+GitFetch: refs/tags/v20231126.0.194797
 File: Dockerfile.base-devel
+
+Tags: multilib-devel, multilib-devel-20231126.0.194797
+GitCommit: 52e6c79506dd9e5dd372939b4798831f448a0b3e
+GitFetch: refs/tags/v20231126.0.194797
+File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks