### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,45 +5,45 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 Builder: buildkit
 
-Tags: 25.0.0-beta.1-cli, 25-rc-cli, rc-cli, 25.0.0-beta.1-cli-alpine3.18
+Tags: 25.0.0-beta.2-cli, 25-rc-cli, rc-cli, 25.0.0-beta.2-cli-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 01cebba606d33d2eeb9e3dcf52e4bf218913e211
+GitCommit: d8b20e0d84b8bac8629e782e0fc779d537eab8d8
 Directory: 25-rc/cli
 
-Tags: 25.0.0-beta.1-dind, 25-rc-dind, rc-dind, 25.0.0-beta.1-dind-alpine3.18, 25.0.0-beta.1, 25-rc, rc, 25.0.0-beta.1-alpine3.18
+Tags: 25.0.0-beta.2-dind, 25-rc-dind, rc-dind, 25.0.0-beta.2-dind-alpine3.18, 25.0.0-beta.2, 25-rc, rc, 25.0.0-beta.2-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 5c2833e7ce9e5af0921154416d59ee13c6185cbf
+GitCommit: d8b20e0d84b8bac8629e782e0fc779d537eab8d8
 Directory: 25-rc/dind
 
-Tags: 25.0.0-beta.1-dind-rootless, 25-rc-dind-rootless, rc-dind-rootless
+Tags: 25.0.0-beta.2-dind-rootless, 25-rc-dind-rootless, rc-dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 2e213030c57a2134a77bf17b0710dff1a184a7c1
+GitCommit: d8b20e0d84b8bac8629e782e0fc779d537eab8d8
 Directory: 25-rc/dind-rootless
 
-Tags: 25.0.0-beta.1-git, 25-rc-git, rc-git
+Tags: 25.0.0-beta.2-git, 25-rc-git, rc-git
 Architectures: amd64, arm32v6, arm32v7, arm64v8
 GitCommit: 2e213030c57a2134a77bf17b0710dff1a184a7c1
 Directory: 25-rc/git
 
-Tags: 25.0.0-beta.1-windowsservercore-ltsc2022, 25-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 25.0.0-beta.1-windowsservercore, 25-rc-windowsservercore, rc-windowsservercore
+Tags: 25.0.0-beta.2-windowsservercore-ltsc2022, 25-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 25.0.0-beta.2-windowsservercore, 25-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 01cebba606d33d2eeb9e3dcf52e4bf218913e211
+GitCommit: d8b20e0d84b8bac8629e782e0fc779d537eab8d8
 Directory: 25-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 25.0.0-beta.1-windowsservercore-1809, 25-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 25.0.0-beta.1-windowsservercore, 25-rc-windowsservercore, rc-windowsservercore
+Tags: 25.0.0-beta.2-windowsservercore-1809, 25-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 25.0.0-beta.2-windowsservercore, 25-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 01cebba606d33d2eeb9e3dcf52e4bf218913e211
+GitCommit: d8b20e0d84b8bac8629e782e0fc779d537eab8d8
 Directory: 25-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
 
 Tags: 24.0.7-cli, 24.0-cli, 24-cli, cli, 24.0.7-cli-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 6d541d27b5dd12639e5a33a675ebca04d3837d74
+GitCommit: 71bd9300d17fb5b0722360fa298d9eace51c27c4
 Directory: 24/cli
 
 Tags: 24.0.7-dind, 24.0-dind, 24-dind, dind, 24.0.7-dind-alpine3.18, 24.0.7, 24.0, 24, latest, 24.0.7-alpine3.18
@@ -64,7 +64,7 @@ Directory: 24/git
 Tags: 24.0.7-windowsservercore-ltsc2022, 24.0-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 24.0.7-windowsservercore, 24.0-windowsservercore, 24-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 6d541d27b5dd12639e5a33a675ebca04d3837d74
+GitCommit: 71bd9300d17fb5b0722360fa298d9eace51c27c4
 Directory: 24/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -72,7 +72,7 @@ Builder: classic
 Tags: 24.0.7-windowsservercore-1809, 24.0-windowsservercore-1809, 24-windowsservercore-1809, windowsservercore-1809
 SharedTags: 24.0.7-windowsservercore, 24.0-windowsservercore, 24-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 6d541d27b5dd12639e5a33a675ebca04d3837d74
+GitCommit: 71bd9300d17fb5b0722360fa298d9eace51c27c4
 Directory: 24/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/d8b20e0: Update 25-rc to 25.0.0-beta.2
- https://github.com/docker-library/docker/commit/71bd930: Adjust Compose version code to ignore pre-releases more aggressively (downgrading back to 2.23.3)
- https://github.com/docker-library/docker/commit/069c491: Update 25-rc to compose 2.24.0-birthday.10
- https://github.com/docker-library/docker/commit/797b244: Update 24 to compose 2.24.0-birthday.10