### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.80.5, 5.80, 5, latest
+Tags: 5.81.0, 5.81, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b04fdb9200f9a33d99f38968145a6d9fda0bcca0
+GitCommit: 847b8a45a6108ad80d25e53333f65a6f91205659
 Directory: 5/debian
 
-Tags: 5.80.5-alpine, 5.80-alpine, 5-alpine, alpine
+Tags: 5.81.0-alpine, 5.81-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: b04fdb9200f9a33d99f38968145a6d9fda0bcca0
+GitCommit: 847b8a45a6108ad80d25e53333f65a6f91205659
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/847b8a4: Update to 5.81.0, ghost-cli 1.26.0