### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,100 +4,100 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-8-jdk-oraclelinux8, 23-ea-8-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-8-jdk-oracle, 23-ea-8-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-8-jdk, 23-ea-8, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-10-jdk-oraclelinux8, 23-ea-10-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-10-jdk-oracle, 23-ea-10-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-10-jdk, 23-ea-10, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-8-jdk-oraclelinux7, 23-ea-8-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
+Tags: 23-ea-10-jdk-oraclelinux7, 23-ea-10-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/oraclelinux7
 
-Tags: 23-ea-8-jdk-bookworm, 23-ea-8-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-10-jdk-bookworm, 23-ea-10-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-8-jdk-slim-bookworm, 23-ea-8-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-8-jdk-slim, 23-ea-8-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-10-jdk-slim-bookworm, 23-ea-10-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-10-jdk-slim, 23-ea-10-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-8-jdk-bullseye, 23-ea-8-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-10-jdk-bullseye, 23-ea-10-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-8-jdk-slim-bullseye, 23-ea-8-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-10-jdk-slim-bullseye, 23-ea-10-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-8-jdk-windowsservercore-ltsc2022, 23-ea-8-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-8-jdk-windowsservercore, 23-ea-8-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-8-jdk, 23-ea-8, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-10-jdk-windowsservercore-ltsc2022, 23-ea-10-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-10-jdk-windowsservercore, 23-ea-10-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-10-jdk, 23-ea-10, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-8-jdk-windowsservercore-1809, 23-ea-8-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-8-jdk-windowsservercore, 23-ea-8-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-8-jdk, 23-ea-8, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-10-jdk-windowsservercore-1809, 23-ea-10-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-10-jdk-windowsservercore, 23-ea-10-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-10-jdk, 23-ea-10, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-8-jdk-nanoserver-1809, 23-ea-8-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-8-jdk-nanoserver, 23-ea-8-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-10-jdk-nanoserver-1809, 23-ea-10-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-10-jdk-nanoserver, 23-ea-10-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 44d72b4f36cbd2986dafcc3eacb1cd8068ae0229
+GitCommit: 72217229af3413cacdcd577670d697db2554d38f
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 22-rc-jdk-oraclelinux8, 22-rc-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-rc-jdk-oracle, 22-rc-oracle, 22-jdk-oracle, 22-oracle
 SharedTags: 22-rc-jdk, 22-rc, 22-jdk, 22
 Architectures: amd64, arm64v8
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/oraclelinux8
 
 Tags: 22-rc-jdk-oraclelinux7, 22-rc-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/oraclelinux7
 
 Tags: 22-rc-jdk-bookworm, 22-rc-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/bookworm
 
 Tags: 22-rc-jdk-slim-bookworm, 22-rc-slim-bookworm, 22-jdk-slim-bookworm, 22-slim-bookworm, 22-rc-jdk-slim, 22-rc-slim, 22-jdk-slim, 22-slim
 Architectures: amd64, arm64v8
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/slim-bookworm
 
 Tags: 22-rc-jdk-bullseye, 22-rc-bullseye, 22-jdk-bullseye, 22-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/bullseye
 
 Tags: 22-rc-jdk-slim-bullseye, 22-rc-slim-bullseye, 22-jdk-slim-bullseye, 22-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/slim-bullseye
 
 Tags: 22-rc-jdk-windowsservercore-ltsc2022, 22-rc-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
 SharedTags: 22-rc-jdk-windowsservercore, 22-rc-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-rc-jdk, 22-rc, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 22-rc-jdk-windowsservercore-1809, 22-rc-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
 SharedTags: 22-rc-jdk-windowsservercore, 22-rc-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22-rc-jdk, 22-rc, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: f1a2ae80c1b84d81e424371557fb46ec05fed5c8
+GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/7221722: Update 23 to 23-ea+10
- https://github.com/docker-library/openjdk/commit/e582736: Update 22