### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -16,12 +16,12 @@ Directory: 16/bullseye
 
 Tags: 16.1-alpine3.19, 16-alpine3.19, alpine3.19, 16.1-alpine, 16-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f6ba56f915bb41b2e2def0ed3acc5ae5439f44
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 16/alpine3.19
 
 Tags: 16.1-alpine3.18, 16-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2468c9d91a2ef4055411e09c42cd054732ebf579
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 16/alpine3.18
 
 Tags: 15.5, 15, 15.5-bookworm, 15-bookworm
@@ -36,12 +36,12 @@ Directory: 15/bullseye
 
 Tags: 15.5-alpine3.19, 15-alpine3.19, 15.5-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f6ba56f915bb41b2e2def0ed3acc5ae5439f44
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 15/alpine3.19
 
 Tags: 15.5-alpine3.18, 15-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2468c9d91a2ef4055411e09c42cd054732ebf579
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 15/alpine3.18
 
 Tags: 14.10, 14, 14.10-bookworm, 14-bookworm
@@ -56,12 +56,12 @@ Directory: 14/bullseye
 
 Tags: 14.10-alpine3.19, 14-alpine3.19, 14.10-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f6ba56f915bb41b2e2def0ed3acc5ae5439f44
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 14/alpine3.19
 
 Tags: 14.10-alpine3.18, 14-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2468c9d91a2ef4055411e09c42cd054732ebf579
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 14/alpine3.18
 
 Tags: 13.13, 13, 13.13-bookworm, 13-bookworm
@@ -76,12 +76,12 @@ Directory: 13/bullseye
 
 Tags: 13.13-alpine3.19, 13-alpine3.19, 13.13-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f6ba56f915bb41b2e2def0ed3acc5ae5439f44
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 13/alpine3.19
 
 Tags: 13.13-alpine3.18, 13-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2468c9d91a2ef4055411e09c42cd054732ebf579
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 13/alpine3.18
 
 Tags: 12.17, 12, 12.17-bookworm, 12-bookworm
@@ -96,30 +96,10 @@ Directory: 12/bullseye
 
 Tags: 12.17-alpine3.19, 12-alpine3.19, 12.17-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f6ba56f915bb41b2e2def0ed3acc5ae5439f44
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 12/alpine3.19
 
 Tags: 12.17-alpine3.18, 12-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2468c9d91a2ef4055411e09c42cd054732ebf579
+GitCommit: 1d4651c6c9ee4caf314a62a41111e7c65710f77e
 Directory: 12/alpine3.18
-
-Tags: 11.22-bookworm, 11-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a42b68455866552c2ad2fc9a8e18d46b50712139
-Directory: 11/bookworm
-
-Tags: 11.22-bullseye, 11-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a42b68455866552c2ad2fc9a8e18d46b50712139
-Directory: 11/bullseye
-
-Tags: 11.22-alpine3.19, 11-alpine3.19, 11.22-alpine, 11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 25f6ba56f915bb41b2e2def0ed3acc5ae5439f44
-Directory: 11/alpine3.19
-
-Tags: 11.22-alpine3.18, 11-alpine3.18
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2468c9d91a2ef4055411e09c42cd054732ebf579
-Directory: 11/alpine3.18


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/def0855: Merge pull request https://github.com/docker-library/postgres/pull/1164 from LaurentGoderre/remove-inline-sbom
- https://github.com/docker-library/postgres/commit/1d4651c: Revert "Added inline SBOM for binaries downloaded outside package manager"
- https://github.com/docker-library/postgres/commit/d8c3360: Merge pull request https://github.com/docker-library/postgres/pull/1162 from infosiftr/eol-11
- https://github.com/docker-library/postgres/commit/3e5f87d: Remove PostgreSQL 11 since it is end of life