### PR TITLE
releasing Neo4j 4.3.24

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -35,3 +35,17 @@ Tags: 4.4.28-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
 GitCommit: a39a0b8e97fea5e7c232771059a1a857345f6715
 Directory: 4.4.28/bullseye/enterprise
+
+
+
+
+
+
+
+Tags: 4.3.24, 4.3.24-community, 4.3, 4.3-community
+GitCommit: f84645770acc041f8057245c540dba622e0da5f8
+Directory: 4.3.24/bullseye/community
+
+Tags: 4.3.24-enterprise, 4.3-enterprise
+GitCommit: f84645770acc041f8057245c540dba622e0da5f8
+Directory: 4.3.24/bullseye/enterprise


### PR DESCRIPTION
This is a bug fix to the old 4.3 releases. It won't stay in the official images for long.
Thanks!