### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev0, 3.0-dev, 3.0-dev0-bullseye, 3.0-dev-bullseye
+Tags: 3.0-dev0, 3.0-dev, 3.0-dev0-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e3fc1f8a671d2362e20ce2895fe284bef3934926
+GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
 Directory: 3.0
 
 Tags: 3.0-dev0-alpine, 3.0-dev-alpine, 3.0-dev0-alpine3.19, 3.0-dev-alpine3.19
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
 Directory: 3.0/alpine
 
-Tags: 2.9.0, 2.9, latest, 2.9.0-bullseye, 2.9-bullseye, bullseye
+Tags: 2.9.0, 2.9, latest, 2.9.0-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a2cdec0b128a2c128a6e81c93b67ec502b2131f3
+GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
 Directory: 2.9
 
 Tags: 2.9.0-alpine, 2.9-alpine, alpine, 2.9.0-alpine3.19, 2.9-alpine3.19, alpine3.19
@@ -24,9 +24,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
 Directory: 2.9/alpine
 
-Tags: 2.8.5, 2.8, lts, 2.8.5-bullseye, 2.8-bullseye, lts-bullseye
+Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a287ce7a211b83adb90b1b3bd97d534c0520be8a
+GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
 Directory: 2.8
 
 Tags: 2.8.5-alpine, 2.8-alpine, lts-alpine, 2.8.5-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
@@ -34,9 +34,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
 Directory: 2.8/alpine
 
-Tags: 2.7.11, 2.7, 2.7.11-bullseye, 2.7-bullseye
+Tags: 2.7.11, 2.7, 2.7.11-bookworm, 2.7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 68e4a3bbf0ff9acbdba492321b63c2bfdf9f9e22
+GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
 Directory: 2.7
 
 Tags: 2.7.11-alpine, 2.7-alpine, 2.7.11-alpine3.19, 2.7-alpine3.19
@@ -44,19 +44,19 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
 Directory: 2.7/alpine
 
-Tags: 2.6.15, 2.6, 2.6.15-bullseye, 2.6-bullseye
+Tags: 2.6.16, 2.6, 2.6.16-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fc50ce81390257a9702f3ea74237a73c658a1789
+GitCommit: e4b286a573e8f3bad0cc367ffc0f8e0a330d8307
 Directory: 2.6
 
-Tags: 2.6.15-alpine, 2.6-alpine, 2.6.15-alpine3.19, 2.6-alpine3.19
+Tags: 2.6.16-alpine, 2.6-alpine, 2.6.16-alpine3.19, 2.6-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: e4b286a573e8f3bad0cc367ffc0f8e0a330d8307
 Directory: 2.6/alpine
 
-Tags: 2.4.24, 2.4, 2.4.24-bullseye, 2.4-bullseye
+Tags: 2.4.24, 2.4, 2.4.24-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4c041fe042121e9f30046440f12cf0d2747a5061
+GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
 Directory: 2.4
 
 Tags: 2.4.24-alpine, 2.4-alpine, 2.4.24-alpine3.19, 2.4-alpine3.19
@@ -66,17 +66,17 @@ Directory: 2.4/alpine
 
 Tags: 2.2.31, 2.2, 2.2.31-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ad34487167b0bb727cb56000f26d8ea37449c590
+GitCommit: 37ba32b245a7c55a5a42a554795d7140acbf4113
 Directory: 2.2
 
-Tags: 2.2.31-alpine, 2.2-alpine, 2.2.31-alpine3.19, 2.2-alpine3.19
+Tags: 2.2.31-alpine, 2.2-alpine, 2.2.31-alpine3.16, 2.2-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: 37ba32b245a7c55a5a42a554795d7140acbf4113
 Directory: 2.2/alpine
 
 Tags: 2.0.33, 2.0, 2.0.33-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9c85db58f62beefbcbc4fabc5697ddaeb9ff3ff2
+GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
 Directory: 2.0
 
 Tags: 2.0.33-alpine, 2.0-alpine, 2.0.33-alpine3.16, 2.0-alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e4b286a: Update 2.6 to 2.6.16
- https://github.com/docker-library/haproxy/commit/f74e9f8: Merge pull request https://github.com/docker-library/haproxy/pull/214 from infosiftr/bookworm
- https://github.com/docker-library/haproxy/commit/37ba32b: Pin 2.2 to Debian Bullseye and Alpine 3.16 to avoid OpenSSL 3 (unsupported until 2.6+ and backported to 2.4)
- https://github.com/docker-library/haproxy/commit/71aadfa: Update to Debian bookworm