### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -6,24 +6,24 @@ GitRepo: https://github.com/docker-library/mysql.git
 
 Tags: 8.2.0, 8.2, 8, innovation, latest, 8.2.0-oracle, 8.2-oracle, 8-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 76806cdd0acee2dec39b1b66e9c8015ef75be196
+GitCommit: 0097ab8a1fde788a9a51357339fa5498855623e2
 Directory: innovation
 File: Dockerfile.oracle
 
 Tags: 8.0.35, 8.0, 8.0.35-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 84ba05eaa75e1f0e1d33185e23f95a9cdc607b51
+GitCommit: 0097ab8a1fde788a9a51357339fa5498855623e2
 Directory: 8.0
 File: Dockerfile.oracle
 
 Tags: 8.0.35-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 84ba05eaa75e1f0e1d33185e23f95a9cdc607b51
+GitCommit: dc35beded3a41c4c62dfaa7f86ea5721c02a2e8b
 Directory: 8.0
 File: Dockerfile.debian
 
 Tags: 5.7.44, 5.7, 5, 5.7.44-oracle, 5.7-oracle, 5-oracle
 Architectures: amd64
-GitCommit: 9678ed1d27794ae9529c43b4411e30f981ce39ea
+GitCommit: 0097ab8a1fde788a9a51357339fa5498855623e2
 Directory: 5.7
 File: Dockerfile.oracle


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/64f9436: Merge pull request https://github.com/docker-library/mysql/pull/1015 from infosiftr/repo-urls
- https://github.com/docker-library/mysql/commit/0097ab8: Update tools repo handling and update innovation to mysql-shell 8.2.1
- https://github.com/docker-library/mysql/commit/dc35bed: Fix skip-host-cache deprecation warning (https://github.com/docker-library/mysql/pull/1002)