### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,40 +1,40 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/00b26e718cb2a42fca77676383917c1e5c15b6ca/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/6d49ef0aad84aee23d918a9dba54ffc62927d9a9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2023-07-27
-Tags: 13.2.0, 13.2, 13, latest, 13.2.0-bookworm, 13.2-bookworm, 13-bookworm, bookworm
+# Last Modified: 2024-05-07
+Tags: 14.1.0, 14.1, 14, latest, 14.1.0-bookworm, 14.1-bookworm, 14-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
+GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
+Directory: 14
+# Docker EOL: 2025-11-07
+
+# Last Modified: 2023-07-27
+Tags: 13.2.0, 13.2, 13, 13.2.0-bookworm, 13.2-bookworm, 13-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
 Directory: 13
 # Docker EOL: 2025-01-27
 
 # Last Modified: 2023-05-08
 Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
+GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
 Directory: 12
 # Docker EOL: 2024-11-08
 
 # Last Modified: 2023-05-29
 Tags: 11.4.0, 11.4, 11, 11.4.0-bullseye, 11.4-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
+GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
 Directory: 11
 # Docker EOL: 2024-11-29
 
 # Last Modified: 2023-07-07
 Tags: 10.5.0, 10.5, 10, 10.5.0-bullseye, 10.5-bullseye, 10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
+GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
 Directory: 10
 # Docker EOL: 2025-01-07
-
-# Last Modified: 2022-05-27
-Tags: 9.5.0, 9.5, 9, 9.5.0-bullseye, 9.5-bullseye, 9-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9fbc8275f1adad750cdc7ad71a70254b7db4501e
-Directory: 9
-# Docker EOL: 2023-11-27


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/478283b: Merge pull request https://github.com/docker-library/gcc/pull/104 from infosiftr/abigail
- https://github.com/docker-library/gcc/commit/b1e7fc6: Use `abidiff` to verify ABI compatibility
- https://github.com/docker-library/gcc/commit/6d49ef0: Update latest to 14
- https://github.com/docker-library/gcc/commit/28c22d3: Merge pull request https://github.com/docker-library/gcc/pull/103 from infosiftr/14
- https://github.com/docker-library/gcc/commit/243999e: Add GCC 14 (remove 9)