### PR TITLE
[oraclelinux] Updating 8, 9 and 9-slim for ELSA-2024-1130, ELSA-2024-1129, ELSA-2024-0606.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1a4d4777ce89cdde9e3f7ed984cfc6397e9f2dae
+amd64-GitCommit: 5874902983c0098d8adc187cd905e83f196c9c5d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a96b183398918b5d2ea9095743377fa15440704e
+arm64v8-GitCommit: 0f0fd113e8a1093b39e83f6e6ef46b5b489e0e37
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-48795, CVE-2023-51385, CVE-2023-46218

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-1129.html
https://linux.oracle.com/errata/ELSA-2024-0606.html
https://linux.oracle.com/errata/ELSA-2024-1130.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>