### PR TITLE
Update Clear Linux OS to 41760

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 9260b23005ad461a3b0f8cf552ab03a9edd92ce0
-GitFetch: refs/heads/base-41730
+GitCommit: de7b43d93c25cda5141e1329b7dea0c0e810dd75
+GitFetch: refs/heads/base-41760


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41760

@bryteise @djklimes @bryteise