### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 96f3826f13a598a4b303bb01489ca00da4908ddd
 Directory: 3.0/alpine
 
-Tags: 2.9.3, 2.9, latest, 2.9.3-bookworm, 2.9-bookworm, bookworm
+Tags: 2.9.4, 2.9, latest, 2.9.4-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6336b496c8634e994cc23261a20b493f08750e82
+GitCommit: dda21d77a2e1e9e7273cd0f3b829c975fc367841
 Directory: 2.9
 
-Tags: 2.9.3-alpine, 2.9-alpine, alpine, 2.9.3-alpine3.19, 2.9-alpine3.19, alpine3.19
+Tags: 2.9.4-alpine, 2.9-alpine, alpine, 2.9.4-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6336b496c8634e994cc23261a20b493f08750e82
+GitCommit: dda21d77a2e1e9e7273cd0f3b829c975fc367841
 Directory: 2.9/alpine
 
 Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/dda21d7: Update 2.9 to 2.9.4