### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0-beta1, 5.0, 5, 5.0-beta1-focal, 5.0-focal, 5-focal
+Tags: 5.0-beta1, 5.0, 5, 5.0-beta1-jammy, 5.0-jammy, 5-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8313dd9e2e5d049117c1aa190494702f5ee60c83
+GitCommit: 2c12419510e30fb7fbacf4b1e3da31dc464d925a
 Directory: 5.0
 
-Tags: 4.1.3, 4.1, 4, latest, 4.1.3-focal, 4.1-focal, 4-focal, focal
+Tags: 4.1.3, 4.1, 4, latest, 4.1.3-jammy, 4.1-jammy, 4-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 44614387cda4278e477056c24cde3070f679a32a
+GitCommit: 8cdda79acc014840c36161dfad2f5d4368e778a6
 Directory: 4.1
 
-Tags: 4.0.11, 4.0, 4.0.11-focal, 4.0-focal
+Tags: 4.0.11, 4.0, 4.0.11-jammy, 4.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b57fae57e886db7b46c0851ed761b6b0a260f065
+GitCommit: 66348dba5ed2ea13d9d5a7ff6c0b51f2383d012b
 Directory: 4.0
 
-Tags: 3.11.16, 3.11, 3, 3.11.16-focal, 3.11-focal, 3-focal
+Tags: 3.11.16, 3.11, 3, 3.11.16-jammy, 3.11-jammy, 3-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 76e413ded2e5eb2c61d97296d01400d2fff2d6d5
+GitCommit: a1e2446ab30903f6a21e1c06831a45ab763f2719
 Directory: 3.11
 
-Tags: 3.0.29, 3.0, 3.0.29-focal, 3.0-focal
+Tags: 3.0.29, 3.0, 3.0.29-jammy, 3.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 0472adffa9e3b3361f2dbe4b089592d1cb84d36d
+GitCommit: 6e4848e04a9f6f36e7e03e99cc3087bbf7ccb49f
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/a1e2446: Update 3.11 to FROM eclipse-temurin:8-jre-jammy
- https://github.com/docker-library/cassandra/commit/6e4848e: Update 3.0 to FROM eclipse-temurin:8-jre-jammy
- https://github.com/docker-library/cassandra/commit/a03ffc3: Switch to "python2" explicitly for 3.x versions
- https://github.com/docker-library/cassandra/commit/2c12419: Update 5.0 to FROM eclipse-temurin:17-jre-jammy
- https://github.com/docker-library/cassandra/commit/8cdda79: Update 4.1 to FROM eclipse-temurin:11-jre-jammy
- https://github.com/docker-library/cassandra/commit/66348db: Update 4.0 to FROM eclipse-temurin:11-jre-jammy