### PR TITLE
eclipse-temurin: trigger rebuild of alpine images

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -8,7 +8,7 @@ GitFetch: refs/heads/main
 #------------------------------v8 images---------------------------------
 Tags: 8u402-b06-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 8/jdk/alpine
 
 Tags: 8u402-b06-jdk-focal, 8-jdk-focal, 8-focal
@@ -62,7 +62,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u402-b06-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 8/jre/alpine
 
 Tags: 8u402-b06-jre-focal, 8-jre-focal
@@ -118,7 +118,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.22_7-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 11/jdk/alpine
 
 Tags: 11.0.22_7-jdk-focal, 11-jdk-focal, 11-focal
@@ -172,7 +172,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.22_7-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 11/jre/alpine
 
 Tags: 11.0.22_7-jre-focal, 11-jre-focal
@@ -228,7 +228,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.10_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 17/jdk/alpine
 
 Tags: 17.0.10_7-jdk-focal, 17-jdk-focal, 17-focal
@@ -282,7 +282,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.10_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 17/jre/alpine
 
 Tags: 17.0.10_7-jre-focal, 17-jre-focal
@@ -338,7 +338,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v21 images---------------------------------
 Tags: 21.0.2_13-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 21/jdk/alpine
 
 Tags: 21.0.2_13-jdk-jammy, 21-jdk-jammy, 21-jammy
@@ -382,7 +382,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.2_13-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 5ef325612fc29e529a339ea7e35e4183cf9ae888
+GitCommit: 2dae22b74703ce78b2951bc458945fdfde5b8f50
 Directory: 21/jre/alpine
 
 Tags: 21.0.2_13-jre-jammy, 21-jre-jammy


### PR DESCRIPTION
This PR is an update to the git commits for Alpine in an attempt to force a rebuild to resolve the high severity issues that are visible in the `eclipse-temurin` images.

While my preference would be for a one-off rebuild to be performed I believe this is the only way that we can trigger such a rebuild (Noting that the Dockerfiles are unchanged, this is purely to pull in the newer expat library which is causing the vulnerability notification)

Ref: https://github.com/docker-library/official-images/issues/16289