### PR TITLE
caddy: v2.8.0-rc.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,52 +1,52 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/efcb9dd09f5ed76555fe65cb641225838250486e/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/b0a0cdbc0537af7b8ee85b480262414d2179455f/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
-Tags: 2.8.0-beta.2-alpine, 2.8-alpine
-SharedTags: 2.8.0-beta.2, 2.8
+Tags: 2.8.0-rc.1-alpine, 2.8-alpine
+SharedTags: 2.8.0-rc.1, 2.8
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.8/alpine
-GitCommit: efcb9dd09f5ed76555fe65cb641225838250486e
+GitCommit: b0a0cdbc0537af7b8ee85b480262414d2179455f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.8.0-beta.2-builder-alpine, 2.8-builder-alpine
-SharedTags: 2.8.0-beta.2-builder, 2.8-builder
+Tags: 2.8.0-rc.1-builder-alpine, 2.8-builder-alpine
+SharedTags: 2.8.0-rc.1-builder, 2.8-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.8/builder
-GitCommit: efcb9dd09f5ed76555fe65cb641225838250486e
+GitCommit: b0a0cdbc0537af7b8ee85b480262414d2179455f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
 
-Tags: 2.8.0-beta.2-windowsservercore-1809, 2.8-windowsservercore-1809
-SharedTags: 2.8.0-beta.2-windowsservercore, 2.8-windowsservercore, 2.8.0-beta.2, 2.8
+Tags: 2.8.0-rc.1-windowsservercore-1809, 2.8-windowsservercore-1809
+SharedTags: 2.8.0-rc.1-windowsservercore, 2.8-windowsservercore, 2.8.0-rc.1, 2.8
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.8/windows/1809
-GitCommit: efcb9dd09f5ed76555fe65cb641225838250486e
+GitCommit: b0a0cdbc0537af7b8ee85b480262414d2179455f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.8.0-beta.2-windowsservercore-ltsc2022, 2.8-windowsservercore-ltsc2022
-SharedTags: 2.8.0-beta.2-windowsservercore, 2.8-windowsservercore, 2.8.0-beta.2, 2.8
+Tags: 2.8.0-rc.1-windowsservercore-ltsc2022, 2.8-windowsservercore-ltsc2022
+SharedTags: 2.8.0-rc.1-windowsservercore, 2.8-windowsservercore, 2.8.0-rc.1, 2.8
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.8/windows/ltsc2022
-GitCommit: efcb9dd09f5ed76555fe65cb641225838250486e
+GitCommit: b0a0cdbc0537af7b8ee85b480262414d2179455f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.8.0-beta.2-builder-windowsservercore-1809, 2.8-builder-windowsservercore-1809
-SharedTags: 2.8.0-beta.2-builder, 2.8-builder
+Tags: 2.8.0-rc.1-builder-windowsservercore-1809, 2.8-builder-windowsservercore-1809
+SharedTags: 2.8.0-rc.1-builder, 2.8-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.8/windows-builder/1809
-GitCommit: efcb9dd09f5ed76555fe65cb641225838250486e
+GitCommit: b0a0cdbc0537af7b8ee85b480262414d2179455f
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
 
-Tags: 2.8.0-beta.2-builder-windowsservercore-ltsc2022, 2.8-builder-windowsservercore-ltsc2022
-SharedTags: 2.8.0-beta.2-builder, 2.8-builder
+Tags: 2.8.0-rc.1-builder-windowsservercore-ltsc2022, 2.8-builder-windowsservercore-ltsc2022
+SharedTags: 2.8.0-rc.1-builder, 2.8-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.8/windows-builder/ltsc2022
-GitCommit: efcb9dd09f5ed76555fe65cb641225838250486e
+GitCommit: b0a0cdbc0537af7b8ee85b480262414d2179455f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.8.0-rc.1