### PR TITLE
Update Monica to v4.1.2

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -1,19 +1,34 @@
-# This file is generated via https://github.com/monicahq/docker/blob/7337376d98838bc3ab2b7517da05a89e830d68b1/generate-stackbrew-library.sh
+# This file is generated via https://github.com/monicahq/docker/blob/4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee/generate-stackbrew-library.sh
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 GitFetch: refs/heads/main
 
-Tags: 4.0.0-apache, 4.0-apache, 4-apache, apache, 4.0.0, 4.0, 4, latest
+Tags: 4.1.1-apache, 4.1-apache, 4-apache, apache, 4.1.1, 4.1, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 4/apache
-GitCommit: 96189780c639d1511691a3151dd4d90d2f757ee3
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
 
-Tags: 4.0.0-fpm, 4.0-fpm, 4-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-Directory: 4/fpm
-GitCommit: 96189780c639d1511691a3151dd4d90d2f757ee3
-
-Tags: 4.0.0-fpm-alpine, 4.0-fpm-alpine, 4-fpm-alpine, fpm-alpine
+Tags: 4.1.1-fpm-alpine, 4.1-fpm-alpine, 4-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 4/fpm-alpine
-GitCommit: 96189780c639d1511691a3151dd4d90d2f757ee3
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+
+Tags: 4.1.1-fpm, 4.1-fpm, 4-fpm, fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 4/fpm
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+
+Tags: 5.0.0-beta.4-apache, 5.0.0-beta-apache, 5.0-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5/apache
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+
+Tags: 5.0.0-beta.4-fpm-alpine, 5.0.0-beta-fpm-alpine, 5.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 5/fpm-alpine
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+
+Tags: 5.0.0-beta.4-fpm, 5.0.0-beta-fpm, 5.0-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Directory: 5/fpm
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee

--- a/library/monica
+++ b/library/monica
@@ -3,32 +3,32 @@ Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 GitFetch: refs/heads/main
 
-Tags: 4.1.1-apache, 4.1-apache, 4-apache, apache, 4.1.1, 4.1, 4, latest
+Tags: 4.1.2-apache, 4.1-apache, 4-apache, apache, 4.1.2, 4.1, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 4/apache
-GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+GitCommit: 92af56dec9f147c16916ed4537dd4263108dcbf3
 
-Tags: 4.1.1-fpm-alpine, 4.1-fpm-alpine, 4-fpm-alpine, fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-Directory: 4/fpm-alpine
-GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
-
-Tags: 4.1.1-fpm, 4.1-fpm, 4-fpm, fpm
+Tags: 4.1.2-fpm, 4.1-fpm, 4-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 4/fpm
-GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+GitCommit: 92af56dec9f147c16916ed4537dd4263108dcbf3
+
+Tags: 4.1.2-fpm-alpine, 4.1-fpm-alpine, 4-fpm-alpine, fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 4/fpm-alpine
+GitCommit: 92af56dec9f147c16916ed4537dd4263108dcbf3
 
 Tags: 5.0.0-beta.4-apache, 5.0.0-beta-apache, 5.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5/apache
 GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
 
-Tags: 5.0.0-beta.4-fpm-alpine, 5.0.0-beta-fpm-alpine, 5.0-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-Directory: 5/fpm-alpine
-GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
-
 Tags: 5.0.0-beta.4-fpm, 5.0.0-beta-fpm, 5.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5/fpm
+GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee
+
+Tags: 5.0.0-beta.4-fpm-alpine, 5.0.0-beta-fpm-alpine, 5.0-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Directory: 5/fpm-alpine
 GitCommit: 4ad283502e6b5411bacc3dcf3b55ff5dd57f29ee


### PR DESCRIPTION
Update Monica to [v4.1.2](https://github.com/monicahq/monica/releases/tag/v4.1.2).