### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -6,19 +6,18 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Tanu Rampal (@trampal),
              Sam Thornton (@mrthornazon),
              Preston Carpenter (@timidger),
-             Joseph Howell-Burke (@jhowell-burke),
              Miriam Clark (@mgclark001),
              Ade Adetayo (@dadetayo),
-             Colin McCoy (@cmccoypdx)
+             Jason Jiannuo Pei (@peijiannuo)
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.3.20240304.0
+Tags: 2023, latest, 2023.3.20240312.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 2d1587cdff03f97742f2e2f24b892fd7d0e5e173
+amd64-GitCommit: d47743dd0c45c9c951e869683f785d282b2ed5de
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: d4b289fde20ac5741bcbcccbba95429460d63015
+arm64v8-GitCommit: d269f16600b88dbcd028c707701d5e3281a980b6
 
 Tags: 2, 2.0.20240306.2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
- update to latest AL2023 release
- update maintainers based on staffing changes