### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.0-rc.2, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4fcdb55f5e7b8953fa265ade0452a2313129926e
+GitCommit: 2a94ce3f0fe97b7c56e6bc985e97059c72910903
 Directory: 3.13-rc/ubuntu
 
 Tags: 3.13.0-rc.2-management, 3.13-rc-management
@@ -17,7 +17,7 @@ Directory: 3.13-rc/ubuntu/management
 
 Tags: 3.13.0-rc.2-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 12f56d211d04474b18940528cc218dcb9da88a96
+GitCommit: 2a94ce3f0fe97b7c56e6bc985e97059c72910903
 Directory: 3.13-rc/alpine
 
 Tags: 3.13.0-rc.2-management-alpine, 3.13-rc-management-alpine
@@ -45,22 +45,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: c30652127ae871535b7ec8ecda8046948a52ab79
 Directory: 3.12/alpine/management
 
-Tags: 3.11.26, 3.11
+Tags: 3.11.27, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2740bd4780a9e5f6abc22f9ebddc399e021b7a28
+GitCommit: c759a936021d9abf72c78573798703a56cd35504
 Directory: 3.11/ubuntu
 
-Tags: 3.11.26-management, 3.11-management
+Tags: 3.11.27-management, 3.11-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.11/ubuntu/management
 
-Tags: 3.11.26-alpine, 3.11-alpine
+Tags: 3.11.27-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 12f56d211d04474b18940528cc218dcb9da88a96
+GitCommit: c759a936021d9abf72c78573798703a56cd35504
 Directory: 3.11/alpine
 
-Tags: 3.11.26-management-alpine, 3.11-management-alpine
+Tags: 3.11.27-management-alpine, 3.11-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b41c10aaddc91da62f96994ab62e9d1ea590c455
 Directory: 3.11/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2a94ce3: Update 3.13-rc to otp 26.2
- https://github.com/docker-library/rabbitmq/commit/c759a93: Update 3.11 to 3.11.27