### PR TITLE
Update Clear Linux OS to 41370

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 1910926e5951ac896bb6462d3625c96d8668a3f2
-GitFetch: refs/heads/base-41270
+GitCommit: d9e458fd8490a5c976f2c4e9cec922bebe96af30
+GitFetch: refs/heads/base-41370


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41370

@bryteise @djklimes @bryteise