### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,21 +13,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.2.20231113.0
+Tags: 2023, latest, 2023.3.20231211.4
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: bb26f34bf58219b9c2833ddfc550edf24dc5d2b1
+amd64-GitCommit: 5d43cabd0e15c15ab51395153458ebe099466da8
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 8ad82e04839d21d355f530f64b80a66109bdb839
+arm64v8-GitCommit: 9e7a021bc2cd51b244881c0630295d2ddd3936e2
 
-Tags: 2, 2.0.20231116.0
+Tags: 2, 2.0.20231206.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: e513900321398ab144fa1c8c422035e04d5f22d4
+amd64-GitCommit: a10480da4e07a2ec233ecc200f621d240fcc47e2
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 8fedb973d1887194b817560609f54171b40f4dd1
+arm64v8-GitCommit: ba3f8cb26ca227ea706ea612c74b0761e3b597cc
 
-Tags: 1, 2018.03, 2018.03.0.20231106.0
+Tags: 1, 2018.03, 2018.03.0.20231206.1
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 4e00ac2c097d0ed30dbcd4e7a9cce4d3dee18a9b
+amd64-GitCommit: f185bfc0b26db5b22fbf77d56e1330e47fecf6b7


### PR DESCRIPTION
    Updated Packages for Amazon Linux 1:
    - openssl-1.0.2k-16.165.amzn1

    Updated Packages for Amazon Linux 2:
    - vim-minimal-9.0.2120-1.amzn2.0.1
    - vim-data-9.0.2120-1.amzn2.0.1
    - openssl-libs-1.0.2k-24.amzn2.0.11
    - gawk-4.0.2-4.amzn2.1.3
    - gmp-6.0.0-15.amzn2.0.3

    Updated Packages for Amazon Linux 2023:
    - openssl-libs-3.0.8-1.amzn2023.0.10
    - python3-pip-wheel-21.3.1-2.amzn2023.0.7
    - amazon-linux-repo-cdn-2023.3.20231211-0.amzn2023
    - system-release-2023.3.20231211-0.amzn2023