### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,19 +13,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.3.20231218.0
+Tags: 2023, latest, 2023.3.20240108.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: b873d5675468bf092eb887e9ff01d72625a13945
+amd64-GitCommit: 6d4428e0e6eeaa40e6fe5df520a2747659bc6396
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 99620d2242c57d3e03eaa76c0dfd21d6e04eeee3
+arm64v8-GitCommit: f0f23b214065caf3c28bcd90a9638ed386d1906a
 
-Tags: 2, 2.0.20231218.0
+Tags: 2, 2.0.20240109.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: a062c0d5722a2c85f82df96a01a5a21a15adff7d
+amd64-GitCommit: 2e6be1003ccf1fb8210e2b67df79eb7cf67bdf99
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: ccf6d7de3dc21508efe0a045b88e1c5cac598410
+arm64v8-GitCommit: 833dadf24a84f5339f3eacd80dd9a2ac8b6bdf5d
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- python-2.7.18-1.amzn2.0.8, python-libs-2.7.18-1.amzn2.0.8
  - [CVE-2022-48566](https://alas.aws.amazon.com/cve/html/CVE-2022-48566.html)
- vim-minimal-9.0.2153-1.amzn2.0.1, vim-data-9.0.2153-1.amzn2.0.1
  - [CVE-2023-48706](https://alas.aws.amazon.com/cve/html/CVE-2023-48706.html)
- ncurses-base-6.0-8.20170212.amzn2.1.7, ncurses-libs-6.0-8.20170212.amzn2.1.7, ncurses-6.0-8.20170212.amzn2.1.7
  - [CVE-2023-50495](https://alas.aws.amazon.com/cve/html/CVE-2023-50495.html)
- curl-8.3.0-1.amzn2.0.5, libcurl-8.3.0-1.amzn2.0.5
  - [CVE-2023-46218](https://alas.aws.amazon.com/cve/html/CVE-2023-46218.html)
  - [CVE-2023-46219](https://alas.aws.amazon.com/cve/html/CVE-2023-46219.html)

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.3.20240108-0.amzn2023
- system-release-2023.3.20240108-0.amzn2023
- curl-minimal-8.5.0-1.amzn2023.0.1, libcurl-minimal-8.5.0-1.amzn2023.0.1
  - [CVE-2023-46218](https://alas.aws.amazon.com/cve/html/CVE-2023-46218.html)
  - [CVE-2023-46219](https://alas.aws.amazon.com/cve/html/CVE-2023-46219.html)
- ncurses-base-6.2-4.20200222.amzn2023.0.5, ncurses-libs-6.2-4.20200222.amzn2023.0.5
  - [CVE-2023-50495](https://alas.aws.amazon.com/cve/html/CVE-2023-50495.html)

_**Note: Amazon Linux 1 is now end-of-life and unlikely to receive any future updates. Please migrate to AL2023.**_