### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -11,12 +11,12 @@ GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
 Directory: 14
 # Docker EOL: 2025-11-07
 
-# Last Modified: 2023-07-27
-Tags: 13.2.0, 13.2, 13, 13.2.0-bookworm, 13.2-bookworm, 13-bookworm
+# Last Modified: 2024-05-21
+Tags: 13.3.0, 13.3, 13, 13.3.0-bookworm, 13.3-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
+GitCommit: 6f09c34227daae15e71f398f0073e31f3ef74234
 Directory: 13
-# Docker EOL: 2025-01-27
+# Docker EOL: 2025-11-21
 
 # Last Modified: 2023-05-08
 Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/6f09c34: Update 13 to 13.3.0