### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 3.13.0-rc.3, 3.13-rc
+Tags: 3.13.0-rc.4, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 00e4d971adc2fb074b22e908fac4eb637ccb414c
+GitCommit: 38dfee76aca22741e236c2496894c0c197fca018
 Directory: 3.13-rc/ubuntu
 
-Tags: 3.13.0-rc.3-management, 3.13-rc-management
+Tags: 3.13.0-rc.4-management, 3.13-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/ubuntu/management
 
-Tags: 3.13.0-rc.3-alpine, 3.13-rc-alpine
+Tags: 3.13.0-rc.4-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 00e4d971adc2fb074b22e908fac4eb637ccb414c
+GitCommit: 38dfee76aca22741e236c2496894c0c197fca018
 Directory: 3.13-rc/alpine
 
-Tags: 3.13.0-rc.3-management-alpine, 3.13-rc-management-alpine
+Tags: 3.13.0-rc.4-management-alpine, 3.13-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 80011d74327aea3ddd460b189c6533c1f177f48f
 Directory: 3.13-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/38dfee7: Update 3.13-rc to 3.13.0-rc.4