### PR TITLE
Add Storm image based on JRE 17

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -7,3 +7,7 @@ Architectures: amd64, arm64v8
 Tags: 2.6.2, 2.6, latest
 GitCommit: d8c821ffb599be733400c98cc10fe4c05966b552
 Directory: 2.6.2
+
+Tags: 2.6.2-jre17, 2.6-jre17
+GitCommit: 31209f0cde237834a3602a382e69a6caa6bdcffc
+Directory: 2.6.2-jre17


### PR DESCRIPTION
Updates Apache Storm Image with an additional tag for a Java 17 runtime.