### PR TITLE
Update Clear Linux OS to 41270

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 3e425852017b24fe9935533aa8790657e43bd908
-GitFetch: refs/heads/base-41230
+GitCommit: 1910926e5951ac896bb6462d3625c96d8668a3f2
+GitFetch: refs/heads/base-41270


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41270

@bryteise @djklimes @bryteise