### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 7ae558bbbbfa3f07eaaecae0ff84a4537d37c570
 Directory: 4.1
 
-Tags: 4.0.12, 4.0, 4.0.12-jammy, 4.0-jammy
+Tags: 4.0.13, 4.0, 4.0.13-jammy, 4.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: dd34dfac80c45a1c4e6ac6029e80385c778e8d1d
+GitCommit: b51ed0210fc94d22dce73d8f07d1af1a3416d56a
 Directory: 4.0
 
 Tags: 3.11.17, 3.11, 3, 3.11.17-jammy, 3.11-jammy, 3-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/b51ed02: Update 4.0 to 4.0.13