### PR TITLE
Upgrade Zookeeper to 3.8.4 and 3.9.2

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -6,22 +6,14 @@ Tags: 3.7.2, 3.7, 3.7.2-jre-11, 3.7-jre-11
 GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
 Directory: 3.7.2
 
-Tags: 3.8.3, 3.8, 3.8.3-jre-11, 3.8-jre-11
-GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
-Directory: 3.8.3
-
-Tags: 3.9.1, 3.9, 3.9.1-jre-11, 3.9-jre-11
-GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
-Directory: 3.9.1
-
 Tags: 3.7.2-jre-17, 3.7-jre-17
 GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
 Directory: 3.7.2
 
-Tags: 3.8.3-jre-17, 3.8-jre-17
-GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
-Directory: 3.8.3
+Tags: 3.8.4, 3.8, 3.8.4-jre-17, 3.8-jre-17
+GitCommit: ec1050affd761a7886c1f1f5d18165c19d3143e8
+Directory: 3.8.4
 
-Tags: 3.9.1-jre-17, 3.9-jre-17, latest
-GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
-Directory: 3.9.1
+Tags: 3.9.2, 3.9, 3.9.2-jre-17, 3.9-jre-17, latest
+GitCommit: ec1050affd761a7886c1f1f5d18165c19d3143e8
+Directory: 3.9.2


### PR DESCRIPTION
Move plain tags to `jre-17` as planned in https://github.com/docker-library/official-images/pull/15544#pullrequestreview-1681134761