### PR TITLE
Update rethinkdb to 2.4.3

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,7 +1,7 @@
 Maintainers: RethinkDB <services@rethinkdb.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 
-Tags: 2.4.2-bullseye-slim, 2.4-bullseye-slim, 2-bullseye-slim, bullseye-slim, 2.4.2, 2.4, 2, latest
-Directory: bullseye/2.4.2
-GitCommit: 826a4193366e7d0ff176d101679385125b8fa4f1
+Tags: 2.4.3-bookworm-slim, 2.4-bookworm-slim, 2-bookworm-slim, bookworm-slim, 2.4.3, 2.4, 2, latest
+Directory: bookworm/2.4.3
+GitCommit: f5d6158f85c1fd7082814063e0a9cf5665dfcddc
 Architectures: amd64, arm64v8, s390x


### PR DESCRIPTION
Points at https://github.com/rethinkdb/rethinkdb-dockerfiles/releases/tag/2.4.3