### PR TITLE
Updated nginx mainline to 1.25.5.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,44 +3,44 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.25.4, mainline, 1, 1.25, latest, 1.25.4-bookworm, mainline-bookworm, 1-bookworm, 1.25-bookworm, bookworm
+Tags: 1.25.5, mainline, 1, 1.25, latest, 1.25.5-bookworm, mainline-bookworm, 1-bookworm, 1.25-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1f227619c1f1baa0bed8bed844ea614437ff14fb
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/debian
 
-Tags: 1.25.4-perl, mainline-perl, 1-perl, 1.25-perl, perl, 1.25.4-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.25-bookworm-perl, bookworm-perl
+Tags: 1.25.5-perl, mainline-perl, 1-perl, 1.25-perl, perl, 1.25.5-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.25-bookworm-perl, bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1f227619c1f1baa0bed8bed844ea614437ff14fb
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/debian-perl
 
-Tags: 1.25.4-otel, mainline-otel, 1-otel, 1.25-otel, otel, 1.25.4-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.25-bookworm-otel, bookworm-otel
+Tags: 1.25.5-otel, mainline-otel, 1-otel, 1.25-otel, otel, 1.25.5-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.25-bookworm-otel, bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: 9cb278860bdcea48abc0bc770a29ead3fc9a1fe6
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/debian-otel
 
-Tags: 1.25.4-alpine, mainline-alpine, 1-alpine, 1.25-alpine, alpine, 1.25.4-alpine3.18, mainline-alpine3.18, 1-alpine3.18, 1.25-alpine3.18, alpine3.18
+Tags: 1.25.5-alpine, mainline-alpine, 1-alpine, 1.25-alpine, alpine, 1.25.5-alpine3.19, mainline-alpine3.19, 1-alpine3.19, 1.25-alpine3.19, alpine3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 1f227619c1f1baa0bed8bed844ea614437ff14fb
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/alpine
 
-Tags: 1.25.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.25-alpine-perl, alpine-perl, 1.25.4-alpine3.18-perl, mainline-alpine3.18-perl, 1-alpine3.18-perl, 1.25-alpine3.18-perl, alpine3.18-perl
+Tags: 1.25.5-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.25-alpine-perl, alpine-perl, 1.25.5-alpine3.19-perl, mainline-alpine3.19-perl, 1-alpine3.19-perl, 1.25-alpine3.19-perl, alpine3.19-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 1f227619c1f1baa0bed8bed844ea614437ff14fb
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/alpine-perl
 
-Tags: 1.25.4-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.25-alpine-slim, alpine-slim, 1.25.4-alpine3.18-slim, mainline-alpine3.18-slim, 1-alpine3.18-slim, 1.25-alpine3.18-slim, alpine3.18-slim
+Tags: 1.25.5-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.25-alpine-slim, alpine-slim, 1.25.5-alpine3.19-slim, mainline-alpine3.19-slim, 1-alpine3.19-slim, 1.25-alpine3.19-slim, alpine3.19-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 1f227619c1f1baa0bed8bed844ea614437ff14fb
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/alpine-slim
 
-Tags: 1.25.4-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.25-alpine-otel, alpine-otel, 1.25.4-alpine3.18-otel, mainline-alpine3.18-otel, 1-alpine3.18-otel, 1.25-alpine3.18-otel, alpine3.18-otel
+Tags: 1.25.5-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.25-alpine-otel, alpine-otel, 1.25.5-alpine3.19-otel, mainline-alpine3.19-otel, 1-alpine3.19-otel, 1.25-alpine3.19-otel, alpine3.19-otel
 Architectures: amd64, arm64v8
-GitCommit: 9cb278860bdcea48abc0bc770a29ead3fc9a1fe6
+GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
 Directory: mainline/alpine-otel
 
 Tags: 1.24.0, stable, 1.24, 1.24.0-bullseye, stable-bullseye, 1.24-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a8d87b69760693a8e33cd8a9e0c2e5f0e8b0e3c
+GitCommit: 75d5e98b637f193781676bf5ea7c7704273b4355
 Directory: stable/debian
 
 Tags: 1.24.0-perl, stable-perl, 1.24-perl, 1.24.0-bullseye-perl, stable-bullseye-perl, 1.24-bullseye-perl


### PR DESCRIPTION
- njs updated to 0.8.4
- alpine updated to 3.19
- nginx mainline updated to 1.25.5

njs cli tool now uses quickjs engine (as part of njs-0.8.4).