### PR TITLE
chore: Update to Rust version 1.77.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/52210a27e61827edc257687d4b7cad1fd71d6f6f/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-buster, 1.76-buster, 1.76.0-buster, buster
+Tags: 1-buster, 1.77-buster, 1.77.0-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/buster
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/buster
 
-Tags: 1-slim-buster, 1.76-slim-buster, 1.76.0-slim-buster, slim-buster
+Tags: 1-slim-buster, 1.77-slim-buster, 1.77.0-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/buster/slim
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/buster/slim
 
-Tags: 1-bullseye, 1.76-bullseye, 1.76.0-bullseye, bullseye
+Tags: 1-bullseye, 1.77-bullseye, 1.77.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/bullseye
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/bullseye
 
-Tags: 1-slim-bullseye, 1.76-slim-bullseye, 1.76.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/bullseye/slim
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/bullseye/slim
 
-Tags: 1-bookworm, 1.76-bookworm, 1.76.0-bookworm, bookworm, 1, 1.76, 1.76.0, latest
+Tags: 1-bookworm, 1.77-bookworm, 1.77.0-bookworm, bookworm, 1, 1.77, 1.77.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/bookworm
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/bookworm
 
-Tags: 1-slim-bookworm, 1.76-slim-bookworm, 1.76.0-slim-bookworm, slim-bookworm, 1-slim, 1.76-slim, 1.76.0-slim, slim
+Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.0-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/bookworm/slim
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/bookworm/slim
 
-Tags: 1-alpine3.18, 1.76-alpine3.18, 1.76.0-alpine3.18, alpine3.18
+Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.0-alpine3.18, alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/alpine3.18
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/alpine3.18
 
-Tags: 1-alpine3.19, 1.76-alpine3.19, 1.76.0-alpine3.19, alpine3.19, 1-alpine, 1.76-alpine, 1.76.0-alpine, alpine
+Tags: 1-alpine3.19, 1.77-alpine3.19, 1.77.0-alpine3.19, alpine3.19, 1-alpine, 1.77-alpine, 1.77.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 52210a27e61827edc257687d4b7cad1fd71d6f6f
-Directory: 1.76.0/alpine3.19
+GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
+Directory: 1.77.0/alpine3.19


### PR DESCRIPTION
This updates the `rust` version to `1.77.0`.
- Release: https://github.com/rust-lang/rust/releases/tag/1.77.0
- Blog: https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html
