### PR TITLE
arangodb 3.11.6

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,7 +7,7 @@ Architectures: amd64, arm64v8
 GitCommit: 855faa5aa4d4e065c46e5d999af83c3a7cba5ccb
 Directory: alpine/3.10.11
 
-Tags: 3.11, 3.11.5, latest
+Tags: 3.11, 3.11.6, latest
 Architectures: amd64, arm64v8
-GitCommit: dde13e51d1fc110c1349d75e4aee156af2adc8b2
-Directory: alpine/3.11.5
+GitCommit: 5e80cd97d8ccedf2314fbee99e235894e0b46393
+Directory: alpine/3.11.6


### PR DESCRIPTION
Updated ArangoDB 3.11 to 3.11.6.