### PR TITLE
MariaDB-11.4.2 LTS/ 11.5.1 RC release + UBI

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,19 +1,29 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/b4ff4700163e71e066a8f1d9df01137e2100eca1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/bd767859579606f8af92013309e1a9aa626d24da/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
              Faustin Lammler <faustin@mariadb.org> (@fauust)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 
-Tags: 11.4.1-rc-jammy, 11.4-rc-jammy, 11.4.1-rc, 11.4-rc
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e0677724cbe9f932a568c8f85bca6c14d460bbb4
-Directory: 11.4
+Tags: 11.5.1-ubi9-rc, 11.5-ubi9-rc, 11.5.1-ubi-rc, 11.5-ubi-rc
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: eac33f601ec635b4e0ce921efc6ac63884abceaf
+Directory: 11.5-ubi
 
-Tags: 11.3.2-jammy, 11.3-jammy, 11-jammy, jammy, 11.3.2, 11.3, 11, latest
+Tags: 11.5.1-noble-rc, 11.5-noble-rc, 11.5.1-rc, 11.5-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e0677724cbe9f932a568c8f85bca6c14d460bbb4
-Directory: 11.3
+GitCommit: 7dabf47ac1c0f2f324563f5a0616812bf332f781
+Directory: 11.5
+
+Tags: 11.4.2-ubi9, 11.4-ubi9, 11-ubi9, lts-ubi9, 11.4.2-ubi, 11.4-ubi, 11-ubi, lts-ubi
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: eac33f601ec635b4e0ce921efc6ac63884abceaf
+Directory: 11.4-ubi
+
+Tags: 11.4.2-noble, 11.4-noble, 11-noble, noble, lts-noble, 11.4.2, 11.4, 11, latest, lts
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 4e20774a56c8fb93cec9ee9d4a5b476bc0f8dd0d
+Directory: 11.4
 
 Tags: 11.2.4-jammy, 11.2-jammy, 11.2.4, 11.2
 Architectures: amd64, arm64v8, ppc64le, s390x
@@ -25,15 +35,20 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 11.1
 
-Tags: 11.0.6-jammy, 11.0-jammy, 11.0.6, 11.0
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
-Directory: 11.0
+Tags: 10.11.8-ubi9, 10.11-ubi9, 10-ubi9, 10.11.8-ubi, 10.11-ubi, 10-ubi
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: eac33f601ec635b4e0ce921efc6ac63884abceaf
+Directory: 10.11-ubi
 
-Tags: 10.11.8-jammy, 10.11-jammy, 10-jammy, lts-jammy, 10.11.8, 10.11, 10, lts
+Tags: 10.11.8-jammy, 10.11-jammy, 10-jammy, 10.11.8, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 44ed2e231207787c08d56acc94b79d5f06efe006
 Directory: 10.11
+
+Tags: 10.6.18-ubi9, 10.6-ubi9, 10.6.18-ubi, 10.6-ubi
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: eac33f601ec635b4e0ce921efc6ac63884abceaf
+Directory: 10.6-ubi
 
 Tags: 10.6.18-focal, 10.6-focal, 10.6.18, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
UBI Base images added for 10.6 /10.11 / 11.4, the LTS releases
+ the new RC release 11.5.1.