### PR TITLE
Update Clear Linux OS to 41120

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: e640bf66db11cb213d860ead1ec6bff7855344eb
-GitFetch: refs/heads/base-41040
+GitCommit: 823fc7b99ed223b958af260b90240bd5387339f5
+GitFetch: refs/heads/base-41120


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41120

@bryteise @djklimes @bryteise