### PR TITLE
chore: Update to Rust version 1.78.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/7b280d7b867cff2c84ea301fd4030d89d87c4930/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/cc31986e1dfe94671c639231ecf0503942c121d9/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-buster, 1.77-buster, 1.77.2-buster, buster
+Tags: 1-buster, 1.78-buster, 1.78.0-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
-Directory: 1.77.2/buster
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/buster
 
-Tags: 1-slim-buster, 1.77-slim-buster, 1.77.2-slim-buster, slim-buster
+Tags: 1-slim-buster, 1.78-slim-buster, 1.78.0-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
-Directory: 1.77.2/buster/slim
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/buster/slim
 
-Tags: 1-bullseye, 1.77-bullseye, 1.77.2-bullseye, bullseye
+Tags: 1-bullseye, 1.78-bullseye, 1.78.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
-Directory: 1.77.2/bullseye
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/bullseye
 
-Tags: 1-slim-bullseye, 1.77-slim-bullseye, 1.77.2-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.78-slim-bullseye, 1.78.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
-Directory: 1.77.2/bullseye/slim
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/bullseye/slim
 
-Tags: 1-bookworm, 1.77-bookworm, 1.77.2-bookworm, bookworm, 1, 1.77, 1.77.2, latest
+Tags: 1-bookworm, 1.78-bookworm, 1.78.0-bookworm, bookworm, 1, 1.78, 1.78.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
-Directory: 1.77.2/bookworm
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/bookworm
 
-Tags: 1-slim-bookworm, 1.77-slim-bookworm, 1.77.2-slim-bookworm, slim-bookworm, 1-slim, 1.77-slim, 1.77.2-slim, slim
+Tags: 1-slim-bookworm, 1.78-slim-bookworm, 1.78.0-slim-bookworm, slim-bookworm, 1-slim, 1.78-slim, 1.78.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7b280d7b867cff2c84ea301fd4030d89d87c4930
-Directory: 1.77.2/bookworm/slim
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/bookworm/slim
 
-Tags: 1-alpine3.18, 1.77-alpine3.18, 1.77.2-alpine3.18, alpine3.18
+Tags: 1-alpine3.18, 1.78-alpine3.18, 1.78.0-alpine3.18, alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
-Directory: 1.77.2/alpine3.18
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/alpine3.18
 
-Tags: 1-alpine3.19, 1.77-alpine3.19, 1.77.2-alpine3.19, alpine3.19, 1-alpine, 1.77-alpine, 1.77.2-alpine, alpine
+Tags: 1-alpine3.19, 1.78-alpine3.19, 1.78.0-alpine3.19, alpine3.19, 1-alpine, 1.78-alpine, 1.78.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 73b57d936481598421d27c4d722a24774a2267ea
-Directory: 1.77.2/alpine3.19
+GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
+Directory: 1.78.0/alpine3.19


### PR DESCRIPTION
Blog: https://blog.rust-lang.org/2024/05/02/Rust-1.78.0.html
Release: https://github.com/rust-lang/rust/releases/tag/1.78.0