### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 16.2, 16, latest, 16.2-bookworm, 16-bookworm, bookworm
+Tags: 16.3, 16, latest, 16.3-bookworm, 16-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: d08757ccb56ee047efd76c41dbc148e2e2c4f68f
 Directory: 16/bookworm
 
-Tags: 16.2-bullseye, 16-bullseye, bullseye
+Tags: 16.3-bullseye, 16-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: d08757ccb56ee047efd76c41dbc148e2e2c4f68f
 Directory: 16/bullseye
 
-Tags: 16.2-alpine3.19, 16-alpine3.19, alpine3.19, 16.2-alpine, 16-alpine, alpine
+Tags: 16.3-alpine3.19, 16-alpine3.19, alpine3.19, 16.3-alpine, 16-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5403edd423ba9fd047d2abf5ed7fdb9131c7a527
+GitCommit: d08757ccb56ee047efd76c41dbc148e2e2c4f68f
 Directory: 16/alpine3.19
 
-Tags: 16.2-alpine3.18, 16-alpine3.18, alpine3.18
+Tags: 16.3-alpine3.18, 16-alpine3.18, alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5403edd423ba9fd047d2abf5ed7fdb9131c7a527
+GitCommit: d08757ccb56ee047efd76c41dbc148e2e2c4f68f
 Directory: 16/alpine3.18
 
-Tags: 15.6, 15, 15.6-bookworm, 15-bookworm
+Tags: 15.7, 15, 15.7-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: 8a0b96710d917d1c3b32a5fe5b66687ad83827da
 Directory: 15/bookworm
 
-Tags: 15.6-bullseye, 15-bullseye
+Tags: 15.7-bullseye, 15-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: 8a0b96710d917d1c3b32a5fe5b66687ad83827da
 Directory: 15/bullseye
 
-Tags: 15.6-alpine3.19, 15-alpine3.19, 15.6-alpine, 15-alpine
+Tags: 15.7-alpine3.19, 15-alpine3.19, 15.7-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 539bdac35db7b6a7f91c0b9d911522d21f5b9083
+GitCommit: 8a0b96710d917d1c3b32a5fe5b66687ad83827da
 Directory: 15/alpine3.19
 
-Tags: 15.6-alpine3.18, 15-alpine3.18
+Tags: 15.7-alpine3.18, 15-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 539bdac35db7b6a7f91c0b9d911522d21f5b9083
+GitCommit: 8a0b96710d917d1c3b32a5fe5b66687ad83827da
 Directory: 15/alpine3.18
 
-Tags: 14.11, 14, 14.11-bookworm, 14-bookworm
+Tags: 14.12, 14, 14.12-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: 662dbe5225f4d404364bdcf5e49dd5d88357ed31
 Directory: 14/bookworm
 
-Tags: 14.11-bullseye, 14-bullseye
+Tags: 14.12-bullseye, 14-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: 662dbe5225f4d404364bdcf5e49dd5d88357ed31
 Directory: 14/bullseye
 
-Tags: 14.11-alpine3.19, 14-alpine3.19, 14.11-alpine, 14-alpine
+Tags: 14.12-alpine3.19, 14-alpine3.19, 14.12-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b6cb599da1bab72e4f57c54879e41c8c20fd036
+GitCommit: 662dbe5225f4d404364bdcf5e49dd5d88357ed31
 Directory: 14/alpine3.19
 
-Tags: 14.11-alpine3.18, 14-alpine3.18
+Tags: 14.12-alpine3.18, 14-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3b6cb599da1bab72e4f57c54879e41c8c20fd036
+GitCommit: 662dbe5225f4d404364bdcf5e49dd5d88357ed31
 Directory: 14/alpine3.18
 
-Tags: 13.14, 13, 13.14-bookworm, 13-bookworm
+Tags: 13.15, 13, 13.15-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: f3ab8c6db63e2986453e0a4fae2c5f372dd4f05e
 Directory: 13/bookworm
 
-Tags: 13.14-bullseye, 13-bullseye
+Tags: 13.15-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: f3ab8c6db63e2986453e0a4fae2c5f372dd4f05e
 Directory: 13/bullseye
 
-Tags: 13.14-alpine3.19, 13-alpine3.19, 13.14-alpine, 13-alpine
+Tags: 13.15-alpine3.19, 13-alpine3.19, 13.15-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c66a192905283ee9c9c34b03c73180975e6fad
+GitCommit: f3ab8c6db63e2986453e0a4fae2c5f372dd4f05e
 Directory: 13/alpine3.19
 
-Tags: 13.14-alpine3.18, 13-alpine3.18
+Tags: 13.15-alpine3.18, 13-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c3c66a192905283ee9c9c34b03c73180975e6fad
+GitCommit: f3ab8c6db63e2986453e0a4fae2c5f372dd4f05e
 Directory: 13/alpine3.18
 
-Tags: 12.18, 12, 12.18-bookworm, 12-bookworm
+Tags: 12.19, 12, 12.19-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: ccf4f2289a1e59ddf74a5d1e6eb7693b7f464b54
 Directory: 12/bookworm
 
-Tags: 12.18-bullseye, 12-bullseye
+Tags: 12.19-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ab6925051ca097d415816928a50c483ecc370c00
+GitCommit: ccf4f2289a1e59ddf74a5d1e6eb7693b7f464b54
 Directory: 12/bullseye
 
-Tags: 12.18-alpine3.19, 12-alpine3.19, 12.18-alpine, 12-alpine
+Tags: 12.19-alpine3.19, 12-alpine3.19, 12.19-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 764632913153817ef4216eebea6a4708ec5549fb
+GitCommit: ccf4f2289a1e59ddf74a5d1e6eb7693b7f464b54
 Directory: 12/alpine3.19
 
-Tags: 12.18-alpine3.18, 12-alpine3.18
+Tags: 12.19-alpine3.18, 12-alpine3.18
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 764632913153817ef4216eebea6a4708ec5549fb
+GitCommit: ccf4f2289a1e59ddf74a5d1e6eb7693b7f464b54
 Directory: 12/alpine3.18


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/d08757c: Update 16 to 16.3, bookworm 16.3-1.pgdg120+1, bullseye 16.3-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/8a0b967: Update 15 to 15.7, bookworm 15.7-1.pgdg120+1, bullseye 15.7-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/662dbe5: Update 14 to 14.12, bookworm 14.12-1.pgdg120+1, bullseye 14.12-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/f3ab8c6: Update 13 to 13.15, bookworm 13.15-1.pgdg120+1, bullseye 13.15-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/ccf4f22: Update 12 to 12.19, bookworm 12.19-1.pgdg120+1, bullseye 12.19-1.pgdg110+1