### PR TITLE
Update XWiki LTS to 15.10.2

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -1,33 +1,34 @@
 Maintainers: XWiki Core Dev Team <committers@xwiki.org> (@xwiki)
 GitRepo: https://github.com/xwiki-contrib/docker-xwiki.git
 
-Tags: 15, 15.10, 15.10.1, 15-mysql-tomcat, 15.10-mysql-tomcat, 15.10.1-mysql-tomcat, mysql-tomcat, stable-mysql-tomcat, stable-mysql, stable, latest
+# LTS and stable
+Tags: 15, 15.10, 15.10.2, 15-mysql-tomcat, 15.10-mysql-tomcat, 15.10.2-mysql-tomcat, mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts, stable-mysql-tomcat, stable-mysql, stable, latest
 Architectures: amd64, arm64v8
 Directory: 15/mysql-tomcat
-GitCommit: 9fb3640d614f7b29d39093ef9645201dff8e57ca
+GitCommit: aa1b428676a0796e57ffc3285de545b4ad343bbc
 
-Tags: 15-postgres-tomcat, 15.10-postgres-tomcat, 15.10.1-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres
+Tags: 15-postgres-tomcat, 15.10-postgres-tomcat, 15.10.2-postgres-tomcat, postgres-tomcat, lts-postgres-tomcat, lts-postgres, stable-postgres-tomcat, stable-postgres
 Architectures: amd64, arm64v8
 Directory: 15/postgres-tomcat
-GitCommit: 9fb3640d614f7b29d39093ef9645201dff8e57ca
+GitCommit: aa1b428676a0796e57ffc3285de545b4ad343bbc
 
-Tags: 15-mariadb-tomcat, 15.10-mariadb-tomcat, 15.10.1-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb
+Tags: 15-mariadb-tomcat, 15.10-mariadb-tomcat, 15.10.2-mariadb-tomcat, mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb, stable-mariadb-tomcat, stable-mariadb
 Architectures: amd64, arm64v8
 Directory: 15/mariadb-tomcat
-GitCommit: 9fb3640d614f7b29d39093ef9645201dff8e57ca
+GitCommit: aa1b428676a0796e57ffc3285de545b4ad343bbc
 
-# LTS 
-Tags: 14, 14.10, 14.10.20, 14-mysql-tomcat, 14.10-mysql-tomcat, 14.10.20-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+# Still maintained 14.10.x branch
+Tags: 14, 14.10, 14.10.20, 14-mysql-tomcat, 14.10-mysql-tomcat, 14.10.20-mysql-tomcat
 Architectures: amd64, arm64v8
 Directory: 14/mysql-tomcat
 GitCommit: c0c657c87f969d33cec32d9884b64a93f9352b50
 
-Tags: 14-postgres-tomcat, 14.10-postgres-tomcat, 14.10.20-postgres-tomcat, lts-postgres-tomcat, lts-postgres
+Tags: 14-postgres-tomcat, 14.10-postgres-tomcat, 14.10.20-postgres-tomcat
 Architectures: amd64, arm64v8
 Directory: 14/postgres-tomcat
 GitCommit: c0c657c87f969d33cec32d9884b64a93f9352b50
 
-Tags: 14-mariadb-tomcat, 14.10-mariadb-tomcat, 14.10.20-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
+Tags: 14-mariadb-tomcat, 14.10-mariadb-tomcat, 14.10.20-mariadb-tomcat
 Architectures: amd64, arm64v8
 Directory: 14/mariadb-tomcat
 GitCommit: c0c657c87f969d33cec32d9884b64a93f9352b50


### PR DESCRIPTION
LTS version is now using 15.10.x branch. 14.10.x branch is kept as it will be maintained internally for a while.