### PR TITLE
Bump Traefik to v2.11.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,41 +20,41 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
 Directory: alpine
 
-Tags: v2.11.0-rc2-windowsservercore-ltsc2022, 2.11.0-rc2-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v2.11.0-rc2-windowsservercore-ltsc2022, 2.11.0-rc2-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 17a3fad865ef2fc8ddd0fe25dce0a470f0fe78a4
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.0-rc2-windowsservercore-1809, 2.11.0-rc2-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809, windowsservercore-1809
+Tags: v2.11.0-rc2-windowsservercore-1809, 2.11.0-rc2-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 17a3fad865ef2fc8ddd0fe25dce0a470f0fe78a4
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.0-rc2, 2.11.0-rc2, v2.11, 2.11, mimolette, latest
+Tags: v2.11.0-rc2, 2.11.0-rc2, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 17a3fad865ef2fc8ddd0fe25dce0a470f0fe78a4
 Directory: alpine
 
-Tags: v2.10.7-windowsservercore-ltsc2022, 2.10.7-windowsservercore-ltsc2022, v2.10-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, saintmarcelin-windowsservercore-ltsc2022
+Tags: v2.10.7-windowsservercore-ltsc2022, 2.10.7-windowsservercore-ltsc2022, v2.10-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, saintmarcelin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 274d14183ad37ff987c85fb0f85e9f862025c297
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.10.7-windowsservercore-1809, 2.10.7-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809
+Tags: v2.10.7-windowsservercore-1809, 2.10.7-windowsservercore-1809, v2.10-windowsservercore-1809, 2.10-windowsservercore-1809, saintmarcelin-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 274d14183ad37ff987c85fb0f85e9f862025c297
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.10.7, 2.10.7, v2.10, 2.10, saintmarcelin
+Tags: v2.10.7, 2.10.7, v2.10, 2.10, saintmarcelin, latest
 Architectures: amd64, arm32v6, arm64v8, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 274d14183ad37ff987c85fb0f85e9f862025c297


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.0-rc2](https://github.com/traefik/traefik/releases/tag/v2.11.0-rc2).

/cc @mmatur @rtribotte @kevinpollet

Cheers
