### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -49,17 +49,17 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 06f28e291877002359e1075e4260123de5403551
 Directory: latest/php8.3/fpm-alpine
 
-Tags: cli-2.9.0-php8.1, cli-2.9-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.10.0-php8.1, cli-2.10-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
+GitCommit: bb6296613aad365656cbba4933c2f7bd135bf243
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.9.0, cli-2.9, cli-2, cli, cli-2.9.0-php8.2, cli-2.9-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.10.0, cli-2.10, cli-2, cli, cli-2.10.0-php8.2, cli-2.10-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 480b5c35eb6382f4ae5581cfb9dfe54873d4f4a0
+GitCommit: bb6296613aad365656cbba4933c2f7bd135bf243
 Directory: cli/php8.2/alpine
 
-Tags: cli-2.9.0-php8.3, cli-2.9-php8.3, cli-2-php8.3, cli-php8.3
+Tags: cli-2.10.0-php8.3, cli-2.10-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d1cc7e6a226cf23ade72b83990310980e7ac5c2b
+GitCommit: bb6296613aad365656cbba4933c2f7bd135bf243
 Directory: cli/php8.3/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/bb62966: Update cli to 2.10.0