### PR TITLE
Updated swipl devel to 9.1.21

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: aed2f55c031507e8fe2a2fede471ffbb5ced5af0
+GitCommit: da988c03e12ce42e6ba3443ec74a17a676e05af1
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 9.1.19
-Directory: 9.1.19/bullseye
+Tags: latest, 9.1.21
+Directory: 9.1.21/bookworm
 
 Tags: stable, 9.0.4
 Directory: 9.0.4/bullseye


### PR DESCRIPTION
Also updated the base image from Debian bullseye to Debian bookworm.

The repo also contains the updated bullseye Dockerfile.   Should we add that as an alternative tag?   What is the best practice wrt. updating the Debian version of the base image?   If this is not according to your best practices, please either edit the commit or reject and point me at what to do.