### PR TITLE
Update Jetty versions to 12.0.4

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -14,6 +14,16 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre8
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
+Tags: 9.4.53-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.53-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/9.4/jre21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 9.4.53-jre21, 9.4-jre21, 9-jre21, 9.4.53-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jre21
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
 Tags: 9.4.53-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.53-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre17-alpine
@@ -39,12 +49,22 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
+Tags: 9.4.53-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.53-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/9.4/jdk21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 9.4.53, 9.4, 9, 9.4.53-jdk21, 9.4-jdk21, 9-jdk21, 9.4.53-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.53-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/9.4/jdk21
+GitCommit: 5245ca814cb972078d8e5bb6526f183d84f6d283
+
 Tags: 9.4.53-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.53-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 9.4.53, 9.4, 9, 9.4.53-jdk17, 9.4-jdk17, 9-jdk17, 9.4.53-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.53-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
+Tags: 9.4.53-jdk17, 9.4-jdk17, 9-jdk17, 9.4.53-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
@@ -59,25 +79,55 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 12.0.3-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.3-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.4-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.4-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0/jre21-alpine
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 12.0.4-jre21, 12.0-jre21, 12-jre21, 12.0.4-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0/jre21
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 12.0.4-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.4-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
 
-Tags: 12.0.3-jre17, 12.0-jre17, 12-jre17, 12.0.3-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.4-jre17, 12.0-jre17, 12-jre17, 12.0.4-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
 
-Tags: 12.0.3-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.3-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.4-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.4-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0/jdk21-alpine
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 12.0.4, 12.0, 12, 12.0.4-jdk21, 12.0-jdk21, 12-jdk21, 12.0.4-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.4-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0/jdk21
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 12.0.4-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.4-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
 
-Tags: 12.0.3, 12.0, 12, 12.0.3-jdk17, 12.0-jdk17, 12-jdk17, 12.0.3-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.3-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, latest, jdk17
+Tags: 12.0.4-jdk17, 12.0-jdk17, 12-jdk17, 12.0.4-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 11.0.18-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.18-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0/jre21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 11.0.18-jre21, 11.0-jre21, 11-jre21, 11.0.18-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0/jre21
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
 
 Tags: 11.0.18-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.18-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
@@ -99,12 +149,22 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
+Tags: 11.0.18-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.18-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0/jdk21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 11.0.18, 11.0, 11, 11.0.18-jdk21, 11.0-jdk21, 11-jdk21, 11.0.18-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.18-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0/jdk21
+GitCommit: 5245ca814cb972078d8e5bb6526f183d84f6d283
+
 Tags: 11.0.18-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.18-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.18, 11.0, 11, 11.0.18-jdk17, 11.0-jdk17, 11-jdk17, 11.0.18-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.18-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.18-jdk17, 11.0-jdk17, 11-jdk17, 11.0.18-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
@@ -118,6 +178,16 @@ Tags: 11.0.18-jdk11, 11.0-jdk11, 11-jdk11, 11.0.18-jdk11-eclipse-temurin, 11.0-j
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+
+Tags: 10.0.18-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.18-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0/jre21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 10.0.18-jre21, 10.0-jre21, 10-jre21, 10.0.18-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0/jre21
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
 
 Tags: 10.0.18-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.18-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
@@ -139,12 +209,22 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
+Tags: 10.0.18-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.18-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0/jdk21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 10.0.18, 10.0, 10, 10.0.18-jdk21, 10.0-jdk21, 10-jdk21, 10.0.18-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.18-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0/jdk21
+GitCommit: 5245ca814cb972078d8e5bb6526f183d84f6d283
+
 Tags: 10.0.18-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.18-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.18, 10.0, 10, 10.0.18-jdk17, 10.0-jdk17, 10-jdk17, 10.0.18-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.18-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.18-jdk17, 10.0-jdk17, 10-jdk17, 10.0.18-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
@@ -169,12 +249,22 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
+Tags: 9.4.53-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 9.4.53-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.53-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/9.4/jdk21
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
 Tags: 9.4.53-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17-alpine
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 9.4.53-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.53-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
+Tags: 9.4.53-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
@@ -189,22 +279,42 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 12.0.3-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.4-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.0/jdk21-alpine
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 12.0.4-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.4-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.0/jdk21
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 12.0.4-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
 
-Tags: 12.0.3-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.3-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.4-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+
+Tags: 11.0.18-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/11.0/jdk21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 11.0.18-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.18-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/11.0/jdk21
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
 
 Tags: 11.0.18-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 11.0.18-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.18-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.18-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
@@ -219,12 +329,22 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
+Tags: 10.0.18-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/10.0/jdk21-alpine
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
+Tags: 10.0.18-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.18-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/10.0/jdk21
+GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+
 Tags: 10.0.18-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
 
-Tags: 10.0.18-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.18-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.18-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
 GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16


### PR DESCRIPTION
## Update Jetty Versions

- `12.0.3` -> `12.0.4`
- adds variants for JDK21.