### PR TITLE
Bump Traefik to v2.11.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -35,7 +35,7 @@ Directory: windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.11.0, 2.11.0, v2.11, 2.11, mimolette, latest
-Architectures: amd64, arm32v6, arm64v8, s390x
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: fccb66b9845fc4266154377b774ac95127d38078
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.0](https://github.com/traefik/traefik/releases/tag/v2.11.0).

/cc @kevinpollet @ldez @rtribotte

Cheers
