### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.80.1, 5.80, 5, latest
+Tags: 5.80.2, 5.80, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 517468a92420794e8a623a09b5845f650a17fa93
+GitCommit: 8015444481d1ff6e404edf833c12378cc89aa40e
 Directory: 5/debian
 
-Tags: 5.80.1-alpine, 5.80-alpine, 5-alpine, alpine
+Tags: 5.80.2-alpine, 5.80-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 517468a92420794e8a623a09b5845f650a17fa93
+GitCommit: 8015444481d1ff6e404edf833c12378cc89aa40e
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/8015444: Update to 5.80.2, ghost-cli 1.25.3