### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 2913aa63fe4594a441e41f13e2c820092064a032
 Directory: 3.0/alpine
 
-Tags: 2.9.4, 2.9, latest, 2.9.4-bookworm, 2.9-bookworm, bookworm
+Tags: 2.9.5, 2.9, latest, 2.9.5-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dda21d77a2e1e9e7273cd0f3b829c975fc367841
+GitCommit: 9bb65c75912f95579f06e1554ca59ed80aac685d
 Directory: 2.9
 
-Tags: 2.9.4-alpine, 2.9-alpine, alpine, 2.9.4-alpine3.19, 2.9-alpine3.19, alpine3.19
+Tags: 2.9.5-alpine, 2.9-alpine, alpine, 2.9.5-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dda21d77a2e1e9e7273cd0f3b829c975fc367841
+GitCommit: 9bb65c75912f95579f06e1554ca59ed80aac685d
 Directory: 2.9/alpine
 
-Tags: 2.8.5, 2.8, lts, 2.8.5-bookworm, 2.8-bookworm, lts-bookworm
+Tags: 2.8.6, 2.8, lts, 2.8.6-bookworm, 2.8-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: cc8baae41343fe053dbf79c3fe50776bd9221cbe
 Directory: 2.8
 
-Tags: 2.8.5-alpine, 2.8-alpine, lts-alpine, 2.8.5-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
+Tags: 2.8.6-alpine, 2.8-alpine, lts-alpine, 2.8.6-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: cc8baae41343fe053dbf79c3fe50776bd9221cbe
 Directory: 2.8/alpine
 
 Tags: 2.7.11, 2.7, 2.7.11-bookworm, 2.7-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9bb65c7: Update 2.9 to 2.9.5
- https://github.com/docker-library/haproxy/commit/cc8baae: Update 2.8 to 2.8.6