### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/2d996d559b3ab3c8ca910ea76137d96313c5a6e8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/3afd681ef7a1dd37837694a5c42e36a99c0f9320/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 2d996d559b3ab3c8ca910ea76137d96313c5a6e8
+GitCommit: 3afd681ef7a1dd37837694a5c42e36a99c0f9320
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a662a9bdc9d91f9cdf730dd7b187b7e0e81810dd
+amd64-GitCommit: 73986f3481e96ff79c39b7dae40a3f8e3700cf10
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: c6ff2e29964037dd6c8af5cedee00c83614e2dad
+arm32v5-GitCommit: 9e37e20d1416a9334c807d4e795cbcc58405edd1
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: b1cad9741236fc3b4e8c167b98937b7bb07faf9b
+arm32v6-GitCommit: 509b8bb35e0cb5f571bb5e82264ddea2dabc8f7d
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: dc78e52d515ccfa96214287b802bf2ac48ad0e25
+arm32v7-GitCommit: 908a79ff0569abbeec240f5df0e13b4249d10184
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 27266635e744d34a01f3282828147eac8e7f28a8
+arm64v8-GitCommit: e83be66361b1cf2ea7ffd59dbb73c2c0f08b055f
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: c64aa13925df4cbe58b56df5b68aa83e141d75e6
+i386-GitCommit: 6968b031ff533fb55d44f029f1586751818c6184
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: f4031e3caba59a2a3b7f0e33e358ffc6f5c7880c
+mips64le-GitCommit: 116a03b0f02c8a4705d9db350a26c39fb24a8a7e
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 5530dc51d84060462244a369e5ee008d47df96c5
+ppc64le-GitCommit: 9fde01136e0b2142624ad3789a7b9aa99ae0d72b
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 8a392a39bf30fdbac0caa63c19b72aa8bc33527f
+riscv64-GitCommit: 6d8c7cc58edd5fedc0d0e0b9abbd9396bb1207f3
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 44b972c7f31cc774cee5d4f379d16773b939c2ac
+s390x-GitCommit: 55d3efd847da80f75c7b1ce33b52d5e338fe8632
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/3afd681: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/3ced3b8: Update metadata for i386
- https://github.com/docker-library/busybox/commit/69a65f3: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/688027b: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/5928a1b: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/e8f737b: Merge pull request https://github.com/docker-library/busybox/pull/193 from infosiftr/buildroot-2024.02.1
- https://github.com/docker-library/busybox/commit/21db221: Merge pull request https://github.com/docker-library/busybox/pull/194 from infosiftr/alpine-edge
- https://github.com/docker-library/busybox/commit/f4bd993: Add `apk upgrade libssl3 libcrypto3` as temporary Alpine Edge woes balm
- https://github.com/docker-library/busybox/commit/b807fe5: Update buildroot to 2024.02.1