### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,39 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.11.0-alpha1-bookworm, 1.11-rc-bookworm, rc-bookworm
-SharedTags: 1.11.0-alpha1, 1.11-rc, rc
+Tags: 1.11.0-alpha2-bookworm, 1.11-rc-bookworm, rc-bookworm
+SharedTags: 1.11.0-alpha2, 1.11-rc, rc
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 433c7947c2af4ccd9788e9cae7230429d63d8669
+GitCommit: e6bc76709c9a6536707d07b75b42c4702d7e7843
 Directory: 1.11-rc/bookworm
 
-Tags: 1.11.0-alpha1-bullseye, 1.11-rc-bullseye, rc-bullseye
+Tags: 1.11.0-alpha2-bullseye, 1.11-rc-bullseye, rc-bullseye
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 433c7947c2af4ccd9788e9cae7230429d63d8669
+GitCommit: e6bc76709c9a6536707d07b75b42c4702d7e7843
 Directory: 1.11-rc/bullseye
 
-Tags: 1.11.0-alpha1-alpine3.19, 1.11-rc-alpine3.19, rc-alpine3.19, 1.11.0-alpha1-alpine, 1.11-rc-alpine, rc-alpine
-Architectures: amd64
-GitCommit: 433c7947c2af4ccd9788e9cae7230429d63d8669
-Directory: 1.11-rc/alpine3.19
-
-Tags: 1.11.0-alpha1-alpine3.18, 1.11-rc-alpine3.18, rc-alpine3.18
-Architectures: amd64
-GitCommit: 433c7947c2af4ccd9788e9cae7230429d63d8669
-Directory: 1.11-rc/alpine3.18
-
-Tags: 1.11.0-alpha1-windowsservercore-ltsc2022, 1.11-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 1.11.0-alpha1, 1.11-rc, rc, 1.11.0-alpha1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
+Tags: 1.11.0-alpha2-windowsservercore-ltsc2022, 1.11-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 1.11.0-alpha2, 1.11-rc, rc, 1.11.0-alpha2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 433c7947c2af4ccd9788e9cae7230429d63d8669
+GitCommit: e6bc76709c9a6536707d07b75b42c4702d7e7843
 Directory: 1.11-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 1.11.0-alpha1-windowsservercore-1809, 1.11-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.11.0-alpha1, 1.11-rc, rc, 1.11.0-alpha1-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
+Tags: 1.11.0-alpha2-windowsservercore-1809, 1.11-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.11.0-alpha2, 1.11-rc, rc, 1.11.0-alpha2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 433c7947c2af4ccd9788e9cae7230429d63d8669
+GitCommit: e6bc76709c9a6536707d07b75b42c4702d7e7843
 Directory: 1.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/e6bc767: Update 1.11-rc to 1.11.0-alpha2
- https://github.com/docker-library/julia/commit/12da47b: Handle `./version.sh 1.11` more gracefully