### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.82.11, 5.82, 5, latest
+Tags: 5.82.12, 5.82, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 79abd0869b93e23ba21d951e92bd9e838ddcf8b9
+GitCommit: a7b83c8d1c61cce86548725f2df3f0ede71a91cf
 Directory: 5/debian
 
-Tags: 5.82.11-alpine, 5.82-alpine, 5-alpine, alpine
+Tags: 5.82.12-alpine, 5.82-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 79abd0869b93e23ba21d951e92bd9e838ddcf8b9
+GitCommit: a7b83c8d1c61cce86548725f2df3f0ede71a91cf
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/a7b83c8: Update to 5.82.12, ghost-cli 1.26.0