### PR TITLE
Update CrateDB to 5.3.9, 5.4.8, 5.5.4 and 5.6.1

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -4,17 +4,21 @@ Maintainers: Mathias Fußenegger <mathias@crate.io> (@mfussenegger),
              Andreas Motl <andreas.motl@crate.io> (@amotl)
 GitRepo: https://github.com/crate/docker-crate.git
 
-Tags: 5.5.3, 5.5, latest
+Tags: 5.6.1, 5.6, latest
 Architectures: amd64, arm64v8
-GitCommit: d4f4c950c62936fc73de1332bce40cc463844cc3
+GitCommit: de22e3a208322e68cd484c7de00c78bc236e563a
 
-Tags: 5.4.7, 5.4
+Tags: 5.5.5, 5.5
 Architectures: amd64, arm64v8
-GitCommit: a26a53fcc220137c14220c2301eaded65e12b5e4
+GitCommit: 976468768511b4574a26631fe646ff7fdfaf03ef
 
-Tags: 5.3.8, 5.3
+Tags: 5.4.8, 5.4
 Architectures: amd64, arm64v8
-GitCommit: c98a94b81223ff693fd1a7b325032b2e535bc084
+GitCommit: 87d8fc91744a3760211335884ba8cb82884451c2
+
+Tags: 5.3.9, 5.3
+Architectures: amd64, arm64v8
+GitCommit: b26e81edb1d6b551a5a7697855270346dbd63619
 
 Tags: 5.2.11, 5.2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
CrateDB 5.6.0 never went stable due to issues. So 5.6.1 is the first stable release of 5.6.