### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,50 +4,35 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.1.0-alpha4-php8.1-apache, 5.1-php8.1-apache, 5.1.alpha-php8.1-apache, 5.1.0-alpha-php8.1-apache
+Tags: 5.1.0-beta1-php8.1-apache, 5.1-php8.1-apache, 5.1.beta-php8.1-apache, 5.1.0-beta-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.1/apache
+GitCommit: 138e91ac6ba8d84b03b2089e3e5e3d974e5de812
+Directory: 5.1.beta/php8.1/apache
 
-Tags: 5.1.0-alpha4-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5.1.alpha-php8.1-fpm-alpine, 5.1.0-alpha-php8.1-fpm-alpine
+Tags: 5.1.0-beta1-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5.1.beta-php8.1-fpm-alpine, 5.1.0-beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.1/fpm-alpine
+GitCommit: 138e91ac6ba8d84b03b2089e3e5e3d974e5de812
+Directory: 5.1.beta/php8.1/fpm-alpine
 
-Tags: 5.1.0-alpha4-php8.1-fpm, 5.1-php8.1-fpm, 5.1.alpha-php8.1-fpm, 5.1.0-alpha-php8.1-fpm
+Tags: 5.1.0-beta1-php8.1-fpm, 5.1-php8.1-fpm, 5.1.beta-php8.1-fpm, 5.1.0-beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.1/fpm
+GitCommit: 138e91ac6ba8d84b03b2089e3e5e3d974e5de812
+Directory: 5.1.beta/php8.1/fpm
 
-Tags: 5.1.0-alpha4, 5.1, 5.1.alpha, 5.1.0-alpha, 5.1.0-alpha4-apache, 5.1-apache, 5.1.alpha-apache, 5.1.0-alpha-apache, 5.1.0-alpha4-php8.2, 5.1-php8.2, 5.1.alpha-php8.2, 5.1.0-alpha-php8.2, 5.1.0-alpha4-php8.2-apache, 5.1-php8.2-apache, 5.1.alpha-php8.2-apache, 5.1.0-alpha-php8.2-apache
+Tags: 5.1.0-beta1, 5.1, 5.1.beta, 5.1.0-beta, 5.1.0-beta1-apache, 5.1-apache, 5.1.beta-apache, 5.1.0-beta-apache, 5.1.0-beta1-php8.2, 5.1-php8.2, 5.1.beta-php8.2, 5.1.0-beta-php8.2, 5.1.0-beta1-php8.2-apache, 5.1-php8.2-apache, 5.1.beta-php8.2-apache, 5.1.0-beta-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.2/apache
+GitCommit: 138e91ac6ba8d84b03b2089e3e5e3d974e5de812
+Directory: 5.1.beta/php8.2/apache
 
-Tags: 5.1.0-alpha4-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5.1.alpha-php8.2-fpm-alpine, 5.1.0-alpha-php8.2-fpm-alpine
+Tags: 5.1.0-beta1-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5.1.beta-php8.2-fpm-alpine, 5.1.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.2/fpm-alpine
+GitCommit: 138e91ac6ba8d84b03b2089e3e5e3d974e5de812
+Directory: 5.1.beta/php8.2/fpm-alpine
 
-Tags: 5.1.0-alpha4-php8.2-fpm, 5.1-php8.2-fpm, 5.1.alpha-php8.2-fpm, 5.1.0-alpha-php8.2-fpm
+Tags: 5.1.0-beta1-php8.2-fpm, 5.1-php8.2-fpm, 5.1.beta-php8.2-fpm, 5.1.0-beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.2/fpm
-
-Tags: 5.1.0-alpha4-php8.3-apache, 5.1-php8.3-apache, 5.1.alpha-php8.3-apache, 5.1.0-alpha-php8.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.3/apache
-
-Tags: 5.1.0-alpha4-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5.1.alpha-php8.3-fpm-alpine, 5.1.0-alpha-php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.3/fpm-alpine
-
-Tags: 5.1.0-alpha4-php8.3-fpm, 5.1-php8.3-fpm, 5.1.alpha-php8.3-fpm, 5.1.0-alpha-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 667ef17a8fdf0fe6c67cae2aff095a7e803687a0
-Directory: 5.1.alpha/php8.3/fpm
+GitCommit: 138e91ac6ba8d84b03b2089e3e5e3d974e5de812
+Directory: 5.1.beta/php8.2/fpm
 
 Tags: 5.0.3-php8.1-apache, 5.0-php8.1-apache, 5-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@54e9266: Remove PHP8.3 (due to Imagick error)
- joomla-docker/docker-joomla@138e91a: Add Joomla 5.1.beta. Removes Joomla 5.1.alpha