### PR TITLE
Add Nextcloud AIO

### DIFF
--- a/library/nextcloud-aio
+++ b/library/nextcloud-aio
@@ -1,0 +1,8 @@
+Maintainers: Nextcloud <docker@nextcloud.com> (@nextcloud),
+             Simon L. <szaimen@e.mail.de> (@szaimen)
+GitRepo: https://github.com/nextcloud/all-in-one.git
+
+Tags: latest
+GitCommit: 8cf535e187c1811e8f80fcef9bb424edb5c04075
+Architectures: amd64, arm64v8
+Directory: Containers/mastercontainer


### PR DESCRIPTION
The official Nextcloud installation method. Provides easy deployment and maintenance with most features included in this one Nextcloud instance.

- docs PR: https://github.com/docker-library/docs/pull/2412