### PR TITLE
[oraclelinux] Updating 8, 8-slim,8-slim-fips,9, 9-slim and 9-slim-fips for OL9.4 GA, ELSA-2024-2679 ELSA-2024-2570 ELSA-2024-2722

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 25b69e893143e2aa810c4bd2906e66ae6f5be75b
+amd64-GitCommit: c107874aaa8980a697bf8258c85a0f60aa415c17
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 69c8d724936548aa03583706f7178c265170516d
+arm64v8-GitCommit: 4f14cd7084170191044db0afeaaef12c670a4626
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-25062, CVE-2024-28834, CVE-2024-28835, CVE-2024-2961

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-2679.html
https://linux.oracle.com/errata/ELSA-2024-2570.html
https://linux.oracle.com/errata/ELSA-2024-2722.html

In addition, this includes the OL9.4 GA release. See:
https://docs.oracle.com/en/operating-systems/oracle-linux/9/relnotes9.4/

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
