### PR TITLE
Bump Traefik to v2.10.6

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,15 +13,15 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 9c7773b44918428aed9d425932dbd220e700fed3
 Directory: alpine
 
-Tags: v2.10.5-windowsservercore-1809, 2.10.5-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.10.6-windowsservercore-1809, 2.10.6-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 71a4619eca4f504c7034876c171626c1755944f3
+GitCommit: 66eed101dfeadb185a4e3087fc5dc3e167a9c89f
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.10.5, 2.10.5, v2.10, 2.10, saintmarcelin, latest
+Tags: v2.10.6, 2.10.6, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 71a4619eca4f504c7034876c171626c1755944f3
+GitCommit: 66eed101dfeadb185a4e3087fc5dc3e167a9c89f
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.10.6](https://github.com/traefik/traefik/releases/tag/v2.10.6).

/cc @mmatur @kevinpollet @ldez

Cheers
