### PR TITLE
Update Dart for Dart 3.2.2 release

### DIFF
--- a/library/dart
+++ b/library/dart
@@ -1,8 +1,8 @@
 Maintainers: Alexander Thomas <athom@google.com> (@athomas), Tony Pujals <tonypujals@google.com> (@subfuzion)
 GitRepo: https://github.com/dart-lang/dart-docker.git
 GitFetch: refs/heads/main
-GitCommit: ab6a6394c533c317e590d0f8fd8df680e2293159
+GitCommit: d6a24501ca8f35542032db8bdbc408bd5e9c71a5
 
-Tags: 3.2.0-sdk, 3.2-sdk, 3-sdk, stable-sdk, sdk, 3.2.0, 3.2, 3, stable, latest, beta-sdk, beta
+Tags: 3.2.2-sdk, 3.2-sdk, 3-sdk, stable-sdk, sdk, 3.2.2, 3.2, 3, stable, latest, beta-sdk, beta
 Architectures: amd64, arm32v7, arm64v8
 Directory: stable/bookworm


### PR DESCRIPTION
Commit reference: https://github.com/dart-lang/dart-docker/commit/d6a24501ca8f35542032db8bdbc408bd5e9c71a5

GitHub release reference: https://github.com/dart-lang/sdk/releases/tag/3.2.2