### PR TITLE
eclipse-temurin: Bump JDK11, JDK17 and JDK21

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -8,219 +8,219 @@ GitFetch: refs/heads/main
 #------------------------------v8 images---------------------------------
 Tags: 8u392-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/alpine
 
 Tags: 8u392-b08-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u392-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u392-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u392-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/centos
 
 Tags: 8u392-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u392-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
 SharedTags: 8u392-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u392-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
 SharedTags: 8u392-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u392-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u392-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u392-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u392-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u392-b08-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/alpine
 
 Tags: 8u392-b08-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u392-b08-jre-jammy, 8-jre-jammy
 SharedTags: 8u392-b08-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u392-b08-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/centos
 
 Tags: 8u392-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u392-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
 SharedTags: 8u392-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u392-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
 SharedTags: 8u392-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u392-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u392-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u392-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u392-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.21_9-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.22_7-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/alpine
 
 Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.22_7-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.22_7-jdk, 11-jdk, 11
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.22_7-jdk-centos7, 11-jdk-centos7, 11-centos7
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/centos
 
 Tags: 11.0.22_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.21_9-jre-alpine, 11-jre-alpine
+Tags: 11.0.22_7-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/alpine
 
 Tags: 11.0.22_7-jre-focal, 11-jre-focal
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.22_7-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.22_7-jre, 11-jre
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.22_7-jre-centos7, 11-jre-centos7
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/centos
 
 Tags: 11.0.22_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -228,109 +228,109 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.9_9-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/alpine
 
-Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jdk-focal, 17-jdk-focal, 17-focal
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/ubuntu/focal
 
-Tags: 17.0.10_7-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.10_7-jdk, 17-jdk, 17
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jdk-jammy, 17-jdk-jammy, 17-jammy
+SharedTags: 17.0.9_9-jdk, 17-jdk, 17
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.10_7-jdk-centos7, 17-jdk-centos7, 17-centos7
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jdk-centos7, 17-jdk-centos7, 17-centos7
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/centos
 
-Tags: 17.0.10_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.10_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
+Tags: 17.0.9_9-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.10_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.9_9-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.10_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
+Tags: 17.0.9_9-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.10_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.9_9-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.9_9-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/alpine
 
-Tags: 17.0.10_7-jre-focal, 17-jre-focal
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jre-focal, 17-jre-focal
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/ubuntu/focal
 
-Tags: 17.0.10_7-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.10_7-jre, 17-jre
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jre-jammy, 17-jre-jammy
+SharedTags: 17.0.9_9-jre, 17-jre
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/ubuntu/jammy
 
-Tags: 17.0.10_7-jre-centos7, 17-jre-centos7
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jre-centos7, 17-jre-centos7
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/centos
 
-Tags: 17.0.10_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
-Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Tags: 17.0.9_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.10_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
+Tags: 17.0.9_9-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.10_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.9_9-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.10_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
+Tags: 17.0.9_9-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.10_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.9_9-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
 Directory: 17/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -338,88 +338,88 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v21 images---------------------------------
 Tags: 21.0.1_12-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/alpine
 
 Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
 SharedTags: 21.0.2_13-jdk, 21-jdk, 21, latest
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.2_13-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/ubi/ubi9-minimal
 
-Tags: 21.0.1_12-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21.0.1_12-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.1_12-jdk, 21-jdk, 21, latest
+Tags: 21.0.2_13-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.1_12-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
-SharedTags: 21.0.1_12-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.2_13-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
+SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.1_12-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21.0.1_12-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.1_12-jdk, 21-jdk, 21, latest
+Tags: 21.0.2_13-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21.0.1_12-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21.0.1_12-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.2_13-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.1_12-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/alpine
 
 Tags: 21.0.2_13-jre-jammy, 21-jre-jammy
 SharedTags: 21.0.2_13-jre, 21-jre
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.2_13-jre-ubi9-minimal, 21-jre-ubi9-minimal
-Architectures: amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/ubi/ubi9-minimal
 
-Tags: 21.0.1_12-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
-SharedTags: 21.0.1_12-jre-windowsservercore, 21-jre-windowsservercore, 21.0.1_12-jre, 21-jre
+Tags: 21.0.2_13-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
+SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.1_12-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
-SharedTags: 21.0.1_12-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.2_13-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
+SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.1_12-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
-SharedTags: 21.0.1_12-jre-windowsservercore, 21-jre-windowsservercore, 21.0.1_12-jre, 21-jre
+Tags: 21.0.2_13-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
+SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 21.0.1_12-jre-nanoserver-1809, 21-jre-nanoserver-1809
-SharedTags: 21.0.1_12-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.2_13-jre-nanoserver-1809, 21-jre-nanoserver-1809
+SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
+GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
 Directory: 21/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -8,109 +8,109 @@ GitFetch: refs/heads/main
 #------------------------------v8 images---------------------------------
 Tags: 8u392-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/alpine
 
 Tags: 8u392-b08-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u392-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u392-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u392-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/centos
 
 Tags: 8u392-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u392-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
 SharedTags: 8u392-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u392-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
 SharedTags: 8u392-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u392-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u392-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u392-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u392-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u392-b08-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/alpine
 
 Tags: 8u392-b08-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u392-b08-jre-jammy, 8-jre-jammy
 SharedTags: 8u392-b08-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u392-b08-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/centos
 
 Tags: 8u392-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u392-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
 SharedTags: 8u392-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u392-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
 SharedTags: 8u392-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u392-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u392-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u392-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u392-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u392-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -118,109 +118,109 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.21_9-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/alpine
 
-Tags: 11.0.21_9-jdk-focal, 11-jdk-focal, 11-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/ubuntu/focal
 
-Tags: 11.0.21_9-jdk-jammy, 11-jdk-jammy, 11-jammy
-SharedTags: 11.0.21_9-jdk, 11-jdk, 11
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jdk-jammy, 11-jdk-jammy, 11-jammy
+SharedTags: 11.0.22_7-jdk, 11-jdk, 11
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/ubuntu/jammy
 
-Tags: 11.0.21_9-jdk-centos7, 11-jdk-centos7, 11-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jdk-centos7, 11-jdk-centos7, 11-centos7
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/centos
 
-Tags: 11.0.21_9-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/ubi/ubi9-minimal
 
-Tags: 11.0.21_9-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.21_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.21_9-jdk, 11-jdk, 11
+Tags: 11.0.22_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.21_9-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.21_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.22_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.21_9-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.21_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.21_9-jdk, 11-jdk, 11
+Tags: 11.0.22_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.21_9-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.21_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.22_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.21_9-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/alpine
 
-Tags: 11.0.21_9-jre-focal, 11-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jre-focal, 11-jre-focal
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/ubuntu/focal
 
-Tags: 11.0.21_9-jre-jammy, 11-jre-jammy
-SharedTags: 11.0.21_9-jre, 11-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jre-jammy, 11-jre-jammy
+SharedTags: 11.0.22_7-jre, 11-jre
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/ubuntu/jammy
 
-Tags: 11.0.21_9-jre-centos7, 11-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jre-centos7, 11-jre-centos7
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/centos
 
-Tags: 11.0.21_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 11.0.22_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/ubi/ubi9-minimal
 
-Tags: 11.0.21_9-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.21_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.21_9-jre, 11-jre
+Tags: 11.0.22_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.21_9-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.21_9-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.22_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.21_9-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.21_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.21_9-jre, 11-jre
+Tags: 11.0.22_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 11.0.21_9-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.21_9-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.22_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -228,109 +228,109 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.9_9-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/alpine
 
-Tags: 17.0.9_9-jdk-focal, 17-jdk-focal, 17-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/ubuntu/focal
 
-Tags: 17.0.9_9-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.9_9-jdk, 17-jdk, 17
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jdk-jammy, 17-jdk-jammy, 17-jammy
+SharedTags: 17.0.10_7-jdk, 17-jdk, 17
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.9_9-jdk-centos7, 17-jdk-centos7, 17-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jdk-centos7, 17-jdk-centos7, 17-centos7
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/centos
 
-Tags: 17.0.9_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.9_9-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
+Tags: 17.0.10_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.10_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
+Tags: 17.0.10_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.9_9-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.10_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.9_9-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/alpine
 
-Tags: 17.0.9_9-jre-focal, 17-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jre-focal, 17-jre-focal
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/ubuntu/focal
 
-Tags: 17.0.9_9-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.9_9-jre, 17-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jre-jammy, 17-jre-jammy
+SharedTags: 17.0.10_7-jre, 17-jre
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/ubuntu/jammy
 
-Tags: 17.0.9_9-jre-centos7, 17-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jre-centos7, 17-jre-centos7
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/centos
 
-Tags: 17.0.9_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 17.0.10_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Architectures: amd64, arm64v8
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.9_9-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
+Tags: 17.0.10_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.10_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
+Tags: 17.0.10_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.9_9-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.10_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 17/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -338,89 +338,88 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v21 images---------------------------------
 Tags: 21.0.1_12-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/alpine
 
-Tags: 21.0.1_12-jdk-jammy, 21-jdk-jammy, 21-jammy
-SharedTags: 21.0.1_12-jdk, 21-jdk, 21, latest
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
+SharedTags: 21.0.2_13-jdk, 21-jdk, 21, latest
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/ubuntu/jammy
 
-Tags: 21.0.1_12-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 21.0.2_13-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.1_12-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
 SharedTags: 21.0.1_12-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.1_12-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.1_12-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
 SharedTags: 21.0.1_12-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.1_12-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
 SharedTags: 21.0.1_12-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.1_12-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.1_12-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
 SharedTags: 21.0.1_12-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.1_12-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/alpine
 
-Tags: 21.0.1_12-jre-jammy, 21-jre-jammy
-SharedTags: 21.0.1_12-jre, 21-jre
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 21.0.2_13-jre-jammy, 21-jre-jammy
+SharedTags: 21.0.2_13-jre, 21-jre
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/ubuntu/jammy
 
-Tags: 21.0.1_12-jre-ubi9-minimal, 21-jre-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+Tags: 21.0.2_13-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Architectures: amd64
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.1_12-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
 SharedTags: 21.0.1_12-jre-windowsservercore, 21-jre-windowsservercore, 21.0.1_12-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.1_12-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
 SharedTags: 21.0.1_12-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.1_12-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
 SharedTags: 21.0.1_12-jre-windowsservercore, 21-jre-windowsservercore, 21.0.1_12-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.1_12-jre-nanoserver-1809, 21-jre-nanoserver-1809
 SharedTags: 21.0.1_12-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: 9f92660082f4b901c3b409ef20032916953300c5
 Directory: 21/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
-

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -8,109 +8,109 @@ GitFetch: refs/heads/main
 #------------------------------v8 images---------------------------------
 Tags: 8u402-b06-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/alpine
 
 Tags: 8u402-b06-jdk-focal, 8-jdk-focal, 8-focal
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u402-b06-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u402-b06-jdk, 8-jdk, 8
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u402-b06-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/centos
 
 Tags: 8u402-b06-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u402-b06-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
 SharedTags: 8u402-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u402-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
 SharedTags: 8u402-b06-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u402-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u402-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u402-b06-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u402-b06-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u402-b06-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/alpine
 
 Tags: 8u402-b06-jre-focal, 8-jre-focal
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u402-b06-jre-jammy, 8-jre-jammy
 SharedTags: 8u402-b06-jre, 8-jre
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u402-b06-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/centos
 
 Tags: 8u402-b06-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u402-b06-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
 SharedTags: 8u402-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u402-b06-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
 SharedTags: 8u402-b06-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u402-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u402-b06-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u402-b06-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u402-b06-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -118,109 +118,109 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.22_7-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/alpine
 
 Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.22_7-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.22_7-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.22_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/centos
 
 Tags: 11.0.22_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.22_7-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/alpine
 
 Tags: 11.0.22_7-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.22_7-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.22_7-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.22_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/centos
 
 Tags: 11.0.22_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -228,199 +228,199 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.10_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/alpine
 
 Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/ubuntu/focal
 
 Tags: 17.0.10_7-jdk-jammy, 17-jdk-jammy, 17-jammy
 SharedTags: 17.0.10_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/ubuntu/jammy
 
 Tags: 17.0.10_7-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/centos
 
 Tags: 17.0.10_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/ubi/ubi9-minimal
 
 Tags: 17.0.10_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
 SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
 SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
 SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 17.0.10_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
 SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.10_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/alpine
 
 Tags: 17.0.10_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.10_7-jre-jammy, 17-jre-jammy
 SharedTags: 17.0.10_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/ubuntu/jammy
 
 Tags: 17.0.10_7-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/centos
 
 Tags: 17.0.10_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/ubi/ubi9-minimal
 
 Tags: 17.0.10_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
 SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
 SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
 SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 17.0.10_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
 SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 17/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v21 images---------------------------------
 Tags: 21.0.2_13-jdk-alpine, 21-jdk-alpine, 21-alpine
-Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+Architectures: amd64, arm64v8
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/alpine
 
 Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
 SharedTags: 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.2_13-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.2_13-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
 SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
 SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
 SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.2_13-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
 SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.2_13-jre-alpine, 21-jre-alpine
-Architectures: amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+Architectures: amd64, arm64v8
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/alpine
 
 Tags: 21.0.2_13-jre-jammy, 21-jre-jammy
 SharedTags: 21.0.2_13-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.2_13-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.2_13-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
 SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
 SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
 SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.2_13-jre-nanoserver-1809, 21-jre-nanoserver-1809
 SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
+GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
 Directory: 21/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -8,109 +8,109 @@ GitFetch: refs/heads/main
 #------------------------------v8 images---------------------------------
 Tags: 8u402-b06-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/alpine
 
 Tags: 8u402-b06-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u402-b06-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u402-b06-jdk, 8-jdk, 8
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u402-b06-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/centos
 
 Tags: 8u402-b06-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u402-b06-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
 SharedTags: 8u402-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u402-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
 SharedTags: 8u402-b06-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u402-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u402-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u402-b06-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u402-b06-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u402-b06-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/alpine
 
 Tags: 8u402-b06-jre-focal, 8-jre-focal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u402-b06-jre-jammy, 8-jre-jammy
 SharedTags: 8u402-b06-jre, 8-jre
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u402-b06-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/centos
 
 Tags: 8u402-b06-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u402-b06-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
 SharedTags: 8u402-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u402-b06-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
 SharedTags: 8u402-b06-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 8u402-b06-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u402-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u402-b06-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 8u402-b06-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u402-b06-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -118,109 +118,109 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.22_7-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/alpine
 
 Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.22_7-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.22_7-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.22_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/centos
 
 Tags: 11.0.22_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.22_7-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/alpine
 
 Tags: 11.0.22_7-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.22_7-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.22_7-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.22_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/centos
 
 Tags: 11.0.22_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -228,199 +228,199 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.10_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/alpine
 
 Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/ubuntu/focal
 
 Tags: 17.0.10_7-jdk-jammy, 17-jdk-jammy, 17-jammy
 SharedTags: 17.0.10_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/ubuntu/jammy
 
 Tags: 17.0.10_7-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/centos
 
 Tags: 17.0.10_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/ubi/ubi9-minimal
 
 Tags: 17.0.10_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
 SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
 SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
 SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 17.0.10_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
 SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.10_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/alpine
 
 Tags: 17.0.10_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.10_7-jre-jammy, 17-jre-jammy
 SharedTags: 17.0.10_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/ubuntu/jammy
 
 Tags: 17.0.10_7-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/centos
 
 Tags: 17.0.10_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/ubi/ubi9-minimal
 
 Tags: 17.0.10_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
 SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
 SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 17.0.10_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
 SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 17.0.10_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
 SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 17/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v21 images---------------------------------
-Tags: 21.0.1_12-jdk-alpine, 21-jdk-alpine, 21-alpine
-Architectures: amd64, arm64v8
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+Tags: 21.0.2_13-jdk-alpine, 21-jdk-alpine, 21-alpine
+Architectures: amd64
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/alpine
 
 Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
 SharedTags: 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.2_13-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.2_13-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
 SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
 SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
 SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.2_13-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
 SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 21.0.1_12-jre-alpine, 21-jre-alpine
-Architectures: amd64, arm64v8
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+Tags: 21.0.2_13-jre-alpine, 21-jre-alpine
+Architectures: amd64
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/alpine
 
 Tags: 21.0.2_13-jre-jammy, 21-jre-jammy
 SharedTags: 21.0.2_13-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.2_13-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.2_13-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
 SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
 SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
 SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.2_13-jre-nanoserver-1809, 21-jre-nanoserver-1809
 SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
+GitCommit: 334e6b802fc5b3c671a820416b2f74c1c98f8eaf
 Directory: 21/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -6,111 +6,111 @@ GitRepo: https://github.com/adoptium/containers.git
 GitFetch: refs/heads/main
 
 #------------------------------v8 images---------------------------------
-Tags: 8u392-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u402-b06-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/alpine
 
-Tags: 8u392-b08-jdk-focal, 8-jdk-focal, 8-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+Tags: 8u402-b06-jdk-focal, 8-jdk-focal, 8-focal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/ubuntu/focal
 
-Tags: 8u392-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
-SharedTags: 8u392-b08-jdk, 8-jdk, 8
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+Tags: 8u402-b06-jdk-jammy, 8-jdk-jammy, 8-jammy
+SharedTags: 8u402-b06-jdk, 8-jdk, 8
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/ubuntu/jammy
 
-Tags: 8u392-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
+Tags: 8u402-b06-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/centos
 
-Tags: 8u392-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Tags: 8u402-b06-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/ubi/ubi9-minimal
 
-Tags: 8u392-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u392-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u392-b08-jdk, 8-jdk, 8
+Tags: 8u402-b06-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u402-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u402-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u392-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
-SharedTags: 8u392-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u402-b06-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
+SharedTags: 8u402-b06-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u392-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u392-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u392-b08-jdk, 8-jdk, 8
+Tags: 8u402-b06-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u402-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u402-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u392-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u392-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u402-b06-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u402-b06-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u392-b08-jre-alpine, 8-jre-alpine
+Tags: 8u402-b06-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/alpine
 
-Tags: 8u392-b08-jre-focal, 8-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+Tags: 8u402-b06-jre-focal, 8-jre-focal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/ubuntu/focal
 
-Tags: 8u392-b08-jre-jammy, 8-jre-jammy
-SharedTags: 8u392-b08-jre, 8-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+Tags: 8u402-b06-jre-jammy, 8-jre-jammy
+SharedTags: 8u402-b06-jre, 8-jre
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/ubuntu/jammy
 
-Tags: 8u392-b08-jre-centos7, 8-jre-centos7
+Tags: 8u402-b06-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/centos
 
-Tags: 8u392-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Tags: 8u402-b06-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/ubi/ubi9-minimal
 
-Tags: 8u392-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u392-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u392-b08-jre, 8-jre
+Tags: 8u402-b06-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u402-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u402-b06-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u392-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
-SharedTags: 8u392-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u402-b06-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
+SharedTags: 8u402-b06-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u392-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u392-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u392-b08-jre, 8-jre
+Tags: 8u402-b06-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u402-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u402-b06-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8u392-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u392-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u402-b06-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u402-b06-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 376294c245eba65108cee487ce209f39c15e84c8
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 8/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -118,219 +118,219 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.22_7-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/alpine
 
 Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.22_7-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.22_7-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.22_7-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/centos
 
 Tags: 11.0.22_7-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
 SharedTags: 11.0.22_7-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.22_7-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
 SharedTags: 11.0.22_7-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.22_7-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/alpine
 
 Tags: 11.0.22_7-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.22_7-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.22_7-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.22_7-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/centos
 
 Tags: 11.0.22_7-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.22_7-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 11.0.22_7-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
 SharedTags: 11.0.22_7-jre-windowsservercore, 11-jre-windowsservercore, 11.0.22_7-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 11.0.22_7-jre-nanoserver-1809, 11-jre-nanoserver-1809
 SharedTags: 11.0.22_7-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 11/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.9_9-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.10_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/alpine
 
-Tags: 17.0.9_9-jdk-focal, 17-jdk-focal, 17-focal
+Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/ubuntu/focal
 
-Tags: 17.0.9_9-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.9_9-jdk, 17-jdk, 17
+Tags: 17.0.10_7-jdk-jammy, 17-jdk-jammy, 17-jammy
+SharedTags: 17.0.10_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.9_9-jdk-centos7, 17-jdk-centos7, 17-centos7
+Tags: 17.0.10_7-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/centos
 
-Tags: 17.0.9_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.10_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.9_9-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
+Tags: 17.0.10_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.10_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.9_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.9_9-jdk, 17-jdk, 17
+Tags: 17.0.10_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.10_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.10_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.9_9-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.9_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.10_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.10_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17.0.9_9-jre-alpine, 17-jre-alpine
+Tags: 17.0.10_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/alpine
 
-Tags: 17.0.9_9-jre-focal, 17-jre-focal
+Tags: 17.0.10_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/ubuntu/focal
 
-Tags: 17.0.9_9-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.9_9-jre, 17-jre
+Tags: 17.0.10_7-jre-jammy, 17-jre-jammy
+SharedTags: 17.0.10_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/ubuntu/jammy
 
-Tags: 17.0.9_9-jre-centos7, 17-jre-centos7
+Tags: 17.0.10_7-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/centos
 
-Tags: 17.0.9_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.10_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.9_9-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
+Tags: 17.0.10_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.10_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.9_9-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.9_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.9_9-jre, 17-jre
+Tags: 17.0.10_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.10_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.10_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 17.0.9_9-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.9_9-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.10_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.10_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: f6d4923380ecb1ec4b0d58c633ebb0aeed4c8332
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 17/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
@@ -338,88 +338,89 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v21 images---------------------------------
 Tags: 21.0.1_12-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/alpine
 
 Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
 SharedTags: 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.2_13-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.2_13-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
 SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
 SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
 SharedTags: 21.0.2_13-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.2_13-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
 SharedTags: 21.0.2_13-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.1_12-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/alpine
 
 Tags: 21.0.2_13-jre-jammy, 21-jre-jammy
 SharedTags: 21.0.2_13-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.2_13-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.2_13-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
 SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
 SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 21.0.2_13-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
 SharedTags: 21.0.2_13-jre-windowsservercore, 21-jre-windowsservercore, 21.0.2_13-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 21.0.2_13-jre-nanoserver-1809, 21-jre-nanoserver-1809
 SharedTags: 21.0.2_13-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: c02cff4c9da92d2fe8e99e970477d1043d9f780b
+GitCommit: a9164522bf4c8b885b716727c0df26d0d6f2cf92
 Directory: 21/jre/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
+


### PR DESCRIPTION
Bumped to 21.0.2, 17.0.10 and 11.0.22. 8u401 isn't available yet but we can merge this already so people can get the latest bug fixes, especially for JDK 21.