### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.4.3-php8.1-apache, 6.4-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.4.3-php8.1, 6.4-php8.1, 6-php8.1, php8.1
+Tags: 6.5.0-php8.1-apache, 6.5-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.5.0-php8.1, 6.5-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.1/apache
 
-Tags: 6.4.3-php8.1-fpm, 6.4-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.5.0-php8.1-fpm, 6.5-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.1/fpm
 
-Tags: 6.4.3-php8.1-fpm-alpine, 6.4-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.5.0-php8.1-fpm-alpine, 6.5-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.4.3-apache, 6.4-apache, 6-apache, apache, 6.4.3, 6.4, 6, latest, 6.4.3-php8.2-apache, 6.4-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.4.3-php8.2, 6.4-php8.2, 6-php8.2, php8.2
+Tags: 6.5.0-apache, 6.5-apache, 6-apache, apache, 6.5.0, 6.5, 6, latest, 6.5.0-php8.2-apache, 6.5-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.5.0-php8.2, 6.5-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.2/apache
 
-Tags: 6.4.3-fpm, 6.4-fpm, 6-fpm, fpm, 6.4.3-php8.2-fpm, 6.4-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.5.0-fpm, 6.5-fpm, 6-fpm, fpm, 6.5.0-php8.2-fpm, 6.5-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.2/fpm
 
-Tags: 6.4.3-fpm-alpine, 6.4-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.4.3-php8.2-fpm-alpine, 6.4-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.5.0-fpm-alpine, 6.5-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.5.0-php8.2-fpm-alpine, 6.5-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.4.3-php8.3-apache, 6.4-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.4.3-php8.3, 6.4-php8.3, 6-php8.3, php8.3
+Tags: 6.5.0-php8.3-apache, 6.5-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.5.0-php8.3, 6.5-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.3/apache
 
-Tags: 6.4.3-php8.3-fpm, 6.4-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.5.0-php8.3-fpm, 6.5-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.3/fpm
 
-Tags: 6.4.3-php8.3-fpm-alpine, 6.4-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.5.0-php8.3-fpm-alpine, 6.5-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
 Directory: latest/php8.3/fpm-alpine
 
 Tags: cli-2.10.0-php8.1, cli-2.10-php8.1, cli-2-php8.1, cli-php8.1
@@ -63,48 +63,3 @@ Tags: cli-2.10.0-php8.3, cli-2.10-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
 Directory: cli/php8.3/alpine
-
-Tags: beta-6.5-RC4-php8.1-apache, beta-6.5-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.5-RC4-php8.1, beta-6.5-php8.1, beta-6-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.1/apache
-
-Tags: beta-6.5-RC4-php8.1-fpm, beta-6.5-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.1/fpm
-
-Tags: beta-6.5-RC4-php8.1-fpm-alpine, beta-6.5-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.1/fpm-alpine
-
-Tags: beta-6.5-RC4-apache, beta-6.5-apache, beta-6-apache, beta-apache, beta-6.5-RC4, beta-6.5, beta-6, beta, beta-6.5-RC4-php8.2-apache, beta-6.5-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.5-RC4-php8.2, beta-6.5-php8.2, beta-6-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.2/apache
-
-Tags: beta-6.5-RC4-fpm, beta-6.5-fpm, beta-6-fpm, beta-fpm, beta-6.5-RC4-php8.2-fpm, beta-6.5-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.2/fpm
-
-Tags: beta-6.5-RC4-fpm-alpine, beta-6.5-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.5-RC4-php8.2-fpm-alpine, beta-6.5-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.2/fpm-alpine
-
-Tags: beta-6.5-RC4-php8.3-apache, beta-6.5-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.5-RC4-php8.3, beta-6.5-php8.3, beta-6-php8.3, beta-php8.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.3/apache
-
-Tags: beta-6.5-RC4-php8.3-fpm, beta-6.5-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.3/fpm
-
-Tags: beta-6.5-RC4-php8.3-fpm-alpine, beta-6.5-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: af5796d0ba46989ca8b93078fafd42d89f912123
-Directory: beta/php8.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/8bd179f: Update latest to 6.5.0
- https://github.com/docker-library/wordpress/commit/89bad22: Update beta to 6.5.0