### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev5, 3.0-dev, 3.0-dev5-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev6, 3.0-dev, 3.0-dev6-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fa21bcf0b535763ce7501e62333e18c24dc79e7
+GitCommit: 1f1e1651fb0e05ce891ae12dc9da6ac4717f9420
 Directory: 3.0
 
-Tags: 3.0-dev5-alpine, 3.0-dev-alpine, 3.0-dev5-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev6-alpine, 3.0-dev-alpine, 3.0-dev6-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3fa21bcf0b535763ce7501e62333e18c24dc79e7
+GitCommit: 1f1e1651fb0e05ce891ae12dc9da6ac4717f9420
 Directory: 3.0/alpine
 
 Tags: 2.9.6, 2.9, latest, 2.9.6-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/1f1e165: Update 3.0 to 3.0-dev6