### PR TITLE
Chmod the .gradle directory for use with arbitrary users

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -6,62 +6,62 @@ GitRepo: https://github.com/keeganwitt/docker-gradle.git
 
 Tags: 8.5.0-jdk8, 8.5-jdk8, 8-jdk8, jdk8, 8.5.0-jdk8-jammy, 8.5-jdk8-jammy, 8-jdk8-jammy, jdk8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk8
 
 Tags: 8.5.0-jdk8-focal, 8.5-jdk8-focal, 8-jdk8-focal, jdk8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk8-focal
 
 Tags: 8.5.0-jdk11, 8.5-jdk11, 8-jdk11, jdk11, 8.5.0-jdk11-jammy, 8.5-jdk11-jammy, 8-jdk11-jammy, jdk11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk11
 
 Tags: 8.5.0-jdk11-focal, 8.5-jdk11-focal, 8-jdk11-focal, jdk11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk11-focal
 
 Tags: 8.5.0-jdk11-alpine, 8.5-jdk11-alpine, 8-jdk11-alpine, jdk11-alpine
 Architectures: amd64
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk11-alpine
 
 Tags: 8.5.0-jdk17, 8.5-jdk17, 8-jdk17, jdk17, 8.5.0-jdk, 8.5-jdk, 8-jdk, jdk, 8.5.0, 8.5, 8, latest, 8.5.0-jdk17-jammy, 8.5-jdk17-jammy, 8-jdk17-jammy, jdk17-jammy, 8.5.0-jdk-jammy, 8.5-jdk-jammy, 8-jdk-jammy, jdk-jammy, 8.5.0-jammy, 8.5-jammy, 8-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk17
 
 Tags: 8.5.0-jdk17-focal, 8.5-jdk17-focal, 8-jdk17-focal, jdk17-focal, 8.5.0-jdk-focal, 8.5-jdk-focal, 8-jdk-focal, jdk-focal, 8.5.0-focal, 8.5-focal, 8-focal, focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk17-focal
 
 Tags: 8.5.0-jdk17-alpine, 8.5-jdk17-alpine, 8-jdk17-alpine, jdk17-alpine, 8.5.0-jdk-alpine, 8.5-jdk-alpine, 8-jdk-alpine, jdk-alpine, 8.5.0-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk17-alpine
 
 Tags: 8.5.0-jdk17-graal, 8.5-jdk17-graal, 8-jdk17-graal, jdk17-graal, 8.5.0-jdk-graal, 8.5-jdk-graal, 8-jdk-graal, jdk-graal, 8.5.0-graal, 8.5-graal, 8-graal, graal, 8.5.0-jdk17-graal-jammy, 8.5-jdk17-graal-jammy, 8-jdk17-graal-jammy, jdk17-graal-jammy, 8.5.0-jdk-graal-jammy, 8.5-jdk-graal-jammy, 8-jdk-graal-jammy, jdk-graal-jammy, 8.5.0-graal-jammy, 8.5-graal-jammy, 8-graal-jammy, graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk17-graal
 
 Tags: 8.5.0-jdk21, 8.5-jdk21, 8-jdk21, jdk21, 8.5.0-jdk21-jammy, 8.5-jdk21-jammy, 8-jdk21-jammy, jdk21-jammy
 Architectures: amd64, arm64v8
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk21
 
 Tags: 8.5.0-jdk21-alpine, 8.5-jdk21-alpine, 8-jdk21-alpine, jdk21-alpine
 Architectures: amd64
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk21-alpine
 
 Tags: 8.5.0-jdk21-graal, 8.5-jdk21-graal, 8-jdk21-graal, jdk21-graal, 8.5.0-jdk21-graal-jammy, 8.5-jdk21-graal-jammy, 8-jdk21-graal-jammy, jdk21-graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 792a35389f800e589fbfe50d96c38ac5b21eaf34
+GitCommit: 37da2e7c1aa258b10e94fe42029e1e6fe8b33bdb
 Directory: jdk21-graal
 
 
@@ -70,49 +70,49 @@ Directory: jdk21-graal
 Tags: 7.6.3-jdk8, 7.6-jdk8, 7-jdk8, 7.6.3-jdk8-jammy, 7.6-jdk8-jammy, 7-jdk8-jammy
 GitFetch: refs/heads/7
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk8
 
 Tags: 7.6.3-jdk8-focal, 7.6-jdk8-focal, 7-jdk8-focal
 GitFetch: refs/heads/7
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk8-focal
 
 Tags: 7.6.3-jdk11, 7.6-jdk11, 7-jdk11, 7.6.3-jdk11-jammy, 7.6-jdk11-jammy, 7-jdk11-jammy
 GitFetch: refs/heads/7
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk11
 
 Tags: 7.6.3-jdk11-focal, 7.6-jdk11-focal, 7-jdk11-focal
 GitFetch: refs/heads/7
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk11-focal
 
 Tags: 7.6.3-jdk11-alpine, 7.6-jdk11-alpine, 7-jdk11-alpine
 GitFetch: refs/heads/7
 Architectures: amd64
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk11-alpine
 
 Tags: 7.6.3-jdk17, 7.6-jdk17, 7-jdk17, 7.6.3-jdk, 7.6-jdk, 7-jdk, 7.6.3, 7.6, 7, 7.6.3-jdk17-jammy, 7.6-jdk17-jammy, 7-jdk17-jammy, 7.6.3-jdk-jammy, 7.6-jdk-jammy, 7-jdk-jammy, 7.6.3-jammy, 7.6-jammy, 7-jammy
 GitFetch: refs/heads/7
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk17
 
 Tags: 7.6.3-jdk17-focal, 7.6-jdk17-focal, 7-jdk17-focal, 7.6.3-jdk-focal, 7.6-jdk-focal, 7-jdk-focal, 7.6.3-focal, 7.6-focal, 7-focal
 GitFetch: refs/heads/7
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk17-focal
 
 Tags: 7.6.3-jdk17-alpine, 7.6-jdk17-alpine, 7-jdk17-alpine, 7.6.3-jdk-alpine, 7.6-jdk-alpine, 7-jdk-alpine, 7.6.3-alpine, 7.6-alpine, 7-alpine
 GitFetch: refs/heads/7
 Architectures: amd64
-GitCommit: 318da3df050a9a05ae13c8b1481194c6ee056692
+GitCommit: 1ab3f2f44513ac091bb9dbdb72341c74b5e4a74e
 Directory: jdk17-alpine
 
 
@@ -121,47 +121,47 @@ Directory: jdk17-alpine
 Tags: 6.9.4-jdk8, 6.9-jdk8, 6-jdk8, 6.9.4-jdk8-jammy, 6.9-jdk8-jammy, 6-jdk8-jammy
 GitFetch: refs/heads/6
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk8
 
 Tags: 6.9.4-jdk8-focal, 6.9-jdk8-focal, 6-jdk8-focal
 GitFetch: refs/heads/6
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk8-focal
 
 Tags: 6.9.4-jdk11, 6.9-jdk11, 6-jdk11, 6.9.4-jdk11-jammy, 6.9-jdk11-jammy, 6-jdk11-jammy
 GitFetch: refs/heads/6
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk11
 
 Tags: 6.9.4-jdk11-focal, 6.9-jdk11-focal, 6-jdk11-focal
 GitFetch: refs/heads/6
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk11-focal
 
 Tags: 6.9.4-jdk11-alpine, 6.9-jdk11-alpine, 6-jdk11-alpine
 GitFetch: refs/heads/6
 Architectures: amd64
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk11-alpine
 
 Tags: 6.9.4-jdk17, 6.9-jdk17, 6-jdk17, 6.9.4-jdk, 6.9-jdk, 6-jdk, 6.9.4, 6.9, 6, 6.9.4-jdk17-jammy, 6.9-jdk17-jammy, 6-jdk17-jammy, 6.9.4-jdk-jammy, 6.9-jdk-jammy, 6-jdk-jammy, 6.9.4-jammy, 6.9-jammy, 6-jammy
 GitFetch: refs/heads/6
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk17
 
 Tags: 6.9.4-jdk17-focal, 6.9-jdk17-focal, 6-jdk17-focal, 6.9.4-jdk-focal, 6.9-jdk-focal, 6-jdk-focal, 6.9.4-focal, 6.9-focal, 6-focal
 GitFetch: refs/heads/6
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk17-focal
 
 Tags: 6.9.4-jdk17-alpine, 6.9-jdk17-alpine, 6-jdk17-alpine, 6.9.4-jdk-alpine, 6.9-jdk-alpine, 6-jdk-alpine, 6.9.4-alpine, 6.9-alpine, 6-alpine
 GitFetch: refs/heads/6
 Architectures: amd64
-GitCommit: 06672bd7ca729b51ef850b51306882c61a8ca606
+GitCommit: 5860d04d193e0a97c41d63a00f6eed1df67be293
 Directory: jdk17-alpine


### PR DESCRIPTION
keeganwitt/docker-gradle#271 raised an issue where running with users other than root (0) or gradle (1000) (for example `docker run -u 1098:1002`) would result in failures like

```
FAILURE: Build failed with an exception.

* What went wrong:
Gradle could not start your build.
> Could not initialize native services.
   > Failed to load native library 'libnative-platform.so' for Linux amd64.
```

This can be avoided by configuring Gradle to use a new volume as the user home, but the most intuitive solution would be to chmod the .gradle directory so that it is writable by all users.