### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 23-ea-23-jdk-oraclelinux9, 23-ea-23-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-23-jdk-oracle, 23-ea-23-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-23-jdk, 23-ea-23, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-24-jdk-oraclelinux9, 23-ea-24-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-24-jdk-oracle, 23-ea-24-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-24-jdk, 23-ea-24, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 46252c0e08809392788c73796bb194690c7d3426
 Directory: 23/jdk/oraclelinux9
 
-Tags: 23-ea-23-jdk-oraclelinux8, 23-ea-23-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
+Tags: 23-ea-24-jdk-oraclelinux8, 23-ea-24-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 46252c0e08809392788c73796bb194690c7d3426
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-23-jdk-bookworm, 23-ea-23-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-24-jdk-bookworm, 23-ea-24-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-23-jdk-slim-bookworm, 23-ea-23-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-23-jdk-slim, 23-ea-23-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-24-jdk-slim-bookworm, 23-ea-24-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-24-jdk-slim, 23-ea-24-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-23-jdk-bullseye, 23-ea-23-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-24-jdk-bullseye, 23-ea-24-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-23-jdk-slim-bullseye, 23-ea-23-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-24-jdk-slim-bullseye, 23-ea-24-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-23-jdk-windowsservercore-ltsc2022, 23-ea-23-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-23-jdk-windowsservercore, 23-ea-23-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-23-jdk, 23-ea-23, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-24-jdk-windowsservercore-ltsc2022, 23-ea-24-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-24-jdk-windowsservercore, 23-ea-24-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-24-jdk, 23-ea-24, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-23-jdk-windowsservercore-1809, 23-ea-23-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-23-jdk-windowsservercore, 23-ea-23-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-23-jdk, 23-ea-23, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-24-jdk-windowsservercore-1809, 23-ea-24-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-24-jdk-windowsservercore, 23-ea-24-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-24-jdk, 23-ea-24, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-23-jdk-nanoserver-1809, 23-ea-23-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-23-jdk-nanoserver, 23-ea-23-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-24-jdk-nanoserver-1809, 23-ea-24-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-24-jdk-nanoserver, 23-ea-24-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: fe0b881aa2bc3318a316455978c2670f2f24bea3
+GitCommit: 453845e43a3d296e8aba9c8052c676029d7b9ea2
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5b5944a: Merge pull request https://github.com/docker-library/openjdk/pull/537 from infosiftr/rpm-query-rpm
- https://github.com/docker-library/openjdk/commit/46252c0: Ask RPM for its own arch instead of objdump hacks
- https://github.com/docker-library/openjdk/commit/453845e: Update 23 to 23-ea+24