### PR TITLE
Update ELK Images

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -8,16 +8,6 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11
 GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
 
-Tags: 8.11.3
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: 1484679916b52a402f0d02ea290d60f6e1eca39a
-
-Tags: 8.11.2
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: 58aa6df8045922c7c6ac92055a120365e158dd20
-
 Tags: 7.17.16
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -3,6 +3,11 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: elasticsearch
 Builder: buildkit
 
+Tags: 8.11.4
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/8.11
+GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
+
 Tags: 8.11.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11

--- a/library/kibana
+++ b/library/kibana
@@ -3,6 +3,11 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: kibana
 Builder: buildkit
 
+Tags: 8.11.4
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/8.11
+GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
+
 Tags: 8.11.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11

--- a/library/kibana
+++ b/library/kibana
@@ -8,16 +8,6 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11
 GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
 
-Tags: 8.11.3
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: 1484679916b52a402f0d02ea290d60f6e1eca39a
-
-Tags: 8.11.2
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: 58aa6df8045922c7c6ac92055a120365e158dd20
-
 Tags: 7.17.16
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17

--- a/library/logstash
+++ b/library/logstash
@@ -3,6 +3,11 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: logstash
 Builder: buildkit
 
+Tags: 8.11.4
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/8.11
+GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
+
 Tags: 8.11.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11

--- a/library/logstash
+++ b/library/logstash
@@ -8,16 +8,6 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.11
 GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
 
-Tags: 8.11.3
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: 1484679916b52a402f0d02ea290d60f6e1eca39a
-
-Tags: 8.11.2
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: 58aa6df8045922c7c6ac92055a120365e158dd20
-
 Tags: 7.17.16
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17


### PR DESCRIPTION
This updates ELK images to point to the original source repository so they build directly and updates the maintainers appropriately.