### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,80 +1,60 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/9805367fb85866f8a273a0c983f274e3be98638a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/41679683d8bdf995d53318bef2e34e328239eace/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.4.1-apache, 6.4-apache, 6-apache, apache, 6.4.1, 6.4, 6, latest, 6.4.1-php8.0-apache, 6.4-php8.0-apache, 6-php8.0-apache, php8.0-apache, 6.4.1-php8.0, 6.4-php8.0, 6-php8.0, php8.0
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
-Directory: latest/php8.0/apache
-
-Tags: 6.4.1-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.1-php8.0-fpm, 6.4-php8.0-fpm, 6-php8.0-fpm, php8.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
-Directory: latest/php8.0/fpm
-
-Tags: 6.4.1-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.1-php8.0-fpm-alpine, 6.4-php8.0-fpm-alpine, 6-php8.0-fpm-alpine, php8.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
-Directory: latest/php8.0/fpm-alpine
-
 Tags: 6.4.1-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.1-php8.1, 6.4-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.1/apache
 
 Tags: 6.4.1-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.1/fpm
 
 Tags: 6.4.1-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.4.1-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.1-php8.2, 6.4-php8.2, 6-php8.2, php8.2
+Tags: 6.4.1-apache, 6.4-apache, 6-apache, apache, 6.4.1, 6.4, 6, latest, 6.4.1-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.1-php8.2, 6.4-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.2/apache
 
-Tags: 6.4.1-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.4.1-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.1-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.2/fpm
 
-Tags: 6.4.1-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.4.1-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.1-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4b4966247eb33c6c219cf682f1750ed5685d21c9
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.2/fpm-alpine
 
 Tags: 6.4.1-php8.3-apache, 6.4-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.4.1-php8.3, 6.4-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1cc7e6a226cf23ade72b83990310980e7ac5c2b
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.3/apache
 
 Tags: 6.4.1-php8.3-fpm, 6.4-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d1cc7e6a226cf23ade72b83990310980e7ac5c2b
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.3/fpm
 
 Tags: 6.4.1-php8.3-fpm-alpine, 6.4-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1cc7e6a226cf23ade72b83990310980e7ac5c2b
+GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
 Directory: latest/php8.3/fpm-alpine
-
-Tags: cli-2.9.0, cli-2.9, cli-2, cli, cli-2.9.0-php8.0, cli-2.9-php8.0, cli-2-php8.0, cli-php8.0
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
-Directory: cli/php8.0/alpine
 
 Tags: cli-2.9.0-php8.1, cli-2.9-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.9.0-php8.2, cli-2.9-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.9.0, cli-2.9, cli-2, cli, cli-2.9.0-php8.2, cli-2.9-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
 Directory: cli/php8.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/86753ab: Resync "wp-config-docker" with upstream "wp-config-sample"
- https://github.com/docker-library/wordpress/commit/304fa4f: Merge pull request https://github.com/docker-library/wordpress/pull/863 from infosiftr/php8.0-eol
- https://github.com/docker-library/wordpress/commit/4167968: Remove php8.0 variants as it has reached end of life