### PR TITLE
arangodb 3.12.0.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,17 +2,12 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.10, 3.10.14
-Architectures: amd64, arm64v8
-GitCommit: 7b5dbaf1499367a8215a11bb5728f1d7264046cf
-Directory: alpine/3.10.14
-
 Tags: 3.11, 3.11.8
 Architectures: amd64, arm64v8
 GitCommit: 22a949aa3755175bfa869c48b5a0a9633109e291
 Directory: alpine/3.11.8
 
-Tags: 3.12, 3.12.0, latest
+Tags: 3.12, 3.12.0.2, latest
 Architectures: amd64, arm64v8
-GitCommit: c507e8709115419c988f47f735f72a4d95538131
-Directory: alpine/3.12.0
+GitCommit: 2ef14f68bdb95bef50e50d3edaf00c646e2e5d87
+Directory: alpine/3.12.0.2


### PR DESCRIPTION
Updated ArangoDB 3.12 to 3.12.0.2 and removed 3.10 (EoL).