### PR TITLE
feat(Rust): Add Alpine 3.20 variant

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/cc31986e1dfe94671c639231ecf0503942c121d9/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/e2c6ff15ac68eb3ca95d05c491a48127936b40bd/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
@@ -34,12 +34,12 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
 Directory: 1.78.0/bookworm/slim
 
-Tags: 1-alpine3.18, 1.78-alpine3.18, 1.78.0-alpine3.18, alpine3.18
-Architectures: amd64, arm64v8
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/alpine3.18
-
-Tags: 1-alpine3.19, 1.78-alpine3.19, 1.78.0-alpine3.19, alpine3.19, 1-alpine, 1.78-alpine, 1.78.0-alpine, alpine
+Tags: 1-alpine3.19, 1.78-alpine3.19, 1.78.0-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8
 GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
 Directory: 1.78.0/alpine3.19
+
+Tags: 1-alpine3.20, 1.78-alpine3.20, 1.78.0-alpine3.20, alpine3.20, 1-alpine, 1.78-alpine, 1.78.0-alpine, alpine
+Architectures: amd64, arm64v8
+GitCommit: e2c6ff15ac68eb3ca95d05c491a48127936b40bd
+Directory: 1.78.0/alpine3.20


### PR DESCRIPTION
This adds an Alpine 3.20 variant for Rust.

See rust-lang/docker-rust#202

