### PR TITLE
alpine: bump 3.19.1

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.19.0, 3.19, 3, latest
+Tags: 3.19.1, 3.19, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.19
-GitCommit: 97c57449282d97cfa1c0b64669aed9afbf08645a
+GitCommit: 7385303148c97ef32a3f225ec03bafa46b689d12
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -26,10 +26,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.18.5, 3.18
+Tags: 3.18.6, 3.18
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.18
-GitCommit: a83fe3481a89201ac736f735062360f5953be635
+GitCommit: 08dbcabbd55e7430a326b582e544c6e1695126f3
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -38,10 +38,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.17.6, 3.17
+Tags: 3.17.7, 3.17
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.17
-GitCommit: 4de8583a90c86e251755f4bae4080f86e2449df8
+GitCommit: 1041155cbf4b410b02729c23a198d632945a1744
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -50,10 +50,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.16.8, 3.16
+Tags: 3.16.9, 3.16
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.16
-GitCommit: 6e630a20c86d1d0e5987681e02ed6de64ecbbf37
+GitCommit: 9c372c82f691cfe76c2058d75e2c4f9cd589d4c5
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Fixes:
- CVE-2023-6129
- CVE-2023-6237
- CVE-2024-0727