### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: dd34dfac80c45a1c4e6ac6029e80385c778e8d1d
 Directory: 5.0
 
-Tags: 4.1.4, 4.1, 4, latest, 4.1.4-jammy, 4.1-jammy, 4-jammy, jammy
+Tags: 4.1.5, 4.1, 4, latest, 4.1.5-jammy, 4.1-jammy, 4-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: dd34dfac80c45a1c4e6ac6029e80385c778e8d1d
+GitCommit: 7ae558bbbbfa3f07eaaecae0ff84a4537d37c570
 Directory: 4.1
 
 Tags: 4.0.12, 4.0, 4.0.12-jammy, 4.0-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/7ae558b: Update 4.1 to 4.1.5