### PR TITLE
[nats] Release v2.10.16 - fix image

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,7 +4,7 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 8d800ec8480ff944f4ee16619ef84082bdc14cf5
+GitCommit: 5f465e202f1338403efe81be5e172272b5803cd3
 GitFetch: refs/heads/main
 
 Tags: 2.10.16-alpine3.19, 2.10-alpine3.19, 2-alpine3.19, alpine3.19, 2.10.16-alpine, 2.10-alpine, 2-alpine, alpine


### PR DESCRIPTION
This is a follow-up to #16797 to remove a setcap call in the Dockerfile which caused issues for users in more constrained environments.

The NATS binary remains the same.