### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,25 +1,35 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/2d7b121a1dda3f7844ae094f17346be7252e2ad6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/81e9df259751f1ec391f5c45905c198145e1cc0f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 2.9-dev12, 2.9-dev, 2.9-dev12-bullseye, 2.9-dev-bullseye
+Tags: 3.0-dev0, 3.0-dev, 3.0-dev0-bullseye, 3.0-dev-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f7d1d26511f3cf69eee01dbbea741130e2a2f8c3
+GitCommit: e3fc1f8a671d2362e20ce2895fe284bef3934926
+Directory: 3.0
+
+Tags: 3.0-dev0-alpine, 3.0-dev-alpine, 3.0-dev0-alpine3.18, 3.0-dev-alpine3.18
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: e3fc1f8a671d2362e20ce2895fe284bef3934926
+Directory: 3.0/alpine
+
+Tags: 2.9.0, 2.9, latest, 2.9.0-bullseye, 2.9-bullseye, bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: a2cdec0b128a2c128a6e81c93b67ec502b2131f3
 Directory: 2.9
 
-Tags: 2.9-dev12-alpine, 2.9-dev-alpine, 2.9-dev12-alpine3.18, 2.9-dev-alpine3.18
+Tags: 2.9.0-alpine, 2.9-alpine, alpine, 2.9.0-alpine3.18, 2.9-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7d1d26511f3cf69eee01dbbea741130e2a2f8c3
+GitCommit: a2cdec0b128a2c128a6e81c93b67ec502b2131f3
 Directory: 2.9/alpine
 
-Tags: 2.8.4, 2.8, lts, latest, 2.8.4-bullseye, 2.8-bullseye, lts-bullseye, bullseye
+Tags: 2.8.4, 2.8, lts, 2.8.4-bullseye, 2.8-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 3b21ae1e4abb804305fcda315a390ef27f8e2caa
 Directory: 2.8
 
-Tags: 2.8.4-alpine, 2.8-alpine, lts-alpine, alpine, 2.8.4-alpine3.18, 2.8-alpine3.18, lts-alpine3.18, alpine3.18
+Tags: 2.8.4-alpine, 2.8-alpine, lts-alpine, 2.8.4-alpine3.18, 2.8-alpine3.18, lts-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 3b21ae1e4abb804305fcda315a390ef27f8e2caa
 Directory: 2.8/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c5aae27: Merge pull request https://github.com/docker-library/haproxy/pull/222 from TimWolla/haproxy-3.0
- https://github.com/docker-library/haproxy/commit/e3fc1f8: Add HAProxy 3.0
- https://github.com/docker-library/haproxy/commit/81e9df2: Update "latest" for 2.9 GA
- https://github.com/docker-library/haproxy/commit/a2cdec0: Update 2.9 to 2.9.0