### PR TITLE
Add lts-and-current images to allow Gradle to use Java 22

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -6,63 +6,78 @@ GitRepo: https://github.com/keeganwitt/docker-gradle.git
 
 Tags: 8.7.0-jdk8, 8.7-jdk8, 8-jdk8, jdk8, 8.7.0-jdk8-jammy, 8.7-jdk8-jammy, 8-jdk8-jammy, jdk8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk8
 
 Tags: 8.7.0-jdk8-focal, 8.7-jdk8-focal, 8-jdk8-focal, jdk8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk8-focal
 
 Tags: 8.7.0-jdk11, 8.7-jdk11, 8-jdk11, jdk11, 8.7.0-jdk11-jammy, 8.7-jdk11-jammy, 8-jdk11-jammy, jdk11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk11
 
 Tags: 8.7.0-jdk11-focal, 8.7-jdk11-focal, 8-jdk11-focal, jdk11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk11-focal
 
 Tags: 8.7.0-jdk11-alpine, 8.7-jdk11-alpine, 8-jdk11-alpine, jdk11-alpine
 Architectures: amd64
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk11-alpine
 
 Tags: 8.7.0-jdk17, 8.7-jdk17, 8-jdk17, jdk17, 8.7.0-jdk17-jammy, 8.7-jdk17-jammy, 8-jdk17-jammy, jdk17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk17
 
 Tags: 8.7.0-jdk17-focal, 8.7-jdk17-focal, 8-jdk17-focal, jdk17-focal, 8.7.0-jdk-focal, 8.7-jdk-focal, 8-jdk-focal, jdk-focal, 8.7.0-focal, 8.7-focal, 8-focal, focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk17-focal
 
 Tags: 8.7.0-jdk17-alpine, 8.7-jdk17-alpine, 8-jdk17-alpine, jdk17-alpine, 8.7.0-jdk-alpine, 8.7-jdk-alpine, 8-jdk-alpine, jdk-alpine, 8.7.0-alpine, 8.7-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk17-alpine
 
 Tags: 8.7.0-jdk17-graal, 8.7-jdk17-graal, 8-jdk17-graal, jdk17-graal, 8.7.0-jdk-graal, 8.7-jdk-graal, 8-jdk-graal, jdk-graal, 8.7.0-graal, 8.7-graal, 8-graal, graal, 8.7.0-jdk17-graal-jammy, 8.7-jdk17-graal-jammy, 8-jdk17-graal-jammy, jdk17-graal-jammy, 8.7.0-jdk-graal-jammy, 8.7-jdk-graal-jammy, 8-jdk-graal-jammy, jdk-graal-jammy, 8.7.0-graal-jammy, 8.7-graal-jammy, 8-graal-jammy, graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk17-graal
 
 Tags: 8.7.0-jdk21, 8.7-jdk21, 8-jdk21, jdk21, 8.7.0-jdk21-jammy, 8.7-jdk21-jammy, 8-jdk21-jammy, jdk21-jammy, latest, 8.7.0-jdk, 8.7-jdk, 8-jdk, jdk, 8.7.0, 8.7, 8, 8.7.0-jdk-jammy, 8.7-jdk-jammy, 8-jdk-jammy, jdk-jammy, 8.7.0-jammy, 8.7-jammy, 8-jammy, jammy
 Architectures: amd64, arm64v8
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk21
 
 Tags: 8.7.0-jdk21-alpine, 8.7-jdk21-alpine, 8-jdk21-alpine, jdk21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk21-alpine
 
 Tags: 8.7.0-jdk21-graal, 8.7-jdk21-graal, 8-jdk21-graal, jdk21-graal, 8.7.0-jdk21-graal-jammy, 8.7-jdk21-graal-jammy, 8-jdk21-graal-jammy, jdk21-graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 9a1868d61f289a711881d5af0299308968b0fc65
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
 Directory: jdk21-graal
+
+Tags: 8.7.0-jdk-lts-and-current, 8.7-jdk-lts-and-current, 8-jdk-lts-and-current, jdk-lts-and-current, 8.7.0-jdk-lts-and-current-jammy, 8.7-jdk-lts-and-current-jammy, 8-jdk-lts-and-current-jammy, jdk-lts-and-current-jammy,8.7.0-jdk-21-and-22, 8.7-jdk-21-and-22, 8-jdk-21-and-22, jdk-21-and-22, 8.7.0-jdk-21-and-22-jammy, 8.7-jdk-21-and-22-jammy, 8-jdk-21-and-22-jammy, jdk-21-and-22-jammy
+Architectures: amd64, arm64v8
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+Directory: jdk-lts-and-current
+
+Tags: 8.7.0-jdk-lts-and-current-alpine, 8.7-jdk-lts-and-current-alpine, 8-jdk-lts-and-current-alpine, jdk-lts-and-current-alpine,8.7.0-jdk-21-and-22-alpine, 8.7-jdk-21-and-22-alpine, 8-jdk-21-and-22-alpine, jdk-21-and-22-alpine
+Architectures: amd64, arm64v8
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+Directory: jdk-lts-and-current-alpine
+
+Tags: 8.7.0-jdk-lts-and-current-graal, 8.7-jdk-lts-and-current-graal, 8-jdk-lts-and-current-graal, jdk-lts-and-current-graal, 8.7.0-jdk-lts-and-current-graal-jammy, 8.7-jdk-lts-and-current-graal-jammy, 8-jdk-lts-and-current-graal-jammy, jdk-lts-and-current-graal-jammy,8.7.0-jdk-21-and-22-graal, 8.7-jdk-21-and-22-graal, 8-jdk-21-and-22-graal, jdk-21-and-22-graal, 8.7.0-jdk-21-and-22-graal-jammy, 8.7-jdk-21-and-22-graal-jammy, 8-jdk-21-and-22-graal-jammy, jdk-21-and-22-graal-jammy
+Architectures: amd64, arm64v8
+GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+Directory: jdk-lts-and-current-graal
 
 
 # Gradle 7.x

--- a/library/gradle
+++ b/library/gradle
@@ -6,77 +6,77 @@ GitRepo: https://github.com/keeganwitt/docker-gradle.git
 
 Tags: 8.7.0-jdk8, 8.7-jdk8, 8-jdk8, jdk8, 8.7.0-jdk8-jammy, 8.7-jdk8-jammy, 8-jdk8-jammy, jdk8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk8
 
 Tags: 8.7.0-jdk8-focal, 8.7-jdk8-focal, 8-jdk8-focal, jdk8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk8-focal
 
 Tags: 8.7.0-jdk11, 8.7-jdk11, 8-jdk11, jdk11, 8.7.0-jdk11-jammy, 8.7-jdk11-jammy, 8-jdk11-jammy, jdk11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk11
 
 Tags: 8.7.0-jdk11-focal, 8.7-jdk11-focal, 8-jdk11-focal, jdk11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk11-focal
 
 Tags: 8.7.0-jdk11-alpine, 8.7-jdk11-alpine, 8-jdk11-alpine, jdk11-alpine
 Architectures: amd64
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk11-alpine
 
 Tags: 8.7.0-jdk17, 8.7-jdk17, 8-jdk17, jdk17, 8.7.0-jdk17-jammy, 8.7-jdk17-jammy, 8-jdk17-jammy, jdk17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk17
 
 Tags: 8.7.0-jdk17-focal, 8.7-jdk17-focal, 8-jdk17-focal, jdk17-focal, 8.7.0-jdk-focal, 8.7-jdk-focal, 8-jdk-focal, jdk-focal, 8.7.0-focal, 8.7-focal, 8-focal, focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk17-focal
 
 Tags: 8.7.0-jdk17-alpine, 8.7-jdk17-alpine, 8-jdk17-alpine, jdk17-alpine, 8.7.0-jdk-alpine, 8.7-jdk-alpine, 8-jdk-alpine, jdk-alpine, 8.7.0-alpine, 8.7-alpine, 8-alpine, alpine
 Architectures: amd64
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk17-alpine
 
 Tags: 8.7.0-jdk17-graal, 8.7-jdk17-graal, 8-jdk17-graal, jdk17-graal, 8.7.0-jdk-graal, 8.7-jdk-graal, 8-jdk-graal, jdk-graal, 8.7.0-graal, 8.7-graal, 8-graal, graal, 8.7.0-jdk17-graal-jammy, 8.7-jdk17-graal-jammy, 8-jdk17-graal-jammy, jdk17-graal-jammy, 8.7.0-jdk-graal-jammy, 8.7-jdk-graal-jammy, 8-jdk-graal-jammy, jdk-graal-jammy, 8.7.0-graal-jammy, 8.7-graal-jammy, 8-graal-jammy, graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk17-graal
 
 Tags: 8.7.0-jdk21, 8.7-jdk21, 8-jdk21, jdk21, 8.7.0-jdk21-jammy, 8.7-jdk21-jammy, 8-jdk21-jammy, jdk21-jammy, latest, 8.7.0-jdk, 8.7-jdk, 8-jdk, jdk, 8.7.0, 8.7, 8, 8.7.0-jdk-jammy, 8.7-jdk-jammy, 8-jdk-jammy, jdk-jammy, 8.7.0-jammy, 8.7-jammy, 8-jammy, jammy
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk21
 
 Tags: 8.7.0-jdk21-alpine, 8.7-jdk21-alpine, 8-jdk21-alpine, jdk21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk21-alpine
 
 Tags: 8.7.0-jdk21-graal, 8.7-jdk21-graal, 8-jdk21-graal, jdk21-graal, 8.7.0-jdk21-graal-jammy, 8.7-jdk21-graal-jammy, 8-jdk21-graal-jammy, jdk21-graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk21-graal
 
 Tags: 8.7.0-jdk-lts-and-current, 8.7-jdk-lts-and-current, 8-jdk-lts-and-current, jdk-lts-and-current, 8.7.0-jdk-lts-and-current-jammy, 8.7-jdk-lts-and-current-jammy, 8-jdk-lts-and-current-jammy, jdk-lts-and-current-jammy,8.7.0-jdk-21-and-22, 8.7-jdk-21-and-22, 8-jdk-21-and-22, jdk-21-and-22, 8.7.0-jdk-21-and-22-jammy, 8.7-jdk-21-and-22-jammy, 8-jdk-21-and-22-jammy, jdk-21-and-22-jammy
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk-lts-and-current
 
 Tags: 8.7.0-jdk-lts-and-current-alpine, 8.7-jdk-lts-and-current-alpine, 8-jdk-lts-and-current-alpine, jdk-lts-and-current-alpine,8.7.0-jdk-21-and-22-alpine, 8.7-jdk-21-and-22-alpine, 8-jdk-21-and-22-alpine, jdk-21-and-22-alpine
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk-lts-and-current-alpine
 
 Tags: 8.7.0-jdk-lts-and-current-graal, 8.7-jdk-lts-and-current-graal, 8-jdk-lts-and-current-graal, jdk-lts-and-current-graal, 8.7.0-jdk-lts-and-current-graal-jammy, 8.7-jdk-lts-and-current-graal-jammy, 8-jdk-lts-and-current-graal-jammy, jdk-lts-and-current-graal-jammy,8.7.0-jdk-21-and-22-graal, 8.7-jdk-21-and-22-graal, 8-jdk-21-and-22-graal, jdk-21-and-22-graal, 8.7.0-jdk-21-and-22-graal-jammy, 8.7-jdk-21-and-22-graal-jammy, 8-jdk-21-and-22-graal-jammy, jdk-21-and-22-graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 5ca02d087b9989b0d54bc4a62a797c86c1b77d38
+GitCommit: 9c247e401b860bb49937454ae84f6e77f1f3eab5
 Directory: jdk-lts-and-current-graal
 
 


### PR DESCRIPTION
As noted in the [compatibility guide](https://docs.gradle.org/current/userguide/compatibility.html#java), Gradle supports compiling with Java 22 using toolchains, but doesn't yet support executing Gradle. This means Gradle must be launched with a supported version of Java (such as the last LTS release) and then use toolchains to configure compilation using a second JDK on the image. I've tried to document this [here](https://github.com/keeganwitt/docker-gradle?tab=readme-ov-file#lts-and-current-images).