### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,29 +5,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.13.0-rc.2, 3.13-rc
+Tags: 3.13.0-rc.3, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2a94ce3f0fe97b7c56e6bc985e97059c72910903
+GitCommit: 00e4d971adc2fb074b22e908fac4eb637ccb414c
 Directory: 3.13-rc/ubuntu
 
-Tags: 3.13.0-rc.2-management, 3.13-rc-management
+Tags: 3.13.0-rc.3-management, 3.13-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/ubuntu/management
 
-Tags: 3.13.0-rc.2-alpine, 3.13-rc-alpine
+Tags: 3.13.0-rc.3-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2a94ce3f0fe97b7c56e6bc985e97059c72910903
+GitCommit: 00e4d971adc2fb074b22e908fac4eb637ccb414c
 Directory: 3.13-rc/alpine
 
-Tags: 3.13.0-rc.2-management-alpine, 3.13-rc-management-alpine
+Tags: 3.13.0-rc.3-management-alpine, 3.13-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/alpine/management
 
 Tags: 3.12.10, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b6b4cd71df7d15918afbd4e7ab021266bb2310b7
+GitCommit: 986a970fcf1135300bddc78c15d84cde14a08b61
 Directory: 3.12/ubuntu
 
 Tags: 3.12.10-management, 3.12-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.10-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 12f56d211d04474b18940528cc218dcb9da88a96
+GitCommit: 986a970fcf1135300bddc78c15d84cde14a08b61
 Directory: 3.12/alpine
 
 Tags: 3.12.10-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.12/alpine/management
 
 Tags: 3.11.27, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c759a936021d9abf72c78573798703a56cd35504
+GitCommit: 47915328ad29b0e11e34043dcd0639493687af10
 Directory: 3.11/ubuntu
 
 Tags: 3.11.27-management, 3.11-management
@@ -57,7 +57,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.27-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c759a936021d9abf72c78573798703a56cd35504
+GitCommit: 47915328ad29b0e11e34043dcd0639493687af10
 Directory: 3.11/alpine
 
 Tags: 3.11.27-management-alpine, 3.11-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.25, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0e547c0d4ef0a09238c1b0f514835f3733f69148
+GitCommit: a684a9201f2cb3a42ac5451d5d694cc26ef26c0e
 Directory: 3.10/ubuntu
 
 Tags: 3.10.25-management, 3.10-management
@@ -77,7 +77,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.25-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 12f56d211d04474b18940528cc218dcb9da88a96
+GitCommit: a684a9201f2cb3a42ac5451d5d694cc26ef26c0e
 Directory: 3.10/alpine
 
 Tags: 3.10.25-management-alpine, 3.10-management-alpine
@@ -87,7 +87,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4ef39c16217ca65831d0a997f60e54c916244a3c
+GitCommit: 0adc2a913923b76247388e4eea8e77ef9bea14d6
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -97,7 +97,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 12f56d211d04474b18940528cc218dcb9da88a96
+GitCommit: 0adc2a913923b76247388e4eea8e77ef9bea14d6
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/0adc2a9: Update 3.9 to otp 25.3.2.8
- https://github.com/docker-library/rabbitmq/commit/00e4d97: Update 3.13-rc to 3.13.0-rc.3, otp 26.2.1
- https://github.com/docker-library/rabbitmq/commit/986a970: Update 3.12 to otp 25.3.2.8
- https://github.com/docker-library/rabbitmq/commit/4791532: Update 3.11 to otp 25.3.2.8
- https://github.com/docker-library/rabbitmq/commit/a684a92: Update 3.10 to otp 25.3.2.8