### PR TITLE
Odoo: update 15.0-17.0 to release 20231215

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,6 +1,6 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 930f56df4052d0d7af0ccd5f2ca6b6096a8003fe
+GitCommit: 5b67879040592cb5d37969d0309f49355ece7d05
 
 Tags: 17.0, 17, latest
 Architectures: amd64, arm64v8, ppc64le


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks a lot.