### PR TITLE
Add missing SapMachine JRE images

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -111,6 +111,16 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 57124976c93709a1972c2b0c860edb2ca6525815
 Directory: dockerfiles/official/21/ubuntu/20_04/jdk-headless
 
+Tags: 21-jre-ubuntu-focal, 21-jre-ubuntu-20.04, lts-jre-ubuntu-focal, lts-jre-ubuntu-20.04, 21.0.3-jre-ubuntu-focal, 21.0.3-jre-ubuntu-20.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 57124976c93709a1972c2b0c860edb2ca6525815
+Directory: dockerfiles/official/21/ubuntu/20_04/jre
+
+Tags: 21-jre-headless-ubuntu-focal, 21-jre-headless-ubuntu-20.04, lts-jre-headless-ubuntu-focal, lts-jre-headless-ubuntu-20.04, 21.0.3-jre-headless-ubuntu-focal, 21.0.3-jre-headless-ubuntu-20.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 57124976c93709a1972c2b0c860edb2ca6525815
+Directory: dockerfiles/official/21/ubuntu/20_04/jre-headless
+
 Tags: 17, 17-jdk-ubuntu, 17.0.11, 17.0.11-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17.0.11-ubuntu-noble, 17.0.11-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.11-jdk-ubuntu-noble, 17.0.11-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: dfb41efa53bcb479c2ec52d7117f2e39db4acb34
@@ -161,6 +171,16 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: dfb41efa53bcb479c2ec52d7117f2e39db4acb34
 Directory: dockerfiles/official/17/ubuntu/20_04/jdk-headless
 
+Tags: 17-jre-ubuntu-focal, 17-jre-ubuntu-20.04, 17.0.11-jre-ubuntu-focal, 17.0.11-jre-ubuntu-20.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: dfb41efa53bcb479c2ec52d7117f2e39db4acb34
+Directory: dockerfiles/official/17/ubuntu/20_04/jre
+
+Tags: 17-jre-headless-ubuntu-focal, 17-jre-headless-ubuntu-20.04, 17.0.11-jre-headless-ubuntu-focal, 17.0.11-jre-headless-ubuntu-20.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: dfb41efa53bcb479c2ec52d7117f2e39db4acb34
+Directory: dockerfiles/official/17/ubuntu/20_04/jre-headless
+
 Tags: 11, 11-jdk-ubuntu, 11.0.23, 11.0.23-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11.0.23-ubuntu-noble, 11.0.23-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.23-jdk-ubuntu-noble, 11.0.23-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 05efe26bea6456dc7e561c6d601b2132f6bae6f2
@@ -210,3 +230,13 @@ Tags: 11-jdk-headless-ubuntu-focal, 11-jdk-headless-ubuntu-20.04, 11.0.23-jdk-he
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 05efe26bea6456dc7e561c6d601b2132f6bae6f2
 Directory: dockerfiles/official/11/ubuntu/20_04/jdk-headless
+
+Tags: 11-jre-ubuntu-focal, 11-jre-ubuntu-20.04, 11.0.23-jre-ubuntu-focal, 11.0.23-jre-ubuntu-20.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 05efe26bea6456dc7e561c6d601b2132f6bae6f2
+Directory: dockerfiles/official/11/ubuntu/20_04/jre
+
+Tags: 11-jre-headless-ubuntu-focal, 11-jre-headless-ubuntu-20.04, 11.0.23-jre-headless-ubuntu-focal, 11.0.23-jre-headless-ubuntu-20.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 05efe26bea6456dc7e561c6d601b2132f6bae6f2
+Directory: dockerfiles/official/11/ubuntu/20_04/jre-headless


### PR DESCRIPTION
In #16764 I left out some JRE images due to failing tests. With the PR merged, these should be green now, too.