### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.26, 1.6, 1, latest, 1.6.26-bookworm, 1.6-bookworm, 1-bookworm, bookworm
+Tags: 1.6.27, 1.6, 1, latest, 1.6.27-bookworm, 1.6-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8508f4b565116fb0fa338b124848768453026c68
+GitCommit: 89cfc0a083fd575c2d809c280e7e5ba9b1622072
 Directory: 1/debian
 
-Tags: 1.6.26-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.26-alpine3.19, 1.6-alpine3.19, 1-alpine3.19, alpine3.19
+Tags: 1.6.27-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.27-alpine3.19, 1.6-alpine3.19, 1-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8, i386, ppc64le, s390x
-GitCommit: 5699d909d4f9d7f733a79d4793b323d3ad63453a
+GitCommit: 89cfc0a083fd575c2d809c280e7e5ba9b1622072
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/89cfc0a: Update 1 to 1.6.27