### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: e14e1d121f1b1d78422f12210e0e256188a60c82
 Directory: 2.9/alpine
 
-Tags: 2.8.6, 2.8, lts, 2.8.6-bookworm, 2.8-bookworm, lts-bookworm
+Tags: 2.8.7, 2.8, lts, 2.8.7-bookworm, 2.8-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cc8baae41343fe053dbf79c3fe50776bd9221cbe
+GitCommit: b63a60b648f47d0b0c7b71492f93536c3aef6910
 Directory: 2.8
 
-Tags: 2.8.6-alpine, 2.8-alpine, lts-alpine, 2.8.6-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
+Tags: 2.8.7-alpine, 2.8-alpine, lts-alpine, 2.8.7-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc8baae41343fe053dbf79c3fe50776bd9221cbe
+GitCommit: b63a60b648f47d0b0c7b71492f93536c3aef6910
 Directory: 2.8/alpine
 
 Tags: 2.7.11, 2.7, 2.7.11-bookworm, 2.7-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b63a60b: Update 2.8 to 2.8.7