### PR TITLE
Bump Traefik to v2.10.7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -13,15 +13,15 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
 Directory: alpine
 
-Tags: v2.10.6-windowsservercore-1809, 2.10.6-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
+Tags: v2.10.7-windowsservercore-1809, 2.10.7-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66eed101dfeadb185a4e3087fc5dc3e167a9c89f
+GitCommit: 274d14183ad37ff987c85fb0f85e9f862025c297
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.10.6, 2.10.6, v2.10, 2.10, saintmarcelin, latest
+Tags: v2.10.7, 2.10.7, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66eed101dfeadb185a4e3087fc5dc3e167a9c89f
+GitCommit: 274d14183ad37ff987c85fb0f85e9f862025c297
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.10.7](https://github.com/traefik/traefik/releases/tag/v2.10.7).

/cc @mmatur @rtribotte @kevinpollet

Cheers
