### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev2, 3.0-dev, 3.0-dev2-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev3, 3.0-dev, 3.0-dev3-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 96f3826f13a598a4b303bb01489ca00da4908ddd
+GitCommit: 2913aa63fe4594a441e41f13e2c820092064a032
 Directory: 3.0
 
-Tags: 3.0-dev2-alpine, 3.0-dev-alpine, 3.0-dev2-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev3-alpine, 3.0-dev-alpine, 3.0-dev3-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 96f3826f13a598a4b303bb01489ca00da4908ddd
+GitCommit: 2913aa63fe4594a441e41f13e2c820092064a032
 Directory: 3.0/alpine
 
 Tags: 2.9.4, 2.9, latest, 2.9.4-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2913aa6: Update 3.0 to 3.0-dev3