### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
 Directory: 3.0/alpine
 
-Tags: 2.9.0, 2.9, latest, 2.9.0-bookworm, 2.9-bookworm, bookworm
+Tags: 2.9.1, 2.9, latest, 2.9.1-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
+GitCommit: 7643b2d41ab7eb48e2ebfe2ce99ca453a125993c
 Directory: 2.9
 
-Tags: 2.9.0-alpine, 2.9-alpine, alpine, 2.9.0-alpine3.19, 2.9-alpine3.19, alpine3.19
+Tags: 2.9.1-alpine, 2.9-alpine, alpine, 2.9.1-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: 7643b2d41ab7eb48e2ebfe2ce99ca453a125993c
 Directory: 2.9/alpine
 
 Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e4b286a573e8f3bad0cc367ffc0f8e0a330d8307
 Directory: 2.6/alpine
 
-Tags: 2.4.24, 2.4, 2.4.24-bookworm, 2.4-bookworm
+Tags: 2.4.25, 2.4, 2.4.25-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
+GitCommit: b2d07293f7145e5630e88695f8b570dcb0650bf9
 Directory: 2.4
 
-Tags: 2.4.24-alpine, 2.4-alpine, 2.4.24-alpine3.19, 2.4-alpine3.19
+Tags: 2.4.25-alpine, 2.4-alpine, 2.4.25-alpine3.19, 2.4-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: b2d07293f7145e5630e88695f8b570dcb0650bf9
 Directory: 2.4/alpine
 
 Tags: 2.2.31, 2.2, 2.2.31-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7643b2d: Update 2.9 to 2.9.1
- https://github.com/docker-library/haproxy/commit/b2d0729: Update 2.4 to 2.4.25