### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -12,7 +12,7 @@ Directory: 25-rc/cli
 
 Tags: 25.0.0-beta.2-dind, 25-rc-dind, rc-dind, 25.0.0-beta.2-dind-alpine3.19, 25.0.0-beta.2, 25-rc, rc, 25.0.0-beta.2-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4c2674df4f40c965cdb8ccc77b8ce9dbc247a6c9
+GitCommit: 7ac5702b51ae559c03bfe90404f4b8c63977c601
 Directory: 25-rc/dind
 
 Tags: 25.0.0-beta.2-dind-rootless, 25-rc-dind-rootless, rc-dind-rootless
@@ -48,7 +48,7 @@ Directory: 24/cli
 
 Tags: 24.0.7-dind, 24.0-dind, 24-dind, dind, 24.0.7-dind-alpine3.19, 24.0.7, 24.0, 24, latest, 24.0.7-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4c2674df4f40c965cdb8ccc77b8ce9dbc247a6c9
+GitCommit: 7ac5702b51ae559c03bfe90404f4b8c63977c601
 Directory: 24/dind
 
 Tags: 24.0.7-dind-rootless, 24.0-dind-rootless, 24-dind-rootless, dind-rootless


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/7ac5702: Switch over to xtables-legacy when nf_tables module isn't available (https://github.com/docker-library/docker/pull/465)