### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-10-jdk-oraclelinux8, 23-ea-10-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-10-jdk-oracle, 23-ea-10-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-10-jdk, 23-ea-10, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-11-jdk-oraclelinux8, 23-ea-11-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-11-jdk-oracle, 23-ea-11-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-11-jdk, 23-ea-11, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-10-jdk-oraclelinux7, 23-ea-10-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
+Tags: 23-ea-11-jdk-oraclelinux7, 23-ea-11-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
 Architectures: amd64, arm64v8
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/oraclelinux7
 
-Tags: 23-ea-10-jdk-bookworm, 23-ea-10-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-11-jdk-bookworm, 23-ea-11-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-10-jdk-slim-bookworm, 23-ea-10-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-10-jdk-slim, 23-ea-10-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-11-jdk-slim-bookworm, 23-ea-11-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-11-jdk-slim, 23-ea-11-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-10-jdk-bullseye, 23-ea-10-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-11-jdk-bullseye, 23-ea-11-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-10-jdk-slim-bullseye, 23-ea-10-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-11-jdk-slim-bullseye, 23-ea-11-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-10-jdk-windowsservercore-ltsc2022, 23-ea-10-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-10-jdk-windowsservercore, 23-ea-10-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-10-jdk, 23-ea-10, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-11-jdk-windowsservercore-ltsc2022, 23-ea-11-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-11-jdk-windowsservercore, 23-ea-11-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-11-jdk, 23-ea-11, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-10-jdk-windowsservercore-1809, 23-ea-10-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-10-jdk-windowsservercore, 23-ea-10-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-10-jdk, 23-ea-10, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-11-jdk-windowsservercore-1809, 23-ea-11-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-11-jdk-windowsservercore, 23-ea-11-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-11-jdk, 23-ea-11, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-10-jdk-nanoserver-1809, 23-ea-10-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-10-jdk-nanoserver, 23-ea-10-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-11-jdk-nanoserver-1809, 23-ea-11-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-11-jdk-nanoserver, 23-ea-11-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 72217229af3413cacdcd577670d697db2554d38f
+GitCommit: 0960f0d4ee7e8ef1148a838328ceced057f4f4af
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0960f0d: Update 23 to 23-ea+11