### PR TITLE
feat: Add s390x to rust images

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/73b57d936481598421d27c4d722a24774a2267ea/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/7b280d7b867cff2c84ea301fd4030d89d87c4930/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
@@ -15,23 +15,23 @@ GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
 Directory: 1.77.2/buster/slim
 
 Tags: 1-bullseye, 1.77-bullseye, 1.77.2-bullseye, bullseye
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
 Directory: 1.77.2/bullseye
 
 Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.2-slim-bullseye, slim-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
 Directory: 1.77.2/bullseye/slim
 
 Tags: 1-bookworm, 1.77-bookworm, 1.77.2-bookworm, bookworm, 1, 1.77, 1.77.2, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
 Directory: 1.77.2/bookworm
 
 Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.2-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.2-slim, slim
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
 Directory: 1.77.2/bookworm/slim
 
 Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.2-alpine3.18, alpine3.18


### PR DESCRIPTION
This adds the `s390x` architecture to some Debian versions for Rust. 


See: [rust-lang/docker-rust#198](https://github.com/rust-lang/docker-rust/pull/198)