### PR TITLE
releasing Neo4j 5.16.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -4,25 +4,25 @@ Maintainers: Jenny Owen <jenny.owen@neo4j.com> (@jennyowen),
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 
-Tags: 5.15.0-community-bullseye, 5.15-community-bullseye, 5-community-bullseye, 5.15.0-community, 5.15-community, 5-community, 5.15.0-bullseye, 5.15-bullseye, 5-bullseye, 5.15.0, 5.15, 5, community-bullseye, community, bullseye, latest
+Tags: 5.16.0-community-bullseye, 5.16-community-bullseye, 5-community-bullseye, 5.16.0-community, 5.16-community, 5-community, 5.16.0-bullseye, 5.16-bullseye, 5-bullseye, 5.16.0, 5.16, 5, community-bullseye, community, bullseye, latest
 Architectures: amd64, arm64v8
-GitCommit: 26e67efc2fa0211478d9d83387c9f090d5a1873b
-Directory: 5.15.0/bullseye/community
+GitCommit: 05a868b63d35ca3e3ccb96342bc6a2faa8bd500c
+Directory: 5.16.0/bullseye/community
 
-Tags: 5.15.0-enterprise-bullseye, 5.15-enterprise-bullseye, 5-enterprise-bullseye, 5.15.0-enterprise, 5.15-enterprise, 5-enterprise, enterprise-bullseye, enterprise
+Tags: 5.16.0-enterprise-bullseye, 5.16-enterprise-bullseye, 5-enterprise-bullseye, 5.16.0-enterprise, 5.16-enterprise, 5-enterprise, enterprise-bullseye, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 26e67efc2fa0211478d9d83387c9f090d5a1873b
-Directory: 5.15.0/bullseye/enterprise
+GitCommit: 05a868b63d35ca3e3ccb96342bc6a2faa8bd500c
+Directory: 5.16.0/bullseye/enterprise
 
-Tags: 5.15.0-community-ubi8, 5.15-community-ubi8, 5-community-ubi8, 5.15.0-ubi8, 5.15-ubi8, 5-ubi8, community-ubi8, ubi8
+Tags: 5.16.0-community-ubi8, 5.16-community-ubi8, 5-community-ubi8, 5.16.0-ubi8, 5.16-ubi8, 5-ubi8, community-ubi8, ubi8
 Architectures: amd64, arm64v8
-GitCommit: 26e67efc2fa0211478d9d83387c9f090d5a1873b
-Directory: 5.15.0/ubi8/community
+GitCommit: 05a868b63d35ca3e3ccb96342bc6a2faa8bd500c
+Directory: 5.16.0/ubi8/community
 
-Tags: 5.15.0-enterprise-ubi8, 5.15-enterprise-ubi8, 5-enterprise-ubi8, enterprise-ubi8
+Tags: 5.16.0-enterprise-ubi8, 5.16-enterprise-ubi8, 5-enterprise-ubi8, enterprise-ubi8
 Architectures: amd64, arm64v8
-GitCommit: 26e67efc2fa0211478d9d83387c9f090d5a1873b
-Directory: 5.15.0/ubi8/enterprise
+GitCommit: 05a868b63d35ca3e3ccb96342bc6a2faa8bd500c
+Directory: 5.16.0/ubi8/enterprise
 
 
 


### PR DESCRIPTION
We'd like to start releasing the redhat images based on ubi9 rather than ubi8 in the near future. Do you have an established best practice for doing that kind of deprecation?

The best way I can think to do it is to release the two images concurrently for a short while, and have a deprecation notice in the ubi8 image saying to update to ubi9. Would you be ok with me adding a notice like that in the image?

Thanks as always :slightly_smiling_face: 