### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.0-dev12, 3.0-dev, 3.0-dev12-bookworm, 3.0-dev-bookworm
+Tags: 3.0-dev13, 3.0-dev, 3.0-dev13-bookworm, 3.0-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 893c649e60e147302a9e466e476e60fd0880726b
+GitCommit: 41ccd7198efc94f07d0f651592b78d721a3d55fa
 Directory: 3.0
 
-Tags: 3.0-dev12-alpine, 3.0-dev-alpine, 3.0-dev12-alpine3.20, 3.0-dev-alpine3.20
+Tags: 3.0-dev13-alpine, 3.0-dev-alpine, 3.0-dev13-alpine3.20, 3.0-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
+GitCommit: 41ccd7198efc94f07d0f651592b78d721a3d55fa
 Directory: 3.0/alpine
 
 Tags: 2.9.7, 2.9, latest, 2.9.7-bookworm, 2.9-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/41ccd71: Update 3.0 to 3.0-dev13