### PR TITLE
[nats] Release v2.10.9

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 75b79822ed20804361fa5781ef02c9e40bbe7172
+GitCommit: 98cc8de8d3c0848951ba74733d7f7997b8f5389a
 GitFetch: refs/heads/main
 
-Tags: 2.10.8-alpine3.19, 2.10-alpine3.19, 2-alpine3.19, alpine3.19, 2.10.8-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.10.9-alpine3.19, 2.10-alpine3.19, 2-alpine3.19, alpine3.19, 2.10.9-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x
 Directory: 2.10.x/alpine3.19
 
-Tags: 2.10.8-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.8-linux, 2.10-linux, 2-linux, linux
-SharedTags: 2.10.8, 2.10, 2, latest
+Tags: 2.10.9-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.9-linux, 2.10-linux, 2-linux, linux
+SharedTags: 2.10.9, 2.10, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x
 Directory: 2.10.x/scratch
 
-Tags: 2.10.8-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.10.8-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.10.9-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.10.9-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.8-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.10.8-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.8, 2.10, 2, latest
+Tags: 2.10.9-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.10.9-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.9, 2.10, 2, latest
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Details can be found [here](https://github.com/nats-io/nats-server/releases/tag/v2.10.9)