### PR TITLE
Update GeoNetwork 3.12.11 to use Tomcat 9

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,13 +1,14 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/692f3d2851d6fc7e2482291774b19a856eae43f8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/3424a84a700eedab3bf43a8281b9f3fca4c4512e/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
-     Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp)
+     Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp),
+ Jose Garcia <jose.garcia@geocat.net> (@josegar74)
 GitRepo: https://github.com/geonetwork/docker-geonetwork.git
 GitFetch: refs/heads/main
 
 Tags: 3.12.11, 3.12, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: de27e28bd62ce359bae1940caf83fadc8d5108ac
+GitCommit: faf221905720b5ebc904b5db8329be70e2028050
 Directory: 3.12.11
 
 Tags: 3.12.11-postgres, 3.12-postgres, 3-postgres


### PR DESCRIPTION
Tomcat 8.5 reached end-of-live on 2024-03-31 and the upstream Tomcat
official docker image will not be updated anymore. To keep maintaining
the GeoNetwork 3.12 image in the official repo Docker team has asked to
update Tomcat or to remove the version from the list. We are updating
to Tomcat 9.

docker-library/official-images#16518
