### PR TITLE
[oraclelinux] Updating 8, 8-slim,8-slim-fips,9 and 9-slim for  for ELSA-2024-0627 ELSA-2024-0628 ELSA-2024-0647 ELSA-2024-0533 

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 673c834ea41774d3dabdb98234fac1ea39ab3f36
+amd64-GitCommit: c039cbef4f40abcfe75b0254188ad75a2169b895
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 41746acfa08c8ad235e5e5902317a3c0eb099a3e
+arm64v8-GitCommit: f1e49efe0dda25a060ca071efd15b65ebc8dab4c
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-0553, CVE-2023-48795, CVE-2021-35937, CVE-2021-35938, CVE-2021-35939, CVE-2023-5981, CVE-2024-0567, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-0627.html
https://linux.oracle.com/errata/ELSA-2024-0628.html
https://linux.oracle.com/errata/ELSA-2024-0647.html
https://linux.oracle.com/errata/ELSA-2024-0533.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>