### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev10, 2.9-dev, 2.9-dev10-bullseye, 2.9-dev-bullseye
+Tags: 2.9-dev11, 2.9-dev, 2.9-dev11-bullseye, 2.9-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fdb46d56e1f9512e05b4f5acf63d2ffa2044b5bf
+GitCommit: d077b7002ef0f097bed1bb65a6a3508f24b0cb90
 Directory: 2.9
 
-Tags: 2.9-dev10-alpine, 2.9-dev-alpine, 2.9-dev10-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9-dev11-alpine, 2.9-dev-alpine, 2.9-dev11-alpine3.18, 2.9-dev-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: fdb46d56e1f9512e05b4f5acf63d2ffa2044b5bf
+GitCommit: d077b7002ef0f097bed1bb65a6a3508f24b0cb90
 Directory: 2.9/alpine
 
 Tags: 2.8.4, 2.8, lts, latest, 2.8.4-bullseye, 2.8-bullseye, lts-bullseye, bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/d077b70: Update 2.9 to 2.9-dev11