### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-1615 ELSA-2024-1601

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f2f581f34293af40bc3376b8e9138c849bdc811f
+amd64-GitCommit: 91272579843237f77158e36247d703b272b0fc00
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ccf27952b7db49fd70899d54e8d939cb625b4ae0
+arm64v8-GitCommit: 089a01b284e25f086abe2594004e8477af1d97fd
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-52425, CVE-2023-28322, CVE-2023-38546, CVE-2023-46218

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-1615.html
https://linux.oracle.com/errata/ELSA-2024-1601.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>