### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,16 +34,6 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 5d34d74e22c28578cf57033f78017613ea0ced0c
 Directory: 2.8/alpine
 
-Tags: 2.7.12, 2.7, 2.7.12-bookworm, 2.7-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
-Directory: 2.7
-
-Tags: 2.7.12-alpine, 2.7-alpine, 2.7.12-alpine3.19, 2.7-alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 2d23827e47f9c010a8f4c0144d00997e1963e991
-Directory: 2.7/alpine
-
 Tags: 2.6.17, 2.6, 2.6.17-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/1cae2e3: Merge pull request https://github.com/docker-library/haproxy/pull/228 from TimWolla/2.7-eol
- https://github.com/docker-library/haproxy/commit/2dbe02f: Remove EOL 2.7