### PR TITLE
[oraclelinux] Updating 7, 7-slim/7-slim-fips,8,8-slim,8-slim-fips,9,9-slim for tzdata-2024a.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c039cbef4f40abcfe75b0254188ad75a2169b895
+amd64-GitCommit: 1a4d4777ce89cdde9e3f7ed984cfc6397e9f2dae
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f1e49efe0dda25a060ca071efd15b65ebc8dab4c
+arm64v8-GitCommit: a96b183398918b5d2ea9095743377fa15440704e
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for rebase to tzdata-2024a.

See the following for details:
https://linux.oracle.com/errata/ELBA-2024-0762.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>