### PR TITLE
Add official images for openEuler Linux

### DIFF
--- a/library/openeuler
+++ b/library/openeuler
@@ -29,11 +29,20 @@ GitRepo: https://github.com/openeuler-mirror/docker-official-image.git
 #arm64v8-GitCommit: be000f02309378563d4528bbbd306bcb53076086
 #arm64v8-File: Dockerfile-22.03-lts-sp1-aarch64
 
-Tags: 22.03-lts-sp2
+#Tags: 22.03-lts-sp2
+#Architectures: amd64, arm64v8
+#GitFetch: refs/heads/22.03-lts-sp2-x86_64
+#GitCommit: 1d922153a397dcaa37785fea43bcbcc6b7dfbb0a
+#amd64-File: Dockerfile-22.03-lts-sp2-x86_64
+#arm64v8-GitFetch: refs/heads/22.03-lts-sp2-aarch64
+#arm64v8-GitCommit: 7957d7717e5116d9418ea0a0725282ac4c8a90c6
+#arm64v8-File: Dockerfile-22.03-lts-sp2-aarch64
+
+Tags: 22.03-lts-sp3
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/22.03-lts-sp2-x86_64
-GitCommit: 1d922153a397dcaa37785fea43bcbcc6b7dfbb0a
-amd64-File: Dockerfile-22.03-lts-sp2-x86_64
-arm64v8-GitFetch: refs/heads/22.03-lts-sp2-aarch64
-arm64v8-GitCommit: 7957d7717e5116d9418ea0a0725282ac4c8a90c6
-arm64v8-File: Dockerfile-22.03-lts-sp2-aarch64
+GitFetch: refs/heads/22.03-lts-sp3-x86_64
+GitCommit: 66d6ab5de1fe2f0852b8755ea74206e1e5d9bcad
+amd64-File: Dockerfile-22.03-lts-sp3-x86_64
+arm64v8-GitFetch: refs/heads/22.03-lts-sp3-aarch64
+arm64v8-GitCommit: 98798444936eb425b61b37c0c8c2472471ff4b24
+arm64v8-File: Dockerfile-22.03-lts-sp3-aarch64

--- a/library/openeuler
+++ b/library/openeuler
@@ -1,25 +1,31 @@
 Maintainers: openEuler CloudNative SIG <cloudnative@openeuler.org> (@openeuler-mirror),
              Martin Grigorov <mgrigorov@openeuler.sh> (@martin-g)
-GitRepo: https://github.com/openeuler-mirror/docker-official-image
-GitCommit: 2e2f34fe91a8cc5b01ad449335efbe567126a2d0
-GitFetch: refs/heads/main
+GitRepo: https://github.com/openeuler-mirror/docker-official-image.git
 
 Tags: 23.09
 Architectures: amd64, arm64v8
+GitFetch: refs/heads/23.09
+GitCommit: 0e0e1750fe89702e8a8ed04e2f80d9a4022c0310
 amd64-File: Dockerfile-23.09-x86_64
 arm64v8-File: Dockerfile-23.09-aarch64
 
 Tags: 22.03-lts
 Architectures: amd64, arm64v8
+GitFetch: refs/heads/22.03-lts
+GitCommit: aab4c8e7320a90a5776586ce782ed9c12fa70c21
 amd64-File: Dockerfile-22.03-lts-x86_64
 arm64v8-File: Dockerfile-22.03-lts-aarch64
 
 Tags: 22.03-lts-sp1
 Architectures: amd64, arm64v8
+GitFetch: refs/heads/22.03-lts-sp1
+GitCommit: cd0485bb049bf1db4f279c407df4be2933d098df
 amd64-File: Dockerfile-22.03-lts-sp1-x86_64
 arm64v8-File: Dockerfile-22.03-lts-sp1-aarch64
 
 Tags: 22.03-lts-sp2
 Architectures: amd64, arm64v8
+GitFetch: refs/heads/22.03-lts-sp2
+GitCommit: b48da1ffa8ebaf4aa8bd34094c5d0fe9a01b2272
 amd64-File: Dockerfile-22.03-lts-sp2-x86_64
 arm64v8-File: Dockerfile-22.03-lts-sp2-aarch64

--- a/library/openeuler
+++ b/library/openeuler
@@ -2,32 +2,32 @@ Maintainers: openEuler CloudNative SIG <cloudnative@openeuler.org> (@openeuler-m
              Martin Grigorov <mgrigorov@openeuler.sh> (@martin-g)
 GitRepo: https://github.com/openeuler-mirror/docker-official-image.git
 
-Tags: 23.09
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/23.09-x86_64
-GitCommit: d949f1d14dea7ef42305e41750ab3195c2b9dedc
-amd64-File: Dockerfile-23.09-x86_64
-arm64v8-GitFetch: refs/heads/23.09-aarch64
-arm64v8-GitCommit: 4753d7a10a37f5336693da9c4f588d8af19a2e43
-arm64v8-File: Dockerfile-23.09-aarch64
+#Tags: 23.09
+#Architectures: amd64, arm64v8
+#GitFetch: refs/heads/23.09-x86_64
+#GitCommit: d949f1d14dea7ef42305e41750ab3195c2b9dedc
+#amd64-File: Dockerfile-23.09-x86_64
+#arm64v8-GitFetch: refs/heads/23.09-aarch64
+#arm64v8-GitCommit: 4753d7a10a37f5336693da9c4f588d8af19a2e43
+#arm64v8-File: Dockerfile-23.09-aarch64
 
-Tags: 22.03-lts
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/22.03-lts-x86_64
-GitCommit: 3fcc224614068ffc13a53a2301087af406652e69
-amd64-File: Dockerfile-22.03-lts-x86_64
-arm64v8-GitFetch: refs/heads/22.03-lts-aarch64
-arm64v8-GitCommit: fbdcee20b5e76ead420416d8dcb1632818fc026d
-arm64v8-File: Dockerfile-22.03-lts-aarch64
+#Tags: 22.03-lts
+#Architectures: amd64, arm64v8
+#GitFetch: refs/heads/22.03-lts-x86_64
+#GitCommit: 3fcc224614068ffc13a53a2301087af406652e69
+#amd64-File: Dockerfile-22.03-lts-x86_64
+#arm64v8-GitFetch: refs/heads/22.03-lts-aarch64
+#arm64v8-GitCommit: fbdcee20b5e76ead420416d8dcb1632818fc026d
+#arm64v8-File: Dockerfile-22.03-lts-aarch64
 
-Tags: 22.03-lts-sp1
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/22.03-lts-sp1-x86_64
-GitCommit: 066bba8e7ed398ebbd3536811f17e8147369e3a9
-amd64-File: Dockerfile-22.03-lts-sp1-x86_64
-arm64v8-GitFetch: refs/heads/22.03-lts-sp1-aarch64
-arm64v8-GitCommit: be000f02309378563d4528bbbd306bcb53076086
-arm64v8-File: Dockerfile-22.03-lts-sp1-aarch64
+#Tags: 22.03-lts-sp1
+#Architectures: amd64, arm64v8
+#GitFetch: refs/heads/22.03-lts-sp1-x86_64
+#GitCommit: 066bba8e7ed398ebbd3536811f17e8147369e3a9
+#amd64-File: Dockerfile-22.03-lts-sp1-x86_64
+#arm64v8-GitFetch: refs/heads/22.03-lts-sp1-aarch64
+#arm64v8-GitCommit: be000f02309378563d4528bbbd306bcb53076086
+#arm64v8-File: Dockerfile-22.03-lts-sp1-aarch64
 
 Tags: 22.03-lts-sp2
 Architectures: amd64, arm64v8

--- a/library/openeuler
+++ b/library/openeuler
@@ -4,28 +4,36 @@ GitRepo: https://github.com/openeuler-mirror/docker-official-image.git
 
 Tags: 23.09
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/23.09
-GitCommit: 0e0e1750fe89702e8a8ed04e2f80d9a4022c0310
+GitFetch: refs/heads/23.09-x86_64
+GitCommit: d949f1d14dea7ef42305e41750ab3195c2b9dedc
 amd64-File: Dockerfile-23.09-x86_64
+arm64v8-GitFetch: refs/heads/23.09-aarch64
+arm64v8-GitCommit: 4753d7a10a37f5336693da9c4f588d8af19a2e43
 arm64v8-File: Dockerfile-23.09-aarch64
 
 Tags: 22.03-lts
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/22.03-lts
-GitCommit: aab4c8e7320a90a5776586ce782ed9c12fa70c21
+GitFetch: refs/heads/22.03-lts-x86_64
+GitCommit: 3fcc224614068ffc13a53a2301087af406652e69
 amd64-File: Dockerfile-22.03-lts-x86_64
+arm64v8-GitFetch: refs/heads/22.03-lts-aarch64
+arm64v8-GitCommit: fbdcee20b5e76ead420416d8dcb1632818fc026d
 arm64v8-File: Dockerfile-22.03-lts-aarch64
 
 Tags: 22.03-lts-sp1
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/22.03-lts-sp1
-GitCommit: cd0485bb049bf1db4f279c407df4be2933d098df
+GitFetch: refs/heads/22.03-lts-sp1-x86_64
+GitCommit: 066bba8e7ed398ebbd3536811f17e8147369e3a9
 amd64-File: Dockerfile-22.03-lts-sp1-x86_64
+arm64v8-GitFetch: refs/heads/22.03-lts-sp1-aarch64
+arm64v8-GitCommit: be000f02309378563d4528bbbd306bcb53076086
 arm64v8-File: Dockerfile-22.03-lts-sp1-aarch64
 
 Tags: 22.03-lts-sp2
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/22.03-lts-sp2
-GitCommit: b48da1ffa8ebaf4aa8bd34094c5d0fe9a01b2272
+GitFetch: refs/heads/22.03-lts-sp2-x86_64
+GitCommit: 1d922153a397dcaa37785fea43bcbcc6b7dfbb0a
 amd64-File: Dockerfile-22.03-lts-sp2-x86_64
+arm64v8-GitFetch: refs/heads/22.03-lts-sp2-aarch64
+arm64v8-GitCommit: 7957d7717e5116d9418ea0a0725282ac4c8a90c6
 arm64v8-File: Dockerfile-22.03-lts-sp2-aarch64

--- a/library/openeuler
+++ b/library/openeuler
@@ -1,0 +1,25 @@
+Maintainers: openEuler CloudNative SIG <cloudnative@openeuler.org> (@openeuler-mirror),
+             Martin Grigorov <mgrigorov@openeuler.sh> (@martin-g)
+GitRepo: https://github.com/openeuler-mirror/docker-official-image
+GitCommit: 2e2f34fe91a8cc5b01ad449335efbe567126a2d0
+GitFetch: refs/heads/main
+
+Tags: 23.09
+Architectures: amd64, arm64v8
+amd64-File: Dockerfile-23.09-x86_64
+arm64v8-File: Dockerfile-23.09-aarch64
+
+Tags: 22.03-lts
+Architectures: amd64, arm64v8
+amd64-File: Dockerfile-22.03-lts-x86_64
+arm64v8-File: Dockerfile-22.03-lts-aarch64
+
+Tags: 22.03-lts-sp1
+Architectures: amd64, arm64v8
+amd64-File: Dockerfile-22.03-lts-sp1-x86_64
+arm64v8-File: Dockerfile-22.03-lts-sp1-aarch64
+
+Tags: 22.03-lts-sp2
+Architectures: amd64, arm64v8
+amd64-File: Dockerfile-22.03-lts-sp2-x86_64
+arm64v8-File: Dockerfile-22.03-lts-sp2-aarch64


### PR DESCRIPTION
This is a proposal to add openEuler OS as official images

- Tags: 
   * 22.03-lts
   * 22.03-lts-sp1 
   * 22.03-lts-sp2 
   * 22.03-lts-sp3
   * 23.09
- Architectures: 
   * amd64 
   * arm64
   
Docs PR: https://github.com/docker-library/docs/pull/2408


-	[ ] associated with or contacted upstream?
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)?
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[x] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[x] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)