### PR TITLE
Update Apache Flink to 1.18.1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,37 +3,47 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.18.0-scala_2.12-java8, 1.18-scala_2.12-java8, scala_2.12-java8, 1.18.0-java8, 1.18-java8, java8
+Tags: 1.18.1-scala_2.12-java8, 1.18-scala_2.12-java8, scala_2.12-java8, 1.18.1-java8, 1.18-java8, java8
 Architectures: amd64,arm64v8
-GitCommit: 3154e4800c2aa8f183ac4b03dcdc90b14a6404a1
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.18/scala_2.12-java8-ubuntu
 
-Tags: 1.18.0-scala_2.12-java17, 1.18-scala_2.12-java17, scala_2.12-java17, 1.18.0-java17, 1.18-java17, java17
+Tags: 1.18.1-scala_2.12-java17, 1.18-scala_2.12-java17, scala_2.12-java17, 1.18.1-java17, 1.18-java17, java17
 Architectures: amd64,arm64v8
-GitCommit: 3154e4800c2aa8f183ac4b03dcdc90b14a6404a1
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.18/scala_2.12-java17-ubuntu
 
-Tags: 1.18.0-scala_2.12-java11, 1.18-scala_2.12-java11, scala_2.12-java11, 1.18.0-scala_2.12, 1.18-scala_2.12, scala_2.12, 1.18.0-java11, 1.18-java11, java11, 1.18.0, 1.18, latest
+Tags: 1.18.1-scala_2.12-java11, 1.18-scala_2.12-java11, scala_2.12-java11, 1.18.1-scala_2.12, 1.18-scala_2.12, scala_2.12, 1.18.1-java11, 1.18-java11, java11, 1.18.1, 1.18, latest
 Architectures: amd64,arm64v8
-GitCommit: 3154e4800c2aa8f183ac4b03dcdc90b14a6404a1
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.18/scala_2.12-java11-ubuntu
 
 Tags: 1.17.2-scala_2.12-java8, 1.17-scala_2.12-java8, 1.17.2-java8, 1.17-java8
 Architectures: amd64,arm64v8
-GitCommit: f433de5a1d764638392cea1737fc6b03b8e760aa
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.17/scala_2.12-java8-ubuntu
 
 Tags: 1.17.2-scala_2.12-java11, 1.17-scala_2.12-java11, 1.17.2-scala_2.12, 1.17-scala_2.12, 1.17.2-java11, 1.17-java11, 1.17.2, 1.17
 Architectures: amd64,arm64v8
-GitCommit: f433de5a1d764638392cea1737fc6b03b8e760aa
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.17/scala_2.12-java11-ubuntu
 
 Tags: 1.16.3-scala_2.12-java8, 1.16-scala_2.12-java8, 1.16.3-java8, 1.16-java8
 Architectures: amd64,arm64v8
-GitCommit: fce2e96cea2ef6ced375c113486db5cbb02e0480
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.16/scala_2.12-java8-ubuntu
 
 Tags: 1.16.3-scala_2.12-java11, 1.16-scala_2.12-java11, 1.16.3-scala_2.12, 1.16-scala_2.12, 1.16.3-java11, 1.16-java11, 1.16.3, 1.16
 Architectures: amd64,arm64v8
-GitCommit: fce2e96cea2ef6ced375c113486db5cbb02e0480
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.16/scala_2.12-java11-ubuntu
+
+Tags: 1.15.4-scala_2.12-java8, 1.15-scala_2.12-java8, 1.15.4-java8, 1.15-java8
+Architectures: amd64,arm64v8
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
+Directory: ./1.15/scala_2.12-java8-ubuntu
+
+Tags: 1.15.4-scala_2.12-java11, 1.15-scala_2.12-java11, 1.15.4-scala_2.12, 1.15-scala_2.12, 1.15.4-java11, 1.15-java11, 1.15.4, 1.15
+Architectures: amd64,arm64v8
+GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
+Directory: ./1.15/scala_2.12-java11-ubuntu


### PR DESCRIPTION
This adds the new Flink 1.18.1 release: https://flink.apache.org/2024/01/19/apache-flink-1.18.1-release-announcement/

Change apache download link for asc files and therefore updated tags for 1.17.2, 1.16.3, and 1.15.4 accordingly.