### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 5.1.1, 5.1, 5, latest, 5.1.1-bookworm, 5.1-bookworm, 5-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5b28bcaaca4e14c41564d43cf5e53b0a13b49155
+GitCommit: 739992185fb35540b8a598b867beb54d6b7c4065
 Directory: 5.1/bookworm
 
 Tags: 5.1.1-alpine3.18, 5.1-alpine3.18, 5-alpine3.18, alpine3.18, 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 5.1/alpine3.18
 
 Tags: 5.0.7, 5.0, 5.0.7-bookworm, 5.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d65c2af08af53ba1c68beca8b10ae59fa4e402d5
+GitCommit: 739992185fb35540b8a598b867beb54d6b7c4065
 Directory: 5.0/bookworm
 
 Tags: 5.0.7-alpine3.18, 5.0-alpine3.18, 5.0.7-alpine, 5.0-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/40f9f14: Merge pull request https://github.com/docker-library/redmine/pull/310 from infosiftr/missing-dep
- https://github.com/docker-library/redmine/commit/7399921: Add missing build dependency to fix 5.1 builds on s390x and ppc64le