### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.4.1-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.1-php8.1, 6.4-php8.1, 6-php8.1, php8.1
+Tags: 6.4.2-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.2-php8.1, 6.4-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.1/apache
 
-Tags: 6.4.1-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.4.2-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.1/fpm
 
-Tags: 6.4.1-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.4.2-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.4.1-apache, 6.4-apache, 6-apache, apache, 6.4.1, 6.4, 6, latest, 6.4.1-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.1-php8.2, 6.4-php8.2, 6-php8.2, php8.2
+Tags: 6.4.2-apache, 6.4-apache, 6-apache, apache, 6.4.2, 6.4, 6, latest, 6.4.2-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.2-php8.2, 6.4-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.2/apache
 
-Tags: 6.4.1-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.1-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.4.2-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.2-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.2/fpm
 
-Tags: 6.4.1-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.1-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.4.2-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.2-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.4.1-php8.3-apache, 6.4-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.4.1-php8.3, 6.4-php8.3, 6-php8.3, php8.3
+Tags: 6.4.2-php8.3-apache, 6.4-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.4.2-php8.3, 6.4-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.3/apache
 
-Tags: 6.4.1-php8.3-fpm, 6.4-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.4.2-php8.3-fpm, 6.4-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.3/fpm
 
-Tags: 6.4.1-php8.3-fpm-alpine, 6.4-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.4.2-php8.3-fpm-alpine, 6.4-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 86753ab5151bc5bbb49f370f519d4c5e531e2df7
+GitCommit: ac65dab91d64f611e4fa89b5e92903e163d24572
 Directory: latest/php8.3/fpm-alpine
 
 Tags: cli-2.9.0-php8.1, cli-2.9-php8.1, cli-2-php8.1, cli-php8.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/ac65dab: Update latest to 6.4.2
- https://github.com/docker-library/wordpress/commit/741295e: Update beta to 6.4.2