### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3afd681ef7a1dd37837694a5c42e36a99c0f9320/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/b00bb2d4f646eb60fc59b2602d5d17152bc4d35a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3afd681ef7a1dd37837694a5c42e36a99c0f9320
+GitCommit: b00bb2d4f646eb60fc59b2602d5d17152bc4d35a
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 73986f3481e96ff79c39b7dae40a3f8e3700cf10
+amd64-GitCommit: ea7dea56f1c0ce149bffae43b601949e97fd4356
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 9e37e20d1416a9334c807d4e795cbcc58405edd1
+arm32v5-GitCommit: ef883620f30f2a31a03a1da96783c4f22e2aba5c
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 509b8bb35e0cb5f571bb5e82264ddea2dabc8f7d
+arm32v6-GitCommit: eb87aa902eb521ebdb9576cdc773bc3913802853
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 908a79ff0569abbeec240f5df0e13b4249d10184
+arm32v7-GitCommit: 98e2c298623e1084faaf1f33f1a4a9b2e8af939f
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e83be66361b1cf2ea7ffd59dbb73c2c0f08b055f
+arm64v8-GitCommit: 8584c56db318c9da3b71bbfb6c6b3f1a24eacec7
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 6968b031ff533fb55d44f029f1586751818c6184
+i386-GitCommit: 3ad57c232f903543da9884ff9dd40a114e0e41d7
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 116a03b0f02c8a4705d9db350a26c39fb24a8a7e
+mips64le-GitCommit: dd9ac2946c4a790bacb481cfdfb5ade832e97659
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 9fde01136e0b2142624ad3789a7b9aa99ae0d72b
+ppc64le-GitCommit: b66f29708be876fc4b61850b49de3a12edb3cdc6
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 6d8c7cc58edd5fedc0d0e0b9abbd9396bb1207f3
+riscv64-GitCommit: 622e6e184702b00b23159317111ad5f15b8431ca
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 55d3efd847da80f75c7b1ce33b52d5e338fe8632
+s390x-GitCommit: b246b36efc17c78c92c711e56d7c91a70f307c76
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Specifically, this contains a rebuild of all glibc variants to include the Debian fix for CVE-2024-2961 (https://github.com/docker-library/official-images/pull/16653, https://github.com/debuerreotype/docker-debian-artifacts/issues/216, https://security-tracker.debian.org/tracker/CVE-2024-2961).

I do not _believe_ this CVE really has much impact on BusyBox, but out of both an abundance of caution and to ensure our reproducible checksums are up-to-date, we have rebuilt.