### PR TITLE
Add semver major version tag for v2

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -46,10 +46,10 @@ Directory: influxdb/1.11/meta
 Tags: 1.11-meta-alpine, 1.11.5-meta-alpine
 Directory: influxdb/1.11/meta/alpine
 
-Tags: 2.7, 2.7.5, latest
+Tags: 2, 2.7, 2.7.5, latest
 Architectures: amd64, arm64v8
 Directory: influxdb/2.7
 
-Tags: 2.7-alpine, 2.7.5-alpine, alpine
+Tags: 2-alpine, 2.7-alpine, 2.7.5-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.7/alpine


### PR DESCRIPTION
This PR adds a `2` major version tag to point to the latest InfluxDB v2 release.

Justification:

- Improves maintainability of the Dockerhub README--code samples in the v2 section can use `influxdb:2`.
- Allows for mapping future major versions (for example, `3`) to `latest`.
- Follows good [semantic versioning practice for images](https://medium.com/@mccode/using-semantic-versioning-for-docker-image-tags-dfde8be06699).