### PR TITLE
archlinux: Release 20240101.0.204074

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,13 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20231112.0.191179
-GitCommit: 9e3e5066b444021f47836449f6a9d89d0cf5861a
-GitFetch: refs/tags/v20231112.0.191179
+Tags: latest, base, base-20240101.0.204074
+GitCommit: 4caef241ef62b1e01362a6d0c7eab7f6149aa3be
+GitFetch: refs/tags/v20240101.0.204074
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20231112.0.191179
-GitCommit: 9e3e5066b444021f47836449f6a9d89d0cf5861a
-GitFetch: refs/tags/v20231112.0.191179
+Tags: base-devel, base-devel-20240101.0.204074
+GitCommit: 4caef241ef62b1e01362a6d0c7eab7f6149aa3be
+GitFetch: refs/tags/v20240101.0.204074
 File: Dockerfile.base-devel
+
+Tags: multilib-devel, multilib-devel-20240101.0.204074
+GitCommit: 4caef241ef62b1e01362a6d0c7eab7f6149aa3be
+GitFetch: refs/tags/v20240101.0.204074
+File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks