### PR TITLE
[ros] add ROS Jazzy images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -73,6 +73,28 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 
 ################################################################################
+# Release: jazzy
+
+########################################
+# Distro: ubuntu:noble
+
+Tags: jazzy-ros-core, jazzy-ros-core-noble
+Architectures: amd64, arm64v8
+GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+Directory: ros/jazzy/ubuntu/noble/ros-core
+
+Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy
+Architectures: amd64, arm64v8
+GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+Directory: ros/jazzy/ubuntu/noble/ros-base
+
+Tags: jazzy-perception, jazzy-perception-noble
+Architectures: amd64, arm64v8
+GitCommit: 543aabeed37ee905ac3737fd38ffbc9894e997db
+Directory: ros/jazzy/ubuntu/noble/perception
+
+
+################################################################################
 # Release: rolling
 
 ########################################


### PR DESCRIPTION
This PR is to create a first version of the docker images for the ROS Jazzy release (the next LTS version of ROS)

The official release will take place on May 23rd at which point a new PR updating the Dockerfiles and the `latest` tag will be made 

---
Cross-referencing: https://github.com/osrf/docker_images/pull/741
https://discourse.ros.org/t/jazzy-pre-release-is-ready-for-the-tutorial-party/37472