### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: a2cdec0b128a2c128a6e81c93b67ec502b2131f3
 Directory: 2.9/alpine
 
-Tags: 2.8.4, 2.8, lts, 2.8.4-bullseye, 2.8-bullseye, lts-bullseye
+Tags: 2.8.5, 2.8, lts, 2.8.5-bullseye, 2.8-bullseye, lts-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b21ae1e4abb804305fcda315a390ef27f8e2caa
+GitCommit: a287ce7a211b83adb90b1b3bd97d534c0520be8a
 Directory: 2.8
 
-Tags: 2.8.4-alpine, 2.8-alpine, lts-alpine, 2.8.4-alpine3.18, 2.8-alpine3.18, lts-alpine3.18
+Tags: 2.8.5-alpine, 2.8-alpine, lts-alpine, 2.8.5-alpine3.18, 2.8-alpine3.18, lts-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b21ae1e4abb804305fcda315a390ef27f8e2caa
+GitCommit: a287ce7a211b83adb90b1b3bd97d534c0520be8a
 Directory: 2.8/alpine
 
-Tags: 2.7.10, 2.7, 2.7.10-bullseye, 2.7-bullseye
+Tags: 2.7.11, 2.7, 2.7.11-bullseye, 2.7-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6ac34139426d79e07ec76ff9a8b9948dc85e34b3
+GitCommit: 68e4a3bbf0ff9acbdba492321b63c2bfdf9f9e22
 Directory: 2.7
 
-Tags: 2.7.10-alpine, 2.7-alpine, 2.7.10-alpine3.18, 2.7-alpine3.18
+Tags: 2.7.11-alpine, 2.7-alpine, 2.7.11-alpine3.18, 2.7-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6ac34139426d79e07ec76ff9a8b9948dc85e34b3
+GitCommit: 68e4a3bbf0ff9acbdba492321b63c2bfdf9f9e22
 Directory: 2.7/alpine
 
 Tags: 2.6.15, 2.6, 2.6.15-bullseye, 2.6-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a287ce7: Update 2.8 to 2.8.5
- https://github.com/docker-library/haproxy/commit/68e4a3b: Update 2.7 to 2.7.11