### PR TITLE
chore: Update to Rust version 1.77.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/74b78da07f51bc273970b8d1d97b3c1c91b589a0/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-buster, 1.77-buster, 1.77.0-buster, buster
+Tags: 1-buster, 1.77-buster, 1.77.1-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/buster
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/buster
 
-Tags: 1-slim-buster, 1.77-slim-buster, 1.77.0-slim-buster, slim-buster
+Tags: 1-slim-buster, 1.77-slim-buster, 1.77.1-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/buster/slim
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/buster/slim
 
-Tags: 1-bullseye, 1.77-bullseye, 1.77.0-bullseye, bullseye
+Tags: 1-bullseye, 1.77-bullseye, 1.77.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/bullseye
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/bullseye
 
-Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/bullseye/slim
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/bullseye/slim
 
-Tags: 1-bookworm, 1.77-bookworm, 1.77.0-bookworm, bookworm, 1, 1.77, 1.77.0, latest
+Tags: 1-bookworm, 1.77-bookworm, 1.77.1-bookworm, bookworm, 1, 1.77, 1.77.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/bookworm
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/bookworm
 
-Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.0-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.0-slim, slim
+Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.1-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/bookworm/slim
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/bookworm/slim
 
-Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.0-alpine3.18, alpine3.18
+Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.1-alpine3.18, alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/alpine3.18
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/alpine3.18
 
-Tags: 1-alpine3.19, 1.77-alpine3.19, 1.77.0-alpine3.19, alpine3.19, 1-alpine, 1.77-alpine, 1.77.0-alpine, alpine
+Tags: 1-alpine3.19, 1.77-alpine3.19, 1.77.1-alpine3.19, alpine3.19, 1-alpine, 1.77-alpine, 1.77.1-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: c8d1e4f5c563dacb16b2aadf827f1be3ff3ac25b
-Directory: 1.77.0/alpine3.19
+GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
+Directory: 1.77.1/alpine3.19


### PR DESCRIPTION
This updates the `rust` version to `1.77.1`

- Release: https://github.com/rust-lang/rust/releases/tag/1.77.1
- Blog: https://blog.rust-lang.org/2024/03/28/Rust-1.77.1.html