### PR TITLE
Update Clear Linux OS to 40620

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: dc6a516cae38c61d549241c4ab939bc5d062273d
-GitFetch: refs/heads/base-40580
+GitCommit: 217f4343f59409f73803e4499d26af52b36c42cf
+GitFetch: refs/heads/base-40620


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 40620

@bryteise @djklimes @bryteise