### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -66,17 +66,17 @@ Directory: debian/sid
 
 Tags: trixie-curl, testing-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6b4838ad208cd3447d2c8d6535827e0dfc74a145
+GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie/curl
 
 Tags: trixie-scm, testing-scm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
+GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie/scm
 
 Tags: trixie, testing
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
+GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie
 
 Tags: focal-curl, 20.04-curl
@@ -108,21 +108,6 @@ Tags: jammy, 22.04
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: ubuntu/jammy
-
-Tags: lunar-curl, 23.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3e18c3af1f5dce6a48abf036857f9097b6bd79cc
-Directory: ubuntu/lunar/curl
-
-Tags: lunar-scm, 23.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
-Directory: ubuntu/lunar/scm
-
-Tags: lunar, 23.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
-Directory: ubuntu/lunar
 
 Tags: mantic-curl, 23.10-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/103e790: Merge pull request https://github.com/docker-library/buildpack-deps/pull/155 from infosiftr/trixie-dist-clean
- https://github.com/docker-library/buildpack-deps/commit/1f4fe49: Add `apt-get dist-clean` to Debian Testing / Trixie 🎉