### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -7,34 +7,34 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2023-07-27
 Tags: 13.2.0, 13.2, 13, latest, 13.2.0-bookworm, 13.2-bookworm, 13-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: af458ec8254ef7ca3344f12631e2356b20b4a7f1
+GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
 Directory: 13
 # Docker EOL: 2025-01-27
 
 # Last Modified: 2023-05-08
 Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
+GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
 Directory: 12
 # Docker EOL: 2024-11-08
 
 # Last Modified: 2023-05-29
 Tags: 11.4.0, 11.4, 11, 11.4.0-bullseye, 11.4-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
+GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
 Directory: 11
 # Docker EOL: 2024-11-29
 
 # Last Modified: 2023-07-07
 Tags: 10.5.0, 10.5, 10, 10.5.0-bullseye, 10.5-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 82cd9a2f8eb0da43f9b938b92ee78d8747eb16d1
+GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
 Directory: 10
 # Docker EOL: 2025-01-07
 
 # Last Modified: 2022-05-27
 Tags: 9.5.0, 9.5, 9, 9.5.0-bullseye, 9.5-bullseye, 9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e7e43ba8177ce15f473d9a799c9e69735e4dbab4
+GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
 Directory: 9
 # Docker EOL: 2023-11-27


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/fd0da24: Merge pull request https://github.com/docker-library/gcc/pull/100 from LaurentGoderre/temp-gpg
- https://github.com/docker-library/gcc/commit/9fbc827: Use temporary directory for gpg keys

(This isn't really critical, so we've been waiting for a release of `gcc` or larger changes to include it with, but it's `gcc` so we might as well just get it in so it's off the pending list. :sweat_smile: :heart:)