### PR TITLE
Update redis

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -11,7 +11,7 @@ Directory: 7.2/debian
 
 Tags: 7.2.4-alpine, 7.2-alpine, 7-alpine, alpine, 7.2.4-alpine3.19, 7.2-alpine3.19, 7-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b77450d34ae54354f41970fc44bf840353f59ef4
+GitCommit: b628649ceee29da4c28c889417f264c219ca2afb
 Directory: 7.2/alpine
 
 Tags: 7.0.15, 7.0, 7.0.15-bookworm, 7.0-bookworm
@@ -21,7 +21,7 @@ Directory: 7.0/debian
 
 Tags: 7.0.15-alpine, 7.0-alpine, 7.0.15-alpine3.19, 7.0-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 313fd068a6751fd9f611e94addfa9ea56a23a3a7
+GitCommit: b628649ceee29da4c28c889417f264c219ca2afb
 Directory: 7.0/alpine
 
 Tags: 6.2.14, 6.2, 6, 6.2.14-bookworm, 6.2-bookworm, 6-bookworm
@@ -31,15 +31,5 @@ Directory: 6.2/debian
 
 Tags: 6.2.14-alpine, 6.2-alpine, 6-alpine, 6.2.14-alpine3.19, 6.2-alpine3.19, 6-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 531cfa59d944bbbfb22b8228646d12c926dfc010
+GitCommit: b628649ceee29da4c28c889417f264c219ca2afb
 Directory: 6.2/alpine
-
-Tags: 6.0.20, 6.0, 6.0.20-bookworm, 6.0-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f623bf8a6fef29b1459a29ff9f852c0f88d76b5a
-Directory: 6.0/debian
-
-Tags: 6.0.20-alpine, 6.0-alpine, 6.0.20-alpine3.19, 6.0-alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ac5605ebe2e7b4b371edcf94ad06e873986a6b63
-Directory: 6.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redis/commit/eb923da: Merge pull request https://github.com/docker-library/redis/pull/398 from infosiftr/eol-6.0
- https://github.com/docker-library/redis/commit/b628649: Remove 6.0 since it is end of life