### PR TITLE
Update Jetty versions to 10.0.19, 11.0.19 & 12.0.5

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -7,242 +7,242 @@ GitRepo: https://github.com/eclipse/jetty.docker.git
 Tags: 9.4.53-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.53-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre8-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jre8, 9.4-jre8, 9-jre8, 9.4.53-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre8
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.53-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jre21, 9.4-jre21, 9-jre21, 9.4.53-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre21
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.53-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jre17, 9.4-jre17, 9-jre17, 9.4.53-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.53-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jre11, 9.4-jre11, 9-jre11, 9.4.53-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jdk8, 9.4-jdk8, 9-jdk8, 9.4.53-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.53-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53, 9.4, 9, 9.4.53-jdk21, 9.4-jdk21, 9-jdk21, 9.4.53-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.53-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk21
-GitCommit: 5245ca814cb972078d8e5bb6526f183d84f6d283
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.53-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jdk17, 9.4-jdk17, 9-jdk17, 9.4.53-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
 Tags: 9.4.53-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.53-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jdk11, 9.4-jdk11, 9-jdk11, 9.4.53-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
-Tags: 12.0.4-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.4-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.5-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.5-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4-jre21, 12.0-jre21, 12-jre21, 12.0.4-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.5-jre21, 12.0-jre21, 12-jre21, 12.0.5-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.4-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.5-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.5-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4-jre17, 12.0-jre17, 12-jre17, 12.0.4-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.5-jre17, 12.0-jre17, 12-jre17, 12.0.5-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.4-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.5-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.5-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4, 12.0, 12, 12.0.4-jdk21, 12.0-jdk21, 12-jdk21, 12.0.4-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.4-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.5, 12.0, 12, 12.0.5-jdk21, 12.0-jdk21, 12-jdk21, 12.0.5-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.5-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.4-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.5-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.5-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 12.0.4-jdk17, 12.0-jdk17, 12-jdk17, 12.0.4-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.5-jdk17, 12.0-jdk17, 12-jdk17, 12.0.5-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.18-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
+Tags: 11.0.19-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.19-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jre21, 11.0-jre21, 11-jre21, 11.0.18-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
+Tags: 11.0.19-jre21, 11.0-jre21, 11-jre21, 11.0.19-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.18-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
+Tags: 11.0.19-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.19-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jre17, 11.0-jre17, 11-jre17, 11.0.18-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
+Tags: 11.0.19-jre17, 11.0-jre17, 11-jre17, 11.0.19-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.18-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
+Tags: 11.0.19-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.19-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jre11, 11.0-jre11, 11-jre11, 11.0.18-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
+Tags: 11.0.19-jre11, 11.0-jre11, 11-jre11, 11.0.19-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.18-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
+Tags: 11.0.19-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.19-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18, 11.0, 11, 11.0.18-jdk21, 11.0-jdk21, 11-jdk21, 11.0.18-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.18-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
+Tags: 11.0.19, 11.0, 11, 11.0.19-jdk21, 11.0-jdk21, 11-jdk21, 11.0.19-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.19-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: 5245ca814cb972078d8e5bb6526f183d84f6d283
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.18-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.19-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.19-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jdk17, 11.0-jdk17, 11-jdk17, 11.0.18-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.19-jdk17, 11.0-jdk17, 11-jdk17, 11.0.19-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.18-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.19-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.19-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 11.0.18-jdk11, 11.0-jdk11, 11-jdk11, 11.0.18-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.19-jdk11, 11.0-jdk11, 11-jdk11, 11.0.19-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 10.0.18-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.18-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
+Tags: 10.0.19-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.19-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 10.0.18-jre21, 10.0-jre21, 10-jre21, 10.0.18-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
+Tags: 10.0.19-jre21, 10.0-jre21, 10-jre21, 10.0.19-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 10.0.18-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.18-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
+Tags: 10.0.19-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.19-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 10.0.18-jre17, 10.0-jre17, 10-jre17, 10.0.18-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
+Tags: 10.0.19-jre17, 10.0-jre17, 10-jre17, 10.0.19-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
 
-Tags: 10.0.18-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.18-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
+Tags: 10.0.19-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.19-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jre11, 10.0-jre11, 10-jre11, 10.0.18-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
+Tags: 10.0.19-jre11, 10.0-jre11, 10-jre11, 10.0.19-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.18-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
+Tags: 10.0.19-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.19-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18, 10.0, 10, 10.0.18-jdk21, 10.0-jdk21, 10-jdk21, 10.0.18-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.18-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
+Tags: 10.0.19, 10.0, 10, 10.0.19-jdk21, 10.0-jdk21, 10-jdk21, 10.0.19-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.19-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: 5245ca814cb972078d8e5bb6526f183d84f6d283
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.18-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.19-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.19-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk17, 10.0-jdk17, 10-jdk17, 10.0.18-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.19-jdk17, 10.0-jdk17, 10-jdk17, 10.0.19-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.18-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.19-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.19-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk11, 10.0-jdk11, 10-jdk11, 10.0.18-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.19-jdk11, 10.0-jdk11, 10-jdk11, 10.0.19-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
 Tags: 9.4.53-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
@@ -252,7 +252,7 @@ GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 Tags: 9.4.53-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.53-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
@@ -262,7 +262,7 @@ GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
 Tags: 9.4.53-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
@@ -272,89 +272,89 @@ GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 Tags: 9.4.53-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
+GitCommit: fe3da4a0e79a7cc2aea01ee10ec832f8b9f426d8
 
 Tags: 9.4.53-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 12.0.4-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.5-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 12.0.4-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.4-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.5-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.5-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 12.0.4-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.5-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 12.0.4-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.5-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: de6acd5b920d21e2ee35e7aaa8abe7cb2d8bb985
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 11.0.18-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
+Tags: 11.0.19-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 11.0.18-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.18-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
+Tags: 11.0.19-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.19-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 11.0.18-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.19-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 11.0.18-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.19-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 11.0.18-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.19-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 11.0.18-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.19-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
+Tags: 10.0.19-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.18-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
+Tags: 10.0.19-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.19-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: 0d6216680eb612c3672965c0029d67dde6b3039c
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.19-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.19-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.19-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
 
-Tags: 10.0.18-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.19-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: a23ba914308dd1439bd177ad3f36a380402f2d16
+GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc


### PR DESCRIPTION
## Update Jetty Versions
- `10.0.18` -> `10.0.19`
- `11.0.18` -> `11.0.19`
- `12.0.4` -> `12.0.5`