### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-15-jdk-oraclelinux9, 23-ea-15-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-15-jdk-oracle, 23-ea-15-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-15-jdk, 23-ea-15, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-16-jdk-oraclelinux9, 23-ea-16-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-16-jdk-oracle, 23-ea-16-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-16-jdk, 23-ea-16, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/oraclelinux9
 
-Tags: 23-ea-15-jdk-oraclelinux8, 23-ea-15-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
+Tags: 23-ea-16-jdk-oraclelinux8, 23-ea-16-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-15-jdk-bookworm, 23-ea-15-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-16-jdk-bookworm, 23-ea-16-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-15-jdk-slim-bookworm, 23-ea-15-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-15-jdk-slim, 23-ea-15-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-16-jdk-slim-bookworm, 23-ea-16-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-16-jdk-slim, 23-ea-16-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-15-jdk-bullseye, 23-ea-15-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-16-jdk-bullseye, 23-ea-16-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-15-jdk-slim-bullseye, 23-ea-15-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-16-jdk-slim-bullseye, 23-ea-16-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-15-jdk-windowsservercore-ltsc2022, 23-ea-15-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-15-jdk-windowsservercore, 23-ea-15-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-15-jdk, 23-ea-15, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-16-jdk-windowsservercore-ltsc2022, 23-ea-16-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-16-jdk-windowsservercore, 23-ea-16-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-16-jdk, 23-ea-16, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-15-jdk-windowsservercore-1809, 23-ea-15-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-15-jdk-windowsservercore, 23-ea-15-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-15-jdk, 23-ea-15, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-16-jdk-windowsservercore-1809, 23-ea-16-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-16-jdk-windowsservercore, 23-ea-16-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-16-jdk, 23-ea-16, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-15-jdk-nanoserver-1809, 23-ea-15-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-15-jdk-nanoserver, 23-ea-15-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-16-jdk-nanoserver-1809, 23-ea-16-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-16-jdk-nanoserver, 23-ea-16-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 29413b7a4a8cfec0a856961829befe652d37bb7e
+GitCommit: d0d5210b6ff7395386ac2194f0e3303c144cc652
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/d0d5210: Update 23 to 23-ea+16