### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,32 +6,32 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 3.3.0-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.0, 3.3, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+GitCommit: 90c7a1d6999710f5502d69162a197e979f90bb1a
 Directory: 3.3/bookworm
 
 Tags: 3.3.0-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.0-slim, 3.3-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+GitCommit: 90c7a1d6999710f5502d69162a197e979f90bb1a
 Directory: 3.3/slim-bookworm
 
 Tags: 3.3.0-bullseye, 3.3-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+GitCommit: 90c7a1d6999710f5502d69162a197e979f90bb1a
 Directory: 3.3/bullseye
 
 Tags: 3.3.0-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+GitCommit: 90c7a1d6999710f5502d69162a197e979f90bb1a
 Directory: 3.3/slim-bullseye
 
 Tags: 3.3.0-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19, 3.3.0-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+GitCommit: 90c7a1d6999710f5502d69162a197e979f90bb1a
 Directory: 3.3/alpine3.19
 
 Tags: 3.3.0-alpine3.18, 3.3-alpine3.18, 3-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 52e176c1dee983d991d9cff0c6371f5c50bfd636
+GitCommit: 90c7a1d6999710f5502d69162a197e979f90bb1a
 Directory: 3.3/alpine3.18
 
 Tags: 3.2.3-bookworm, 3.2-bookworm, 3.2.3, 3.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/7e8e485: Merge pull request https://github.com/docker-library/ruby/pull/438 from hachi8833/remove_bison_for_ruby330
- https://github.com/docker-library/ruby/commit/90c7a1d: Remove unnecessary bison for Ruby 3.3.0