### PR TITLE
Fix typo in `python-pip-requests-ssl` test

### DIFF
--- a/test/tests/python-pip-requests-ssl/container.py
+++ b/test/tests/python-pip-requests-ssl/container.py
@@ -1,5 +1,5 @@
 import subprocess, sys
-subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'ignore', 'requests'])
+subprocess.check_call([sys.executable, '-m', 'pip', 'install', 'requests'])
 
 import requests
 r = requests.get('https://google.com')


### PR DESCRIPTION
In 44b79e2186b43ee1f3ecda9f8b0d00209a2104aa (https://github.com/docker-library/official-images/pull/15590), we removed `--root-user-action` from our `pip install` invocation, but missed the `ignore` value, so we've been installing https://pypi.org/project/ignore/ in this test ever since. 😂