### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0-alpha2, 5.0, 5
+Tags: 5.0-beta1, 5.0, 5
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 12ee728efc59b4aa6cc02c637396c8460ee1e3cd
+GitCommit: 8313dd9e2e5d049117c1aa190494702f5ee60c83
 Directory: 5.0
 
 Tags: 4.1.3, 4.1, 4, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/8313dd9: Update 5.0 to 5.0-beta1