### PR TITLE
Update Clear Linux OS to 41610

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: ce9786e46427dc6b47a68b8ae730ca15a4c53f1f
-GitFetch: refs/heads/base-41560
+GitCommit: fa6f05c3b03696821ec9c3a03b98220db6411564
+GitFetch: refs/heads/base-41610


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41610

@bryteise @djklimes @bryteise