### PR TITLE
[security] Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.58, 2.4, 2, latest, 2.4.58-bookworm, 2.4-bookworm, 2-bookworm, bookworm
+Tags: 2.4.59, 2.4, 2, latest, 2.4.59-bookworm, 2.4-bookworm, 2-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 89aed068235d9a480f245e03edf038621ab8ed8f
+GitCommit: 082047ae2f5373e3f542f983a7997b8f957ed518
 Directory: 2.4
 
-Tags: 2.4.58-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.58-alpine3.19, 2.4-alpine3.19, 2-alpine3.19, alpine3.19
+Tags: 2.4.59-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.59-alpine3.19, 2.4-alpine3.19, 2-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8a57cc5e01d709b1ae7176a2e85a47923865da0c
+GitCommit: 082047ae2f5373e3f542f983a7997b8f957ed518
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/082047a: Update to 2.4.59

https://downloads.apache.org/httpd/CHANGES_2.4.59