### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev0, 3.0-dev, 3.0-dev0-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev1, 3.0-dev, 3.0-dev1-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 7f6a9c1c093af888a7d5f3e32150c3ea157617e0
 Directory: 3.0
 
-Tags: 3.0-dev0-alpine, 3.0-dev-alpine, 3.0-dev0-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev1-alpine, 3.0-dev-alpine, 3.0-dev1-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 7f6a9c1c093af888a7d5f3e32150c3ea157617e0
 Directory: 3.0/alpine
 
 Tags: 2.9.1, 2.9, latest, 2.9.1-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7f6a9c1: Update 3.0 to 3.0-dev1