### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.76.2, 5.76, 5, latest
+Tags: 5.77.0, 5.77, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4cfca650bc02e58152b13f852bf67fb0bd163081
+GitCommit: d9d06d69f39a26671d024f8ab44b7e780fb05dc6
 Directory: 5/debian
 
-Tags: 5.76.2-alpine, 5.76-alpine, 5-alpine, alpine
+Tags: 5.77.0-alpine, 5.77-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4cfca650bc02e58152b13f852bf67fb0bd163081
+GitCommit: d9d06d69f39a26671d024f8ab44b7e780fb05dc6
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/d9d06d6: Update to 5.77.0, ghost-cli 1.25.3