### PR TITLE
Update Clear Linux OS to 41680

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 645ef28f75cecfb06bbf2e20403bd921443a256a
-GitFetch: refs/heads/base-41660
+GitCommit: 0a57e13031956cb4c3c4329a45a9c557d5fd7186
+GitFetch: refs/heads/base-41680


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41680

@bryteise @djklimes @bryteise