### PR TITLE
Transfer library maintenance to the Apache Storm Project

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -1,5 +1,7 @@
-Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
-GitRepo: https://github.com/31z4/storm-docker.git
+Maintainers: The Apache Storm Project <dev@storm.apache.org> (@asfbot),
+             Julien Nioche (@jnioche),
+             Richard Zowalla (@rzo1)
+GitRepo: https://github.com/apache/storm-docker.git
 Architectures: amd64, arm64v8
 
 Tags: 1.2.4-temurin, 1.2-temurin


### PR DESCRIPTION
The Apache Storm project will be taking over maintenance of the official `storm` image as per https://lists.apache.org/thread/34kkzbcfr4qxcxmclgqmjc08o9s28gjz from the previous maintainer @31z4

The mail goes to the project's developer list responsible for releases and administration. I also added @jnioche and myself from the Storm PMC.

In the long run, we want to publish the images from the Storm PMC under `apache/storm` on DockerHub. However, (for now) we just want to take control over the publishing of this official image, which wasn't maintained for the last few months.

Transferring the repo (instead of forking) to the ASF organization on GitHub would be much more overhead compared to loosing the few issues / prs on the original repo. I hope, that this is ok because we want to switch to `apache/storm` on DockerHub in the near future anyway.

ASF Infra told me, that a redirect from `storm` to `apache/storm` on DockerHub isn't feasable / possible at the moment, so perhaps best to get control here, put up an image for 2.6.0 and than update the README on DockerHub and start distributing under `apache/storm`. Thoughts are welcome, though.