### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 7f6a9c1c093af888a7d5f3e32150c3ea157617e0
 Directory: 3.0/alpine
 
-Tags: 2.9.2, 2.9, latest, 2.9.2-bookworm, 2.9-bookworm, bookworm
+Tags: 2.9.3, 2.9, latest, 2.9.3-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b392e587eaca4394492248524cd0297ddb86aa5e
+GitCommit: 6336b496c8634e994cc23261a20b493f08750e82
 Directory: 2.9
 
-Tags: 2.9.2-alpine, 2.9-alpine, alpine, 2.9.2-alpine3.19, 2.9-alpine3.19, alpine3.19
+Tags: 2.9.3-alpine, 2.9-alpine, alpine, 2.9.3-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b392e587eaca4394492248524cd0297ddb86aa5e
+GitCommit: 6336b496c8634e994cc23261a20b493f08750e82
 Directory: 2.9/alpine
 
 Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6336b49: Update 2.9 to 2.9.3