### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2024-0310

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c384d40b8784514c5d09947f9e5075705b9f13f0
+amd64-GitCommit: 3c3b822f58048ddfec0ac23a945e15874a5aef1e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0cfeb366fefdc9b9ecbedf3644d586de2f82054a
+arm64v8-GitCommit: 51ca7dc6072752b7b6b3e95ea42e71b068a7e0cf
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-5363.

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-0310.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
