### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/81e9df259751f1ec391f5c45905c198145e1cc0f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/7eb71e6990a7d42494707c04d3230dee3c424a82/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 893c649e60e147302a9e466e476e60fd0880726b
 Directory: 3.0
 
-Tags: 3.0-dev12-alpine, 3.0-dev-alpine, 3.0-dev12-alpine3.19, 3.0-dev-alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 893c649e60e147302a9e466e476e60fd0880726b
+Tags: 3.0-dev12-alpine, 3.0-dev-alpine, 3.0-dev12-alpine3.20, 3.0-dev-alpine3.20
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
 Directory: 3.0/alpine
 
 Tags: 2.9.7, 2.9, latest, 2.9.7-bookworm, 2.9-bookworm, bookworm
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.9
 
-Tags: 2.9.7-alpine, 2.9-alpine, alpine, 2.9.7-alpine3.19, 2.9-alpine3.19, alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 92d0a2f516f348c774861766fba6bfd87b145eca
+Tags: 2.9.7-alpine, 2.9-alpine, alpine, 2.9.7-alpine3.20, 2.9-alpine3.20, alpine3.20
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
 Directory: 2.9/alpine
 
 Tags: 2.8.9, 2.8, lts, 2.8.9-bookworm, 2.8-bookworm, lts-bookworm
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.8
 
-Tags: 2.8.9-alpine, 2.8-alpine, lts-alpine, 2.8.9-alpine3.19, 2.8-alpine3.19, lts-alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 5d34d74e22c28578cf57033f78017613ea0ced0c
+Tags: 2.8.9-alpine, 2.8-alpine, lts-alpine, 2.8.9-alpine3.20, 2.8-alpine3.20, lts-alpine3.20
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
 Directory: 2.8/alpine
 
 Tags: 2.6.17, 2.6, 2.6.17-bookworm, 2.6-bookworm
@@ -39,9 +39,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.6
 
-Tags: 2.6.17-alpine, 2.6-alpine, 2.6.17-alpine3.19, 2.6-alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20e1b3f92d1e74b2644f5748c62a148d07e2ca43
+Tags: 2.6.17-alpine, 2.6-alpine, 2.6.17-alpine3.20, 2.6-alpine3.20
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
 Directory: 2.6/alpine
 
 Tags: 2.4.26, 2.4, 2.4.26-bookworm, 2.4-bookworm
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.4
 
-Tags: 2.4.26-alpine, 2.4-alpine, 2.4.26-alpine3.19, 2.4-alpine3.19
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a8296a8e525bfff099f553cf79a46fc9ad384f2
+Tags: 2.4.26-alpine, 2.4-alpine, 2.4.26-alpine3.20, 2.4-alpine3.20
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
 Directory: 2.4/alpine
 
 Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye
@@ -59,17 +59,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.2
 
-Tags: 2.2.33-alpine, 2.2-alpine, 2.2.33-alpine3.16, 2.2-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3eaa160ca6c050f3451b7aad648f06ebc0a8bb22
-Directory: 2.2/alpine
-
 Tags: 2.0.35, 2.0, 2.0.35-buster, 2.0-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: 7eb71e6990a7d42494707c04d3230dee3c424a82
 Directory: 2.0
-
-Tags: 2.0.35-alpine, 2.0-alpine, 2.0.35-alpine3.16, 2.0-alpine3.16
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ecaebdd6ebd66297882800ef9d55edfd0b52237d
-Directory: 2.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fa5d16b: Merge pull request https://github.com/docker-library/haproxy/pull/232 from infosiftr/restore-2.0
- https://github.com/docker-library/haproxy/commit/7eb71e6: Restore 2.0 (not yet EOL)
- https://github.com/docker-library/haproxy/commit/67485bd: Merge pull request https://github.com/docker-library/haproxy/pull/231 from infosiftr/alpine3.20
- https://github.com/docker-library/haproxy/commit/5804096: Update to Alpine 3.20