### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,39 +1,39 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/0b122f1ef94dd9d5f390e3975288285ffff7537e/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/e704abc9f3ea787541fff3a4708a4186a3c054cc/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 0b122f1ef94dd9d5f390e3975288285ffff7537e
+GitCommit: e704abc9f3ea787541fff3a4708a4186a3c054cc
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6f8c96df0b81947e6b3d3e636d96ff94471b121c
+amd64-GitCommit: 09ee80aedec1d8c604f104e8bec41ed19274620a
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 94c25d664649dc3c4c2f231ca1abce926c5cc348
+arm32v5-GitCommit: 5f49fc0f041f4e31f1d63053aff7e21119b13c92
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 168e298bca1165005c11c8e6a7d9f306568410a7
+arm32v6-GitCommit: 2ef3ae50941f78eb12b4390e6061872eb6cd265e
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0be4906cc5256d74ec87b2e764dd18754aaf44f1
+arm32v7-GitCommit: 0eb501729094b55ea54edcaf90b5b6a18ee525af
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2d92c2c307eb4e37d474f6d6cf22581cc9631cde
+arm64v8-GitCommit: e5e22cb0710fe54da4beaa6a72c1bd56b8fc9c54
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: c13de2813c5072394eb559b9adcb4919a7f09049
+i386-GitCommit: 6aa089195212439337f81bc85f50345cdd9b10a0
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 72ac77c9a6bf148629e29ac6f85a799caaa5ad31
+mips64le-GitCommit: c03a246318934c35ceb0dce51afd716cfda96d90
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 2d6a9c1e6b9664b86e1757f750eae94bf2a9a636
+ppc64le-GitCommit: aa059e43d48801abcb012dfa965a432fa12c385d
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 68791e4a26664a2f23ca81bed2797ed5d1aa4058
+riscv64-GitCommit: 87e855bf697e45c8ad2bba661368d7d6e8f367f3
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: d8521ac4cdfeaf34e206460c99f9e0b6970d9112
+s390x-GitCommit: 1aa6d53247f4ee8239f326cf5331ee49b3ea2cc7
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/e704abc: Merge pull request https://github.com/docker-library/busybox/pull/187 from infosiftr/buildroot-2023.11.1
- https://github.com/docker-library/busybox/commit/9c8f069: Update buildroot to 2023.11.1