### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.3.20240312.0
+Tags: 2023, latest, 2023.4.20240401.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: d47743dd0c45c9c951e869683f785d282b2ed5de
+amd64-GitCommit: 36c1aadfc5c6f53c0572a40d41ede17b7c355bc9
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: d269f16600b88dbcd028c707701d5e3281a980b6
+arm64v8-GitCommit: 67633f82b53e8d507b605e376608bf32eaf3cae9
 
-Tags: 2, 2.0.20240306.2
+Tags: 2, 2.0.20240329.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 72c7597eb8c7bd8ba4d81c0ae9bcd604d2ed526e
+amd64-GitCommit: e20ac656379f27bacd1d4a07c6e0b97fe02fc0e3
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 67c0a52935a4f98b4f8801aaa42112b6e9340902
+arm64v8-GitCommit: 8bdb5f0f1d4f783d7ea83b03af7b35cfbb812efd
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- glibc-common-2.34-52.amzn2023.0.9
- libblkid-2.37.4-1.amzn2023.0.4
- libcurl-minimal-8.5.0-1.amzn2023.0.3
- amazon-linux-repo-cdn-2023.4.20240401-0.amzn2023
- system-release-2023.4.20240401-0.amzn2023
- glibc-minimal-langpack-2.34-52.amzn2023.0.9
- glibc-2.34-52.amzn2023.0.9
- libuuid-2.37.4-1.amzn2023.0.4
- expat-2.5.0-1.amzn2023.0.4
- libsmartcols-2.37.4-1.amzn2023.0.4
- libmount-2.37.4-1.amzn2023.0.4
- curl-minimal-8.5.0-1.amzn2023.0.3 Packages addressing CVES:
- libcurl-minimal-8.5.0-1.amzn2023.0.3, curl-minimal-8.5.0-1.amzn2023.0.3
  - [CVE-2024-0853](https://alas.aws.amazon.com/cve/html/CVE-2024-0853.html)
- expat-2.5.0-1.amzn2023.0.4
  - [CVE-2024-28757](https://alas.aws.amazon.com/cve/html/CVE-2024-28757.html)