### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-1-jdk-oraclelinux8, 23-ea-1-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-1-jdk-oracle, 23-ea-1-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-1-jdk, 23-ea-1, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-2-jdk-oraclelinux8, 23-ea-2-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-2-jdk-oracle, 23-ea-2-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-2-jdk, 23-ea-2, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-1-jdk-oraclelinux7, 23-ea-1-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
+Tags: 23-ea-2-jdk-oraclelinux7, 23-ea-2-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/oraclelinux7
 
-Tags: 23-ea-1-jdk-bookworm, 23-ea-1-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-2-jdk-bookworm, 23-ea-2-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-1-jdk-slim-bookworm, 23-ea-1-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-1-jdk-slim, 23-ea-1-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-2-jdk-slim-bookworm, 23-ea-2-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-2-jdk-slim, 23-ea-2-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-1-jdk-bullseye, 23-ea-1-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-2-jdk-bullseye, 23-ea-2-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-1-jdk-slim-bullseye, 23-ea-1-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-2-jdk-slim-bullseye, 23-ea-2-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-1-jdk-windowsservercore-ltsc2022, 23-ea-1-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-1-jdk-windowsservercore, 23-ea-1-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-1-jdk, 23-ea-1, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-2-jdk-windowsservercore-ltsc2022, 23-ea-2-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-2-jdk-windowsservercore, 23-ea-2-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-2-jdk, 23-ea-2, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-1-jdk-windowsservercore-1809, 23-ea-1-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-1-jdk-windowsservercore, 23-ea-1-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-1-jdk, 23-ea-1, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-2-jdk-windowsservercore-1809, 23-ea-2-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-2-jdk-windowsservercore, 23-ea-2-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-2-jdk, 23-ea-2, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-1-jdk-nanoserver-1809, 23-ea-1-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-1-jdk-nanoserver, 23-ea-1-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-2-jdk-nanoserver-1809, 23-ea-2-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-2-jdk-nanoserver, 23-ea-2-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: fa0b2a98f543bd03e5a73821ee18e2f2b6e27417
+GitCommit: 2f07e3bc7842aec252569a5cbe21c9dce65f6554
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 22-ea-27-jdk-oraclelinux8, 22-ea-27-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-27-jdk-oracle, 22-ea-27-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-27-jdk, 22-ea-27, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-28-jdk-oraclelinux8, 22-ea-28-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-28-jdk-oracle, 22-ea-28-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-28-jdk, 22-ea-28, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-27-jdk-oraclelinux7, 22-ea-27-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-28-jdk-oraclelinux7, 22-ea-28-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-27-jdk-bookworm, 22-ea-27-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-28-jdk-bookworm, 22-ea-28-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-27-jdk-slim-bookworm, 22-ea-27-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-27-jdk-slim, 22-ea-27-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-28-jdk-slim-bookworm, 22-ea-28-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-28-jdk-slim, 22-ea-28-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-27-jdk-bullseye, 22-ea-27-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-28-jdk-bullseye, 22-ea-28-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-27-jdk-slim-bullseye, 22-ea-27-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-28-jdk-slim-bullseye, 22-ea-28-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-27-jdk-windowsservercore-ltsc2022, 22-ea-27-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-27-jdk-windowsservercore, 22-ea-27-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-27-jdk, 22-ea-27, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-28-jdk-windowsservercore-ltsc2022, 22-ea-28-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-28-jdk-windowsservercore, 22-ea-28-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-28-jdk, 22-ea-28, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-27-jdk-windowsservercore-1809, 22-ea-27-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-27-jdk-windowsservercore, 22-ea-27-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-27-jdk, 22-ea-27, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-28-jdk-windowsservercore-1809, 22-ea-28-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-28-jdk-windowsservercore, 22-ea-28-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-28-jdk, 22-ea-28, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-27-jdk-nanoserver-1809, 22-ea-27-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-27-jdk-nanoserver, 22-ea-27-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-28-jdk-nanoserver-1809, 22-ea-28-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-28-jdk-nanoserver, 22-ea-28-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: 57add13396240d2d34d5410f4cc419fac7c599a1
+GitCommit: 4dcc0af633d819ca8c2a6a9ff4ed27293fd99dd9
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/2f07e3b: Update 23 to 23-ea+2
- https://github.com/docker-library/openjdk/commit/4dcc0af: Update 22 to 22-ea+28