### PR TITLE
Bump Traefik to v3.0.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.0-windowsservercore-ltsc2022, 3.0.0-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.0.1-windowsservercore-ltsc2022, 3.0.1-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: eb153677fb43d1956c1c17725e74d9a7ae16b659
+GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
 Directory: windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.0.0-windowsservercore-1809, 3.0.0-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
+Tags: v3.0.1-windowsservercore-1809, 3.0.1-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: eb153677fb43d1956c1c17725e74d9a7ae16b659
+GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
 Directory: windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.0-nanoserver-ltsc2022, 3.0.0-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.0.1-nanoserver-ltsc2022, 3.0.1-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9e921bd38d6f64eca79a681f5d945b99f279a7f4
+GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
 Directory: windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.0.0, 3.0.0, v3.0, 3.0, beaufort, latest
+Tags: v3.0.1, 3.0.1, v3.0, 3.0, beaufort, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: eb153677fb43d1956c1c17725e74d9a7ae16b659
+GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
 Directory: alpine
 
 Tags: v2.11.3-windowsservercore-ltsc2022, 2.11.3-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.0.1](https://github.com/traefik/traefik/releases/tag/v3.0.1).

/cc @ldez @mmatur @nmengin

Cheers
