### PR TITLE
[security] Update golang 1.22.3 and 1.21.10 

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.22.2-bookworm, 1.22-bookworm, 1-bookworm, bookworm
-SharedTags: 1.22.2, 1.22, 1, latest
+Tags: 1.22.3-bookworm, 1.22-bookworm, 1-bookworm, bookworm
+SharedTags: 1.22.3, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/bookworm
 
-Tags: 1.22.2-bullseye, 1.22-bullseye, 1-bullseye, bullseye
+Tags: 1.22.3-bullseye, 1.22-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/bullseye
 
-Tags: 1.22.2-alpine3.19, 1.22-alpine3.19, 1-alpine3.19, alpine3.19, 1.22.2-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.3-alpine3.19, 1.22-alpine3.19, 1-alpine3.19, alpine3.19, 1.22.3-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/alpine3.19
 
-Tags: 1.22.2-alpine3.18, 1.22-alpine3.18, 1-alpine3.18, alpine3.18
+Tags: 1.22.3-alpine3.18, 1.22-alpine3.18, 1-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/alpine3.18
 
-Tags: 1.22.2-windowsservercore-ltsc2022, 1.22-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.22.2-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.2, 1.22, 1, latest
+Tags: 1.22.3-windowsservercore-ltsc2022, 1.22-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.22.3-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.3, 1.22, 1, latest
 Architectures: windows-amd64
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.22.2-windowsservercore-1809, 1.22-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.22.2-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.2, 1.22, 1, latest
+Tags: 1.22.3-windowsservercore-1809, 1.22-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.22.3-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.3, 1.22, 1, latest
 Architectures: windows-amd64
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.22.2-nanoserver-ltsc2022, 1.22-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.22.2-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.22.3-nanoserver-ltsc2022, 1.22-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.22.3-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.22.2-nanoserver-1809, 1.22-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.22.2-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.22.3-nanoserver-1809, 1.22-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.22.3-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: ea6bbce8c9b13acefed0f5507336be01f0918f97
+GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
 Directory: 1.22/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.21.9-bookworm, 1.21-bookworm
-SharedTags: 1.21.9, 1.21
+Tags: 1.21.10-bookworm, 1.21-bookworm
+SharedTags: 1.21.10, 1.21
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/bookworm
 
-Tags: 1.21.9-bullseye, 1.21-bullseye
+Tags: 1.21.10-bullseye, 1.21-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/bullseye
 
-Tags: 1.21.9-alpine3.19, 1.21-alpine3.19, 1.21.9-alpine, 1.21-alpine
+Tags: 1.21.10-alpine3.19, 1.21-alpine3.19, 1.21.10-alpine, 1.21-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/alpine3.19
 
-Tags: 1.21.9-alpine3.18, 1.21-alpine3.18
+Tags: 1.21.10-alpine3.18, 1.21-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/alpine3.18
 
-Tags: 1.21.9-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022
-SharedTags: 1.21.9-windowsservercore, 1.21-windowsservercore, 1.21.9, 1.21
+Tags: 1.21.10-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022
+SharedTags: 1.21.10-windowsservercore, 1.21-windowsservercore, 1.21.10, 1.21
 Architectures: windows-amd64
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.21.9-windowsservercore-1809, 1.21-windowsservercore-1809
-SharedTags: 1.21.9-windowsservercore, 1.21-windowsservercore, 1.21.9, 1.21
+Tags: 1.21.10-windowsservercore-1809, 1.21-windowsservercore-1809
+SharedTags: 1.21.10-windowsservercore, 1.21-windowsservercore, 1.21.10, 1.21
 Architectures: windows-amd64
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.21.9-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022
-SharedTags: 1.21.9-nanoserver, 1.21-nanoserver
+Tags: 1.21.10-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022
+SharedTags: 1.21.10-nanoserver, 1.21-nanoserver
 Architectures: windows-amd64
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.21.9-nanoserver-1809, 1.21-nanoserver-1809
-SharedTags: 1.21.9-nanoserver, 1.21-nanoserver
+Tags: 1.21.10-nanoserver-1809, 1.21-nanoserver-1809
+SharedTags: 1.21.10-nanoserver, 1.21-nanoserver
 Architectures: windows-amd64
-GitCommit: 8e88a7ff80459c7663355a7597aae18097fefc93
+GitCommit: 777111946489bad416e54e378d580f2518632a82
 Directory: 1.21/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/eb57429: Update 1.22 to 1.22.3
- https://github.com/docker-library/golang/commit/7771119: Update 1.21 to 1.21.10

```
cmd/go: arbitrary code execution during build on darwin

On Darwin, building a Go module which contains CGO can trigger arbitrary code execution when using the Apple version of ld, due to usage of the -lto_library flag in a "#cgo LDFLAGS" directive.

This is CVE-2024-24787 and Go issue https://go.dev/issue/67119.


net: malformed DNS message can cause infinite loop

A malformed DNS message in response to a query can cause the Lookup functions to get stuck in an infinite loop.

This is CVE-2024-24788 and Go issue https://go.dev/issue/66754.
```