### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.79.3, 5.79, 5, latest
+Tags: 5.79.4, 5.79, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f09bb4458c9596110fa40dd9ce6c6a6ee143de48
+GitCommit: 03e10bf5352f44ed78525d6a7b4d4096d55b63fc
 Directory: 5/debian
 
-Tags: 5.79.3-alpine, 5.79-alpine, 5-alpine, alpine
+Tags: 5.79.4-alpine, 5.79-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f09bb4458c9596110fa40dd9ce6c6a6ee143de48
+GitCommit: 03e10bf5352f44ed78525d6a7b4d4096d55b63fc
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/03e10bf: Update to 5.79.4, ghost-cli 1.25.3