### PR TITLE
Chronograf 1.10.3

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -1,8 +1,7 @@
 Maintainers: Jonathan A. Sternberg <jonathan@influxdata.com> (@jsternberg),
-             Bucky Schwarz <bucky@influxdata.com> (@hoorayimhelping),
              Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 653ea422f18802f1d361018a9961af3f70d056e4
+GitCommit: 107cbe2cdb717faec1df57a070e2ecab8030d462
 
 Tags: 1.7, 1.7.17
 Architectures: amd64, arm32v7, arm64v8
@@ -25,9 +24,9 @@ Directory: chronograf/1.9
 Tags: 1.9-alpine, 1.9.4-alpine
 Directory: chronograf/1.9/alpine
 
-Tags: 1.10, 1.10.2, latest
+Tags: 1.10, 1.10.3, latest
 Architectures: amd64, arm32v7, arm64v8
 Directory: chronograf/1.10
 
-Tags: 1.10-alpine, 1.10.2-alpine, alpine
+Tags: 1.10-alpine, 1.10.3-alpine, alpine
 Directory: chronograf/1.10/alpine


### PR DESCRIPTION
This also removes Bucky Schwarz <bucky@influxdata.com> (@hoorayimhelping) as a maintainer because he is no longer with InfluxData.