### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -1,23 +1,23 @@
-# this file is generated via https://github.com/docker-library/mysql/blob/3e959c224b965b0dd92a59a1dedeb7c34a24f550/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mysql/blob/9f0f4a14ab251e22545f8ccaa2fff0c3e5206d09/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.3.0, 8.3, 8, innovation, latest, 8.3.0-oraclelinux8, 8.3-oraclelinux8, 8-oraclelinux8, innovation-oraclelinux8, oraclelinux8, 8.3.0-oracle, 8.3-oracle, 8-oracle, innovation-oracle, oracle
+Tags: 8.4.0, 8.4, 8, lts, latest, 8.4.0-oraclelinux8, 8.4-oraclelinux8, 8-oraclelinux8, lts-oraclelinux8, oraclelinux8, 8.4.0-oracle, 8.4-oracle, 8-oracle, lts-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 831e58702aa316b69cdfaa115fc134bfede4c418
-Directory: innovation
+GitCommit: c05422492215b3f0602409288c868ee4fd606ac3
+Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.36, 8.0, 8.0.36-oraclelinux8, 8.0-oraclelinux8, 8.0.36-oracle, 8.0-oracle
+Tags: 8.0.37, 8.0, 8.0.37-oraclelinux8, 8.0-oraclelinux8, 8.0.37-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 831e58702aa316b69cdfaa115fc134bfede4c418
+GitCommit: 5fe2b708e9734809d7f6554c131f0371d517bb22
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.36-bookworm, 8.0-bookworm, 8.0.36-debian, 8.0-debian
+Tags: 8.0.37-bookworm, 8.0-bookworm, 8.0.37-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 831e58702aa316b69cdfaa115fc134bfede4c418
+GitCommit: 5fe2b708e9734809d7f6554c131f0371d517bb22
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/9f0f4a1: Add plain 8 aliases
- https://github.com/docker-library/mysql/commit/d972901: Merge pull request https://github.com/docker-library/mysql/pull/1046 from jnoordsij/add-8.4
- https://github.com/docker-library/mysql/commit/784047f: Skip "innovation" when any other release is newer
- https://github.com/docker-library/mysql/commit/53973fa: Add lts alias
- https://github.com/docker-library/mysql/commit/c054224: Add 8.4 variant (new LTS)
- https://github.com/docker-library/mysql/commit/e3c2853: Update toolsRepo detection in versions.sh
- https://github.com/docker-library/mysql/commit/2319f17: Update innovation to mysql-shell 8.4.0-1.el8
- https://github.com/docker-library/mysql/commit/5fe2b70: Update 8.0 to 8.0.37, debian 8.0.37-1debian12, mysql-shell 8.0.37-1.el8, oracle 8.0.37-1.el8