### PR TITLE
Bump Traefik to v2.11.1 and v3.0.0-rc4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,22 +20,22 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 912cc37ab2fb33dffbe653d3b98a224cdc833c48
 Directory: alpine
 
-Tags: v2.11.0-windowsservercore-ltsc2022, 2.11.0-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v2.11.1-windowsservercore-ltsc2022, 2.11.1-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fccb66b9845fc4266154377b774ac95127d38078
+GitCommit: 444c0a6330b75880dc79547a1cc1d4f24ad2813c
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.0-windowsservercore-1809, 2.11.0-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809, windowsservercore-1809
+Tags: v2.11.1-windowsservercore-1809, 2.11.1-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fccb66b9845fc4266154377b774ac95127d38078
+GitCommit: 444c0a6330b75880dc79547a1cc1d4f24ad2813c
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.0, 2.11.0, v2.11, 2.11, mimolette, latest
+Tags: v2.11.1, 2.11.1, v2.11, 2.11, mimolette, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fccb66b9845fc4266154377b774ac95127d38078
+GitCommit: 444c0a6330b75880dc79547a1cc1d4f24ad2813c
 Directory: alpine

--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.0-rc3-windowsservercore-ltsc2022, 3.0.0-rc3-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022
+Tags: v3.0.0-rc4-windowsservercore-ltsc2022, 3.0.0-rc4-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 912cc37ab2fb33dffbe653d3b98a224cdc833c48
+GitCommit: ae169d270394a64ccc8f29d921f80716048d6912
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.0.0-rc3-windowsservercore-1809, 3.0.0-rc3-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
+Tags: v3.0.0-rc4-windowsservercore-1809, 3.0.0-rc4-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 912cc37ab2fb33dffbe653d3b98a224cdc833c48
+GitCommit: ae169d270394a64ccc8f29d921f80716048d6912
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.0-rc3, 3.0.0-rc3, v3.0, 3.0, beaufort
+Tags: v3.0.0-rc4, 3.0.0-rc4, v3.0, 3.0, beaufort
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 912cc37ab2fb33dffbe653d3b98a224cdc833c48
+GitCommit: ae169d270394a64ccc8f29d921f80716048d6912
 Directory: alpine
 
 Tags: v2.11.1-windowsservercore-ltsc2022, 2.11.1-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.1](https://github.com/traefik/traefik/releases/tag/v2.11.1) and [v3.0.0-rc4](https://github.com/traefik/traefik/releases/tag/v3.0.0-rc4).

/cc @mmatur @kevinpollet @ldez

Cheers
