### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,55 +6,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.22rc1-bookworm, 1.22-rc-bookworm
-SharedTags: 1.22rc1, 1.22-rc
+Tags: 1.22rc2-bookworm, 1.22-rc-bookworm
+SharedTags: 1.22rc2, 1.22-rc
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a6fd6eceb0cb26da2fceefb4353768c472f84420
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/bookworm
 
-Tags: 1.22rc1-bullseye, 1.22-rc-bullseye
+Tags: 1.22rc2-bullseye, 1.22-rc-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a6fd6eceb0cb26da2fceefb4353768c472f84420
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/bullseye
 
-Tags: 1.22rc1-alpine3.19, 1.22-rc-alpine3.19, 1.22rc1-alpine, 1.22-rc-alpine
+Tags: 1.22rc2-alpine3.19, 1.22-rc-alpine3.19, 1.22rc2-alpine, 1.22-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6fd6eceb0cb26da2fceefb4353768c472f84420
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/alpine3.19
 
-Tags: 1.22rc1-alpine3.18, 1.22-rc-alpine3.18
+Tags: 1.22rc2-alpine3.18, 1.22-rc-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6fd6eceb0cb26da2fceefb4353768c472f84420
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/alpine3.18
 
-Tags: 1.22rc1-windowsservercore-ltsc2022, 1.22-rc-windowsservercore-ltsc2022
-SharedTags: 1.22rc1-windowsservercore, 1.22-rc-windowsservercore, 1.22rc1, 1.22-rc
+Tags: 1.22rc2-windowsservercore-ltsc2022, 1.22-rc-windowsservercore-ltsc2022
+SharedTags: 1.22rc2-windowsservercore, 1.22-rc-windowsservercore, 1.22rc2, 1.22-rc
 Architectures: windows-amd64
-GitCommit: 46d44c197aa3ce81c16ad43a2e4b331cc188053a
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.22rc1-windowsservercore-1809, 1.22-rc-windowsservercore-1809
-SharedTags: 1.22rc1-windowsservercore, 1.22-rc-windowsservercore, 1.22rc1, 1.22-rc
+Tags: 1.22rc2-windowsservercore-1809, 1.22-rc-windowsservercore-1809
+SharedTags: 1.22rc2-windowsservercore, 1.22-rc-windowsservercore, 1.22rc2, 1.22-rc
 Architectures: windows-amd64
-GitCommit: 46d44c197aa3ce81c16ad43a2e4b331cc188053a
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.22rc1-nanoserver-ltsc2022, 1.22-rc-nanoserver-ltsc2022
-SharedTags: 1.22rc1-nanoserver, 1.22-rc-nanoserver
+Tags: 1.22rc2-nanoserver-ltsc2022, 1.22-rc-nanoserver-ltsc2022
+SharedTags: 1.22rc2-nanoserver, 1.22-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 46d44c197aa3ce81c16ad43a2e4b331cc188053a
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.22rc1-nanoserver-1809, 1.22-rc-nanoserver-1809
-SharedTags: 1.22rc1-nanoserver, 1.22-rc-nanoserver
+Tags: 1.22rc2-nanoserver-1809, 1.22-rc-nanoserver-1809
+SharedTags: 1.22rc2-nanoserver, 1.22-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 46d44c197aa3ce81c16ad43a2e4b331cc188053a
+GitCommit: 343f83dbad29bb3b6f8c8eb8fa0459b6f2ea6aec
 Directory: 1.22-rc/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/343f83d: Update 1.22-rc to 1.22rc2