### PR TITLE
Update Clear Linux OS to 40830

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ffd49c28c9907b3a6c70049e0782e4a95a0a8355
-GitFetch: refs/heads/base-40690
+GitCommit: dc6a09347858ef7a919c4a28dcc7ccf80c781a13
+GitFetch: refs/heads/base-40830


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 40830

@bryteise @djklimes @bryteise