### PR TITLE
Update JRuby Java 21 images to jammy

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -3,7 +3,7 @@ Maintainers: JRuby Admin <admin@jruby.org> (@jruby),
              Thomas E Enebo <tom.enebo@gmail.com> (@enebo)
 GitRepo: https://github.com/jruby/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: e98cdf3ca642ea35fdf2002d0603f1c03bd55979
+GitCommit: 6f941176b198e2a462f484dd8105c3055e4de4df
 
 Tags: latest, 9, 9.4, 9.4.6, 9.4-jre, 9.4-jre8, 9.4.6-jre, 9.4.6-jre8, 9.4.6.0, 9.4.6.0-jre, 9.4.6.0-jre8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
No Java 21 package in focal.

https://github.com/jruby/docker-jruby/pull/86