### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-17-jdk-oraclelinux9, 23-ea-17-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-17-jdk-oracle, 23-ea-17-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-17-jdk, 23-ea-17, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-18-jdk-oraclelinux9, 23-ea-18-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-18-jdk-oracle, 23-ea-18-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-18-jdk, 23-ea-18, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/oraclelinux9
 
-Tags: 23-ea-17-jdk-oraclelinux8, 23-ea-17-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
+Tags: 23-ea-18-jdk-oraclelinux8, 23-ea-18-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-17-jdk-bookworm, 23-ea-17-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-18-jdk-bookworm, 23-ea-18-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-17-jdk-slim-bookworm, 23-ea-17-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-17-jdk-slim, 23-ea-17-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-18-jdk-slim-bookworm, 23-ea-18-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-18-jdk-slim, 23-ea-18-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-17-jdk-bullseye, 23-ea-17-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-18-jdk-bullseye, 23-ea-18-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-17-jdk-slim-bullseye, 23-ea-17-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-18-jdk-slim-bullseye, 23-ea-18-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-17-jdk-windowsservercore-ltsc2022, 23-ea-17-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-17-jdk-windowsservercore, 23-ea-17-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-17-jdk, 23-ea-17, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-18-jdk-windowsservercore-ltsc2022, 23-ea-18-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-18-jdk-windowsservercore, 23-ea-18-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-18-jdk, 23-ea-18, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-17-jdk-windowsservercore-1809, 23-ea-17-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-17-jdk-windowsservercore, 23-ea-17-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-17-jdk, 23-ea-17, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-18-jdk-windowsservercore-1809, 23-ea-18-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-18-jdk-windowsservercore, 23-ea-18-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-18-jdk, 23-ea-18, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-17-jdk-nanoserver-1809, 23-ea-17-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-17-jdk-nanoserver, 23-ea-17-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-18-jdk-nanoserver-1809, 23-ea-18-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-18-jdk-nanoserver, 23-ea-18-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: fd7577d450e288ab8db89fe5067bd9f2c0907f67
+GitCommit: 69172921782f9cd8982106f9e84b3020a67b4bdc
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/6917292: Update 23 to 23-ea+18