### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -4,6 +4,40 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
+Tags: 8.0.0-rc4-jammy, 8.0-rc-jammy
+SharedTags: 8.0.0-rc4, 8.0-rc
+Architectures: amd64, arm64v8
+GitCommit: 4fc70d45bda4a5d142b875b5f044a94af29a071d
+Directory: 8.0-rc
+
+Tags: 8.0.0-rc4-windowsservercore-ltsc2022, 8.0-rc-windowsservercore-ltsc2022
+SharedTags: 8.0.0-rc4-windowsservercore, 8.0-rc-windowsservercore, 8.0.0-rc4, 8.0-rc
+Architectures: windows-amd64
+GitCommit: 4fc70d45bda4a5d142b875b5f044a94af29a071d
+Directory: 8.0-rc/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 8.0.0-rc4-windowsservercore-1809, 8.0-rc-windowsservercore-1809
+SharedTags: 8.0.0-rc4-windowsservercore, 8.0-rc-windowsservercore, 8.0.0-rc4, 8.0-rc
+Architectures: windows-amd64
+GitCommit: 4fc70d45bda4a5d142b875b5f044a94af29a071d
+Directory: 8.0-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 8.0.0-rc4-nanoserver-ltsc2022, 8.0-rc-nanoserver-ltsc2022
+SharedTags: 8.0.0-rc4-nanoserver, 8.0-rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 4fc70d45bda4a5d142b875b5f044a94af29a071d
+Directory: 8.0-rc/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 8.0.0-rc4-nanoserver-1809, 8.0-rc-nanoserver-1809
+SharedTags: 8.0.0-rc4-nanoserver, 8.0-rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 4fc70d45bda4a5d142b875b5f044a94af29a071d
+Directory: 8.0-rc/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
+
 Tags: 7.0.10-rc0-jammy, 7.0-rc-jammy
 SharedTags: 7.0.10-rc0, 7.0-rc
 Architectures: amd64, arm64v8
@@ -138,38 +172,4 @@ SharedTags: 5.0.26-nanoserver, 5.0-nanoserver, 5-nanoserver
 Architectures: windows-amd64
 GitCommit: 3def65b71cf51011d6da264f2a6b6d701c9d3e8d
 Directory: 5.0/windows/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
-
-Tags: 4.4.29-focal, 4.4-focal, 4-focal
-SharedTags: 4.4.29, 4.4, 4
-Architectures: amd64, arm64v8
-GitCommit: 2ce02fe52826bae7c03f3f20817370396052c925
-Directory: 4.4
-
-Tags: 4.4.29-windowsservercore-ltsc2022, 4.4-windowsservercore-ltsc2022, 4-windowsservercore-ltsc2022
-SharedTags: 4.4.29-windowsservercore, 4.4-windowsservercore, 4-windowsservercore, 4.4.29, 4.4, 4
-Architectures: windows-amd64
-GitCommit: 2ce02fe52826bae7c03f3f20817370396052c925
-Directory: 4.4/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 4.4.29-windowsservercore-1809, 4.4-windowsservercore-1809, 4-windowsservercore-1809
-SharedTags: 4.4.29-windowsservercore, 4.4-windowsservercore, 4-windowsservercore, 4.4.29, 4.4, 4
-Architectures: windows-amd64
-GitCommit: 2ce02fe52826bae7c03f3f20817370396052c925
-Directory: 4.4/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 4.4.29-nanoserver-ltsc2022, 4.4-nanoserver-ltsc2022, 4-nanoserver-ltsc2022
-SharedTags: 4.4.29-nanoserver, 4.4-nanoserver, 4-nanoserver
-Architectures: windows-amd64
-GitCommit: 2ce02fe52826bae7c03f3f20817370396052c925
-Directory: 4.4/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: 4.4.29-nanoserver-1809, 4.4-nanoserver-1809, 4-nanoserver-1809
-SharedTags: 4.4.29-nanoserver, 4.4-nanoserver, 4-nanoserver
-Architectures: windows-amd64
-GitCommit: 2ce02fe52826bae7c03f3f20817370396052c925
-Directory: 4.4/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/7566651: Merge pull request https://github.com/docker-library/mongo/pull/694 from infosiftr/8.0-rc
- https://github.com/docker-library/mongo/commit/4fc70d4: Add 8.0.0-rc4
- https://github.com/docker-library/mongo/commit/317a3a9: Remove more 4.4 references (now that it is EOL)
- https://github.com/docker-library/mongo/commit/74f765f: Update 4.4