### PR TITLE
chore: Update to Rust version 1.76.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,46 +1,45 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/557d703364788c38c82df9b6ff8e89452daa4033/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/e5921dbae8fe56407a992307d1e2c2716ba8202d/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-buster, 1.75-buster, 1.75.0-buster, buster
+Tags: 1-buster, 1.76-buster, 1.76.0-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
-Directory: 1.75.0/buster
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/buster
 
-Tags: 1-slim-buster, 1.75-slim-buster, 1.75.0-slim-buster, slim-buster
+Tags: 1-slim-buster, 1.76-slim-buster, 1.76.0-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
-Directory: 1.75.0/buster/slim
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/buster/slim
 
-Tags: 1-bullseye, 1.75-bullseye, 1.75.0-bullseye, bullseye
+Tags: 1-bullseye, 1.76-bullseye, 1.76.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
-Directory: 1.75.0/bullseye
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/bullseye
 
-Tags: 1-slim-bullseye, 1.75-slim-bullseye, 1.75.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.76-slim-bullseye, 1.76.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
-Directory: 1.75.0/bullseye/slim
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/bullseye/slim
 
-Tags: 1-bookworm, 1.75-bookworm, 1.75.0-bookworm, bookworm, 1, 1.75, 1.75.0, latest
+Tags: 1-bookworm, 1.76-bookworm, 1.76.0-bookworm, bookworm, 1, 1.76, 1.76.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
-Directory: 1.75.0/bookworm
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/bookworm
 
-Tags: 1-slim-bookworm, 1.75-slim-bookworm, 1.75.0-slim-bookworm, slim-bookworm, 1-slim, 1.75-slim, 1.75.0-slim, slim
+Tags: 1-slim-bookworm, 1.76-slim-bookworm, 1.76.0-slim-bookworm, slim-bookworm, 1-slim, 1.76-slim, 1.76.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 743e6f449c680dbf8e9137da9baf16a169c674da
-Directory: 1.75.0/bookworm/slim
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/bookworm/slim
 
-Tags: 1-alpine3.18, 1.75-alpine3.18, 1.75.0-alpine3.18, alpine3.18
+Tags: 1-alpine3.18, 1.76-alpine3.18, 1.76.0-alpine3.18, alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: 7658ad2a35ec2eeb7ea820470449a19bba2b5d5b
-Directory: 1.75.0/alpine3.18
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/alpine3.18
 
-Tags: 1-alpine3.19, 1.75-alpine3.19, 1.75.0-alpine3.19, alpine3.19, 1-alpine, 1.75-alpine, 1.75.0-alpine, alpine
+Tags: 1-alpine3.19, 1.76-alpine3.19, 1.76.0-alpine3.19, alpine3.19, 1-alpine, 1.76-alpine, 1.76.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: e7f8ab58b3feca354792122f4df6624e291c404b
-Directory: 1.75.0/alpine3.19
-
+GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+Directory: 1.76.0/alpine3.19


### PR DESCRIPTION
This updates the `rust` version to `1.76.0`.
- Release: https://github.com/rust-lang/rust/releases/tag/1.76.0
- Blog: https://blog.rust-lang.org/2024/02/08/Rust-1.76.0.html

