### PR TITLE
[ros][gazebo] remove apt-key use in favor of recommended gpg usage

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: gzserver11, gzserver11-focal
 Architectures: amd64
-GitCommit: 532c4f1af8c9dadb54b0c9769543c67c40c0c84f
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: gazebo/11/ubuntu/focal/gzserver11
 
 Tags: libgazebo11, libgazebo11-focal, latest

--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
@@ -36,7 +36,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble, latest
@@ -58,7 +58,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: iron-ros-core, iron-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/iron/ubuntu/jammy/ros-core
 
 Tags: iron-ros-base, iron-ros-base-jammy, iron
@@ -80,7 +80,7 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 Tags: rolling-ros-core, rolling-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
 Directory: ros/rolling/ubuntu/jammy/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-jammy, rolling


### PR DESCRIPTION
Following recommendations from https://github.com/docker-library/official-images/pull/15809#issuecomment-1846053036