### PR TITLE
Update bashbrew to 0.1.11

### DIFF
--- a/.github/workflows/.bashbrew/action.yml
+++ b/.github/workflows/.bashbrew/action.yml
@@ -10,8 +10,8 @@ runs:
 
     # these two version numbers are intentionally as close together as I could possibly get them because no matter what I tried, GitHub will not allow me to DRY them (can't have any useful variables in `uses:` and can't even have YAML references to steal it in `env:` or something)
     - shell: 'bash -Eeuo pipefail -x {0}'
-      run:    echo BASHBREW_VERSION=v0.1.9 >> "$GITHUB_ENV"
-    - uses: docker-library/bashbrew@v0.1.9
+      run:    echo BASHBREW_VERSION=v0.1.11 >> "$GITHUB_ENV"
+    - uses: docker-library/bashbrew@v0.1.11
       if: inputs.build == 'host'
 
     - run: docker build --pull --tag oisupport/bashbrew:base "https://github.com/docker-library/bashbrew.git#$BASHBREW_VERSION"


### PR DESCRIPTION
https://github.com/docker-library/bashbrew/releases/tag/v0.1.10
https://github.com/docker-library/bashbrew/releases/tag/v0.1.11

(this is https://github.com/docker-library/official-images/pull/16099, take two)

This PR is not strictly _necessary_ for https://github.com/docker-library/meta-scripts/pull/16, but it is related.