### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/c82d1f70eedcb3eb3aa93b7f3406f3013fb05265/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/0b122f1ef94dd9d5f390e3975288285ffff7537e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: c82d1f70eedcb3eb3aa93b7f3406f3013fb05265
+GitCommit: 0b122f1ef94dd9d5f390e3975288285ffff7537e
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fd3de9bdd2a72b59a99e7d1c125e5b3b5729326a
+amd64-GitCommit: 6f8c96df0b81947e6b3d3e636d96ff94471b121c
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 7bc82537c44617142c244a1074d2ac6f3ddd7c4a
+arm32v5-GitCommit: 94c25d664649dc3c4c2f231ca1abce926c5cc348
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 54be82b66da36bb791c0376017cf34c6d492f55d
+arm32v6-GitCommit: 168e298bca1165005c11c8e6a7d9f306568410a7
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: a8e56165783eed4a25789743528a84c2ce13c589
+arm32v7-GitCommit: 0be4906cc5256d74ec87b2e764dd18754aaf44f1
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d5964852b804d0dabdd027f3e289ca9479c5ac33
+arm64v8-GitCommit: 2d92c2c307eb4e37d474f6d6cf22581cc9631cde
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 6a9f5d40fe3419d55978b2f384bc13a9893b3cb3
+i386-GitCommit: c13de2813c5072394eb559b9adcb4919a7f09049
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 0b4b2c2ec9a47c94fe2a0b7897b91ebf519c9b12
+mips64le-GitCommit: 72ac77c9a6bf148629e29ac6f85a799caaa5ad31
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 587ef8fac17fe44986954db753ad4509283e7e60
+ppc64le-GitCommit: 2d6a9c1e6b9664b86e1757f750eae94bf2a9a636
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 30e40709eb773b2ad09fafc433c44dad3afeb51d
+riscv64-GitCommit: 68791e4a26664a2f23ca81bed2797ed5d1aa4058
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: bcaf21792f4ec53981fc77a7d9a82ae82e74e77e
+s390x-GitCommit: d8521ac4cdfeaf34e206460c99f9e0b6970d9112
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/0b122f1: Merge pull request https://github.com/docker-library/busybox/pull/185 from infosiftr/alpine3.19
- https://github.com/docker-library/busybox/commit/5557798: Update musl variant to build on Alpine 3.19
- https://github.com/docker-library/busybox/commit/2bee511: Update GHA YAML with bashbrew example improvements (esp. concurrency:)