### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 16.1, 16, latest, 16.1-bookworm, 16-bookworm, bookworm
+Tags: 16.2, 16, latest, 16.2-bookworm, 16-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 1424abf76f421d6f7bf933d9e42bbbed866fae3a
 Directory: 16/bookworm
 
-Tags: 16.1-bullseye, 16-bullseye, bullseye
+Tags: 16.2-bullseye, 16-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 1424abf76f421d6f7bf933d9e42bbbed866fae3a
 Directory: 16/bullseye
 
-Tags: 16.1-alpine3.19, 16-alpine3.19, alpine3.19, 16.1-alpine, 16-alpine, alpine
+Tags: 16.2-alpine3.19, 16-alpine3.19, alpine3.19, 16.2-alpine, 16-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 5403edd423ba9fd047d2abf5ed7fdb9131c7a527
 Directory: 16/alpine3.19
 
-Tags: 16.1-alpine3.18, 16-alpine3.18, alpine3.18
+Tags: 16.2-alpine3.18, 16-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 5403edd423ba9fd047d2abf5ed7fdb9131c7a527
 Directory: 16/alpine3.18
 
-Tags: 15.5, 15, 15.5-bookworm, 15-bookworm
+Tags: 15.6, 15, 15.6-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 34d4c14c235806e57fdd5eaf197f718fccee93b0
 Directory: 15/bookworm
 
-Tags: 15.5-bullseye, 15-bullseye
+Tags: 15.6-bullseye, 15-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 34d4c14c235806e57fdd5eaf197f718fccee93b0
 Directory: 15/bullseye
 
-Tags: 15.5-alpine3.19, 15-alpine3.19, 15.5-alpine, 15-alpine
+Tags: 15.6-alpine3.19, 15-alpine3.19, 15.6-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 539bdac35db7b6a7f91c0b9d911522d21f5b9083
 Directory: 15/alpine3.19
 
-Tags: 15.5-alpine3.18, 15-alpine3.18
+Tags: 15.6-alpine3.18, 15-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 539bdac35db7b6a7f91c0b9d911522d21f5b9083
 Directory: 15/alpine3.18
 
-Tags: 14.10, 14, 14.10-bookworm, 14-bookworm
+Tags: 14.11, 14, 14.11-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 901df4c333940b96e1b438f9bd6dcd0f1c534116
 Directory: 14/bookworm
 
-Tags: 14.10-bullseye, 14-bullseye
+Tags: 14.11-bullseye, 14-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 901df4c333940b96e1b438f9bd6dcd0f1c534116
 Directory: 14/bullseye
 
-Tags: 14.10-alpine3.19, 14-alpine3.19, 14.10-alpine, 14-alpine
+Tags: 14.11-alpine3.19, 14-alpine3.19, 14.11-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 3b6cb599da1bab72e4f57c54879e41c8c20fd036
 Directory: 14/alpine3.19
 
-Tags: 14.10-alpine3.18, 14-alpine3.18
+Tags: 14.11-alpine3.18, 14-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 3b6cb599da1bab72e4f57c54879e41c8c20fd036
 Directory: 14/alpine3.18
 
-Tags: 13.13, 13, 13.13-bookworm, 13-bookworm
+Tags: 13.14, 13, 13.14-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: a2de6cd9b0e9ad68b03148241195e15137246c29
 Directory: 13/bookworm
 
-Tags: 13.13-bullseye, 13-bullseye
+Tags: 13.14-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: a2de6cd9b0e9ad68b03148241195e15137246c29
 Directory: 13/bullseye
 
-Tags: 13.13-alpine3.19, 13-alpine3.19, 13.13-alpine, 13-alpine
+Tags: 13.14-alpine3.19, 13-alpine3.19, 13.14-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: c3c66a192905283ee9c9c34b03c73180975e6fad
 Directory: 13/alpine3.19
 
-Tags: 13.13-alpine3.18, 13-alpine3.18
+Tags: 13.14-alpine3.18, 13-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: c3c66a192905283ee9c9c34b03c73180975e6fad
 Directory: 13/alpine3.18
 
-Tags: 12.17, 12, 12.17-bookworm, 12-bookworm
+Tags: 12.18, 12, 12.18-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 6e883d9b1efe8479bca7ad0eab354a95fee46786
 Directory: 12/bookworm
 
-Tags: 12.17-bullseye, 12-bullseye
+Tags: 12.18-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d416768b1a7f03919b9cf0fef6adc9dcad937888
+GitCommit: 6e883d9b1efe8479bca7ad0eab354a95fee46786
 Directory: 12/bullseye
 
-Tags: 12.17-alpine3.19, 12-alpine3.19, 12.17-alpine, 12-alpine
+Tags: 12.18-alpine3.19, 12-alpine3.19, 12.18-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 764632913153817ef4216eebea6a4708ec5549fb
 Directory: 12/alpine3.19
 
-Tags: 12.17-alpine3.18, 12-alpine3.18
+Tags: 12.18-alpine3.18, 12-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce5bf6e7eb8f339b2a8561bf8fb5fe5d4e8c96aa
+GitCommit: 764632913153817ef4216eebea6a4708ec5549fb
 Directory: 12/alpine3.18


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/1424abf: Update 16 to bookworm 16.2-1.pgdg120+2, bullseye 16.2-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/34d4c14: Update 15 to bookworm 15.6-1.pgdg120+2, bullseye 15.6-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/901df4c: Update 14 to bookworm 14.11-1.pgdg120+2, bullseye 14.11-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/a2de6cd: Update 13 to bookworm 13.14-1.pgdg120+2, bullseye 13.14-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/6e883d9: Update 12 to bookworm 12.18-1.pgdg120+2, bullseye 12.18-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/5403edd: Update 16 to 16.2, bookworm 16.2-1.pgdg120+1, bullseye 16.2-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/539bdac: Update 15 to 15.6, bookworm 15.6-1.pgdg120+1, bullseye 15.6-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/3b6cb59: Update 14 to 14.11, bookworm 14.11-1.pgdg120+1, bullseye 14.11-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/c3c66a1: Update 13 to 13.14, bookworm 13.14-1.pgdg120+1, bullseye 13.14-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/7646329: Update 12 to 12.18, bookworm 12.18-1.pgdg120+1, bullseye 12.18-1.pgdg110+1

Closes https://github.com/docker-library/official-images/issues/16228
Closes https://github.com/docker-library/postgres/issues/1194