### PR TITLE
Solr: remove reference to Shalin

### DIFF
--- a/library/solr
+++ b/library/solr
@@ -1,7 +1,6 @@
 # this file is generated via https://github.com/apache/solr-docker/blob/e743474ec59206f53e6c1003cc852f104b315d43/generate-stackbrew-library.sh
 
 Maintainers: The Apache Solr Project <dev@solr.apache.org> (@asfbot),
- Shalin Mangar (@shalinmangar),
  David Smiley (@dsmiley),
  Jan Høydahl (@janhoy),
  Houston Putman (@houstonputman)


### PR DESCRIPTION
Shalin isn't active in the Solr project anymore.

CC @shalinmangar 