### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 5.1.1, 5.1, 5, latest, 5.1.1-bookworm, 5.1-bookworm, 5-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 711e24b729fb1e39614073f1c0c37402af829ddd
+GitCommit: 5b28bcaaca4e14c41564d43cf5e53b0a13b49155
 Directory: 5.1/bookworm
 
 Tags: 5.1.1-alpine3.18, 5.1-alpine3.18, 5-alpine3.18, alpine3.18, 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 711e24b729fb1e39614073f1c0c37402af829ddd
+GitCommit: 5b28bcaaca4e14c41564d43cf5e53b0a13b49155
 Directory: 5.1/alpine3.18
 
 Tags: 5.0.7, 5.0, 5.0.7-bookworm, 5.0-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/5b28bca: Use ruby-3.2 for redmine-5.1 (https://github.com/docker-library/redmine/pull/309)