### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.1, 3.13, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f83b6d92a99e5bc967fcac201ee6439f1a4849c2
+GitCommit: f28dd30665e448d9aeb4af37d954cff9f427dfca
 Directory: 3.13/ubuntu
 
 Tags: 3.13.1-management, 3.13-management, 3-management, management
@@ -17,7 +17,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.1-alpine, 3.13-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f83b6d92a99e5bc967fcac201ee6439f1a4849c2
+GitCommit: f28dd30665e448d9aeb4af37d954cff9f427dfca
 Directory: 3.13/alpine
 
 Tags: 3.13.1-management-alpine, 3.13-management-alpine, 3-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 3.13/alpine/management
 
 Tags: 3.12.13, 3.12
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: cca4784e6dcac701036a915f3a6900e324c69827
+GitCommit: 5303c63ae02475dd63d7d6c11a9fbb5f06200189
 Directory: 3.12/ubuntu
 
 Tags: 3.12.13-management, 3.12-management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.13-alpine, 3.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cca4784e6dcac701036a915f3a6900e324c69827
+GitCommit: 5303c63ae02475dd63d7d6c11a9fbb5f06200189
 Directory: 3.12/alpine
 
 Tags: 3.12.13-management-alpine, 3.12-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/f28dd30: Update 3.13 to otp 26.2.4
- https://github.com/docker-library/rabbitmq/commit/5303c63: Update 3.12 to otp 25.3.2.11