### PR TITLE
chore: Update to Rustup version 1.27.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/e5921dbae8fe56407a992307d1e2c2716ba8202d/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/52210a27e61827edc257687d4b7cad1fd71d6f6f/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
@@ -6,40 +6,40 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
 
 Tags: 1-buster, 1.76-buster, 1.76.0-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/buster
 
 Tags: 1-slim-buster, 1.76-slim-buster, 1.76.0-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/buster/slim
 
 Tags: 1-bullseye, 1.76-bullseye, 1.76.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/bullseye
 
 Tags: 1-slim-bullseye, 1.76-slim-bullseye, 1.76.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/bullseye/slim
 
 Tags: 1-bookworm, 1.76-bookworm, 1.76.0-bookworm, bookworm, 1, 1.76, 1.76.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/bookworm
 
 Tags: 1-slim-bookworm, 1.76-slim-bookworm, 1.76.0-slim-bookworm, slim-bookworm, 1-slim, 1.76-slim, 1.76.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/bookworm/slim
 
 Tags: 1-alpine3.18, 1.76-alpine3.18, 1.76.0-alpine3.18, alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/alpine3.18
 
 Tags: 1-alpine3.19, 1.76-alpine3.19, 1.76.0-alpine3.19, alpine3.19, 1-alpine, 1.76-alpine, 1.76.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: e5921dbae8fe56407a992307d1e2c2716ba8202d
+GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
 Directory: 1.76.0/alpine3.19


### PR DESCRIPTION
This bumps the `rustup` version to `1.27.0`.

- [Annoucement Blog](https://blog.rust-lang.org/2024/03/11/Rustup-1.27.0.html)
- [`rustup` Changelog](https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1270---2024-03-08)

Note:  [`rustup`](https://rust-lang.github.io/rustup/) is an installer for [Rust](https://www.rust-lang.org/). We use `rustup` to [correctly install and setup](https://github.com/rust-lang/docker-rust/blob/dc219bcfad200f818d50916d6ba63910af91f002/1.76.0/bullseye/Dockerfile#L18-L22) `rust`.