### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev7, 3.0-dev, 3.0-dev7-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev8, 3.0-dev, 3.0-dev8-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: d033d2e4b3486f8d1c30a4fa5d484000604dbf03
 Directory: 3.0
 
-Tags: 3.0-dev7-alpine, 3.0-dev-alpine, 3.0-dev7-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev8-alpine, 3.0-dev-alpine, 3.0-dev8-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d8cdcc09f959ddbb360aa12c5f1c9d6d50573bf3
+GitCommit: d033d2e4b3486f8d1c30a4fa5d484000604dbf03
 Directory: 3.0/alpine
 
 Tags: 2.9.7, 2.9, latest, 2.9.7-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/d033d2e: Update 3.0 to 3.0-dev8