### PR TITLE
Update Clear Linux OS to 41150

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 823fc7b99ed223b958af260b90240bd5387339f5
-GitFetch: refs/heads/base-41120
+GitCommit: 4298b5816ff16a09beb53b87ea02c594f03e8cf7
+GitFetch: refs/heads/base-41150


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41150

@bryteise @djklimes @bryteise