### PR TITLE
Update ELK to 8.11.3, 7.17.16, backfill missed 8.11.2

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -3,12 +3,17 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: elasticsearch
 Builder: buildkit
 
-Tags: 8.11.1
+Tags: 8.11.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11
-GitCommit: 0dbf0d4297a2bf48d0cd980935431c121396885d
+GitCommit: 1484679916b52a402f0d02ea290d60f6e1eca39a
 
-Tags: 7.17.15
+Tags: 8.11.2
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/8.11
+GitCommit: 58aa6df8045922c7c6ac92055a120365e158dd20
+
+Tags: 7.17.16
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
-GitCommit: 63269da8548948c20f3e1650cebbed1ae5eee90e
+GitCommit: f3f1c976063b3549ed75e18aa99d06fdf51f8857

--- a/library/kibana
+++ b/library/kibana
@@ -3,12 +3,17 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: kibana
 Builder: buildkit
 
-Tags: 8.11.1
+Tags: 8.11.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11
-GitCommit: 0dbf0d4297a2bf48d0cd980935431c121396885d
+GitCommit: 1484679916b52a402f0d02ea290d60f6e1eca39a
 
-Tags: 7.17.15
+Tags: 8.11.2
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/8.11
+GitCommit: 58aa6df8045922c7c6ac92055a120365e158dd20
+
+Tags: 7.17.16
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
-GitCommit: 63269da8548948c20f3e1650cebbed1ae5eee90e
+GitCommit: f3f1c976063b3549ed75e18aa99d06fdf51f8857

--- a/library/logstash
+++ b/library/logstash
@@ -3,12 +3,17 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: logstash
 Builder: buildkit
 
-Tags: 8.11.1
+Tags: 8.11.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11
-GitCommit: 0dbf0d4297a2bf48d0cd980935431c121396885d
+GitCommit: 1484679916b52a402f0d02ea290d60f6e1eca39a
 
-Tags: 7.17.15
+Tags: 8.11.2
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/8.11
+GitCommit: 58aa6df8045922c7c6ac92055a120365e158dd20
+
+Tags: 7.17.16
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
-GitCommit: 63269da8548948c20f3e1650cebbed1ae5eee90e
+GitCommit: f3f1c976063b3549ed75e18aa99d06fdf51f8857


### PR DESCRIPTION
Follow up to https://github.com/docker-library/official-images/pull/15808

@mark-vieira @watson @jsvd (@alpar-t) this is a good example of what a "bump" PR would gemerally look like (and this one is an extra fun example because it includes a back-fill for the missed 8.11.2 version -- after that's built successfully once, we'll want to remove it from the list so it doesn't show up on Hub in the "supported tags" list)