### PR TITLE
Bump Traefik to v3.0.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.0-beta5-windowsservercore-ltsc2022, 3.0.0-beta5-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022
+Tags: v3.0.0-rc1-windowsservercore-ltsc2022, 3.0.0-rc1-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
+GitCommit: 6fc860aa66c25c1c4786a34d9398e66043af8d9d
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.0.0-beta5-windowsservercore-1809, 3.0.0-beta5-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
+Tags: v3.0.0-rc1-windowsservercore-1809, 3.0.0-rc1-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
+GitCommit: 6fc860aa66c25c1c4786a34d9398e66043af8d9d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.0-beta5, 3.0.0-beta5, v3.0, 3.0, beaufort
-Architectures: amd64, arm32v6, arm64v8, s390x
+Tags: v3.0.0-rc1, 3.0.0-rc1, v3.0, 3.0, beaufort
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 66250e268eb9c8d592cc85e153d388dca705c7ee
+GitCommit: 6fc860aa66c25c1c4786a34d9398e66043af8d9d
 Directory: alpine
 
 Tags: v2.11.0-windowsservercore-ltsc2022, 2.11.0-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.0.0-rc1](https://github.com/traefik/traefik/releases/tag/v3.0.0-rc1).

/cc @kevinpollet @ldez @rtribotte

Cheers
