### PR TITLE
Remove unsupported flink-1.15

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -37,13 +37,3 @@ Tags: 1.16.2-scala_2.12-java11, 1.16-scala_2.12-java11, 1.16.2-scala_2.12, 1.16-
 Architectures: amd64,arm64v8
 GitCommit: 45c6d230407d89aa83b0d170dd056d6868cf808e
 Directory: ./1.16/scala_2.12-java11-ubuntu
-
-Tags: 1.15.4-scala_2.12-java8, 1.15-scala_2.12-java8, 1.15.4-java8, 1.15-java8
-Architectures: amd64,arm64v8
-GitCommit: c9754889a57fad2d8fff2a1975f076a0caebb28c
-Directory: ./1.15/scala_2.12-java8-ubuntu
-
-Tags: 1.15.4-scala_2.12-java11, 1.15-scala_2.12-java11, 1.15.4-scala_2.12, 1.15-scala_2.12, 1.15.4-java11, 1.15-java11, 1.15.4, 1.15
-Architectures: amd64,arm64v8
-GitCommit: c9754889a57fad2d8fff2a1975f076a0caebb28c
-Directory: ./1.15/scala_2.12-java11-ubuntu


### PR DESCRIPTION
Since flink-1.18 has been released, we could remove the unsupported flink-1.15 now.