### PR TITLE
[security] MediaWiki 1.41.1 / 1.40.3 / 1.39.7 releases

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,38 +3,38 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: 28d34a71bac948ce1f46cd801e512e6a69c9b467
+GitCommit: 1161796f04d6a6bcbec9fb4c67a8ce7248392403
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version
-Tags: 1.41.0, 1.41, stable, latest
+Tags: 1.41.1, 1.41, stable, latest
 Directory: 1.41/apache
 
-Tags: 1.41.0-fpm, 1.41-fpm, stable-fpm
+Tags: 1.41.1-fpm, 1.41-fpm, stable-fpm
 Directory: 1.41/fpm
 
-Tags: 1.41.0-fpm-alpine, 1.41-fpm-alpine, stable-fpm-alpine
+Tags: 1.41.1-fpm-alpine, 1.41-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.41/fpm-alpine
 
 # current legacy version
-Tags: 1.40.2, 1.40, legacy
+Tags: 1.40.3, 1.40, legacy
 Directory: 1.40/apache
 
-Tags: 1.40.2-fpm, 1.40-fpm, legacy-fpm
+Tags: 1.40.3-fpm, 1.40-fpm, legacy-fpm
 Directory: 1.40/fpm
 
-Tags: 1.40.2-fpm-alpine, 1.40-fpm-alpine, legacy-fpm-alpine
+Tags: 1.40.3-fpm-alpine, 1.40-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.40/fpm-alpine
 
 # current lts version
-Tags: 1.39.6, 1.39, lts
+Tags: 1.39.7, 1.39, lts
 Directory: 1.39/apache
 
-Tags: 1.39.6-fpm, 1.39-fpm, lts-fpm
+Tags: 1.39.7-fpm, 1.39-fpm, lts-fpm
 Directory: 1.39/fpm
 
-Tags: 1.39.6-fpm-alpine, 1.39-fpm-alpine, lts-fpm-alpine
+Tags: 1.39.7-fpm-alpine, 1.39-fpm-alpine, lts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.39/fpm-alpine


### PR DESCRIPTION
See <https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/V3WXEPXV2DU6WTVEKK4XHW4QXD5OFKD7/>.

Refs <https://github.com/wikimedia/mediawiki-docker/pull/139>.