### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/d0874f19ca42fc0600e490039aa87877529fd982/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/c82d1f70eedcb3eb3aa93b7f3406f3013fb05265/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: d0874f19ca42fc0600e490039aa87877529fd982
+GitCommit: c82d1f70eedcb3eb3aa93b7f3406f3013fb05265
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 089e2f966d5db5cbc2f6ea1b5f7e2a92d15a07b3
+amd64-GitCommit: fd3de9bdd2a72b59a99e7d1c125e5b3b5729326a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d8159091d0979f96b6b9a05a6f6540fe3512bdc1
+arm32v5-GitCommit: 7bc82537c44617142c244a1074d2ac6f3ddd7c4a
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: f7081677dd0cd1d0524a988dd65c0ffb11e49c8f
+arm32v6-GitCommit: 54be82b66da36bb791c0376017cf34c6d492f55d
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: e56aee48bd5689c21a2d00f792c11e827e6441a2
+arm32v7-GitCommit: a8e56165783eed4a25789743528a84c2ce13c589
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 62541b1cfc447a3752dcd381366298218cfe4ad6
+arm64v8-GitCommit: d5964852b804d0dabdd027f3e289ca9479c5ac33
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 101cedebd5727c62a29afb4cbf5422e1c8e1bfa7
+i386-GitCommit: 6a9f5d40fe3419d55978b2f384bc13a9893b3cb3
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: dbabd02cca3beebc93c8cb9b7110acf2d5e58f27
+mips64le-GitCommit: 0b4b2c2ec9a47c94fe2a0b7897b91ebf519c9b12
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 9a6d19780f408836ce21748fc196559af9c0b1b9
+ppc64le-GitCommit: 587ef8fac17fe44986954db753ad4509283e7e60
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: bf58161f45bb69186efaf530bcfe14903cac3de0
+riscv64-GitCommit: 30e40709eb773b2ad09fafc433c44dad3afeb51d
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 14422e010b735d1a8012bf2d429eab1551e7c527
+s390x-GitCommit: bcaf21792f4ec53981fc77a7d9a82ae82e74e77e
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/c82d1f7: Merge pull request https://github.com/docker-library/busybox/pull/184 from infosiftr/buildroot-2023.11
- https://github.com/docker-library/busybox/commit/7a5f980: Update buildroot to 2023.11