### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev3, 3.0-dev, 3.0-dev3-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev4, 3.0-dev, 3.0-dev4-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2913aa63fe4594a441e41f13e2c820092064a032
+GitCommit: 7ff4e114609c146264294b910f5502d295c7794c
 Directory: 3.0
 
-Tags: 3.0-dev3-alpine, 3.0-dev-alpine, 3.0-dev3-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev4-alpine, 3.0-dev-alpine, 3.0-dev4-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2913aa63fe4594a441e41f13e2c820092064a032
+GitCommit: 7ff4e114609c146264294b910f5502d295c7794c
 Directory: 3.0/alpine
 
-Tags: 2.9.5, 2.9, latest, 2.9.5-bookworm, 2.9-bookworm, bookworm
+Tags: 2.9.6, 2.9, latest, 2.9.6-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9bb65c75912f95579f06e1554ca59ed80aac685d
+GitCommit: e14e1d121f1b1d78422f12210e0e256188a60c82
 Directory: 2.9
 
-Tags: 2.9.5-alpine, 2.9-alpine, alpine, 2.9.5-alpine3.19, 2.9-alpine3.19, alpine3.19
+Tags: 2.9.6-alpine, 2.9-alpine, alpine, 2.9.6-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bb65c75912f95579f06e1554ca59ed80aac685d
+GitCommit: e14e1d121f1b1d78422f12210e0e256188a60c82
 Directory: 2.9/alpine
 
 Tags: 2.8.6, 2.8, lts, 2.8.6-bookworm, 2.8-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e14e1d1: Update 2.9 to 2.9.6
- https://github.com/docker-library/haproxy/commit/7ff4e11: Update 3.0 to 3.0-dev4