### PR TITLE
Bump Traefik to v3.0.0-beta5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,16 +1,16 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.0-beta4-windowsservercore-1809, 3.0.0-beta4-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
+Tags: v3.0.0-beta5-windowsservercore-1809, 3.0.0-beta5-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9c7773b44918428aed9d425932dbd220e700fed3
+GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.0-beta4, 3.0.0-beta4, v3.0, 3.0, beaufort
+Tags: v3.0.0-beta5, 3.0.0-beta5, v3.0, 3.0, beaufort
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9c7773b44918428aed9d425932dbd220e700fed3
+GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
 Directory: alpine
 
 Tags: v2.10.6-windowsservercore-1809, 2.10.6-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.0.0-beta5](https://github.com/traefik/traefik/releases/tag/v3.0.0-beta5).

/cc @mmatur @kevinpollet @ldez

Cheers
