### PR TITLE
Move latest tags to Java 21

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -29,7 +29,7 @@ Architectures: amd64
 GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
 Directory: jdk11-alpine
 
-Tags: 8.7.0-jdk17, 8.7-jdk17, 8-jdk17, jdk17, 8.7.0-jdk, 8.7-jdk, 8-jdk, jdk, 8.7.0, 8.7, 8, latest, 8.7.0-jdk17-jammy, 8.7-jdk17-jammy, 8-jdk17-jammy, jdk17-jammy, 8.7.0-jdk-jammy, 8.7-jdk-jammy, 8-jdk-jammy, jdk-jammy, 8.7.0-jammy, 8.7-jammy, 8-jammy, jammy
+Tags: 8.7.0-jdk17, 8.7-jdk17, 8-jdk17, jdk17, 8.7.0-jdk17-jammy, 8.7-jdk17-jammy, 8-jdk17-jammy, jdk17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
 Directory: jdk17
@@ -49,7 +49,7 @@ Architectures: amd64, arm64v8
 GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
 Directory: jdk17-graal
 
-Tags: 8.7.0-jdk21, 8.7-jdk21, 8-jdk21, jdk21, 8.7.0-jdk21-jammy, 8.7-jdk21-jammy, 8-jdk21-jammy, jdk21-jammy
+Tags: 8.7.0-jdk21, 8.7-jdk21, 8-jdk21, jdk21, 8.7.0-jdk21-jammy, 8.7-jdk21-jammy, 8-jdk21-jammy, jdk21-jammy, latest, 8.7.0-jdk, 8.7-jdk, 8-jdk, jdk, 8.7.0, 8.7, 8, 8.7.0-jdk-jammy, 8.7-jdk-jammy, 8-jdk-jammy, jdk-jammy, 8.7.0-jammy, 8.7-jammy, 8-jammy, jammy
 Architectures: amd64, arm64v8
 GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
 Directory: jdk21


### PR DESCRIPTION
The plan was to keep the latest tags using the latest LTS Java supported by Gradle. So this should have been moved back with Gradle 8.4. Now that Java 21 has been supported for some time by Gradle, we should go ahead and move this now.