### PR TITLE
Update CrateDB to 5.7.0

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -4,7 +4,11 @@ Maintainers: Mathias Fußenegger <mathias@crate.io> (@mfussenegger),
              Andreas Motl <andreas.motl@crate.io> (@amotl)
 GitRepo: https://github.com/crate/docker-crate.git
 
-Tags: 5.6.4, 5.6, latest
+Tags: 5.7.0, 5.7, latest
+Architectures: amd64, arm64v8
+GitCommit: e5f4be7fe5e79bddb6df4db6a1a11b22b6a95228
+
+Tags: 5.6.4, 5.6
 Architectures: amd64, arm64v8
 GitCommit: 51f22540833a2f98b7984019e16d496314934a91
 
@@ -15,7 +19,3 @@ GitCommit: 976468768511b4574a26631fe646ff7fdfaf03ef
 Tags: 5.4.8, 5.4
 Architectures: amd64, arm64v8
 GitCommit: 87d8fc91744a3760211335884ba8cb82884451c2
-
-Tags: 5.3.9, 5.3
-Architectures: amd64, arm64v8
-GitCommit: b26e81edb1d6b551a5a7697855270346dbd63619

--- a/library/crate
+++ b/library/crate
@@ -12,7 +12,7 @@ Tags: 5.6.4, 5.6
 Architectures: amd64, arm64v8
 GitCommit: 51f22540833a2f98b7984019e16d496314934a91
 
-Tags: 5.5.5, 5.5
+Tags: 5.5.5, 5.5.4, 5.5
 Architectures: amd64, arm64v8
 GitCommit: 976468768511b4574a26631fe646ff7fdfaf03ef
 


### PR DESCRIPTION
- Also, remove 5.3 from the list as it's reached end-of-life.
- Also, with: https://github.com/docker-library/official-images/pull/16181/files we accidentally marked the docker image as `5.5.5`, instead of `5.5.4`. As a workaround we skip `5.5.5` CrateDB release and if a hotfix release is needed for `5.5` will release a `5.5.6` version in the future.