### PR TITLE
Update Clear Linux OS to 41660

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: fa6f05c3b03696821ec9c3a03b98220db6411564
-GitFetch: refs/heads/base-41610
+GitCommit: 645ef28f75cecfb06bbf2e20403bd921443a256a
+GitFetch: refs/heads/base-41660


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41660

@bryteise @djklimes @bryteise