### PR TITLE
Bump Traefik to v2.11.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -14,12 +14,6 @@ GitCommit: eb153677fb43d1956c1c17725e74d9a7ae16b659
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.0, 3.0.0, v3.0, 3.0, beaufort, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: eb153677fb43d1956c1c17725e74d9a7ae16b659
-Directory: alpine
-
 Tags: v3.0.0-nanoserver-ltsc2022, 3.0.0-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
@@ -27,22 +21,35 @@ GitCommit: 9e921bd38d6f64eca79a681f5d945b99f279a7f4
 Directory: windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.2-windowsservercore-ltsc2022, 2.11.2-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v3.0.0, 3.0.0, v3.0, 3.0, beaufort, latest
+Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: eb153677fb43d1956c1c17725e74d9a7ae16b659
+Directory: alpine
+
+Tags: v2.11.3-windowsservercore-ltsc2022, 2.11.3-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 20b8a58e55e1874939af980a52ba353c4fad32c5
+GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.2-windowsservercore-1809, 2.11.2-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.3-windowsservercore-1809, 2.11.3-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 20b8a58e55e1874939af980a52ba353c4fad32c5
+GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.2, 2.11.2, v2.11, 2.11, mimolette
+Tags: v2.11.3-nanoserver-ltsc2022, 2.11.3-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
+Directory: windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: v2.11.3, 2.11.3, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 20b8a58e55e1874939af980a52ba353c4fad32c5
+GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
 Directory: alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.3](https://github.com/traefik/traefik/releases/tag/v2.11.3).

/cc @mmatur @rtribotte @kevinpollet

Cheers
