### PR TITLE
Update Clear Linux OS to 41560

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 164a30b74b5bf9a7a412b9ca461504add2c8a8de
-GitFetch: refs/heads/base-41450
+GitCommit: ce9786e46427dc6b47a68b8ae730ca15a4c53f1f
+GitFetch: refs/heads/base-41560


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41560

@bryteise @djklimes @bryteise