### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.81.1, 5.81, 5, latest
+Tags: 5.82.1, 5.82, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 81b224e36c638a8864a1bc4ba952e84de0ae29cb
+GitCommit: 2521c2573e5bf04353c7630f0e97776ff98a5d41
 Directory: 5/debian
 
-Tags: 5.81.1-alpine, 5.81-alpine, 5-alpine, alpine
+Tags: 5.82.1-alpine, 5.82-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 81b224e36c638a8864a1bc4ba952e84de0ae29cb
+GitCommit: 2521c2573e5bf04353c7630f0e97776ff98a5d41
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/2521c25: Update to 5.82.1, ghost-cli 1.26.0
- https://github.com/docker-library/ghost/commit/a2662ac: Update to 5.82.0, ghost-cli 1.26.0