### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.75.0, 5.75, 5, latest
+Tags: 5.75.1, 5.75, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2b5ade9b98a178d1d2980127e19430069a327691
+GitCommit: 6165dced822dbdb27cba064220d1ef07168b4013
 Directory: 5/debian
 
-Tags: 5.75.0-alpine, 5.75-alpine, 5-alpine, alpine
+Tags: 5.75.1-alpine, 5.75-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 2b5ade9b98a178d1d2980127e19430069a327691
+GitCommit: 6165dced822dbdb27cba064220d1ef07168b4013
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/6165dce: Update to 5.75.1, ghost-cli 1.25.3