### PR TITLE
Updated nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,64 +1,74 @@
-# this file is generated via https://github.com/nginxinc/docker-nginx/blob/9cb278860bdcea48abc0bc770a29ead3fc9a1fe6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nginxinc/docker-nginx/blob/435f9c2a06cf2d5fd65767d2f0696b9c988b814b/generate-stackbrew-library.sh
 
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
 Tags: 1.25.5, mainline, 1, 1.25, latest, 1.25.5-bookworm, mainline-bookworm, 1-bookworm, 1.25-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 66c0f94b4c764b1a531528e8c242ad94497011f6
 Directory: mainline/debian
 
 Tags: 1.25.5-perl, mainline-perl, 1-perl, 1.25-perl, perl, 1.25.5-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.25-bookworm-perl, bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 5bf2e65ab9eaa029613e18fc5dfab04693511ed6
 Directory: mainline/debian-perl
 
 Tags: 1.25.5-otel, mainline-otel, 1-otel, 1.25-otel, otel, 1.25.5-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.25-bookworm-otel, bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 5bf2e65ab9eaa029613e18fc5dfab04693511ed6
 Directory: mainline/debian-otel
 
 Tags: 1.25.5-alpine, mainline-alpine, 1-alpine, 1.25-alpine, alpine, 1.25.5-alpine3.19, mainline-alpine3.19, 1-alpine3.19, 1.25-alpine3.19, alpine3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 3fb7e2e6266d5652dabe275dbfd50bdb3418361e
 Directory: mainline/alpine
 
 Tags: 1.25.5-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.25-alpine-perl, alpine-perl, 1.25.5-alpine3.19-perl, mainline-alpine3.19-perl, 1-alpine3.19-perl, 1.25-alpine3.19-perl, alpine3.19-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 3fb7e2e6266d5652dabe275dbfd50bdb3418361e
 Directory: mainline/alpine-perl
 
 Tags: 1.25.5-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.25-alpine-slim, alpine-slim, 1.25.5-alpine3.19-slim, mainline-alpine3.19-slim, 1-alpine3.19-slim, 1.25-alpine3.19-slim, alpine3.19-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 3fb7e2e6266d5652dabe275dbfd50bdb3418361e
 Directory: mainline/alpine-slim
 
 Tags: 1.25.5-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.25-alpine-otel, alpine-otel, 1.25.5-alpine3.19-otel, mainline-alpine3.19-otel, 1-alpine3.19-otel, 1.25-alpine3.19-otel, alpine3.19-otel
 Architectures: amd64, arm64v8
-GitCommit: 29d5001c15e7a2c7b34402c35254cc55199f8cc8
+GitCommit: 3fb7e2e6266d5652dabe275dbfd50bdb3418361e
 Directory: mainline/alpine-otel
 
-Tags: 1.24.0, stable, 1.24, 1.24.0-bullseye, stable-bullseye, 1.24-bullseye
+Tags: 1.26.0, stable, 1.26, 1.26.0-bookworm, stable-bookworm, 1.26-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a8d87b69760693a8e33cd8a9e0c2e5f0e8b0e3c
+GitCommit: 66c0f94b4c764b1a531528e8c242ad94497011f6
 Directory: stable/debian
 
-Tags: 1.24.0-perl, stable-perl, 1.24-perl, 1.24.0-bullseye-perl, stable-bullseye-perl, 1.24-bullseye-perl
+Tags: 1.26.0-perl, stable-perl, 1.26-perl, 1.26.0-bookworm-perl, stable-bookworm-perl, 1.26-bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1a8d87b69760693a8e33cd8a9e0c2e5f0e8b0e3c
+GitCommit: 5bf2e65ab9eaa029613e18fc5dfab04693511ed6
 Directory: stable/debian-perl
 
-Tags: 1.24.0-alpine, stable-alpine, 1.24-alpine, 1.24.0-alpine3.17, stable-alpine3.17, 1.24-alpine3.17
+Tags: 1.26.0-otel, stable-otel, 1.26-otel, 1.26.0-bookworm-otel, stable-bookworm-otel, 1.26-bookworm-otel
+Architectures: amd64, arm64v8
+GitCommit: 5bf2e65ab9eaa029613e18fc5dfab04693511ed6
+Directory: stable/debian-otel
+
+Tags: 1.26.0-alpine, stable-alpine, 1.26-alpine, 1.26.0-alpine3.19, stable-alpine3.19, 1.26-alpine3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 1a8d87b69760693a8e33cd8a9e0c2e5f0e8b0e3c
+GitCommit: 3fb7e2e6266d5652dabe275dbfd50bdb3418361e
 Directory: stable/alpine
 
-Tags: 1.24.0-alpine-perl, stable-alpine-perl, 1.24-alpine-perl, 1.24.0-alpine3.17-perl, stable-alpine3.17-perl, 1.24-alpine3.17-perl
+Tags: 1.26.0-alpine-perl, stable-alpine-perl, 1.26-alpine-perl, 1.26.0-alpine3.19-perl, stable-alpine3.19-perl, 1.26-alpine3.19-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 1a8d87b69760693a8e33cd8a9e0c2e5f0e8b0e3c
+GitCommit: 3fb7e2e6266d5652dabe275dbfd50bdb3418361e
 Directory: stable/alpine-perl
 
-Tags: 1.24.0-alpine-slim, stable-alpine-slim, 1.24-alpine-slim, 1.24.0-alpine3.17-slim, stable-alpine3.17-slim, 1.24-alpine3.17-slim
+Tags: 1.26.0-alpine-slim, stable-alpine-slim, 1.26-alpine-slim, 1.26.0-alpine3.19-slim, stable-alpine3.19-slim, 1.26-alpine3.19-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 1a8d87b69760693a8e33cd8a9e0c2e5f0e8b0e3c
+GitCommit: ed439d2266cee6304339d50c5fe33d8f87f6eb37
 Directory: stable/alpine-slim
+
+Tags: 1.26.0-alpine-otel, stable-alpine-otel, 1.26-alpine-otel, 1.26.0-alpine3.19-otel, stable-alpine3.19-otel, 1.26-alpine3.19-otel
+Architectures: amd64, arm64v8
+GitCommit: 33588b16913fe91d3a201043b73f3366d15fcce1
+Directory: stable/alpine-otel


### PR DESCRIPTION
Updated nginx stable to 1.26.0 and moved to Alpine 3.19 / Debian Bookworm.  This also adds otel module variant for stable as was previously introduced for mainline.

Mainline is also updated to hopefully fix njs 0.8.4+quickjs build on arm32v5.

With that, some simplifications and minor fixes to Dockerfiles were merged.