### PR TITLE
Update couchdb 3.3.3, 3.3, 3 and latest

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -4,11 +4,11 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: b616800e739db18c19e6a8b4131528157f945bcd
+GitCommit: 58910ed097489dc588b2a87592406f8faa1bdadf
 
-Tags: latest, 3.3.2, 3.3, 3
+Tags: latest, 3.3.3, 3.3, 3
 Architectures: amd64, arm64v8, ppc64le, s390x
-Directory: 3.3.2
+Directory: 3.3.3
 
 Tags: 3.2.3, 3.2
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
3.3.3 is the latest release: https://github.com/apache/couchdb-docker/commit/58910ed097489dc588b2a87592406f8faa1bdadf

https://blog.couchdb.org/2023/12/05/3-3-3/