### PR TITLE
Bump Traefik to v2.11.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,12 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
+Tags: v3.0.0-beta5-windowsservercore-ltsc2022, 3.0.0-beta5-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
+Directory: windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
 Tags: v3.0.0-beta5-windowsservercore-1809, 3.0.0-beta5-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
@@ -12,6 +19,33 @@ Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
 Directory: alpine
+
+Tags: v2.11.0-rc1-windowsservercore-ltsc2022, 2.11.0-rc1-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: febb0c2358cbb1033a6d0d0a447d52cbe11ded54
+Directory: windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: v2.11.0-rc1-windowsservercore-1809, 2.11.0-rc1-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: febb0c2358cbb1033a6d0d0a447d52cbe11ded54
+Directory: windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v2.11.0-rc1, 2.11.0-rc1, v2.11, 2.11, mimolette
+Architectures: amd64, arm32v6, arm64v8, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: febb0c2358cbb1033a6d0d0a447d52cbe11ded54
+Directory: alpine
+
+Tags: v2.10.7-windowsservercore-ltsc2022, 2.10.7-windowsservercore-ltsc2022, v2.10-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, saintmarcelin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 274d14183ad37ff987c85fb0f85e9f862025c297
+Directory: windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
 
 Tags: v2.10.7-windowsservercore-1809, 2.10.7-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.0-rc1](https://github.com/traefik/traefik/releases/tag/v2.11.0-rc1).

/cc @kevinpollet @ldez @rtribotte

Cheers
