### PR TITLE
Remove Kong 3.0 due to its EOL

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -49,18 +49,6 @@ GitFetch: refs/tags/3.1.1
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 3.0.2-alpine, 3.0-alpine, 3.0.2, 3.0
-GitCommit: 5a3ee8daf50371db2e3a788abe8f306255eead22
-GitFetch: refs/tags/3.0.2
-File: Dockerfile.apk
-Architectures: amd64, arm64v8
-
-Tags: 3.0.2-ubuntu, 3.0-ubuntu
-GitCommit: 5a3ee8daf50371db2e3a788abe8f306255eead22
-GitFetch: refs/tags/3.0.2
-Directory: ubuntu
-Architectures: amd64, arm64v8
-
 Tags: 2.8.4-alpine, 2.8.4, 2.8
 GitCommit: 1c31704cdc9bbd2c0a20e5479eb307140339582b
 GitFetch: refs/tags/2.8.4


### PR DESCRIPTION
Kong 3.0 is EOL thus remove it from the "supported" list.

This is a PR to follow up a discussion in #15686 