### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev4, 3.0-dev, 3.0-dev4-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev5, 3.0-dev, 3.0-dev5-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7ff4e114609c146264294b910f5502d295c7794c
+GitCommit: 3fa21bcf0b535763ce7501e62333e18c24dc79e7
 Directory: 3.0
 
-Tags: 3.0-dev4-alpine, 3.0-dev-alpine, 3.0-dev4-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev5-alpine, 3.0-dev-alpine, 3.0-dev5-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ff4e114609c146264294b910f5502d295c7794c
+GitCommit: 3fa21bcf0b535763ce7501e62333e18c24dc79e7
 Directory: 3.0/alpine
 
 Tags: 2.9.6, 2.9, latest, 2.9.6-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3fa21bc: Update 3.0 to 3.0-dev5