### PR TITLE
Update Apache Flink to 1.19.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,17 +3,32 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.18.1-scala_2.12-java8, 1.18-scala_2.12-java8, scala_2.12-java8, 1.18.1-java8, 1.18-java8, java8
+Tags: 1.19.0-scala_2.12-java8, 1.19-scala_2.12-java8, scala_2.12-java8, 1.19.0-java8, 1.19-java8, java8
+Architectures: amd64,arm64v8
+GitCommit: 206aa670a6f70dee91ba4474768078450a263958
+Directory: ./1.19/scala_2.12-java8-ubuntu
+
+Tags: 1.19.0-scala_2.12-java17, 1.19-scala_2.12-java17, scala_2.12-java17, 1.19.0-java17, 1.19-java17, java17
+Architectures: amd64,arm64v8
+GitCommit: 206aa670a6f70dee91ba4474768078450a263958
+Directory: ./1.19/scala_2.12-java17-ubuntu
+
+Tags: 1.19.0-scala_2.12-java11, 1.19-scala_2.12-java11, scala_2.12-java11, 1.19.0-scala_2.12, 1.19-scala_2.12, scala_2.12, 1.19.0-java11, 1.19-java11, java11, 1.19.0, 1.19, latest
+Architectures: amd64,arm64v8
+GitCommit: 206aa670a6f70dee91ba4474768078450a263958
+Directory: ./1.19/scala_2.12-java11-ubuntu
+
+Tags: 1.18.1-scala_2.12-java8, 1.18-scala_2.12-java8, 1.18.1-java8, 1.18-java8
 Architectures: amd64,arm64v8
 GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.18/scala_2.12-java8-ubuntu
 
-Tags: 1.18.1-scala_2.12-java17, 1.18-scala_2.12-java17, scala_2.12-java17, 1.18.1-java17, 1.18-java17, java17
+Tags: 1.18.1-scala_2.12-java17, 1.18-scala_2.12-java17, 1.18.1-java17, 1.18-java17
 Architectures: amd64,arm64v8
 GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.18/scala_2.12-java17-ubuntu
 
-Tags: 1.18.1-scala_2.12-java11, 1.18-scala_2.12-java11, scala_2.12-java11, 1.18.1-scala_2.12, 1.18-scala_2.12, scala_2.12, 1.18.1-java11, 1.18-java11, java11, 1.18.1, 1.18, latest
+Tags: 1.18.1-scala_2.12-java11, 1.18-scala_2.12-java11, 1.18.1-scala_2.12, 1.18-scala_2.12, 1.18.1-java11, 1.18-java11, 1.18.1, 1.18
 Architectures: amd64,arm64v8
 GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.18/scala_2.12-java11-ubuntu
@@ -27,23 +42,3 @@ Tags: 1.17.2-scala_2.12-java11, 1.17-scala_2.12-java11, 1.17.2-scala_2.12, 1.17-
 Architectures: amd64,arm64v8
 GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
 Directory: ./1.17/scala_2.12-java11-ubuntu
-
-Tags: 1.16.3-scala_2.12-java8, 1.16-scala_2.12-java8, 1.16.3-java8, 1.16-java8
-Architectures: amd64,arm64v8
-GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
-Directory: ./1.16/scala_2.12-java8-ubuntu
-
-Tags: 1.16.3-scala_2.12-java11, 1.16-scala_2.12-java11, 1.16.3-scala_2.12, 1.16-scala_2.12, 1.16.3-java11, 1.16-java11, 1.16.3, 1.16
-Architectures: amd64,arm64v8
-GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
-Directory: ./1.16/scala_2.12-java11-ubuntu
-
-Tags: 1.15.4-scala_2.12-java8, 1.15-scala_2.12-java8, 1.15.4-java8, 1.15-java8
-Architectures: amd64,arm64v8
-GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
-Directory: ./1.15/scala_2.12-java8-ubuntu
-
-Tags: 1.15.4-scala_2.12-java11, 1.15-scala_2.12-java11, 1.15.4-scala_2.12, 1.15-scala_2.12, 1.15.4-java11, 1.15-java11, 1.15.4, 1.15
-Architectures: amd64,arm64v8
-GitCommit: 8eb7ea1a0e668146b2da1dcd08e311e7f7f318f1
-Directory: ./1.15/scala_2.12-java11-ubuntu

--- a/library/flink
+++ b/library/flink
@@ -5,17 +5,17 @@ GitRepo: https://github.com/apache/flink-docker.git
 
 Tags: 1.19.0-scala_2.12-java8, 1.19-scala_2.12-java8, scala_2.12-java8, 1.19.0-java8, 1.19-java8, java8
 Architectures: amd64,arm64v8
-GitCommit: 206aa670a6f70dee91ba4474768078450a263958
+GitCommit: 20017e8f0e81d54fe74c0f9f6a3a988ea609be8f
 Directory: ./1.19/scala_2.12-java8-ubuntu
 
 Tags: 1.19.0-scala_2.12-java17, 1.19-scala_2.12-java17, scala_2.12-java17, 1.19.0-java17, 1.19-java17, java17
 Architectures: amd64,arm64v8
-GitCommit: 206aa670a6f70dee91ba4474768078450a263958
+GitCommit: 20017e8f0e81d54fe74c0f9f6a3a988ea609be8f
 Directory: ./1.19/scala_2.12-java17-ubuntu
 
 Tags: 1.19.0-scala_2.12-java11, 1.19-scala_2.12-java11, scala_2.12-java11, 1.19.0-scala_2.12, 1.19-scala_2.12, scala_2.12, 1.19.0-java11, 1.19-java11, java11, 1.19.0, 1.19, latest
 Architectures: amd64,arm64v8
-GitCommit: 206aa670a6f70dee91ba4474768078450a263958
+GitCommit: 20017e8f0e81d54fe74c0f9f6a3a988ea609be8f
 Directory: ./1.19/scala_2.12-java11-ubuntu
 
 Tags: 1.18.1-scala_2.12-java8, 1.18-scala_2.12-java8, 1.18.1-java8, 1.18-java8


### PR DESCRIPTION
This adds the new Flink 1.19.0 release:  https://flink.apache.org/2024/03/18/announcing-the-release-of-apache-flink-1.19/

and updates the tags on the 1.18 images accordingly.