### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.82.1, 5.82, 5, latest
+Tags: 5.82.2, 5.82, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2521c2573e5bf04353c7630f0e97776ff98a5d41
+GitCommit: ef2cb4a7dbf11d48534ee74d9f15446436af502c
 Directory: 5/debian
 
-Tags: 5.82.1-alpine, 5.82-alpine, 5-alpine, alpine
+Tags: 5.82.2-alpine, 5.82-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 2521c2573e5bf04353c7630f0e97776ff98a5d41
+GitCommit: ef2cb4a7dbf11d48534ee74d9f15446436af502c
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/ef2cb4a: Update to 5.82.2, ghost-cli 1.26.0