### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.5.0-php8.1-apache, 6.5-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.5.0-php8.1, 6.5-php8.1, 6-php8.1, php8.1
+Tags: 6.5.2-php8.1-apache, 6.5-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.5.2-php8.1, 6.5-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2007d5d69bfa13fd2af075a786bbf544e9f6cbe8
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.1/apache
 
-Tags: 6.5.0-php8.1-fpm, 6.5-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.5.2-php8.1-fpm, 6.5-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2007d5d69bfa13fd2af075a786bbf544e9f6cbe8
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.1/fpm
 
-Tags: 6.5.0-php8.1-fpm-alpine, 6.5-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.5.2-php8.1-fpm-alpine, 6.5-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.5.0-apache, 6.5-apache, 6-apache, apache, 6.5.0, 6.5, 6, latest, 6.5.0-php8.2-apache, 6.5-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.5.0-php8.2, 6.5-php8.2, 6-php8.2, php8.2
+Tags: 6.5.2-apache, 6.5-apache, 6-apache, apache, 6.5.2, 6.5, 6, latest, 6.5.2-php8.2-apache, 6.5-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.5.2-php8.2, 6.5-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2007d5d69bfa13fd2af075a786bbf544e9f6cbe8
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.2/apache
 
-Tags: 6.5.0-fpm, 6.5-fpm, 6-fpm, fpm, 6.5.0-php8.2-fpm, 6.5-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.5.2-fpm, 6.5-fpm, 6-fpm, fpm, 6.5.2-php8.2-fpm, 6.5-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2007d5d69bfa13fd2af075a786bbf544e9f6cbe8
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.2/fpm
 
-Tags: 6.5.0-fpm-alpine, 6.5-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.5.0-php8.2-fpm-alpine, 6.5-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.5.2-fpm-alpine, 6.5-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.5.2-php8.2-fpm-alpine, 6.5-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.5.0-php8.3-apache, 6.5-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.5.0-php8.3, 6.5-php8.3, 6-php8.3, php8.3
+Tags: 6.5.2-php8.3-apache, 6.5-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.5.2-php8.3, 6.5-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2007d5d69bfa13fd2af075a786bbf544e9f6cbe8
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.3/apache
 
-Tags: 6.5.0-php8.3-fpm, 6.5-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.5.2-php8.3-fpm, 6.5-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2007d5d69bfa13fd2af075a786bbf544e9f6cbe8
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.3/fpm
 
-Tags: 6.5.0-php8.3-fpm-alpine, 6.5-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.5.2-php8.3-fpm-alpine, 6.5-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8bd179f11462d26155d98dff696fa7c4ea546d17
+GitCommit: 0c3488c5a6623a4858964ba69950260018201d79
 Directory: latest/php8.3/fpm-alpine
 
 Tags: cli-2.10.0-php8.1, cli-2.10-php8.1, cli-2-php8.1, cli-php8.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/0c3488c: Update latest to 6.5.2
- https://github.com/docker-library/wordpress/commit/df94c6b: Update beta to 6.5.2