### PR TITLE
feat: Add `ppc64le` support for rust image

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,6 +1,7 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/f45ce4fbffce5d24abae45a13ec48ef868f36364/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/557d703364788c38c82df9b6ff8e89452daa4033/x.py
 
-Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler)
+Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
+             Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
 Tags: 1-buster, 1.75-buster, 1.75.0-buster, buster
@@ -14,23 +15,23 @@ GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
 Directory: 1.75.0/buster/slim
 
 Tags: 1-bullseye, 1.75-bullseye, 1.75.0-bullseye, bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
 Directory: 1.75.0/bullseye
 
 Tags: 1-slim-bullseye, 1.75-slim-bullseye, 1.75.0-slim-bullseye, slim-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
 Directory: 1.75.0/bullseye/slim
 
 Tags: 1-bookworm, 1.75-bookworm, 1.75.0-bookworm, bookworm, 1, 1.75, 1.75.0, latest
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
 Directory: 1.75.0/bookworm
 
 Tags: 1-slim-bookworm, 1.75-slim-bookworm, 1.75.0-slim-bookworm, slim-bookworm, 1-slim, 1.75-slim, 1.75.0-slim, slim
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
 Directory: 1.75.0/bookworm/slim
 
 Tags: 1-alpine3.18, 1.75-alpine3.18, 1.75.0-alpine3.18, alpine3.18


### PR DESCRIPTION
This adds `ppc64le` support for the Rust official image, which was added in [rust-lang/docker-rust#156](https://github.com/rust-lang/docker-rust/pull/156)