### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.76.0, 5.76, 5, latest
+Tags: 5.76.1, 5.76, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9ee89aa8776ccd6d9af80ae8dc8c1803b825aa56
+GitCommit: 043b2233e5a02fc3bd1c61235dcc42a1ece7ae82
 Directory: 5/debian
 
-Tags: 5.76.0-alpine, 5.76-alpine, 5-alpine, alpine
+Tags: 5.76.1-alpine, 5.76-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 9ee89aa8776ccd6d9af80ae8dc8c1803b825aa56
+GitCommit: 043b2233e5a02fc3bd1c61235dcc42a1ece7ae82
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/043b223: Update to 5.76.1, ghost-cli 1.25.3