### PR TITLE
[oraclelinux] Updating 7, 7-slim, 7-slim-fips, 8, 8-slim, 8-slim-fips, 9 and 9-slim for ELBA-2024-0076, ELSA-2024-0119, ELSA-2024-0256, CVE-2023-27043, ELSA-2024-0155, ELSA-2024-0253

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 11b61e5a98c62fb97e17d1304e54d3c1397fe32b
+amd64-GitCommit: c384d40b8784514c5d09947f9e5075705b9f13f0
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f054372790ff97da65e403f6903dc7a115519c0d
+arm64v8-GitCommit: 0cfeb366fefdc9b9ecbedf3644d586de2f82054a
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for:

TZDATA update to 2023d
CVE-2023-39615
CVE-2023-27043
CVE-2023-5981
CVE-2023-7104
CVE-2022-48560
CVE-2022-48564

See the following for details:

https://linux.oracle.com/errata/ELBA-2024-0076.html
https://linux.oracle.com/errata/ELSA-2024-0114.html
https://linux.oracle.com/errata/ELSA-2024-0119.html
https://linux.oracle.com/errata/ELSA-2024-0256.html
https://linux.oracle.com/errata/ELSA-2024-0155.html
https://linux.oracle.com/errata/ELSA-2024-0253.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
