### PR TITLE
Updated Unit to 1.32.0.

### DIFF
--- a/library/unit
+++ b/library/unit
@@ -1,88 +1,109 @@
-# this file is generated via https://github.com/nginx/unit/blob/fb33ec86a3b6ca6a844dfa6980bb9e083094abec/pkg/docker/Makefile
+# this file is generated via https://github.com/nginx/unit/blob/d76761901c4084bcdbc5a449e9bbb47d56b7093c/pkg/docker/Makefile
 
 Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/unit.git
 
-Tags: 1.31.1-go1.21, go1.21, go1, go
+Tags: 1.32.0-go1.22, go1.22, go1, go
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
+Directory: pkg/docker
+File: Dockerfile.go1.22
+
+Tags: 1.32.0-go1.21, go1.21
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.go1.21
 
-Tags: 1.31.1-go1.20, go1.20
+Tags: 1.32.0-jsc11, jsc11, jsc
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
-Directory: pkg/docker
-File: Dockerfile.go1.20
-
-Tags: 1.31.1-jsc11, jsc11, jsc
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.jsc11
 
-Tags: 1.31.1-node20, node20, node
+Tags: 1.32.0-node21, node21, node
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
+Directory: pkg/docker
+File: Dockerfile.node21
+
+Tags: 1.32.0-node20, node20
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.node20
 
-Tags: 1.31.1-node18, node18
+Tags: 1.32.0-perl5.38, perl5.38, perl5, perl
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
-Directory: pkg/docker
-File: Dockerfile.node18
-
-Tags: 1.31.1-perl5.38, perl5.38, perl5, perl
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.perl5.38
 
-Tags: 1.31.1-perl5.36, perl5.36
+Tags: 1.32.0-perl5.36, perl5.36
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.perl5.36
 
-Tags: 1.31.1-php8.2, php8.2, php8, php
+Tags: 1.32.0-php8.3, php8.3, php8, php
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
+Directory: pkg/docker
+File: Dockerfile.php8.3
+
+Tags: 1.32.0-php8.2, php8.2
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.php8.2
 
-Tags: 1.31.1-python3.11, python3.11, python3, python
+Tags: 1.32.0-python3.12, python3.12, python3, python
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
+Directory: pkg/docker
+File: Dockerfile.python3.12
+
+Tags: 1.32.0-python3.11, python3.11
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.python3.11
 
-Tags: 1.31.1-ruby3.2, ruby3.2, ruby3, ruby
+Tags: 1.32.0-ruby3.3, ruby3.3, ruby3, ruby
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
+Directory: pkg/docker
+File: Dockerfile.ruby3.3
+
+Tags: 1.32.0-ruby3.2, ruby3.2
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/branches/packaging
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.ruby3.2
 
-Tags: 1.31.1-wasm, wasm
+Tags: 1.32.0-wasm, wasm
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.wasm
 
-Tags: 1.31.1-minimal, minimal, latest
+Tags: 1.32.0-minimal, minimal, latest
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/branches/packaging
-GitCommit: fb33ec86a3b6ca6a844dfa6980bb9e083094abec
+GitCommit: d76761901c4084bcdbc5a449e9bbb47d56b7093c
 Directory: pkg/docker
 File: Dockerfile.minimal


### PR DESCRIPTION
Hello,

Pull request updates nginx-unit to the latest version (1.32.0).
Unit logs are now written to stderr to avoid mixing with application logs (if an application chooses to log to stdout).

This also updates a number of dependent libraries:
* Go: Dropped 1.20, Added 1.22
* Node: Dropped 18, Added 21
* PHP: Added 8.3
* Ruby: Added 3.3
* Python: Added 3.12 
* Rust: bumped to 1.76.0 to support wasmtime 17.
