### PR TITLE
Almalinux auto-update - 20240405 12:37:54

### DIFF
--- a/library/almalinux
+++ b/library/almalinux
@@ -1,64 +1,27 @@
-# This file is generated using https://github.com/almalinux/docker-images/blob/b27b2d450d0db9bd0495c92a1b79c4cfa29d35bd/gen_docker_official_library
+# This file was generated on https://github.com/AlmaLinux/container-images/actions/runs/8569902572
 Maintainers: The AlmaLinux OS Foundation <cloud-infra@almalinux.org> (@AlmaLinux)
-GitRepo: https://github.com/AlmaLinux/docker-images.git
+GitRepo: https://github.com/AlmaLinux/container-images.git
 
-
-Tags: 8, 8.9, 8.9-20231124
-GitFetch: refs/heads/al8-20231124-amd64
-GitCommit: b5c3f2dea7120eee009287009173081dfc079e86
-amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al8-20231124-arm64v8
-arm64v8-GitCommit: a0cdbfe387a83d220492cf4ead1eb83f61daba7f
-arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al8-20231124-ppc64le
-ppc64le-GitCommit: 4ab296c31875230f538c4f2bc4fd4c3192711f8b
-ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al8-20231124-s390x
-s390x-GitCommit: 53124a4e70a9a3d4a5aaa99c4b38fec1db1e5d8a
-s390x-File: Dockerfile-s390x-default
+Tags: 8, 8.9, 8.9-20240405
+GitFetch: refs/heads/docker-library
+GitCommit: a979f75eda6d2f89b64ddb0f923300d7c78d09c6
+File: Containerfiles/8/Containerfile.default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: 8-minimal, 8.9-minimal, 8.9-minimal-20231124
-GitFetch: refs/heads/al8-20231124-amd64
-GitCommit: b5c3f2dea7120eee009287009173081dfc079e86
-amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al8-20231124-arm64v8
-arm64v8-GitCommit: a0cdbfe387a83d220492cf4ead1eb83f61daba7f
-arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al8-20231124-ppc64le
-ppc64le-GitCommit: 4ab296c31875230f538c4f2bc4fd4c3192711f8b
-ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al8-20231124-s390x
-s390x-GitCommit: 53124a4e70a9a3d4a5aaa99c4b38fec1db1e5d8a
-s390x-File: Dockerfile-s390x-minimal
+Tags: 8-minimal, 8.9-minimal, 8.9-minimal-20240405
+GitFetch: refs/heads/docker-library
+GitCommit: a979f75eda6d2f89b64ddb0f923300d7c78d09c6
+File: Containerfiles/8/Containerfile.minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: latest, 9, 9.3, 9.3-20231124
-GitFetch: refs/heads/al9-20231124-amd64
-GitCommit: 5b541a65dc5a6b837e19aec8936bed61b7a8a2bd
-amd64-File: Dockerfile-x86_64-default
-arm64v8-GitFetch: refs/heads/al9-20231124-arm64v8
-arm64v8-GitCommit: f0a97e1ad55d625658c9cb38592f01aea1fa47d9
-arm64v8-File: Dockerfile-aarch64-default
-ppc64le-GitFetch: refs/heads/al9-20231124-ppc64le
-ppc64le-GitCommit: 356dc2b97d1a3b52b4ae5ca42b5220f8c8e19ec3
-ppc64le-File: Dockerfile-ppc64le-default
-s390x-GitFetch: refs/heads/al9-20231124-s390x
-s390x-GitCommit: 1bf4026ff85b2ed8da83f38cfaa834aa472c323f
-s390x-File: Dockerfile-s390x-default
+Tags: latest, 9, 9.3, 9.3-20240405
+GitFetch: refs/heads/docker-library
+GitCommit: 7e91e892328a41e3c405c4a62978e87dbc591695
+File: Containerfiles/9/Containerfile.default
 Architectures: amd64, arm64v8, ppc64le, s390x
 
-Tags: minimal, 9-minimal,  9.3-minimal, 9.3-minimal-20231124
-GitFetch: refs/heads/al9-20231124-amd64
-GitCommit: 5b541a65dc5a6b837e19aec8936bed61b7a8a2bd
-amd64-File: Dockerfile-x86_64-minimal
-arm64v8-GitFetch: refs/heads/al9-20231124-arm64v8
-arm64v8-GitCommit: f0a97e1ad55d625658c9cb38592f01aea1fa47d9
-arm64v8-File: Dockerfile-aarch64-minimal
-ppc64le-GitFetch: refs/heads/al9-20231124-ppc64le
-ppc64le-GitCommit: 356dc2b97d1a3b52b4ae5ca42b5220f8c8e19ec3
-ppc64le-File: Dockerfile-ppc64le-minimal
-s390x-GitFetch: refs/heads/al9-20231124-s390x
-s390x-GitCommit: 1bf4026ff85b2ed8da83f38cfaa834aa472c323f
-s390x-File: Dockerfile-s390x-minimal
+Tags: minimal, 9-minimal, 9.3-minimal, 9.3-minimal-20240405
+GitFetch: refs/heads/docker-library
+GitCommit: 7e91e892328a41e3c405c4a62978e87dbc591695
+File: Containerfiles/9/Containerfile.minimal
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
This is auto-generated commit, any concern or issue, please contact @andrewlukoshko , @LKHN, @yuravk or email to AlmaLinux OS Foundation [cloud-infra@almalinux.org](mailto:cloud-infra@almalinux.org) (https://github.com/AlmaLinux)

This PR was created by AlmaLinux's new pipeline from https://github.com/AlmaLinux/container-images.
And now official Docker images are based on our official images in Quay.io:
https://quay.io/repository/almalinuxorg/almalinux
https://quay.io/repository/almalinuxorg/8-minimal
https://quay.io/repository/almalinuxorg/9-minimal
