### PR TITLE
[oraclelinux] Updating 7, 7-slim, 7-slim-fips, 9, 9-slim for ELSA-2023-7743, ELSA-2023-7747

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: dbeac8db277aba1b552869dc5fce682220c8a5e1
+amd64-GitCommit: 6eebdafb2a35b99afc081d3d49e68558f049bc11
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 33181c2ec34d3e531c15c67df8597bfa51c04549
+arm64v8-GitCommit: 6daa4b4a14ef9aa8b0b70ca8c498ff50447731ed
 
 Tags: 9
 Architectures: amd64, arm64v8
@@ -17,7 +17,7 @@ Tags: 9-slim
 Architectures: amd64, arm64v8
 Directory: 9-slim
 
-Tags: 8.8, 8
+Tags: 8.9, 8
 Architectures: amd64, arm64v8
 Directory: 8
 


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-43552 and CVE-2023-39615.

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-7743.html
https://linux.oracle.com/errata/ELSA-2023-7747.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>