### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2024-0463, ELSA-2024-0466, ELSA-2024-0465

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3c3b822f58048ddfec0ac23a945e15874a5aef1e
+amd64-GitCommit: 673c834ea41774d3dabdb98234fac1ea39ab3f36
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 51ca7dc6072752b7b6b3e95ea42e71b068a7e0cf
+arm64v8-GitCommit: 41746acfa08c8ad235e5e5902317a3c0eb099a3e
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2021-35937, CVE-2021-35938, CVE-2021-35939, CVE-2023-27043, CVE-2023-7104, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-0463.html
https://linux.oracle.com/errata/ELSA-2024-0466.html
https://linux.oracle.com/errata/ELSA-2024-0465.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>