### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -34,21 +34,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 0b054b731bf4c7191ffe1b5d5e289cb385b49821
 Directory: 5.0/php8.2/fpm
 
-Tags: 4.4.1-php8.0-apache, 4.4-php8.0-apache, 4-php8.0-apache, php8.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b054b731bf4c7191ffe1b5d5e289cb385b49821
-Directory: 4.4/php8.0/apache
-
-Tags: 4.4.1-php8.0-fpm-alpine, 4.4-php8.0-fpm-alpine, 4-php8.0-fpm-alpine, php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0b054b731bf4c7191ffe1b5d5e289cb385b49821
-Directory: 4.4/php8.0/fpm-alpine
-
-Tags: 4.4.1-php8.0-fpm, 4.4-php8.0-fpm, 4-php8.0-fpm, php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b054b731bf4c7191ffe1b5d5e289cb385b49821
-Directory: 4.4/php8.0/fpm
-
 Tags: 4.4.1, 4.4, 4, latest, 4.4.1-apache, 4.4-apache, 4-apache, apache, 4.4.1-php8.1, 4.4-php8.1, 4-php8.1, php8.1, 4.4.1-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 0b054b731bf4c7191ffe1b5d5e289cb385b49821
@@ -79,21 +64,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 0b054b731bf4c7191ffe1b5d5e289cb385b49821
 Directory: 4.4/php8.2/fpm
 
-Tags: 4.3.4-php8.0-apache, 4.3-php8.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
-Directory: 4.3/php8.0/apache
-
-Tags: 4.3.4-php8.0-fpm-alpine, 4.3-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
-Directory: 4.3/php8.0/fpm-alpine
-
-Tags: 4.3.4-php8.0-fpm, 4.3-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
-Directory: 4.3/php8.0/fpm
-
 Tags: 4.3.4, 4.3, 4.3.4-apache, 4.3-apache, 4.3.4-php8.1, 4.3-php8.1, 4.3.4-php8.1-apache, 4.3-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
@@ -123,18 +93,3 @@ Tags: 4.3.4-php8.2-fpm, 4.3-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
 Directory: 4.3/php8.2/fpm
-
-Tags: 3.10.12, 3.10, 3, 3.10.12-apache, 3.10-apache, 3-apache, 3.10.12-php8.0, 3.10-php8.0, 3-php8.0, 3.10.12-php8.0-apache, 3.10-php8.0-apache, 3-php8.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
-Directory: 3.10/php8.0/apache
-
-Tags: 3.10.12-php8.0-fpm-alpine, 3.10-php8.0-fpm-alpine, 3-php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
-Directory: 3.10/php8.0/fpm-alpine
-
-Tags: 3.10.12-php8.0-fpm, 3.10-php8.0-fpm, 3-php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ef73b7df0a255212a3334ee238d137f7dcde456f
-Directory: 3.10/php8.0/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@5b28187 Removes all PHP 8.0 images. Removes Joomla 3.10 images.