### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -7,10 +7,10 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 5.80.4, 5.80, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a5c3cd372d7e34d5ea79bd0e544b0cdb800fca26
+GitCommit: ac3466c054515c5e90afe336732e357c425b640e
 Directory: 5/debian
 
 Tags: 5.80.4-alpine, 5.80-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: a5c3cd372d7e34d5ea79bd0e544b0cdb800fca26
+GitCommit: ac3466c054515c5e90afe336732e357c425b640e
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/ac3466c: Update to 5.80.4, ghost-cli 1.26.0