### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,7 +6,7 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 5.1.1, 5.1, 5, latest, 5.1.1-bookworm, 5.1-bookworm, 5-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739992185fb35540b8a598b867beb54d6b7c4065
+GitCommit: 9f8737bd02cab294935e8ef8521ae51bfad9aee8
 Directory: 5.1/bookworm
 
 Tags: 5.1.1-alpine3.18, 5.1-alpine3.18, 5-alpine3.18, alpine3.18, 5.1.1-alpine, 5.1-alpine, 5-alpine, alpine
@@ -16,7 +16,7 @@ Directory: 5.1/alpine3.18
 
 Tags: 5.0.7, 5.0, 5.0.7-bookworm, 5.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 739992185fb35540b8a598b867beb54d6b7c4065
+GitCommit: 9f8737bd02cab294935e8ef8521ae51bfad9aee8
 Directory: 5.0/bookworm
 
 Tags: 5.0.7-alpine3.18, 5.0-alpine3.18, 5.0.7-alpine, 5.0-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/0b2d09d: Merge pull request https://github.com/docker-library/redmine/pull/311 from infosiftr/mips
- https://github.com/docker-library/redmine/commit/9f8737b: fix nokogiri install on mips64le by using system libraries instead of gem-provided ones
- https://github.com/docker-library/redmine/commit/27ae7a1: install gosu from github to fix crash on mips64le