### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.4.20240401.1
+Tags: 2023, latest, 2023.4.20240416.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 36c1aadfc5c6f53c0572a40d41ede17b7c355bc9
+amd64-GitCommit: ccf125ba9199e9dc53a614df2df2c5be14ab95fe
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 67633f82b53e8d507b605e376608bf32eaf3cae9
+arm64v8-GitCommit: 93e4923abc8fbf8729277207b9e4be904dd7ab35
 
-Tags: 2, 2.0.20240329.0
+Tags: 2, 2.0.20240412.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: e20ac656379f27bacd1d4a07c6e0b97fe02fc0e3
+amd64-GitCommit: 8935e6e622c058e7c41af69ae2929be8e6a3a892
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 8bdb5f0f1d4f783d7ea83b03af7b35cfbb812efd
+arm64v8-GitCommit: 6bab03f3e5c498f95771f73ca0fea3f4f3cf94ad
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- glib2-2.56.1-9.amzn2.0.8
- krb5-libs-1.15.1-55.amzn2.2.7 Packages addressing CVES:
- glib2-2.56.1-9.amzn2.0.8
  - [CVE-2020-35457](https://alas.aws.amazon.com/cve/html/CVE-2020-35457.html)
- krb5-libs-1.15.1-55.amzn2.2.7
  - [CVE-2024-26458](https://alas.aws.amazon.com/cve/html/CVE-2024-26458.html)
  - [CVE-2024-26461](https://alas.aws.amazon.com/cve/html/CVE-2024-26461.html)

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.4.20240416-1.amzn2023
- system-release-2023.4.20240416-1.amzn2023
- krb5-libs-1.21-3.amzn2023.0.4 Packages addressing CVES:
- krb5-libs-1.21-3.amzn2023.0.4
  - [CVE-2024-26458](https://alas.aws.amazon.com/cve/html/CVE-2024-26458.html)
  - [CVE-2024-26461](https://alas.aws.amazon.com/cve/html/CVE-2024-26461.html)
  - [CVE-2024-26462](https://alas.aws.amazon.com/cve/html/CVE-2024-26462.html)