### PR TITLE
Update Jetty versions to 10.0.20, 11.0.20 & 12.0.6

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -79,165 +79,165 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: 0eb91ddd049be69b97bf8ffbc51d5731a81f7706
 
-Tags: 12.0.5-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.5-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.6-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.6-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jre21, 12.0-jre21, 12-jre21, 12.0.5-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.6-jre21, 12.0-jre21, 12-jre21, 12.0.6-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.5-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.6-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.6-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jre17, 12.0-jre17, 12-jre17, 12.0.5-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.6-jre17, 12.0-jre17, 12-jre17, 12.0.6-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.5-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.6-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.6-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5, 12.0, 12, 12.0.5-jdk21, 12.0-jdk21, 12-jdk21, 12.0.5-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.5-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.6, 12.0, 12, 12.0.6-jdk21, 12.0-jdk21, 12-jdk21, 12.0.6-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.6-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.5-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.6-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.6-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jdk17, 12.0-jdk17, 12-jdk17, 12.0.5-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.6-jdk17, 12.0-jdk17, 12-jdk17, 12.0.6-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.19-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
+Tags: 11.0.20-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.20-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jre21, 11.0-jre21, 11-jre21, 11.0.19-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
+Tags: 11.0.20-jre21, 11.0-jre21, 11-jre21, 11.0.20-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.19-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
+Tags: 11.0.20-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.20-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jre17, 11.0-jre17, 11-jre17, 11.0.19-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
+Tags: 11.0.20-jre17, 11.0-jre17, 11-jre17, 11.0.20-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.19-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
+Tags: 11.0.20-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.20-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jre11, 11.0-jre11, 11-jre11, 11.0.19-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
+Tags: 11.0.20-jre11, 11.0-jre11, 11-jre11, 11.0.20-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.19-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
+Tags: 11.0.20-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.20-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19, 11.0, 11, 11.0.19-jdk21, 11.0-jdk21, 11-jdk21, 11.0.19-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.19-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
+Tags: 11.0.20, 11.0, 11, 11.0.20-jdk21, 11.0-jdk21, 11-jdk21, 11.0.20-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.20-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.19-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.20-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.20-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk17, 11.0-jdk17, 11-jdk17, 11.0.19-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.20-jdk17, 11.0-jdk17, 11-jdk17, 11.0.20-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.19-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.20-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.20-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk11, 11.0-jdk11, 11-jdk11, 11.0.19-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.20-jdk11, 11.0-jdk11, 11-jdk11, 11.0.20-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.19-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
+Tags: 10.0.20-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.20-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jre21, 10.0-jre21, 10-jre21, 10.0.19-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
+Tags: 10.0.20-jre21, 10.0-jre21, 10-jre21, 10.0.20-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.19-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
+Tags: 10.0.20-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.20-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jre17, 10.0-jre17, 10-jre17, 10.0.19-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
+Tags: 10.0.20-jre17, 10.0-jre17, 10-jre17, 10.0.20-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: f826afd8a329551fb5a6fb85368b1c075b5bc741
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.19-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
+Tags: 10.0.20-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.20-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jre11, 10.0-jre11, 10-jre11, 10.0.19-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
+Tags: 10.0.20-jre11, 10.0-jre11, 10-jre11, 10.0.20-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.19-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
+Tags: 10.0.20-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.20-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19, 10.0, 10, 10.0.19-jdk21, 10.0-jdk21, 10-jdk21, 10.0.19-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.19-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
+Tags: 10.0.20, 10.0, 10, 10.0.20-jdk21, 10.0-jdk21, 10-jdk21, 10.0.20-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.20-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.19-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.20-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.20-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk17, 10.0-jdk17, 10-jdk17, 10.0.19-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.20-jdk17, 10.0-jdk17, 10-jdk17, 10.0.20-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.19-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.20-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.20-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk11, 10.0-jdk11, 10-jdk11, 10.0.19-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.20-jdk11, 10.0-jdk11, 10-jdk11, 10.0.20-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
 Tags: 9.4.53-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -279,82 +279,82 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: d06dfc8b8dbbc3eba71c007e359e1ca0a7e85dff
 
-Tags: 12.0.5-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.6-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.5-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.6-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.6-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.6-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 12.0.5-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.6-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
+Tags: 11.0.20-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.19-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
+Tags: 11.0.20-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.20-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.20-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.20-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.20-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 11.0.19-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.20-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
+Tags: 10.0.20-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.19-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
+Tags: 10.0.20-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.20-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.20-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.20-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.20-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da
 
-Tags: 10.0.19-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.20-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: ef6c13500366af0fc5b941d956d869146b7cd3dc
+GitCommit: 7b1fb72be33eebf2721aac8e4e04afc3fcd211da


### PR DESCRIPTION
### Update Jetty Versions: 
`10.0.19` -> `10.0.20`
`11.0.19` -> `11.0.20`
`12.0.5` -> `12.0.6`