### PR TITLE
Update mongo-express

### DIFF
--- a/library/mongo-express
+++ b/library/mongo-express
@@ -1,26 +1,26 @@
-# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/8c6b9611cffad4ce25f4a83cafb3954b7c0fcea6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/mongo-express/mongo-express-docker/blob/075234363b3c008c7c2e97de8a3639e23a75cfcd/generate-stackbrew-library.sh
 
 Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
              John Steel <john@jskw.dev> (@BlackthornYugen)
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
-GitCommit: 8c6b9611cffad4ce25f4a83cafb3954b7c0fcea6
+GitCommit: 075234363b3c008c7c2e97de8a3639e23a75cfcd
 
 Tags: 1.0.2-20-alpine3.19, 1.0-20-alpine3.19, 1-20-alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: ec6ee123c1ecd59a7662680bec407e0913a0321e
+GitCommit: 403467f350d819b404f3d5150be7776217e810b7
 Directory: 1.0/20-alpine3.19
 
 Tags: 1.0.2-20, 1.0-20, 1-20, 1.0.2-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: ec6ee123c1ecd59a7662680bec407e0913a0321e
+GitCommit: 403467f350d819b404f3d5150be7776217e810b7
 Directory: 1.0/20-alpine3.18
 
 Tags: 1.0.2-18-alpine3.19, 1.0-18-alpine3.19, 1-18-alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: ec6ee123c1ecd59a7662680bec407e0913a0321e
+GitCommit: 403467f350d819b404f3d5150be7776217e810b7
 Directory: 1.0/18-alpine3.19
 
 Tags: 1.0.2, 1.0, 1, 1.0.2-18, 1.0-18, 1-18, 1.0.2-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18, latest
 Architectures: amd64, arm64v8
-GitCommit: ec6ee123c1ecd59a7662680bec407e0913a0321e
+GitCommit: 403467f350d819b404f3d5150be7776217e810b7
 Directory: 1.0/18-alpine3.18


### PR DESCRIPTION
Cleans the yarn cache preventing dev dependencies in the image.

https://github.com/mongo-express/mongo-express-docker/commit/075234363b3c008c7c2e97de8a3639e23a75cfcd