### PR TITLE
MariaDB 2024 Q2 part 1 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/174b68b5ef90f92902c15d73a0cfdd1cb99146d8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/b4ff4700163e71e066a8f1d9df01137e2100eca1/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
@@ -7,45 +7,45 @@ GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
 Tags: 11.4.1-rc-jammy, 11.4-rc-jammy, 11.4.1-rc, 11.4-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: e0677724cbe9f932a568c8f85bca6c14d460bbb4
 Directory: 11.4
 
 Tags: 11.3.2-jammy, 11.3-jammy, 11-jammy, jammy, 11.3.2, 11.3, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: e0677724cbe9f932a568c8f85bca6c14d460bbb4
 Directory: 11.3
 
-Tags: 11.2.3-jammy, 11.2-jammy, 11.2.3, 11.2
+Tags: 11.2.4-jammy, 11.2-jammy, 11.2.4, 11.2
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 11.2
 
-Tags: 11.1.4-jammy, 11.1-jammy, 11.1.4, 11.1
+Tags: 11.1.5-jammy, 11.1-jammy, 11.1.5, 11.1
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 11.1
 
-Tags: 11.0.5-jammy, 11.0-jammy, 11.0.5, 11.0
+Tags: 11.0.6-jammy, 11.0-jammy, 11.0.6, 11.0
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 11.0
 
-Tags: 10.11.7-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.7, 10.11, 10, lts
+Tags: 10.11.8-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.8, 10.11, 10, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 10.11
 
-Tags: 10.6.17-focal, 10.6-focal, 10.6.17, 10.6
+Tags: 10.6.18-focal, 10.6-focal, 10.6.18, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 10.6
 
-Tags: 10.5.24-focal, 10.5-focal, 10.5.24, 10.5
+Tags: 10.5.25-focal, 10.5-focal, 10.5.25, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: d7a950d41e9347ac94ad2d2f28469bff74858db7
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 10.5
 
-Tags: 10.4.33-focal, 10.4-focal, 10.4.33, 10.4
+Tags: 10.4.34-focal, 10.4-focal, 10.4.34, 10.4
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d95dfc811b0666ab39cecdbf88c4d956e74f765
+GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 10.4


### PR DESCRIPTION
The new 11.4 release is a little late going though QA so it will occur later. In the mean time we keep the 11.3 as the latest tag so it isn't a downgrade.