### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,19 +13,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.3.20240131.0
+Tags: 2023, latest, 2023.3.20240219.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 71947dead94d539979e17a0c0584f7302946d528
+amd64-GitCommit: 8a730d778b641585a226adf1ca62679c10946135
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: f06bb80f8bd87114dbf7464780c8c6c69f83729f
+arm64v8-GitCommit: dc5efaaa2fe3961460689b664c99fd23d46519e6
 
-Tags: 2, 2.0.20240131.0
+Tags: 2, 2.0.20240223.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 854ad2b4d01eb36161663ac1e765ac22f2be21e9
+amd64-GitCommit: bee798bb2cb388647364bed3b550f34b432fb81b
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 810eea5ac0da6a0ccb4812e5d0f1ec5d7b16c98c
+arm64v8-GitCommit: 98f164ee35c91710a0eb1c349666e36df34a7355
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- tzdata-2024a-1.amzn2.0.1
- nss-sysinit-3.90.0-2.amzn2.0.2
- nss-softokn-3.90.0-6.amzn2.0.2
- ca-certificates-2023.2.64-1.amzn2.0.1
- nss-tools-3.90.0-2.amzn2.0.2
- nss-softokn-freebl-3.90.0-6.amzn2.0.2
- nss-3.90.0-2.amzn2.0.2 Packages addressing CVES:
- nss-sysinit-3.90.0-2.amzn2.0.2, nss-tools-3.90.0-2.amzn2.0.2, nss-3.90.0-2.amzn2.0.2
  - [CVE-2023-7104](https://alas.aws.amazon.com/cve/html/CVE-2023-7104.html)
- nss-softokn-3.90.0-6.amzn2.0.2, nss-softokn-freebl-3.90.0-6.amzn2.0.2
  - [CVE-2023-6135](https://alas.aws.amazon.com/cve/html/CVE-2023-6135.html)

Updated Packages for Amazon Linux 2023:
- tzdata-2024a-1.amzn2023.0.1
- expat-2.5.0-1.amzn2023.0.3
- ca-certificates-2023.2.64-1.0.amzn2023.0.1
- amazon-linux-repo-cdn-2023.3.20240219-0.amzn2023
- system-release-2023.3.20240219-0.amzn2023
- openssl-libs-3.0.8-1.amzn2023.0.11 Packages addressing CVES:
- expat-2.5.0-1.amzn2023.0.3
  - [CVE-2023-52426](https://alas.aws.amazon.com/cve/html/CVE-2023-52426.html)
- openssl-libs-3.0.8-1.amzn2023.0.11
  - [CVE-2023-6237](https://alas.aws.amazon.com/cve/html/CVE-2023-6237.html)
  - [CVE-2024-0727](https://alas.aws.amazon.com/cve/html/CVE-2024-0727.html)