### PR TITLE
Update ELK

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -3,12 +3,12 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: elasticsearch
 Builder: buildkit
 
-Tags: 8.12.0
+Tags: 8.12.1
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.12
-GitCommit: 6e12e2e098446615fc79fc0ae7eee9b2d3e94a12
+GitCommit: e15eb421da49ad627d48e5b3492948c76bcb8158
 
-Tags: 7.17.17
+Tags: 7.17.18
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
-GitCommit: 4d46f1cb3a7d6ebacab71346708607b5bd44955f
+GitCommit: 3f49356df9e4ffaf56eed9722b8777eef574570b

--- a/library/kibana
+++ b/library/kibana
@@ -3,12 +3,12 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: kibana
 Builder: buildkit
 
-Tags: 8.12.0
+Tags: 8.12.1
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.12
-GitCommit: 6e12e2e098446615fc79fc0ae7eee9b2d3e94a12
+GitCommit: e15eb421da49ad627d48e5b3492948c76bcb8158
 
-Tags: 7.17.17
+Tags: 7.17.18
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
-GitCommit: 4d46f1cb3a7d6ebacab71346708607b5bd44955f
+GitCommit: 3f49356df9e4ffaf56eed9722b8777eef574570b

--- a/library/logstash
+++ b/library/logstash
@@ -3,12 +3,12 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: logstash
 Builder: buildkit
 
-Tags: 8.12.0
+Tags: 8.12.1
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.12
-GitCommit: 6e12e2e098446615fc79fc0ae7eee9b2d3e94a12
+GitCommit: e15eb421da49ad627d48e5b3492948c76bcb8158
 
-Tags: 7.17.17
+Tags: 7.17.18
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
-GitCommit: 4d46f1cb3a7d6ebacab71346708607b5bd44955f
+GitCommit: 3f49356df9e4ffaf56eed9722b8777eef574570b


### PR DESCRIPTION
This updates ELK images to point to the original source repository so they build directly and updates the maintainers appropriately.

