### PR TITLE
MariaDB 2024 Q1 part 1 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -7,45 +7,40 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 11.3.1-rc-jammy, 11.3-rc-jammy, 11.3.1-rc, 11.3-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 54a8a7fb16e45d3414b575e5d9d95e2972cf1f70
+GitCommit: f64d0cd1176b78c8a42a219fdf0b5c54a12b3c6d
 Directory: 11.3
 
-Tags: 11.2.2-jammy, 11.2-jammy, 11-jammy, jammy, 11.2.2, 11.2, 11, latest
+Tags: 11.2.3-jammy, 11.2-jammy, 11-jammy, jammy, 11.2.3, 11.2, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 54a8a7fb16e45d3414b575e5d9d95e2972cf1f70
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 11.2
 
-Tags: 11.1.3-jammy, 11.1-jammy, 11.1.3, 11.1
+Tags: 11.1.4-jammy, 11.1-jammy, 11.1.4, 11.1
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 11.1
 
-Tags: 11.0.4-jammy, 11.0-jammy, 11.0.4, 11.0
+Tags: 11.0.5-jammy, 11.0-jammy, 11.0.5, 11.0
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 11.0
 
-Tags: 10.11.6-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.6, 10.11, 10, lts
+Tags: 10.11.7-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.7, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 10.11
 
-Tags: 10.10.7-jammy, 10.10-jammy, 10.10.7, 10.10
+Tags: 10.6.17-focal, 10.6-focal, 10.6.17, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
-Directory: 10.10
-
-Tags: 10.6.16-focal, 10.6-focal, 10.6.16, 10.6
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 10.6
 
-Tags: 10.5.23-focal, 10.5-focal, 10.5.23, 10.5
+Tags: 10.5.24-focal, 10.5-focal, 10.5.24, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 10.5
 
-Tags: 10.4.32-focal, 10.4-focal, 10.4.32, 10.4
+Tags: 10.4.33-focal, 10.4-focal, 10.4.33, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b1fff513e7b7d015c5cfb2d91ffc24d903d33434
+GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
 Directory: 10.4


### PR DESCRIPTION
10.10 now EOL

Added entrypoint feature to use MARIADB_AUTO_UPGRADE=1 to recreate healthcheck user where cnf file was missing.

Added notes about memory pressure, available in cgroupsv2, but hidden by container runtimes.