### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,117 +4,117 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.3.0-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.0, 3.3, 3, latest
+Tags: 3.3.1-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.1, 3.3, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.3/bookworm
 
-Tags: 3.3.0-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.0-slim, 3.3-slim, 3-slim, slim
+Tags: 3.3.1-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.1-slim, 3.3-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.3/slim-bookworm
 
-Tags: 3.3.0-bullseye, 3.3-bullseye, 3-bullseye, bullseye
+Tags: 3.3.1-bullseye, 3.3-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.3/bullseye
 
-Tags: 3.3.0-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.3.1-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.3/slim-bullseye
 
-Tags: 3.3.0-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19, 3.3.0-alpine, 3.3-alpine, 3-alpine, alpine
+Tags: 3.3.1-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19, 3.3.1-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ac7122778cc764cd50271807efe2e94775b2c21
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.3/alpine3.19
 
-Tags: 3.3.0-alpine3.18, 3.3-alpine3.18, 3-alpine3.18, alpine3.18
+Tags: 3.3.1-alpine3.18, 3.3-alpine3.18, 3-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7ac7122778cc764cd50271807efe2e94775b2c21
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.3/alpine3.18
 
-Tags: 3.2.3-bookworm, 3.2-bookworm, 3.2.3, 3.2
+Tags: 3.2.4-bookworm, 3.2-bookworm, 3.2.4, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.2/bookworm
 
-Tags: 3.2.3-slim-bookworm, 3.2-slim-bookworm, 3.2.3-slim, 3.2-slim
+Tags: 3.2.4-slim-bookworm, 3.2-slim-bookworm, 3.2.4-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.2/slim-bookworm
 
-Tags: 3.2.3-bullseye, 3.2-bullseye
+Tags: 3.2.4-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.2/bullseye
 
-Tags: 3.2.3-slim-bullseye, 3.2-slim-bullseye
+Tags: 3.2.4-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.2/slim-bullseye
 
-Tags: 3.2.3-alpine3.19, 3.2-alpine3.19, 3.2.3-alpine, 3.2-alpine
+Tags: 3.2.4-alpine3.19, 3.2-alpine3.19, 3.2.4-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c473741514de6aa1e3ccdf3a9c6df0aa71348ce3
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.2/alpine3.19
 
-Tags: 3.2.3-alpine3.18, 3.2-alpine3.18
+Tags: 3.2.4-alpine3.18, 3.2-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c473741514de6aa1e3ccdf3a9c6df0aa71348ce3
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.2/alpine3.18
 
-Tags: 3.1.4-bookworm, 3.1-bookworm, 3.1.4, 3.1
+Tags: 3.1.5-bookworm, 3.1-bookworm, 3.1.5, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.1/bookworm
 
-Tags: 3.1.4-slim-bookworm, 3.1-slim-bookworm, 3.1.4-slim, 3.1-slim
+Tags: 3.1.5-slim-bookworm, 3.1-slim-bookworm, 3.1.5-slim, 3.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.1/slim-bookworm
 
-Tags: 3.1.4-bullseye, 3.1-bullseye
+Tags: 3.1.5-bullseye, 3.1-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.1/bullseye
 
-Tags: 3.1.4-slim-bullseye, 3.1-slim-bullseye
+Tags: 3.1.5-slim-bullseye, 3.1-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.1/slim-bullseye
 
-Tags: 3.1.4-alpine3.19, 3.1-alpine3.19, 3.1.4-alpine, 3.1-alpine
+Tags: 3.1.5-alpine3.19, 3.1-alpine3.19, 3.1.5-alpine, 3.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 61a806938da52038916a8fd7b9b4373937bdc28f
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.1/alpine3.19
 
-Tags: 3.1.4-alpine3.18, 3.1-alpine3.18
+Tags: 3.1.5-alpine3.18, 3.1-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39aa7dd5e4ebeef3f466d486f1094b09e41d6c5b
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.1/alpine3.18
 
-Tags: 3.0.6-bullseye, 3.0-bullseye, 3.0.6, 3.0
+Tags: 3.0.7-bullseye, 3.0-bullseye, 3.0.7, 3.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.0/bullseye
 
-Tags: 3.0.6-slim-bullseye, 3.0-slim-bullseye, 3.0.6-slim, 3.0-slim
+Tags: 3.0.7-slim-bullseye, 3.0-slim-bullseye, 3.0.7-slim, 3.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.0/slim-bullseye
 
-Tags: 3.0.6-buster, 3.0-buster
+Tags: 3.0.7-buster, 3.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.0/buster
 
-Tags: 3.0.6-slim-buster, 3.0-slim-buster
+Tags: 3.0.7-slim-buster, 3.0-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 77efb18a0fb15955a4f77c9fa1d3968875915b78
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.0/slim-buster
 
-Tags: 3.0.6-alpine3.16, 3.0-alpine3.16, 3.0.6-alpine, 3.0-alpine
+Tags: 3.0.7-alpine3.16, 3.0-alpine3.16, 3.0.7-alpine, 3.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 39aa7dd5e4ebeef3f466d486f1094b09e41d6c5b
+GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
 Directory: 3.0/alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/a2b957f: Merge pull request https://github.com/docker-library/ruby/pull/446 from infosiftr/security
- https://github.com/docker-library/ruby/commit/53646d3: [security] Update to 3.3.1, 3.2.4, 3.1.5, 3.0.7

> After this release, Ruby 3.0 reaches EOL. In other words, this is expected to be the last release of Ruby 3.0 series. We will not release Ruby 3.0.8 even if a security vulnerability is found (but could release if a severe regression is found). We recommend all Ruby 3.0 users to start migration to Ruby 3.3, 3.2, or 3.1 immediately.

https://www.ruby-lang.org/en/news/2024/04/23/ruby-3-0-7-released/