### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
 Directory: cli/php8.3/alpine
 
-Tags: beta-6.5-RC2-php8.1-apache, beta-6.5-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.5-RC2-php8.1, beta-6.5-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.5-RC3-php8.1-apache, beta-6.5-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.5-RC3-php8.1, beta-6.5-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.1/apache
 
-Tags: beta-6.5-RC2-php8.1-fpm, beta-6.5-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.5-RC3-php8.1-fpm, beta-6.5-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.5-RC2-php8.1-fpm-alpine, beta-6.5-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.5-RC3-php8.1-fpm-alpine, beta-6.5-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.5-RC2-apache, beta-6.5-apache, beta-6-apache, beta-apache, beta-6.5-RC2, beta-6.5, beta-6, beta, beta-6.5-RC2-php8.2-apache, beta-6.5-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.5-RC2-php8.2, beta-6.5-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.5-RC3-apache, beta-6.5-apache, beta-6-apache, beta-apache, beta-6.5-RC3, beta-6.5, beta-6, beta, beta-6.5-RC3-php8.2-apache, beta-6.5-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.5-RC3-php8.2, beta-6.5-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.2/apache
 
-Tags: beta-6.5-RC2-fpm, beta-6.5-fpm, beta-6-fpm, beta-fpm, beta-6.5-RC2-php8.2-fpm, beta-6.5-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.5-RC3-fpm, beta-6.5-fpm, beta-6-fpm, beta-fpm, beta-6.5-RC3-php8.2-fpm, beta-6.5-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.5-RC2-fpm-alpine, beta-6.5-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.5-RC2-php8.2-fpm-alpine, beta-6.5-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.5-RC3-fpm-alpine, beta-6.5-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.5-RC3-php8.2-fpm-alpine, beta-6.5-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.2/fpm-alpine
 
-Tags: beta-6.5-RC2-php8.3-apache, beta-6.5-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.5-RC2-php8.3, beta-6.5-php8.3, beta-6-php8.3, beta-php8.3
+Tags: beta-6.5-RC3-php8.3-apache, beta-6.5-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.5-RC3-php8.3, beta-6.5-php8.3, beta-6-php8.3, beta-php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.3/apache
 
-Tags: beta-6.5-RC2-php8.3-fpm, beta-6.5-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Tags: beta-6.5-RC3-php8.3-fpm, beta-6.5-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.3/fpm
 
-Tags: beta-6.5-RC2-php8.3-fpm-alpine, beta-6.5-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Tags: beta-6.5-RC3-php8.3-fpm-alpine, beta-6.5-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 40969d1b24805bfdae77e83f547c9d057f985759
+GitCommit: 654752dda3941244b10ab45a07bf693d39a05d7c
 Directory: beta/php8.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/654752d: Update beta to 6.5-RC3