### PR TITLE
Update eclipse-temurin entrypoint.sh for Ubuntu

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -13,13 +13,13 @@ Directory: 8/jdk/alpine
 
 Tags: 8u402-b06-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u402-b06-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u402-b06-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u402-b06-jdk-centos7, 8-jdk-centos7, 8-centos7
@@ -67,13 +67,13 @@ Directory: 8/jre/alpine
 
 Tags: 8u402-b06-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u402-b06-jre-jammy, 8-jre-jammy
 SharedTags: 8u402-b06-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u402-b06-jre-centos7, 8-jre-centos7
@@ -123,13 +123,13 @@ Directory: 11/jdk/alpine
 
 Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.22_7-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.22_7-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.22_7-jdk-centos7, 11-jdk-centos7, 11-centos7
@@ -177,13 +177,13 @@ Directory: 11/jre/alpine
 
 Tags: 11.0.22_7-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.22_7-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.22_7-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.22_7-jre-centos7, 11-jre-centos7
@@ -233,13 +233,13 @@ Directory: 17/jdk/alpine
 
 Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 17/jdk/ubuntu/focal
 
 Tags: 17.0.10_7-jdk-jammy, 17-jdk-jammy, 17-jammy
 SharedTags: 17.0.10_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 17/jdk/ubuntu/jammy
 
 Tags: 17.0.10_7-jdk-centos7, 17-jdk-centos7, 17-centos7
@@ -287,13 +287,13 @@ Directory: 17/jre/alpine
 
 Tags: 17.0.10_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.10_7-jre-jammy, 17-jre-jammy
 SharedTags: 17.0.10_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 17/jre/ubuntu/jammy
 
 Tags: 17.0.10_7-jre-centos7, 17-jre-centos7
@@ -344,7 +344,7 @@ Directory: 21/jdk/alpine
 Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
 SharedTags: 21.0.2_13-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.2_13-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
@@ -388,7 +388,7 @@ Directory: 21/jre/alpine
 Tags: 21.0.2_13-jre-jammy, 21-jre-jammy
 SharedTags: 21.0.2_13-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.2_13-jre-ubi9-minimal, 21-jre-ubi9-minimal


### PR DESCRIPTION
We broke the entrypoint in the recent release. This fixes things