### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/a20bcbde28bc3ccb18d189b808d373d27caccbe4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/2d996d559b3ab3c8ca910ea76137d96313c5a6e8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: a20bcbde28bc3ccb18d189b808d373d27caccbe4
+GitCommit: 2d996d559b3ab3c8ca910ea76137d96313c5a6e8
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d0b7d566eb4f1fa9933984e6fc04ab11f08f4592
+amd64-GitCommit: a662a9bdc9d91f9cdf730dd7b187b7e0e81810dd
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 7044abc7ee26712d998311b402b975124786e0cf
+arm32v5-GitCommit: c6ff2e29964037dd6c8af5cedee00c83614e2dad
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: c8b6d08f1f78467e7dd1ae3d5e4ec3563877e9a5
+arm32v6-GitCommit: b1cad9741236fc3b4e8c167b98937b7bb07faf9b
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 185a3f7f21c307b15ef99b7088b228f004ff5f11
+arm32v7-GitCommit: dc78e52d515ccfa96214287b802bf2ac48ad0e25
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a8344687869ba9f95e140a62a915a30822ff2147
+arm64v8-GitCommit: 27266635e744d34a01f3282828147eac8e7f28a8
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 64e761e756e3281bc9a49235ee200dfc1f5a525e
+i386-GitCommit: c64aa13925df4cbe58b56df5b68aa83e141d75e6
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: ea5639e7af6b21b81230ccaba4c05ccb2d80b9e3
+mips64le-GitCommit: f4031e3caba59a2a3b7f0e33e358ffc6f5c7880c
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 97dad737e59de0698f74b81a7dac4ce4d834e36c
+ppc64le-GitCommit: 5530dc51d84060462244a369e5ee008d47df96c5
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 10a1d6f931c0fd84f31e5b3e464fed9773a9fdaa
+riscv64-GitCommit: 8a392a39bf30fdbac0caa63c19b72aa8bc33527f
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ecf31f814875084a2bc85a162b78f512ea2df0c9
+s390x-GitCommit: 44b972c7f31cc774cee5d4f379d16773b939c2ac
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/2d996d5: Merge pull request https://github.com/docker-library/busybox/pull/192 from infosiftr/buildroot-2024.02
- https://github.com/docker-library/busybox/commit/20bf190: Update buildroot to 2024.02