### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.24, 1.6, 1, latest, 1.6.24-bookworm, 1.6-bookworm, 1-bookworm, bookworm
+Tags: 1.6.25, 1.6, 1, latest, 1.6.25-bookworm, 1.6-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c28a68e5a4add95385737ef33b6fc54d446be9f7
+GitCommit: 0215dbaa543d98b7e54eee9162906d31fcb8677e
 Directory: 1/debian
 
-Tags: 1.6.24-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.24-alpine3.19, 1.6-alpine3.19, 1-alpine3.19, alpine3.19
+Tags: 1.6.25-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.25-alpine3.19, 1.6-alpine3.19, 1-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: c28a68e5a4add95385737ef33b6fc54d446be9f7
+GitCommit: 0215dbaa543d98b7e54eee9162906d31fcb8677e
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/0215dba: Update 1 to 1.6.25
- https://github.com/docker-library/memcached/commit/da71ed9: Finally admit defeat on arm32v7