### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,92 +4,107 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
+Tags: 5.1.0-alpha3-php8.1-apache, 5.1-php8.1-apache, 5.1.alpha-php8.1-apache, 5.1.0-alpha-php8.1-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.1/apache
+
+Tags: 5.1.0-alpha3-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5.1.alpha-php8.1-fpm-alpine, 5.1.0-alpha-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.1/fpm-alpine
+
+Tags: 5.1.0-alpha3-php8.1-fpm, 5.1-php8.1-fpm, 5.1.alpha-php8.1-fpm, 5.1.0-alpha-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.1/fpm
+
+Tags: 5.1.0-alpha3, 5.1, 5.1.alpha, 5.1.0-alpha, 5.1.0-alpha3-apache, 5.1-apache, 5.1.alpha-apache, 5.1.0-alpha-apache, 5.1.0-alpha3-php8.2, 5.1-php8.2, 5.1.alpha-php8.2, 5.1.0-alpha-php8.2, 5.1.0-alpha3-php8.2-apache, 5.1-php8.2-apache, 5.1.alpha-php8.2-apache, 5.1.0-alpha-php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.2/apache
+
+Tags: 5.1.0-alpha3-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5.1.alpha-php8.2-fpm-alpine, 5.1.0-alpha-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.2/fpm-alpine
+
+Tags: 5.1.0-alpha3-php8.2-fpm, 5.1-php8.2-fpm, 5.1.alpha-php8.2-fpm, 5.1.0-alpha-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.2/fpm
+
+Tags: 5.1.0-alpha3-php8.3-apache, 5.1-php8.3-apache, 5.1.alpha-php8.3-apache, 5.1.0-alpha-php8.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.3/apache
+
+Tags: 5.1.0-alpha3-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5.1.alpha-php8.3-fpm-alpine, 5.1.0-alpha-php8.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.3/fpm-alpine
+
+Tags: 5.1.0-alpha3-php8.3-fpm, 5.1-php8.3-fpm, 5.1.alpha-php8.3-fpm, 5.1.0-alpha-php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6432995076a6ae520ebaed5e1cdf737c522cd3fb
+Directory: 5.1.alpha/php8.3/fpm
+
 Tags: 5.0.2-php8.1-apache, 5.0-php8.1-apache, 5-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 5.0/php8.1/apache
 
 Tags: 5.0.2-php8.1-fpm-alpine, 5.0-php8.1-fpm-alpine, 5-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: ed91ffe73eb0d47340f13345b9143fa2a1bed62a
 Directory: 5.0/php8.1/fpm-alpine
 
 Tags: 5.0.2-php8.1-fpm, 5.0-php8.1-fpm, 5-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 5.0/php8.1/fpm
 
 Tags: 5.0.2, 5.0, 5, 5.0.2-apache, 5.0-apache, 5-apache, 5.0.2-php8.2, 5.0-php8.2, 5-php8.2, 5.0.2-php8.2-apache, 5.0-php8.2-apache, 5-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 5.0/php8.2/apache
 
 Tags: 5.0.2-php8.2-fpm-alpine, 5.0-php8.2-fpm-alpine, 5-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: ed91ffe73eb0d47340f13345b9143fa2a1bed62a
 Directory: 5.0/php8.2/fpm-alpine
 
 Tags: 5.0.2-php8.2-fpm, 5.0-php8.2-fpm, 5-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 5.0/php8.2/fpm
 
 Tags: 4.4.2, 4.4, 4, latest, 4.4.2-apache, 4.4-apache, 4-apache, apache, 4.4.2-php8.1, 4.4-php8.1, 4-php8.1, php8.1, 4.4.2-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 4.4/php8.1/apache
 
 Tags: 4.4.2-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: ed91ffe73eb0d47340f13345b9143fa2a1bed62a
 Directory: 4.4/php8.1/fpm-alpine
 
 Tags: 4.4.2-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 4.4/php8.1/fpm
 
 Tags: 4.4.2-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 4.4/php8.2/apache
 
 Tags: 4.4.2-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: ed91ffe73eb0d47340f13345b9143fa2a1bed62a
 Directory: 4.4/php8.2/fpm-alpine
 
 Tags: 4.4.2-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
+GitCommit: c9cc3661ef0064e4b2242360ecce780ffc825daa
 Directory: 4.4/php8.2/fpm
-
-Tags: 4.3.4, 4.3, 4.3.4-apache, 4.3-apache, 4.3.4-php8.1, 4.3-php8.1, 4.3.4-php8.1-apache, 4.3-php8.1-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
-Directory: 4.3/php8.1/apache
-
-Tags: 4.3.4-php8.1-fpm-alpine, 4.3-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
-Directory: 4.3/php8.1/fpm-alpine
-
-Tags: 4.3.4-php8.1-fpm, 4.3-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
-Directory: 4.3/php8.1/fpm
-
-Tags: 4.3.4-php8.2-apache, 4.3-php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
-Directory: 4.3/php8.2/apache
-
-Tags: 4.3.4-php8.2-fpm-alpine, 4.3-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
-Directory: 4.3/php8.2/fpm-alpine
-
-Tags: 4.3.4-php8.2-fpm, 4.3-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a416792606b1f49dfbe9ad2155c7df972ade09d3
-Directory: 4.3/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@6432995: Add Joomla 5.1-alpha
- joomla-docker/docker-joomla@82d760e: Remove Joomla 4.3 build
- joomla-docker/docker-joomla@c9cc366: Fix ldd logic for bookworm/usrmerge.
- joomla-docker/docker-joomla@ed91ffe: Drop deprecated opcache.fast_shutdown config.
- joomla-docker/docker-joomla@b4763ad: Replace RemoteIPTrustedProxy with RemoteIPInternalProxy in remoteip.conf else the internal IP ranges are ingnored by Apache.
- joomla-docker/docker-joomla@c94cce0: Remove all Joomla 3 template relations.