### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-1782 ELSA-2024-1784

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 91272579843237f77158e36247d703b272b0fc00
+amd64-GitCommit: d9cafbbc05ea9a812a86d0c6c1d2dbb03cdc0b4f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 089a01b284e25f086abe2594004e8477af1d97fd
+arm64v8-GitCommit: 4642f4418df0fc64cc54734b171c76e575fc07f8
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-4408, CVE-2023-50387, CVE-2023-50868, CVE-2024-28834, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-1782.html
https://linux.oracle.com/errata/ELSA-2024-1784.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>