### PR TITLE
Release 8.12.0 of Elastic Stack

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -3,10 +3,10 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: elasticsearch
 Builder: buildkit
 
-Tags: 8.11.4
+Tags: 8.12.0
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
+GitFetch: refs/heads/8.12
+GitCommit: 6e12e2e098446615fc79fc0ae7eee9b2d3e94a12
 
 Tags: 7.17.16
 Architectures: amd64, arm64v8

--- a/library/kibana
+++ b/library/kibana
@@ -3,10 +3,10 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: kibana
 Builder: buildkit
 
-Tags: 8.11.4
+Tags: 8.12.0
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
+GitFetch: refs/heads/8.12
+GitCommit: 6e12e2e098446615fc79fc0ae7eee9b2d3e94a12
 
 Tags: 7.17.16
 Architectures: amd64, arm64v8

--- a/library/logstash
+++ b/library/logstash
@@ -3,10 +3,10 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: logstash
 Builder: buildkit
 
-Tags: 8.11.4
+Tags: 8.12.0
 Architectures: amd64, arm64v8
-GitFetch: refs/heads/8.11
-GitCommit: ee30c9a59a36e118a6e8738df18eea225459ea2c
+GitFetch: refs/heads/8.12
+GitCommit: 6e12e2e098446615fc79fc0ae7eee9b2d3e94a12
 
 Tags: 7.17.16
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Elastic Stack 8.12.0 was released. This PR updates the config to reflect that.
