### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 47ea6259ee03f28639ffb493b847067689d59c2e
 Directory: 5.0
 
-Tags: 4.1.3, 4.1, 4, latest, 4.1.3-jammy, 4.1-jammy, 4-jammy, jammy
+Tags: 4.1.4, 4.1, 4, latest, 4.1.4-jammy, 4.1-jammy, 4-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 47ea6259ee03f28639ffb493b847067689d59c2e
+GitCommit: 4ad6334c48772ac0d795d777c1ad9a6b37b85eb3
 Directory: 4.1
 
 Tags: 4.0.12, 4.0, 4.0.12-jammy, 4.0-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/4ad6334: Update 4.1 to 4.1.4