### PR TITLE
Bump Traefik to v2.11.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,24 +20,24 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
 Directory: alpine
 
-Tags: v2.11.0-rc1-windowsservercore-ltsc2022, 2.11.0-rc1-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.0-rc2-windowsservercore-ltsc2022, 2.11.0-rc2-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: febb0c2358cbb1033a6d0d0a447d52cbe11ded54
+GitCommit: a0952abba41fc5c1b1d56d2fa37ed766d9a13d26
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.0-rc1-windowsservercore-1809, 2.11.0-rc1-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.0-rc2-windowsservercore-1809, 2.11.0-rc2-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: febb0c2358cbb1033a6d0d0a447d52cbe11ded54
+GitCommit: a0952abba41fc5c1b1d56d2fa37ed766d9a13d26
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.0-rc1, 2.11.0-rc1, v2.11, 2.11, mimolette
+Tags: v2.11.0-rc2, 2.11.0-rc2, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: febb0c2358cbb1033a6d0d0a447d52cbe11ded54
+GitCommit: a0952abba41fc5c1b1d56d2fa37ed766d9a13d26
 Directory: alpine
 
 Tags: v2.10.7-windowsservercore-ltsc2022, 2.10.7-windowsservercore-ltsc2022, v2.10-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, saintmarcelin-windowsservercore-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.11.0-rc2).

/cc @mmatur @kevinpollet @ldez

Cheers
