### PR TITLE
Update spark version to 3.5.1

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -1,7 +1,47 @@
 Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 3.5.0-scala2.12-java17-python3-ubuntu, 3.5.0-java17-python3, 3.5.0-java17, python3-java17
+Tags: 3.5.1-scala2.12-java17-python3-ubuntu, 3.5.1-java17-python3, 3.5.1-java17, python3-java17
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java17-python3-ubuntu
+
+Tags: 3.5.1-scala2.12-java17-r-ubuntu, 3.5.1-java17-r
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java17-r-ubuntu
+
+Tags: 3.5.1-scala2.12-java17-ubuntu, 3.5.1-java17-scala
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java17-ubuntu
+
+Tags: 3.5.1-scala2.12-java17-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java17-python3-r-ubuntu
+
+Tags: 3.5.1-scala2.12-java11-python3-ubuntu, 3.5.1-python3, 3.5.1, python3, latest
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java11-python3-ubuntu
+
+Tags: 3.5.1-scala2.12-java11-r-ubuntu, 3.5.1-r, r
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java11-r-ubuntu
+
+Tags: 3.5.1-scala2.12-java11-ubuntu, 3.5.1-scala, scala
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java11-ubuntu
+
+Tags: 3.5.1-scala2.12-java11-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+Directory: ./3.5.1/scala2.12-java11-python3-r-ubuntu
+
+Tags: 3.5.0-scala2.12-java17-python3-ubuntu, 3.5.0-java17-python3, 3.5.0-java17
 Architectures: amd64, arm64v8
 GitCommit: 6f68fe0f7051c10f2bf43a50a7decfce2e97baf0
 Directory: ./3.5.0/scala2.12-java17-python3-ubuntu
@@ -21,17 +61,17 @@ Architectures: amd64, arm64v8
 GitCommit: 6f68fe0f7051c10f2bf43a50a7decfce2e97baf0
 Directory: ./3.5.0/scala2.12-java17-python3-r-ubuntu
 
-Tags: 3.5.0-scala2.12-java11-python3-ubuntu, 3.5.0-python3, 3.5.0, python3, latest
+Tags: 3.5.0-scala2.12-java11-python3-ubuntu, 3.5.0-python3, 3.5.0
 Architectures: amd64, arm64v8
 GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
 Directory: ./3.5.0/scala2.12-java11-python3-ubuntu
 
-Tags: 3.5.0-scala2.12-java11-r-ubuntu, 3.5.0-r, r
+Tags: 3.5.0-scala2.12-java11-r-ubuntu, 3.5.0-r
 Architectures: amd64, arm64v8
 GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
 Directory: ./3.5.0/scala2.12-java11-r-ubuntu
 
-Tags: 3.5.0-scala2.12-java11-ubuntu, 3.5.0-scala, scala
+Tags: 3.5.0-scala2.12-java11-ubuntu, 3.5.0-scala
 Architectures: amd64, arm64v8
 GitCommit: 028efd4637fb2cf791d5bd9ea70b2fca472de4b7
 Directory: ./3.5.0/scala2.12-java11-ubuntu


### PR DESCRIPTION
This patch add 3.5.1 version for Apache Spark https://spark.apache.org/docs/3.5.1/ [1]

[1] https://github.com/apache/spark-website/pull/502
[2] https://github.com/apache/spark-docker/pull/59
