### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-5-jdk-oraclelinux8, 23-ea-5-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-5-jdk-oracle, 23-ea-5-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-5-jdk, 23-ea-5, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-6-jdk-oraclelinux8, 23-ea-6-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-6-jdk-oracle, 23-ea-6-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-6-jdk, 23-ea-6, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-5-jdk-oraclelinux7, 23-ea-5-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
+Tags: 23-ea-6-jdk-oraclelinux7, 23-ea-6-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/oraclelinux7
 
-Tags: 23-ea-5-jdk-bookworm, 23-ea-5-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-6-jdk-bookworm, 23-ea-6-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-5-jdk-slim-bookworm, 23-ea-5-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-5-jdk-slim, 23-ea-5-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-6-jdk-slim-bookworm, 23-ea-6-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-6-jdk-slim, 23-ea-6-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-5-jdk-bullseye, 23-ea-5-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-6-jdk-bullseye, 23-ea-6-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-5-jdk-slim-bullseye, 23-ea-5-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-6-jdk-slim-bullseye, 23-ea-6-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-5-jdk-windowsservercore-ltsc2022, 23-ea-5-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-5-jdk-windowsservercore, 23-ea-5-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-5-jdk, 23-ea-5, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-6-jdk-windowsservercore-ltsc2022, 23-ea-6-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-6-jdk-windowsservercore, 23-ea-6-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-6-jdk, 23-ea-6, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-5-jdk-windowsservercore-1809, 23-ea-5-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-5-jdk-windowsservercore, 23-ea-5-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-5-jdk, 23-ea-5, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-6-jdk-windowsservercore-1809, 23-ea-6-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-6-jdk-windowsservercore, 23-ea-6-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-6-jdk, 23-ea-6, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-5-jdk-nanoserver-1809, 23-ea-5-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-5-jdk-nanoserver, 23-ea-5-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-6-jdk-nanoserver-1809, 23-ea-6-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-6-jdk-nanoserver, 23-ea-6-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 7db2ee718474d44b74ed2a75dd0beb5396eb9467
+GitCommit: a21444acd7aad36f703897b08024dc929d83f6ec
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 22-ea-31-jdk-oraclelinux8, 22-ea-31-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-31-jdk-oracle, 22-ea-31-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
-SharedTags: 22-ea-31-jdk, 22-ea-31, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-32-jdk-oraclelinux8, 22-ea-32-oraclelinux8, 22-ea-jdk-oraclelinux8, 22-ea-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-ea-32-jdk-oracle, 22-ea-32-oracle, 22-ea-jdk-oracle, 22-ea-oracle, 22-jdk-oracle, 22-oracle
+SharedTags: 22-ea-32-jdk, 22-ea-32, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/oraclelinux8
 
-Tags: 22-ea-31-jdk-oraclelinux7, 22-ea-31-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
+Tags: 22-ea-32-jdk-oraclelinux7, 22-ea-32-oraclelinux7, 22-ea-jdk-oraclelinux7, 22-ea-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/oraclelinux7
 
-Tags: 22-ea-31-jdk-bookworm, 22-ea-31-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
+Tags: 22-ea-32-jdk-bookworm, 22-ea-32-bookworm, 22-ea-jdk-bookworm, 22-ea-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/bookworm
 
-Tags: 22-ea-31-jdk-slim-bookworm, 22-ea-31-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-31-jdk-slim, 22-ea-31-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
+Tags: 22-ea-32-jdk-slim-bookworm, 22-ea-32-slim-bookworm, 22-ea-jdk-slim-bookworm, 22-ea-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-ea-32-jdk-slim, 22-ea-32-slim, 22-ea-jdk-slim, 22-ea-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/slim-bookworm
 
-Tags: 22-ea-31-jdk-bullseye, 22-ea-31-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
+Tags: 22-ea-32-jdk-bullseye, 22-ea-32-bullseye, 22-ea-jdk-bullseye, 22-ea-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/bullseye
 
-Tags: 22-ea-31-jdk-slim-bullseye, 22-ea-31-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
+Tags: 22-ea-32-jdk-slim-bullseye, 22-ea-32-slim-bullseye, 22-ea-jdk-slim-bullseye, 22-ea-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/slim-bullseye
 
-Tags: 22-ea-31-jdk-windowsservercore-ltsc2022, 22-ea-31-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22-ea-31-jdk-windowsservercore, 22-ea-31-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-31-jdk, 22-ea-31, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-32-jdk-windowsservercore-ltsc2022, 22-ea-32-windowsservercore-ltsc2022, 22-ea-jdk-windowsservercore-ltsc2022, 22-ea-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22-ea-32-jdk-windowsservercore, 22-ea-32-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-32-jdk, 22-ea-32, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22-ea-31-jdk-windowsservercore-1809, 22-ea-31-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22-ea-31-jdk-windowsservercore, 22-ea-31-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-31-jdk, 22-ea-31, 22-ea-jdk, 22-ea, 22-jdk, 22
+Tags: 22-ea-32-jdk-windowsservercore-1809, 22-ea-32-windowsservercore-1809, 22-ea-jdk-windowsservercore-1809, 22-ea-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22-ea-32-jdk-windowsservercore, 22-ea-32-windowsservercore, 22-ea-jdk-windowsservercore, 22-ea-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-ea-32-jdk, 22-ea-32, 22-ea-jdk, 22-ea, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 22-ea-31-jdk-nanoserver-1809, 22-ea-31-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22-ea-31-jdk-nanoserver, 22-ea-31-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22-ea-32-jdk-nanoserver-1809, 22-ea-32-nanoserver-1809, 22-ea-jdk-nanoserver-1809, 22-ea-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22-ea-32-jdk-nanoserver, 22-ea-32-nanoserver, 22-ea-jdk-nanoserver, 22-ea-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: 00b8f4ede5ca3cf6d67837591998464aaab175bb
+GitCommit: 1662092abd1ea967b09f5c7bca2c46814b5198c1
 Directory: 22/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/a21444a: Update 23 to 23-ea+6
- https://github.com/docker-library/openjdk/commit/1662092: Update 22 to 22-ea+32