### PR TITLE
ci: Update Github actions

### DIFF
--- a/.github/workflows/munge-pr.yml
+++ b/.github/workflows/munge-pr.yml
@@ -21,7 +21,7 @@ jobs:
     name: Gather Metadata
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # ideally this would be "github.event.pull_request.merge_commit_sha" but according to https://docs.github.com/en/free-pro-team@latest/rest/reference/pulls#get-a-pull-request if "mergeable" is null (meaning there's a background job in-progress to check mergeability), that value is undefined...
           ref: ${{ github.event.pull_request.head.sha }}
@@ -80,7 +80,7 @@ jobs:
     if: fromJSON(needs.gather.outputs.images).imagesAndExternalPinsCount > 0
     steps:
       - name: Apply Labels
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         env:
           IMAGES: ${{ needs.gather.outputs.images }}
         with:
@@ -108,7 +108,7 @@ jobs:
     needs: gather
     if: fromJSON(needs.gather.outputs.images).imagesAndExternalPinsCount > 0
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           # again, this would ideally be "github.event.pull_request.merge_commit_sha" but we might not have that yet when this runs, so we compromise by checkout out the latest code from the target branch (so we get the latest "diff-pr.sh" script to run)
           ref: ${{ github.event.pull_request.base.ref }}
@@ -138,7 +138,7 @@ jobs:
         run: |
           docker run --rm --read-only --tmpfs /tmp oisupport/bashbrew:diff-pr ./diff-pr.sh "$GITHUB_PR_NUMBER" | tee "$GITHUB_WORKSPACE/oi-pr.diff"
       - name: Comment
-        uses: actions/github-script@v6
+        uses: actions/github-script@v7
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -25,7 +25,7 @@ jobs:
     name: Naughty
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/workflows/.bashbrew
@@ -39,7 +39,7 @@ jobs:
       strategy: ${{ steps.generate-jobs.outputs.strategy }}
       length: ${{ steps.generate-jobs.outputs.length }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
       - uses: ./.github/workflows/.bashbrew
@@ -67,7 +67,7 @@ jobs:
           echo 'MSYS=winsymlinks:nativestrict' >> "$GITHUB_ENV"
           # https://github.com/docker-library/bashbrew/blob/a40a54d4d81b9fd2e39b4d7ba3fe203e8b022a67/scripts/github-actions/generate.sh#L146-L149
         if: runner.os == 'Windows'
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
       - uses: ./.github/workflows/.bashbrew
       - name: Prepare Environment
         run: ${{ matrix.runs.prepare }}


### PR DESCRIPTION
checkout from v3 to v4
github-script from v6 to v7

These fix warnings like:
```
Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3. For more information see: https://github.blog/changelog/2023-09-22-github-actions-transitioning-from-node-16-to-node-20/.
```
See https://github.com/docker-library/official-images/actions/runs/7654947388

Also add dependabot config that will open PRs when new versions of the used actions are released