### PR TITLE
Telegraf v1.29.0

### DIFF
--- a/library/telegraf
+++ b/library/telegraf
@@ -1,16 +1,8 @@
 Maintainers: Josh Powers <jpowers@influxdata.com> (@powersj),
              Sven Rebhan <srebhan@influxdata.com> (@srebhan)
 GitRepo: https://github.com/influxdata/influxdata-docker.git
-GitCommit: d636186a1671138ec12a043f89af70e655949f89
+GitCommit: 7bd07a9d6f0120089c90848d0203e8f6b097905b
 
-
-Tags: 1.26, 1.26.3
-Architectures: amd64, arm32v7, arm64v8
-Directory: telegraf/1.26
-
-Tags: 1.26-alpine, 1.26.3-alpine
-Architectures: amd64, arm64v8
-Directory: telegraf/1.26/alpine
 
 Tags: 1.27, 1.27.4
 Architectures: amd64, arm32v7, arm64v8
@@ -20,10 +12,18 @@ Tags: 1.27-alpine, 1.27.4-alpine
 Architectures: amd64, arm64v8
 Directory: telegraf/1.27/alpine
 
-Tags: 1.28, 1.28.5, latest
+Tags: 1.28, 1.28.5
 Architectures: amd64, arm32v7, arm64v8
 Directory: telegraf/1.28
 
-Tags: 1.28-alpine, 1.28.5-alpine, alpine
+Tags: 1.28-alpine, 1.28.5-alpine
 Architectures: amd64, arm64v8
 Directory: telegraf/1.28/alpine
+
+Tags: 1.29, 1.29.0, latest
+Architectures: amd64, arm32v7, arm64v8
+Directory: telegraf/1.29
+
+Tags: 1.29-alpine, 1.29.0-alpine, alpine
+Architectures: amd64, arm64v8
+Directory: telegraf/1.29/alpine


### PR DESCRIPTION
New minor release, remove v1.26, update alpine image to 3.19. Thank you!