### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2023-7877

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6eebdafb2a35b99afc081d3d49e68558f049bc11
+amd64-GitCommit: 11b61e5a98c62fb97e17d1304e54d3c1397fe32b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6daa4b4a14ef9aa8b0b70ca8c498ff50447731ed
+arm64v8-GitCommit: f054372790ff97da65e403f6903dc7a115519c0d
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-3446, CVE-2023-3817, CVE-2023-5678

See the following for details:

https://linux.oracle.com/errata/ELSA-2023-7877.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>