### PR TITLE
Remove a few architectures from satosa that fail to build

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -6,11 +6,11 @@ GitFetch: refs/heads/main
 
 Tags: 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, bookworm
 SharedTags: 8.4.0, 8.4, 8, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8, i386, ppc64le, s390x
 GitCommit: 69038a84d541717d66420f3ad8ec7c9da22c91b4
 Directory: 8.4/bookworm
 
 Tags: 8.4.0-alpine3.19, 8.4-alpine3.19, 8-alpine3.19, alpine3.19, 8.4.0-alpine, 8.4-alpine, 8-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 74a847396f1190ec26679fc3bf09ffcc42d2e999
 Directory: 8.4/alpine3.19


### PR DESCRIPTION
This is to clear these from the respective build queues, so that the builders aren't occupied by failing builds. See also https://github.com/IdentityPython/satosa-docker/issues/11

Happy to add these back once they build successfully on the respective architectures.