### PR TITLE
Update rethinkdb to 2.4.4

### DIFF
--- a/library/rethinkdb
+++ b/library/rethinkdb
@@ -1,7 +1,7 @@
 Maintainers: RethinkDB <services@rethinkdb.com> (@gabor-boros)
 GitRepo: https://github.com/rethinkdb/rethinkdb-dockerfiles.git
 
-Tags: 2.4.3-bookworm-slim, 2.4-bookworm-slim, 2-bookworm-slim, bookworm-slim, 2.4.3, 2.4, 2, latest
-Directory: bookworm/2.4.3
-GitCommit: f5d6158f85c1fd7082814063e0a9cf5665dfcddc
+Tags: 2.4.4-bookworm-slim, 2.4-bookworm-slim, 2-bookworm-slim, bookworm-slim, 2.4.3, 2.4, 2, latest
+Directory: bookworm/2.4.4
+GitCommit: 48876a66c3be922c6b01c436bf78d662e53bceef
 Architectures: amd64, arm64v8, s390x


### PR DESCRIPTION
Points at https://github.com/rethinkdb/rethinkdb-dockerfiles/releases/tag/2.4.4