### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -1,65 +1,65 @@
-# this file is generated via https://github.com/docker-library/ruby/blob/26a1dafd81f4798c0aa44942412fe0465ce3c30d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ruby/blob/088718f389d35483e0cd87354adf7b0f1d0d789e/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.3.0-rc1-bookworm, 3.3-rc-bookworm, 3.3.0-rc1, 3.3-rc
+Tags: 3.3.0-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.0, 3.3, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b166ecb60c263e8880edf86b3fc8c620f7647e8e
-Directory: 3.3-rc/bookworm
+GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+Directory: 3.3/bookworm
 
-Tags: 3.3.0-rc1-slim-bookworm, 3.3-rc-slim-bookworm, 3.3.0-rc1-slim, 3.3-rc-slim
+Tags: 3.3.0-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.0-slim, 3.3-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b166ecb60c263e8880edf86b3fc8c620f7647e8e
-Directory: 3.3-rc/slim-bookworm
+GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+Directory: 3.3/slim-bookworm
 
-Tags: 3.3.0-rc1-bullseye, 3.3-rc-bullseye
+Tags: 3.3.0-bullseye, 3.3-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b166ecb60c263e8880edf86b3fc8c620f7647e8e
-Directory: 3.3-rc/bullseye
+GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+Directory: 3.3/bullseye
 
-Tags: 3.3.0-rc1-slim-bullseye, 3.3-rc-slim-bullseye
+Tags: 3.3.0-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b166ecb60c263e8880edf86b3fc8c620f7647e8e
-Directory: 3.3-rc/slim-bullseye
+GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+Directory: 3.3/slim-bullseye
 
-Tags: 3.3.0-rc1-alpine3.19, 3.3-rc-alpine3.19, 3.3.0-rc1-alpine, 3.3-rc-alpine
+Tags: 3.3.0-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19, 3.3.0-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b166ecb60c263e8880edf86b3fc8c620f7647e8e
-Directory: 3.3-rc/alpine3.19
+GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+Directory: 3.3/alpine3.19
 
-Tags: 3.3.0-rc1-alpine3.18, 3.3-rc-alpine3.18
+Tags: 3.3.0-alpine3.18, 3.3-alpine3.18, 3-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b166ecb60c263e8880edf86b3fc8c620f7647e8e
-Directory: 3.3-rc/alpine3.18
+GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+Directory: 3.3/alpine3.18
 
-Tags: 3.2.2-bookworm, 3.2-bookworm, 3-bookworm, bookworm, 3.2.2, 3.2, 3, latest
+Tags: 3.2.2-bookworm, 3.2-bookworm, 3.2.2, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 423e364cd1681dac6b5afd6191d774aaa1cf6161
 Directory: 3.2/bookworm
 
-Tags: 3.2.2-slim-bookworm, 3.2-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.2.2-slim, 3.2-slim, 3-slim, slim
+Tags: 3.2.2-slim-bookworm, 3.2-slim-bookworm, 3.2.2-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 423e364cd1681dac6b5afd6191d774aaa1cf6161
 Directory: 3.2/slim-bookworm
 
-Tags: 3.2.2-bullseye, 3.2-bullseye, 3-bullseye, bullseye
+Tags: 3.2.2-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 423e364cd1681dac6b5afd6191d774aaa1cf6161
 Directory: 3.2/bullseye
 
-Tags: 3.2.2-slim-bullseye, 3.2-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.2.2-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 423e364cd1681dac6b5afd6191d774aaa1cf6161
 Directory: 3.2/slim-bullseye
 
-Tags: 3.2.2-alpine3.19, 3.2-alpine3.19, 3-alpine3.19, alpine3.19, 3.2.2-alpine, 3.2-alpine, 3-alpine, alpine
+Tags: 3.2.2-alpine3.19, 3.2-alpine3.19, 3.2.2-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 423e364cd1681dac6b5afd6191d774aaa1cf6161
 Directory: 3.2/alpine3.19
 
-Tags: 3.2.2-alpine3.18, 3.2-alpine3.18, 3-alpine3.18, alpine3.18
+Tags: 3.2.2-alpine3.18, 3.2-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 423e364cd1681dac6b5afd6191d774aaa1cf6161
 Directory: 3.2/alpine3.18


### PR DESCRIPTION
Closes https://github.com/docker-library/ruby/issues/434 (aspirationally :crossed_fingers:)

Changes:

- https://github.com/docker-library/ruby/commit/8af6f23: Update 3.3-rc
- https://github.com/docker-library/ruby/commit/52e176c: Update 3.3 to 3.3.0, rust 1.74.1, rustup 1.26.0
- https://github.com/docker-library/ruby/commit/04ee24d: Fix bug with 3.3.0 deleting 3.3 instead of 3.3-rc
- https://github.com/docker-library/ruby/commit/088718f: Automate "latest" and "3" aliases
- https://github.com/docker-library/ruby/commit/2b3b80b: Merge pull request https://github.com/docker-library/ruby/pull/435 from infosiftr/upstream-data
- https://github.com/docker-library/ruby/commit/25e8353: Finally parse upstream releases data properly