### PR TITLE
Upgrade SonarQube LTS to 9.9.5

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -3,25 +3,25 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Davi Koscianski Vidal <davi.koscianski-vidal@sonarsource.com> (@davividal)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: 648e787e5cdf015ee49f43b17063f42b6938bee7
+GitCommit: dc3207752df8b915cd6885a8e1fe76e2546060bc
 
-Tags: 9.9.4-community, 9.9-community, 9-community, lts, lts-community
+Tags: 9.9.5-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8
 Directory: 9/community
 
-Tags: 9.9.4-developer, 9.9-developer, 9-developer, lts-developer
+Tags: 9.9.5-developer, 9.9-developer, 9-developer, lts-developer
 Architectures: amd64, arm64v8
 Directory: 9/developer
 
-Tags: 9.9.4-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
+Tags: 9.9.5-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
 Architectures: amd64, arm64v8
 Directory: 9/enterprise
 
-Tags: 9.9.4-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
+Tags: 9.9.5-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/app
 
-Tags: 9.9.4-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
+Tags: 9.9.5-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/search
 


### PR DESCRIPTION
Dear team,

we would like to get the SonarQube LTS upgraded to 9.9.5.