### PR TITLE
Fedora Update 20240220

### DIFF
--- a/library/fedora
+++ b/library/fedora
@@ -1,19 +1,10 @@
 Maintainers: Clement Verna <cverna@fedoraproject.org> (@cverna), Vipul Siddharth <siddharthvipul1@fedoraproject.org> (@siddharthvipul)
 GitRepo: https://github.com/fedora-cloud/docker-brew-fedora.git
 
-Tags: 37
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitFetch: refs/heads/37
-GitCommit: 7b9394b78eb5309a430d891bfb84d6798bb61880
-amd64-Directory: x86_64/
-arm64v8-Directory: aarch64/
-s390x-Directory: s390x/
-ppc64le-Directory: ppc64le/
-
 Tags: 38
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/38
-GitCommit: 8da9f21c521810b731eb6bdc60474077f4794300
+GitCommit: 0ca7b13adf277d9423dcea1353ca21f36fe3aef3
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
@@ -22,16 +13,25 @@ ppc64le-Directory: ppc64le/
 Tags: 39, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/39
-GitCommit: 3b05fdf8aeb96d1820bb33e8cbbad6a938b50e99
+GitCommit: d855dc12fef7c8d48d53b774d54da78ac5be37f6
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/
 ppc64le-Directory: ppc64le/
 
-Tags: 40, rawhide
+Tags: 40
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/40
-GitCommit: 3a06c848c9f7c4402cf70c2a65e1a5bcd058d323
+GitCommit: ca15e4374cd315b7dba84485bf330377cd50c50f
+amd64-Directory: x86_64/
+arm64v8-Directory: aarch64/
+s390x-Directory: s390x/
+ppc64le-Directory: ppc64le/
+
+Tags: 41, rawhide
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitFetch: refs/heads/41
+GitCommit: 1443124200b0b0674495894ba80aefdaba30a93d
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 s390x-Directory: s390x/


### PR DESCRIPTION
Fedora 37 is EOL, Fedora 41 is the new rawhide.