### PR TITLE
Drop couchdb arches that don't have available packages

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -11,7 +11,7 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 Directory: 3.3.3
 
 Tags: 3.2.3, 3.2
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 Directory: 3.2.3
 
 Tags: 3.1.2, 3.1


### PR DESCRIPTION
> ```console
> + apt-get update
> ...
> Get:3 https://apache.jfrog.io/artifactory/couchdb-deb bullseye/main arm64 Packages [5436 B]
> ### or
> Get:8 https://apache.jfrog.io/artifactory/couchdb-deb bullseye/main ppc64el Packages [5487 B]
> ...
> + apt-get install -y ... couchdb=3.2.3~bullseye
> E: Version '3.2.3~bullseye' for 'couchdb' was not found
> ```

Related discussion: https://github.com/docker-library/official-images/pull/14503#discussion_r1458035904.

The `3.2.3` images fail to build on `arm64v8` and `ppc64le` architectures. They are welcome to come back when they can successfully build.

---

(Side note: there will likely be other PRs like this as I plan to remove tags or arches from other images that are consistently failing so that the build infrastructure doesn't waste time.)