### PR TITLE
caddy: v2.7.6 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,51 +1,51 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/a82cbc5b1bf43757f718d8b21adcca6a0df560c7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/4ce9344fd5c8b1f13533a3bd83b92368d6129836/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson)
 
-Tags: 2.7.5-alpine, 2.7-alpine, 2-alpine, alpine
-SharedTags: 2.7.5, 2.7, 2, latest
+Tags: 2.7.6-alpine, 2.7-alpine, 2-alpine, alpine
+SharedTags: 2.7.6, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/alpine
-GitCommit: 0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a
+GitCommit: 4ce9344fd5c8b1f13533a3bd83b92368d6129836
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.7.5-builder-alpine, 2.7-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.7.5-builder, 2.7-builder, 2-builder, builder
+Tags: 2.7.6-builder-alpine, 2.7-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.7.6-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/builder
-GitCommit: 0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a
+GitCommit: 4ce9344fd5c8b1f13533a3bd83b92368d6129836
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.7.5-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.7.5-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.5, 2.7, 2, latest
+Tags: 2.7.6-windowsservercore-1809, 2.7-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.7.6-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.6, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows/1809
-GitCommit: 0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a
+GitCommit: 4ce9344fd5c8b1f13533a3bd83b92368d6129836
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.7.5-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.7.5-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.5, 2.7, 2, latest
+Tags: 2.7.6-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.7.6-windowsservercore, 2.7-windowsservercore, 2-windowsservercore, windowsservercore, 2.7.6, 2.7, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows/ltsc2022
-GitCommit: 0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a
+GitCommit: 4ce9344fd5c8b1f13533a3bd83b92368d6129836
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.7.5-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.7.5-builder, 2.7-builder, 2-builder, builder
+Tags: 2.7.6-builder-windowsservercore-1809, 2.7-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
+SharedTags: 2.7.6-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows-builder/1809
-GitCommit: 0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a
+GitCommit: 4ce9344fd5c8b1f13533a3bd83b92368d6129836
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.7.5-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.7.5-builder, 2.7-builder, 2-builder, builder
+Tags: 2.7.6-builder-windowsservercore-ltsc2022, 2.7-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.7.6-builder, 2.7-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.7/windows-builder/ltsc2022
-GitCommit: 0b5f063a37d52d579b6d4e64b2e2409ad89f7c7a
+GitCommit: 4ce9344fd5c8b1f13533a3bd83b92368d6129836
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.7.6