### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev10, 3.0-dev, 3.0-dev10-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev11, 3.0-dev, 3.0-dev11-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bee24556617145c3ba3bdba134a540dc5ddae378
+GitCommit: 8db4f308c73a105b2f05c55f144486ccddb2c8af
 Directory: 3.0
 
-Tags: 3.0-dev10-alpine, 3.0-dev-alpine, 3.0-dev10-alpine3.19, 3.0-dev-alpine3.19
+Tags: 3.0-dev11-alpine, 3.0-dev-alpine, 3.0-dev11-alpine3.19, 3.0-dev-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bee24556617145c3ba3bdba134a540dc5ddae378
+GitCommit: 8db4f308c73a105b2f05c55f144486ccddb2c8af
 Directory: 3.0/alpine
 
 Tags: 2.9.7, 2.9, latest, 2.9.7-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8db4f30: Update 3.0 to 3.0-dev11