### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -96,25 +96,25 @@ Directory: 3.1/alpine3.18
 
 Tags: 3.0.7-bullseye, 3.0-bullseye, 3.0.7, 3.0
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: 1db5a7b341c03963ea27b0664f46bcf2e47c0912
 Directory: 3.0/bullseye
 
 Tags: 3.0.7-slim-bullseye, 3.0-slim-bullseye, 3.0.7-slim, 3.0-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: 1db5a7b341c03963ea27b0664f46bcf2e47c0912
 Directory: 3.0/slim-bullseye
 
 Tags: 3.0.7-buster, 3.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: 1db5a7b341c03963ea27b0664f46bcf2e47c0912
 Directory: 3.0/buster
 
 Tags: 3.0.7-slim-buster, 3.0-slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: 1db5a7b341c03963ea27b0664f46bcf2e47c0912
 Directory: 3.0/slim-buster
 
 Tags: 3.0.7-alpine3.16, 3.0-alpine3.16, 3.0.7-alpine, 3.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: 1db5a7b341c03963ea27b0664f46bcf2e47c0912
 Directory: 3.0/alpine3.16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/91faf12: Merge pull request https://github.com/docker-library/ruby/pull/447 from infosiftr/revert-breaks-security
- https://github.com/docker-library/ruby/commit/1db5a7b: Revert RUBY_MAJOR refactoring for 3.0

Follow-up to #16646