### PR TITLE
haskell: upgrade cabal to v3.10.2.0

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,32 +4,32 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.8.1-buster, 9.8-buster, 9-buster, buster, 9.8.1, 9.8, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 30f9d37242fd2ab6a8cf23e546a26b56a0d2636c
+GitCommit: 3d23b935d1de92b907c24b3183a0ee8cdeb459cf
 Directory: 9.8/buster
 
 Tags: 9.8.1-slim-buster, 9.8-slim-buster, 9-slim-buster, slim-buster, 9.8.1-slim, 9.8-slim, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 30f9d37242fd2ab6a8cf23e546a26b56a0d2636c
+GitCommit: 3d23b935d1de92b907c24b3183a0ee8cdeb459cf
 Directory: 9.8/slim-buster
 
 Tags: 9.6.3-buster, 9.6-buster, 9.6.3, 9.6
 Architectures: amd64, arm64v8
-GitCommit: 9bf57e9b736ce1d32fbccbc30f88a48c9e221225
+GitCommit: 3d23b935d1de92b907c24b3183a0ee8cdeb459cf
 Directory: 9.6/buster
 
 Tags: 9.6.3-slim-buster, 9.6-slim-buster, 9.6.3-slim, 9.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 9bf57e9b736ce1d32fbccbc30f88a48c9e221225
+GitCommit: 3d23b935d1de92b907c24b3183a0ee8cdeb459cf
 Directory: 9.6/slim-buster
 
 Tags: 9.4.8-buster, 9.4-buster, 9.4.8, 9.4
 Architectures: amd64, arm64v8
-GitCommit: feaa69933c38c47f92e58aa6e7346c8865c1a9f3
+GitCommit: 3d23b935d1de92b907c24b3183a0ee8cdeb459cf
 Directory: 9.4/buster
 
 Tags: 9.4.8-slim-buster, 9.4-slim-buster, 9.4.8-slim, 9.4-slim
 Architectures: amd64, arm64v8
-GitCommit: feaa69933c38c47f92e58aa6e7346c8865c1a9f3
+GitCommit: 3d23b935d1de92b907c24b3183a0ee8cdeb459cf
 Directory: 9.4/slim-buster
 
 Tags: 9.2.8-buster, 9.2-buster, 9.2.8, 9.2


### PR DESCRIPTION
Upgrades cabal to v3.10.2.0 for 9.8, 9.6 & 9.4 releases (see haskell/docker-haskell#114)

Fixes haskell/docker-haskell#117 (thanks to @DuncanVR for the heads-up!)