### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,22 +6,22 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 3.0-dev0, 3.0-dev, 3.0-dev0-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
+GitCommit: 0d5ae965f4941abfe179b11761bfec9c5ef191ff
 Directory: 3.0
 
 Tags: 3.0-dev0-alpine, 3.0-dev-alpine, 3.0-dev0-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: 0d5ae965f4941abfe179b11761bfec9c5ef191ff
 Directory: 3.0/alpine
 
 Tags: 2.9.1, 2.9, latest, 2.9.1-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7643b2d41ab7eb48e2ebfe2ce99ca453a125993c
+GitCommit: 66c5b5e84b5f86a8047f5d8f9472e5fa6e3711e8
 Directory: 2.9
 
 Tags: 2.9.1-alpine, 2.9-alpine, alpine, 2.9.1-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7643b2d41ab7eb48e2ebfe2ce99ca453a125993c
+GitCommit: 66c5b5e84b5f86a8047f5d8f9472e5fa6e3711e8
 Directory: 2.9/alpine
 
 Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm
@@ -64,22 +64,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: b2d07293f7145e5630e88695f8b570dcb0650bf9
 Directory: 2.4/alpine
 
-Tags: 2.2.31, 2.2, 2.2.31-bullseye, 2.2-bullseye
+Tags: 2.2.32, 2.2, 2.2.32-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 37ba32b245a7c55a5a42a554795d7140acbf4113
+GitCommit: edf0471abcc8d46fec439f9bddffa0d57da97053
 Directory: 2.2
 
-Tags: 2.2.31-alpine, 2.2-alpine, 2.2.31-alpine3.16, 2.2-alpine3.16
+Tags: 2.2.32-alpine, 2.2-alpine, 2.2.32-alpine3.16, 2.2-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 37ba32b245a7c55a5a42a554795d7140acbf4113
+GitCommit: edf0471abcc8d46fec439f9bddffa0d57da97053
 Directory: 2.2/alpine
 
-Tags: 2.0.33, 2.0, 2.0.33-buster, 2.0-buster
+Tags: 2.0.34, 2.0, 2.0.34-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
+GitCommit: 1689052e242008bfabfd0259acdbcf0bf69a1743
 Directory: 2.0
 
-Tags: 2.0.33-alpine, 2.0-alpine, 2.0.33-alpine3.16, 2.0-alpine3.16
+Tags: 2.0.34-alpine, 2.0-alpine, 2.0.34-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c85db58f62beefbcbc4fabc5697ddaeb9ff3ff2
+GitCommit: 1689052e242008bfabfd0259acdbcf0bf69a1743
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/edf0471: Update 2.2 to 2.2.32
- https://github.com/docker-library/haproxy/commit/1689052: Update 2.0 to 2.0.34
- https://github.com/docker-library/haproxy/commit/66c5b5e: Merge pull request https://github.com/docker-library/haproxy/pull/215 from Darlelet/master