### PR TITLE
Update to R 4.4.0 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.3.3, latest
+Tags: 4.4.0, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d373d03aa4d491216905eb24b18d0f56165dd43f
-Directory: r-base/4.3.3
+GitCommit: 69c238cb525faab5486b1920601f3836b15e1384
+Directory: r-base/4.4.0
 


### PR DESCRIPTION
This update R to version 4.4.0 released this morning.

As before, we use the Debian package I prepared hours ago, it takes a moment for unstable to process but it is now available. Because of several ongoing transition some of the underlying libraries are still in unstable rather than testing to the Dockerfile continues to the chang from the recent 4.3.3 release to point to unstable. We also select 4.4.0, of course.

Thanks as always for reviewing the PR.