### PR TITLE
Update amazoncorretto for 2024 q2 release

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -11,200 +11,200 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Chad Rakoczy <chadrako@amazon.com> (@chadrako)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: 3d2365e3db44c13a06c19f71aad789e79f67f691
+GitCommit: 681bfefafc18d88293253af8b529454855f76c81
 
-Tags: 8, 8u402, 8u402-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u402-al2-generic, 8-al2-generic-jdk, latest
+Tags: 8, 8u412, 8u412-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u412-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2-generic
 
-Tags: 8-al2023, 8u402-al2023, 8-al2023-jdk
+Tags: 8-al2023, 8u412-al2023, 8-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2023-jre, 8u402-al2023-jre
+Tags: 8-al2023-jre, 8u412-al2023-jre
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2-native-jre, 8u402-al2-native-jre
+Tags: 8-al2-native-jre, 8u412-al2-native-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2
 
-Tags: 8-al2-native-jdk, 8u402-al2-native-jdk
+Tags: 8-al2-native-jdk, 8u412-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.16, 8u402-alpine3.16, 8-alpine3.16-full, 8-alpine3.16-jdk
+Tags: 8-alpine3.16, 8u412-alpine3.16, 8-alpine3.16-full, 8-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.16
 
-Tags: 8-alpine3.16-jre, 8u402-alpine3.16-jre
+Tags: 8-alpine3.16-jre, 8u412-alpine3.16-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.16
 
-Tags: 8-alpine3.17, 8u402-alpine3.17, 8-alpine3.17-full, 8-alpine3.17-jdk
+Tags: 8-alpine3.17, 8u412-alpine3.17, 8-alpine3.17-full, 8-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.17
 
-Tags: 8-alpine3.17-jre, 8u402-alpine3.17-jre
+Tags: 8-alpine3.17-jre, 8u412-alpine3.17-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.17
 
-Tags: 8-alpine3.18, 8u402-alpine3.18, 8-alpine3.18-full, 8-alpine3.18-jdk
+Tags: 8-alpine3.18, 8u412-alpine3.18, 8-alpine3.18-full, 8-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.18
 
-Tags: 8-alpine3.18-jre, 8u402-alpine3.18-jre
+Tags: 8-alpine3.18-jre, 8u412-alpine3.18-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.18
 
-Tags: 8-alpine3.19, 8u402-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk, 8-alpine, 8u402-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.19, 8u412-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk, 8-alpine, 8u412-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.19
 
-Tags: 8-alpine3.19-jre, 8u402-alpine3.19-jre, 8-alpine-jre, 8u402-alpine-jre
+Tags: 8-alpine3.19-jre, 8u412-alpine3.19-jre, 8-alpine-jre, 8u412-alpine-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.19
 
-Tags: 11, 11.0.22, 11.0.22-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.22-al2-generic, 11-al2-generic-jdk
+Tags: 11, 11.0.23, 11.0.23-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.23-al2-generic, 11-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2-generic
 
-Tags: 11-al2023, 11.0.22-al2023, 11-al2023-jdk
+Tags: 11-al2023, 11.0.23-al2023, 11-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2023
 
-Tags: 11-al2023-headless, 11.0.22-al2023-headless
+Tags: 11-al2023-headless, 11.0.23-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2023
 
-Tags: 11-al2023-headful, 11.0.22-al2023-headful
+Tags: 11-al2023-headful, 11.0.23-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 11/headful/al2023
 
-Tags: 11-al2-native-headless, 11.0.22-al2-native-headless
+Tags: 11-al2-native-headless, 11.0.23-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2
 
-Tags: 11-al2-native-jdk, 11.0.22-al2-native-jdk
+Tags: 11-al2-native-jdk, 11.0.23-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.16, 11.0.22-alpine3.16, 11-alpine3.16-full, 11-alpine3.16-jdk
+Tags: 11-alpine3.16, 11.0.23-alpine3.16, 11-alpine3.16-full, 11-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.16
 
-Tags: 11-alpine3.17, 11.0.22-alpine3.17, 11-alpine3.17-full, 11-alpine3.17-jdk
+Tags: 11-alpine3.17, 11.0.23-alpine3.17, 11-alpine3.17-full, 11-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.17
 
-Tags: 11-alpine3.18, 11.0.22-alpine3.18, 11-alpine3.18-full, 11-alpine3.18-jdk
+Tags: 11-alpine3.18, 11.0.23-alpine3.18, 11-alpine3.18-full, 11-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.18
 
-Tags: 11-alpine3.19, 11.0.22-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk, 11-alpine, 11.0.22-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine3.19, 11.0.23-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk, 11-alpine, 11.0.23-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.19
 
-Tags: 17, 17.0.10, 17.0.10-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.10-al2-generic, 17-al2-generic-jdk
+Tags: 17, 17.0.11, 17.0.11-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.11-al2-generic, 17-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2-generic
 
-Tags: 17-al2023, 17.0.10-al2023, 17-al2023-jdk
+Tags: 17-al2023, 17.0.11-al2023, 17-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2023
 
-Tags: 17-al2023-headless, 17.0.10-al2023-headless
+Tags: 17-al2023-headless, 17.0.11-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2023
 
-Tags: 17-al2023-headful, 17.0.10-al2023-headful
+Tags: 17-al2023-headful, 17.0.11-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2023
 
-Tags: 17-al2-native-headless, 17.0.10-al2-native-headless
+Tags: 17-al2-native-headless, 17.0.11-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2
 
-Tags: 17-al2-native-headful, 17.0.10-al2-native-headful
+Tags: 17-al2-native-headful, 17.0.11-al2-native-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2
 
-Tags: 17-al2-native-jdk, 17.0.10-al2-native-jdk
+Tags: 17-al2-native-jdk, 17.0.11-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.16, 17.0.10-alpine3.16, 17-alpine3.16-full, 17-alpine3.16-jdk
+Tags: 17-alpine3.16, 17.0.11-alpine3.16, 17-alpine3.16-full, 17-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.16
 
-Tags: 17-alpine3.17, 17.0.10-alpine3.17, 17-alpine3.17-full, 17-alpine3.17-jdk
+Tags: 17-alpine3.17, 17.0.11-alpine3.17, 17-alpine3.17-full, 17-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.17
 
-Tags: 17-alpine3.18, 17.0.10-alpine3.18, 17-alpine3.18-full, 17-alpine3.18-jdk
+Tags: 17-alpine3.18, 17.0.11-alpine3.18, 17-alpine3.18-full, 17-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.18
 
-Tags: 17-alpine3.19, 17.0.10-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk, 17-alpine, 17.0.10-alpine, 17-alpine-full, 17-alpine-jdk
+Tags: 17-alpine3.19, 17.0.11-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk, 17-alpine, 17.0.11-alpine, 17-alpine-full, 17-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.19
 
-Tags: 21, 21.0.2, 21.0.2-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.2-al2-generic, 21-al2-generic-jdk
+Tags: 21, 21.0.3, 21.0.3-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.3-al2-generic, 21-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2-generic
 
-Tags: 21-al2023, 21.0.2-al2023, 21-al2023-jdk
+Tags: 21-al2023, 21.0.3-al2023, 21-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2023
 
-Tags: 21-al2023-headless, 21.0.2-al2023-headless
+Tags: 21-al2023-headless, 21.0.3-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 21/headless/al2023
 
-Tags: 21-al2023-headful, 21.0.2-al2023-headful
+Tags: 21-al2023-headful, 21.0.3-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 21/headful/al2023
 
-Tags: 21-alpine3.16, 21.0.2-alpine3.16, 21-alpine3.16-full, 21-alpine3.16-jdk
+Tags: 21-alpine3.16, 21.0.3-alpine3.16, 21-alpine3.16-full, 21-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.16
 
-Tags: 21-alpine3.17, 21.0.2-alpine3.17, 21-alpine3.17-full, 21-alpine3.17-jdk
+Tags: 21-alpine3.17, 21.0.3-alpine3.17, 21-alpine3.17-full, 21-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.17
 
-Tags: 21-alpine3.18, 21.0.2-alpine3.18, 21-alpine3.18-full, 21-alpine3.18-jdk
+Tags: 21-alpine3.18, 21.0.3-alpine3.18, 21-alpine3.18-full, 21-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.18
 
-Tags: 21-alpine3.19, 21.0.2-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk, 21-alpine, 21.0.2-alpine, 21-alpine-full, 21-alpine-jdk
+Tags: 21-alpine3.19, 21.0.3-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk, 21-alpine, 21.0.3-alpine, 21-alpine-full, 21-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.19
 
-Tags: 22-al2023, 22.0.0-al2023, 22-al2023-jdk, 22, 22-jdk
+Tags: 22-al2023, 22.0.1-al2023, 22-al2023-jdk, 22, 22-jdk
 Architectures: amd64, arm64v8
 Directory: 22/jdk/al2023
 
-Tags: 22-al2023-headless, 22.0.0-al2023-headless, 22-headless
+Tags: 22-al2023-headless, 22.0.1-al2023-headless, 22-headless
 Architectures: amd64, arm64v8
 Directory: 22/headless/al2023
 
-Tags: 22-al2023-headful, 22.0.0-al2023-headful, 22-headful
+Tags: 22-al2023-headful, 22.0.1-al2023-headful, 22-headful
 Architectures: amd64, arm64v8
 Directory: 22/headful/al2023
 
-Tags: 22-alpine3.16, 22.0.0-alpine3.16, 22-alpine3.16-full, 22-alpine3.16-jdk
+Tags: 22-alpine3.16, 22.0.1-alpine3.16, 22-alpine3.16-full, 22-alpine3.16-jdk
 Architectures: amd64, arm64v8
 Directory: 22/jdk/alpine/3.16
 
-Tags: 22-alpine3.17, 22.0.0-alpine3.17, 22-alpine3.17-full, 22-alpine3.17-jdk
+Tags: 22-alpine3.17, 22.0.1-alpine3.17, 22-alpine3.17-full, 22-alpine3.17-jdk
 Architectures: amd64, arm64v8
 Directory: 22/jdk/alpine/3.17
 
-Tags: 22-alpine3.18, 22.0.0-alpine3.18, 22-alpine3.18-full, 22-alpine3.18-jdk
+Tags: 22-alpine3.18, 22.0.1-alpine3.18, 22-alpine3.18-full, 22-alpine3.18-jdk
 Architectures: amd64, arm64v8
 Directory: 22/jdk/alpine/3.18
 
-Tags: 22-alpine3.19, 22.0.0-alpine3.19, 22-alpine3.19-full, 22-alpine3.19-jdk, 22-alpine, 22.0.0-alpine, 22-alpine-full, 22-alpine-jdk
+Tags: 22-alpine3.19, 22.0.1-alpine3.19, 22-alpine3.19-full, 22-alpine3.19-jdk, 22-alpine, 22.0.1-alpine, 22-alpine-full, 22-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 22/jdk/alpine/3.19


### PR DESCRIPTION
Update amazoncorretto for 2024 q2 release. Versions: 8.412.08.1, 11.0.23.9.1, 17.0.11.9.1, 21.0.3.9.1, 22.0.1.8.1.