### PR TITLE
Update ELK to "proper" images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,15 +1,14 @@
-# this file is generated via https://github.com/docker-library/elasticsearch/blob/1c213e964445c73ff44e2ed1ff18e28995800d8e/generate-stackbrew-library.sh
-
-Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
-             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
-GitRepo: https://github.com/docker-library/elasticsearch.git
+Maintainers: Mark Vieira (@mark-vieira)
+GitRepo: https://github.com/elastic/dockerfiles.git
+Directory: elasticsearch
+Builder: buildkit
 
 Tags: 8.11.1
 Architectures: amd64, arm64v8
-GitCommit: 84a62adaf958d51f39376ed636a7d59f2e92ca69
-Directory: 8
+GitFetch: refs/heads/8.11
+GitCommit: 0dbf0d4297a2bf48d0cd980935431c121396885d
 
 Tags: 7.17.15
 Architectures: amd64, arm64v8
-GitCommit: 917e6014bd129e3e2193e2ec52245c9f599e1e84
-Directory: 7
+GitFetch: refs/heads/7.17
+GitCommit: 63269da8548948c20f3e1650cebbed1ae5eee90e

--- a/library/kibana
+++ b/library/kibana
@@ -1,15 +1,14 @@
-# this file is generated via https://github.com/docker-library/kibana/blob/094d900939e2a66300d48cbf2f3a8e0fc1d51abc/generate-stackbrew-library.sh
-
-Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
-             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
-GitRepo: https://github.com/docker-library/kibana.git
+Maintainers: Thomas Watson (@watson)
+GitRepo: https://github.com/elastic/dockerfiles.git
+Directory: kibana
+Builder: buildkit
 
 Tags: 8.11.1
 Architectures: amd64, arm64v8
-GitCommit: d86e69a854eb6bb1c4b4b33d629b784eb6ca539d
-Directory: 8
+GitFetch: refs/heads/8.11
+GitCommit: 0dbf0d4297a2bf48d0cd980935431c121396885d
 
 Tags: 7.17.15
 Architectures: amd64, arm64v8
-GitCommit: 9c6a9d1c949c08a7254e2ff66594e25c4be54da7
-Directory: 7
+GitFetch: refs/heads/7.17
+GitCommit: 63269da8548948c20f3e1650cebbed1ae5eee90e

--- a/library/logstash
+++ b/library/logstash
@@ -1,15 +1,14 @@
-# this file is generated via https://github.com/docker-library/logstash/blob/f7d134ebe96d21adc7ff6f0bdc46e06db1a642e7/generate-stackbrew-library.sh
-
-Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
-             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
-GitRepo: https://github.com/docker-library/logstash.git
+Maintainers: João Duarte (@jsvd)
+GitRepo: https://github.com/elastic/dockerfiles.git
+Directory: logstash
+Builder: buildkit
 
 Tags: 8.11.1
 Architectures: amd64, arm64v8
-GitCommit: 7866ca9dec9586e2e4a1a8d19a2958dfac93cede
-Directory: 8
+GitFetch: refs/heads/8.11
+GitCommit: 0dbf0d4297a2bf48d0cd980935431c121396885d
 
 Tags: 7.17.15
 Architectures: amd64, arm64v8
-GitCommit: e8bb7b091d72d4592901eb24379c9dde4975775f
-Directory: 7
+GitFetch: refs/heads/7.17
+GitCommit: 63269da8548948c20f3e1650cebbed1ae5eee90e


### PR DESCRIPTION
~~This is a concrete test of what I was suggesting in https://github.com/docker-library/official-images/issues/15753#issuecomment-1834442877 (not intended for merge as-is)~~

This updates them to point to the original source repository so they build directly instead of being a special case, and updates the maintainers appropriately.

See https://github.com/docker-library/official-images/issues/15753#issuecomment-1834442877 and following conversation :+1: