### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,82 +4,82 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev6, 3.0-dev, 3.0-dev6-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev7, 3.0-dev, 3.0-dev7-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1f1e1651fb0e05ce891ae12dc9da6ac4717f9420
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 3.0
 
-Tags: 3.0-dev6-alpine, 3.0-dev-alpine, 3.0-dev6-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev7-alpine, 3.0-dev-alpine, 3.0-dev7-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1f1e1651fb0e05ce891ae12dc9da6ac4717f9420
+GitCommit: d8cdcc09f959ddbb360aa12c5f1c9d6d50573bf3
 Directory: 3.0/alpine
 
-Tags: 2.9.6, 2.9, latest, 2.9.6-bookworm, 2.9-bookworm, bookworm
+Tags: 2.9.7, 2.9, latest, 2.9.7-bookworm, 2.9-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e14e1d121f1b1d78422f12210e0e256188a60c82
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.9
 
-Tags: 2.9.6-alpine, 2.9-alpine, alpine, 2.9.6-alpine3.19, 2.9-alpine3.19, alpine3.19
+Tags: 2.9.7-alpine, 2.9-alpine, alpine, 2.9.7-alpine3.19, 2.9-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e14e1d121f1b1d78422f12210e0e256188a60c82
+GitCommit: 92d0a2f516f348c774861766fba6bfd87b145eca
 Directory: 2.9/alpine
 
-Tags: 2.8.7, 2.8, lts, 2.8.7-bookworm, 2.8-bookworm, lts-bookworm
+Tags: 2.8.9, 2.8, lts, 2.8.9-bookworm, 2.8-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b63a60b648f47d0b0c7b71492f93536c3aef6910
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.8
 
-Tags: 2.8.7-alpine, 2.8-alpine, lts-alpine, 2.8.7-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
+Tags: 2.8.9-alpine, 2.8-alpine, lts-alpine, 2.8.9-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b63a60b648f47d0b0c7b71492f93536c3aef6910
+GitCommit: 5d34d74e22c28578cf57033f78017613ea0ced0c
 Directory: 2.8/alpine
 
-Tags: 2.7.11, 2.7, 2.7.11-bookworm, 2.7-bookworm
+Tags: 2.7.12, 2.7, 2.7.12-bookworm, 2.7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.7
 
-Tags: 2.7.11-alpine, 2.7-alpine, 2.7.11-alpine3.19, 2.7-alpine3.19
+Tags: 2.7.12-alpine, 2.7-alpine, 2.7.12-alpine3.19, 2.7-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 2d23827e47f9c010a8f4c0144d00997e1963e991
 Directory: 2.7/alpine
 
-Tags: 2.6.16, 2.6, 2.6.16-bookworm, 2.6-bookworm
+Tags: 2.6.17, 2.6, 2.6.17-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.6
 
-Tags: 2.6.16-alpine, 2.6-alpine, 2.6.16-alpine3.19, 2.6-alpine3.19
+Tags: 2.6.17-alpine, 2.6-alpine, 2.6.17-alpine3.19, 2.6-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 20e1b3f92d1e74b2644f5748c62a148d07e2ca43
 Directory: 2.6/alpine
 
-Tags: 2.4.25, 2.4, 2.4.25-bookworm, 2.4-bookworm
+Tags: 2.4.26, 2.4, 2.4.26-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.4
 
-Tags: 2.4.25-alpine, 2.4-alpine, 2.4.25-alpine3.19, 2.4-alpine3.19
+Tags: 2.4.26-alpine, 2.4-alpine, 2.4.26-alpine3.19, 2.4-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 3a8296a8e525bfff099f553cf79a46fc9ad384f2
 Directory: 2.4/alpine
 
-Tags: 2.2.32, 2.2, 2.2.32-bullseye, 2.2-bullseye
+Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.2
 
-Tags: 2.2.32-alpine, 2.2-alpine, 2.2.32-alpine3.16, 2.2-alpine3.16
+Tags: 2.2.33-alpine, 2.2-alpine, 2.2.33-alpine3.16, 2.2-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 3eaa160ca6c050f3451b7aad648f06ebc0a8bb22
 Directory: 2.2/alpine
 
-Tags: 2.0.34, 2.0, 2.0.34-buster, 2.0-buster
+Tags: 2.0.35, 2.0, 2.0.35-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.0
 
-Tags: 2.0.34-alpine, 2.0-alpine, 2.0.34-alpine3.16, 2.0-alpine3.16
+Tags: 2.0.35-alpine, 2.0-alpine, 2.0.35-alpine3.16, 2.0-alpine3.16
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 71cd0194b981bcbf23e964649016ca7498b1c2b8
+GitCommit: ecaebdd6ebd66297882800ef9d55edfd0b52237d
 Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8b639f8: Merge pull request https://github.com/docker-library/haproxy/pull/226 from L3n41c/remove_dev_packages
- https://github.com/docker-library/haproxy/commit/d8cdcc0: Update 3.0 to 3.0-dev7
- https://github.com/docker-library/haproxy/commit/e3b5621: Remove the `*-dev` packages from the final image
- https://github.com/docker-library/haproxy/commit/92d0a2f: Update 2.9 to 2.9.7
- https://github.com/docker-library/haproxy/commit/5d34d74: Update 2.8 to 2.8.9
- https://github.com/docker-library/haproxy/commit/2d23827: Update 2.7 to 2.7.12
- https://github.com/docker-library/haproxy/commit/20e1b3f: Update 2.6 to 2.6.17
- https://github.com/docker-library/haproxy/commit/3a8296a: Update 2.4 to 2.4.26
- https://github.com/docker-library/haproxy/commit/3eaa160: Update 2.2 to 2.2.33
- https://github.com/docker-library/haproxy/commit/ecaebdd: Update 2.0 to 2.0.35