### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,19 +13,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.3.20240219.0
+Tags: 2023, latest, 2023.3.20240304.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 8a730d778b641585a226adf1ca62679c10946135
+amd64-GitCommit: 2d1587cdff03f97742f2e2f24b892fd7d0e5e173
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: dc5efaaa2fe3961460689b664c99fd23d46519e6
+arm64v8-GitCommit: d4b289fde20ac5741bcbcccbba95429460d63015
 
-Tags: 2, 2.0.20240223.0
+Tags: 2, 2.0.20240306.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: bee798bb2cb388647364bed3b550f34b432fb81b
+amd64-GitCommit: 72c7597eb8c7bd8ba4d81c0ae9bcd604d2ed526e
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 98f164ee35c91710a0eb1c349666e36df34a7355
+arm64v8-GitCommit: 67c0a52935a4f98b4f8801aaa42112b6e9340902
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- cpio-2.12-11.amzn2.0.1
- openssl-libs-1.0.2k-24.amzn2.0.12
- glib2-2.56.1-9.amzn2.0.7
- libpsl-0.21.5-1.amzn2
- libcurl-8.3.0-1.amzn2.0.6
- ncurses-base-6.0-8.20170212.amzn2.1.8
- ncurses-libs-6.0-8.20170212.amzn2.1.8
- ncurses-6.0-8.20170212.amzn2.1.8
- publicsuffix-list-dafsa-20240208-1.amzn2.0.1
- curl-8.3.0-1.amzn2.0.6
#### Packages addressing CVES:
- cpio-2.12-11.amzn2.0.1
  - [CVE-2015-1197](https://alas.aws.amazon.com/cve/html/CVE-2015-1197.html)
- openssl-libs-1.0.2k-24.amzn2.0.12
  - [CVE-2024-0727](https://alas.aws.amazon.com/cve/html/CVE-2024-0727.html)
- glib2-2.56.1-9.amzn2.0.7
  - [CVE-2021-28153](https://alas.aws.amazon.com/cve/html/CVE-2021-28153.html)
- ncurses-base-6.0-8.20170212.amzn2.1.8, ncurses-libs-6.0-8.20170212.amzn2.1.8, ncurses-6.0-8.20170212.amzn2.1.8
  - [CVE-2023-45918](https://alas.aws.amazon.com/cve/html/CVE-2023-45918.html)

### Updated Packages for Amazon Linux 2023:
- ncurses-base-6.2-4.20200222.amzn2023.0.6
- amazon-linux-repo-cdn-2023.3.20240304-0.amzn2023
- libcurl-minimal-8.5.0-1.amzn2023.0.2
- publicsuffix-list-dafsa-20240212-61.amzn2023
- ncurses-libs-6.2-4.20200222.amzn2023.0.6
- system-release-2023.3.20240304-0.amzn2023
- libpsl-0.21.1-3.amzn2023.0.2
- curl-minimal-8.5.0-1.amzn2023.0.2
#### Packages addressing CVES:
- ncurses-base-6.2-4.20200222.amzn2023.0.6, ncurses-libs-6.2-4.20200222.amzn2023.0.6
  - [CVE-2023-45918](https://alas.aws.amazon.com/cve/html/CVE-2023-45918.html)