### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,68 +4,68 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-13-jdk-oraclelinux8, 23-ea-13-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8, 23-ea-13-jdk-oracle, 23-ea-13-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-13-jdk, 23-ea-13, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-14-jdk-oraclelinux9, 23-ea-14-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-14-jdk-oracle, 23-ea-14-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-14-jdk, 23-ea-14, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 6bb5ac0dcc5d6db48d6684ccf8dd6c4252ebd5ae
+Directory: 23/jdk/oraclelinux9
+
+Tags: 23-ea-14-jdk-oraclelinux8, 23-ea-14-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
+Architectures: amd64, arm64v8
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-13-jdk-oraclelinux7, 23-ea-13-oraclelinux7, 23-ea-jdk-oraclelinux7, 23-ea-oraclelinux7, 23-jdk-oraclelinux7, 23-oraclelinux7
+Tags: 23-ea-14-jdk-bookworm, 23-ea-14-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
-Directory: 23/jdk/oraclelinux7
-
-Tags: 23-ea-13-jdk-bookworm, 23-ea-13-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
-Architectures: amd64, arm64v8
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-13-jdk-slim-bookworm, 23-ea-13-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-13-jdk-slim, 23-ea-13-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-14-jdk-slim-bookworm, 23-ea-14-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-14-jdk-slim, 23-ea-14-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-13-jdk-bullseye, 23-ea-13-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-14-jdk-bullseye, 23-ea-14-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-13-jdk-slim-bullseye, 23-ea-13-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-14-jdk-slim-bullseye, 23-ea-14-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-13-jdk-windowsservercore-ltsc2022, 23-ea-13-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-13-jdk-windowsservercore, 23-ea-13-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-13-jdk, 23-ea-13, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-14-jdk-windowsservercore-ltsc2022, 23-ea-14-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-14-jdk-windowsservercore, 23-ea-14-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-14-jdk, 23-ea-14, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-13-jdk-windowsservercore-1809, 23-ea-13-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-13-jdk-windowsservercore, 23-ea-13-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-13-jdk, 23-ea-13, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-14-jdk-windowsservercore-1809, 23-ea-14-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-14-jdk-windowsservercore, 23-ea-14-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-14-jdk, 23-ea-14, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-13-jdk-nanoserver-1809, 23-ea-13-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-13-jdk-nanoserver, 23-ea-13-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-14-jdk-nanoserver-1809, 23-ea-14-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-14-jdk-nanoserver, 23-ea-14-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 2dbd57218cdde5092fc8d5ef43b5bc0cea345b1f
+GitCommit: 942cd725dc00274bf639a8ceee51f52d28d3af8e
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 22-rc-jdk-oraclelinux8, 22-rc-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8, 22-rc-jdk-oracle, 22-rc-oracle, 22-jdk-oracle, 22-oracle
+Tags: 22-rc-jdk-oraclelinux9, 22-rc-oraclelinux9, 22-jdk-oraclelinux9, 22-oraclelinux9, 22-rc-jdk-oracle, 22-rc-oracle, 22-jdk-oracle, 22-oracle
 SharedTags: 22-rc-jdk, 22-rc, 22-jdk, 22
+Architectures: amd64, arm64v8
+GitCommit: 6bb5ac0dcc5d6db48d6684ccf8dd6c4252ebd5ae
+Directory: 22/jdk/oraclelinux9
+
+Tags: 22-rc-jdk-oraclelinux8, 22-rc-oraclelinux8, 22-jdk-oraclelinux8, 22-oraclelinux8
 Architectures: amd64, arm64v8
 GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
 Directory: 22/jdk/oraclelinux8
-
-Tags: 22-rc-jdk-oraclelinux7, 22-rc-oraclelinux7, 22-jdk-oraclelinux7, 22-oraclelinux7
-Architectures: amd64, arm64v8
-GitCommit: e582736928a0af546bf984cf6c4b6bbc48a6f091
-Directory: 22/jdk/oraclelinux7
 
 Tags: 22-rc-jdk-bookworm, 22-rc-bookworm, 22-jdk-bookworm, 22-bookworm
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/9f63b2e: Merge pull request https://github.com/docker-library/openjdk/pull/535 from infosiftr/oraclelinux9
- https://github.com/docker-library/openjdk/commit/6bb5ac0: Add oraclelinux9 variants
- https://github.com/docker-library/openjdk/commit/942cd72: Update 23 to 23-ea+14