### PR TITLE
Pin `ruby-binstubs` test gems to fix `brakeman` breakage

### DIFF
--- a/test/tests/ruby-binstubs/Gemfile
+++ b/test/tests/ruby-binstubs/Gemfile
@@ -1,3 +1,3 @@
 source 'https://rubygems.org'
-gem 'bundler-audit'
-gem 'brakeman'
+gem 'bundler-audit', '0.9.1'
+gem 'brakeman', '5.4.1'


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/15959#issuecomment-1869713711

Something about the `brakeman` 6.1.1 released on Christmas Eve led to us needing `make` and we just need this test to verify that `binstubs` install correctly, so we can pin this to an older version instead.