### PR TITLE
chore: Update to Rust version 1.77.2

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/74b78da07f51bc273970b8d1d97b3c1c91b589a0/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/73b57d936481598421d27c4d722a24774a2267ea/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-buster, 1.77-buster, 1.77.1-buster, buster
+Tags: 1-buster, 1.77-buster, 1.77.2-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/buster
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/buster
 
-Tags: 1-slim-buster, 1.77-slim-buster, 1.77.1-slim-buster, slim-buster
+Tags: 1-slim-buster, 1.77-slim-buster, 1.77.2-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/buster/slim
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/buster/slim
 
-Tags: 1-bullseye, 1.77-bullseye, 1.77.1-bullseye, bullseye
+Tags: 1-bullseye, 1.77-bullseye, 1.77.2-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/bullseye
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/bullseye
 
-Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.1-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.2-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/bullseye/slim
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/bullseye/slim
 
-Tags: 1-bookworm, 1.77-bookworm, 1.77.1-bookworm, bookworm, 1, 1.77, 1.77.1, latest
+Tags: 1-bookworm, 1.77-bookworm, 1.77.2-bookworm, bookworm, 1, 1.77, 1.77.2, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/bookworm
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/bookworm
 
-Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.1-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.1-slim, slim
+Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.2-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.2-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/bookworm/slim
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/bookworm/slim
 
-Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.1-alpine3.18, alpine3.18
+Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.2-alpine3.18, alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/alpine3.18
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/alpine3.18
 
-Tags: 1-alpine3.19, 1.77-alpine3.19, 1.77.1-alpine3.19, alpine3.19, 1-alpine, 1.77-alpine, 1.77.1-alpine, alpine
+Tags: 1-alpine3.19, 1.77-alpine3.19, 1.77.2-alpine3.19, alpine3.19, 1-alpine, 1.77-alpine, 1.77.2-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 714d8bde144bc883ccedfa70fbd000c500b15f5a
-Directory: 1.77.1/alpine3.19
+GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Directory: 1.77.2/alpine3.19


### PR DESCRIPTION
Blog: https://blog.rust-lang.org/2024/04/09/Rust-1.77.2.html
Release: https://github.com/rust-lang/rust/releases/tag/1.77.2