### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.0-rc.4, 3.13-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 38dfee76aca22741e236c2496894c0c197fca018
+GitCommit: d5248649e2329a4890b0aedde00fef57b0af9b79
 Directory: 3.13-rc/ubuntu
 
 Tags: 3.13.0-rc.4-management, 3.13-rc-management
@@ -17,7 +17,7 @@ Directory: 3.13-rc/ubuntu/management
 
 Tags: 3.13.0-rc.4-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 38dfee76aca22741e236c2496894c0c197fca018
+GitCommit: d5248649e2329a4890b0aedde00fef57b0af9b79
 Directory: 3.13-rc/alpine
 
 Tags: 3.13.0-rc.4-management-alpine, 3.13-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 3.13-rc/alpine/management
 
 Tags: 3.12.12, 3.12, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 89b84c8bf2ac77544873b62be4cde38b95bf04d7
+GitCommit: f8631e0a55a783b88e68386e6dfa8eda0b09a195
 Directory: 3.12/ubuntu
 
 Tags: 3.12.12-management, 3.12-management, 3-management, management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.12-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89b84c8bf2ac77544873b62be4cde38b95bf04d7
+GitCommit: f8631e0a55a783b88e68386e6dfa8eda0b09a195
 Directory: 3.12/alpine
 
 Tags: 3.12.12-management-alpine, 3.12-management-alpine, 3-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 3.12/alpine/management
 
 Tags: 3.11.28, 3.11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5e4816fd6c970e7deb407bb5014378ada47c830
+GitCommit: f70c213395deb1c5d47b6e5b326a4b90f7269f0c
 Directory: 3.11/ubuntu
 
 Tags: 3.11.28-management, 3.11-management
@@ -57,7 +57,7 @@ Directory: 3.11/ubuntu/management
 
 Tags: 3.11.28-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a5e4816fd6c970e7deb407bb5014378ada47c830
+GitCommit: f70c213395deb1c5d47b6e5b326a4b90f7269f0c
 Directory: 3.11/alpine
 
 Tags: 3.11.28-management-alpine, 3.11-management-alpine
@@ -67,7 +67,7 @@ Directory: 3.11/alpine/management
 
 Tags: 3.10.25, 3.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a684a9201f2cb3a42ac5451d5d694cc26ef26c0e
+GitCommit: 618b50698389a909a4e8be3695ca3e4c6bd4798c
 Directory: 3.10/ubuntu
 
 Tags: 3.10.25-management, 3.10-management
@@ -77,7 +77,7 @@ Directory: 3.10/ubuntu/management
 
 Tags: 3.10.25-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a684a9201f2cb3a42ac5451d5d694cc26ef26c0e
+GitCommit: 618b50698389a909a4e8be3695ca3e4c6bd4798c
 Directory: 3.10/alpine
 
 Tags: 3.10.25-management-alpine, 3.10-management-alpine
@@ -87,7 +87,7 @@ Directory: 3.10/alpine/management
 
 Tags: 3.9.29, 3.9
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0adc2a913923b76247388e4eea8e77ef9bea14d6
+GitCommit: b7a458aced8e3765e9608bbe087b0972642fbeb9
 Directory: 3.9/ubuntu
 
 Tags: 3.9.29-management, 3.9-management
@@ -97,7 +97,7 @@ Directory: 3.9/ubuntu/management
 
 Tags: 3.9.29-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0adc2a913923b76247388e4eea8e77ef9bea14d6
+GitCommit: b7a458aced8e3765e9608bbe087b0972642fbeb9
 Directory: 3.9/alpine
 
 Tags: 3.9.29-management-alpine, 3.9-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/b7a458a: Update 3.9 to openssl 3.1.5
- https://github.com/docker-library/rabbitmq/commit/d524864: Update 3.13-rc to openssl 3.1.5
- https://github.com/docker-library/rabbitmq/commit/f8631e0: Update 3.12 to openssl 3.1.5
- https://github.com/docker-library/rabbitmq/commit/f70c213: Update 3.11 to openssl 3.1.5
- https://github.com/docker-library/rabbitmq/commit/618b506: Update 3.10 to openssl 3.1.5