### PR TITLE
[oraclelinux] Updating 9 and 9-slim for ELSA-2024-1530

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5874902983c0098d8adc187cd905e83f196c9c5d
+amd64-GitCommit: f2f581f34293af40bc3376b8e9138c849bdc811f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0f0fd113e8a1093b39e83f6e6ef46b5b489e0e37
+arm64v8-GitCommit: ccf27952b7db49fd70899d54e8d939cb625b4ae0
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-52425, CVE-2024-28757.

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-1530.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>