### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,80 +6,80 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 3.0-dev0, 3.0-dev, 3.0-dev0-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0d5ae965f4941abfe179b11761bfec9c5ef191ff
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 3.0
 
 Tags: 3.0-dev0-alpine, 3.0-dev-alpine, 3.0-dev0-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0d5ae965f4941abfe179b11761bfec9c5ef191ff
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 3.0/alpine
 
 Tags: 2.9.1, 2.9, latest, 2.9.1-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 66c5b5e84b5f86a8047f5d8f9472e5fa6e3711e8
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.9
 
 Tags: 2.9.1-alpine, 2.9-alpine, alpine, 2.9.1-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 66c5b5e84b5f86a8047f5d8f9472e5fa6e3711e8
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.9/alpine
 
 Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.8
 
 Tags: 2.8.5-alpine, 2.8-alpine, lts-alpine, 2.8.5-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.8/alpine
 
 Tags: 2.7.11, 2.7, 2.7.11-bookworm, 2.7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71aadfadc524b2bec5a4d6e620d1f9a22f431c27
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.7
 
 Tags: 2.7.11-alpine, 2.7-alpine, 2.7.11-alpine3.19, 2.7-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4df9df86887f5422e63e3522f1f958ce735b8ebb
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.7/alpine
 
 Tags: 2.6.16, 2.6, 2.6.16-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4b286a573e8f3bad0cc367ffc0f8e0a330d8307
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.6
 
 Tags: 2.6.16-alpine, 2.6-alpine, 2.6.16-alpine3.19, 2.6-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e4b286a573e8f3bad0cc367ffc0f8e0a330d8307
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.6/alpine
 
 Tags: 2.4.25, 2.4, 2.4.25-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b2d07293f7145e5630e88695f8b570dcb0650bf9
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.4
 
 Tags: 2.4.25-alpine, 2.4-alpine, 2.4.25-alpine3.19, 2.4-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b2d07293f7145e5630e88695f8b570dcb0650bf9
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.4/alpine
 
 Tags: 2.2.32, 2.2, 2.2.32-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: edf0471abcc8d46fec439f9bddffa0d57da97053
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.2
 
 Tags: 2.2.32-alpine, 2.2-alpine, 2.2.32-alpine3.16, 2.2-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: edf0471abcc8d46fec439f9bddffa0d57da97053
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.2/alpine
 
 Tags: 2.0.34, 2.0, 2.0.34-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1689052e242008bfabfd0259acdbcf0bf69a1743
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.0
 
 Tags: 2.0.34-alpine, 2.0-alpine, 2.0.34-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1689052e242008bfabfd0259acdbcf0bf69a1743
+GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/79a32f7: Merge pull request https://github.com/docker-library/haproxy/pull/216 from Darlelet/ca-certs
- https://github.com/docker-library/haproxy/commit/71cd019: Resolving missing ca-certificates dependency that causes client ssl verify to fail