### PR TITLE
MariaDB urgent reissue

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -7,42 +7,42 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 11.4.1-rc-jammy, 11.4-rc-jammy, 11.4.1-rc, 11.4-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 174b68b5ef90f92902c15d73a0cfdd1cb99146d8
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 11.4
 
 Tags: 11.3.2-jammy, 11.3-jammy, 11-jammy, jammy, 11.3.2, 11.3, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 0c710468e3fb2ccec6cdc14350ee0f1eaf668307
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 11.3
 
 Tags: 11.2.3-jammy, 11.2-jammy, 11.2.3, 11.2
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 11.2
 
 Tags: 11.1.4-jammy, 11.1-jammy, 11.1.4, 11.1
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 11.1
 
 Tags: 11.0.5-jammy, 11.0-jammy, 11.0.5, 11.0
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 11.0
 
 Tags: 10.11.7-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.7, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 10.11
 
 Tags: 10.6.17-focal, 10.6-focal, 10.6.17, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 10.6
 
 Tags: 10.5.24-focal, 10.5-focal, 10.5.24, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
 Directory: 10.5
 
 Tags: 10.4.33-focal, 10.4-focal, 10.4.33, 10.4


### PR DESCRIPTION
Unfortunately the last latest release broken PHP and nodejs because of a protocol issue. The configuration item character-set-collations added in the default 11.3/11.4 image generated this.

Closes: https://github.com/MariaDB/mariadb-docker/issues/560