### PR TITLE
Update rakudo-star to 2024.03

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -4,12 +4,12 @@ Maintainers: Moritz Lenz <moritz.lenz@gmail.com> (@moritz),
              Anton Oks <anton.oks@gmx.de> (@AntonOks)
 GitRepo: https://github.com/Raku/docker
 
-Tags: latest, 2024.02
+Tags: latest, 2024.03, bookworm
 Architectures: amd64, arm64v8
-GitCommit: 1357b3acb550569e7ecf2da22fc32c32319fb872
-Directory: 2024.02/bookworm
+GitCommit: 64657bbc83c2536e3d2dcd8f075dde4e206b1421
+Directory: 2024.03/bookworm
 
-Tags: alpine, 2024.02-alpine
+Tags: alpine, 2024.03-alpine
 Architectures: amd64, arm64v8
-GitCommit: 1357b3acb550569e7ecf2da22fc32c32319fb872
-Directory: 2024.02/alpine3.19
+GitCommit: 64657bbc83c2536e3d2dcd8f075dde4e206b1421
+Directory: 2024.03/alpine


### PR DESCRIPTION
Adding a bookworm tag for consistency and clarity and switching the FROM alpine Docker image to "alpine:latest"...