### PR TITLE
Update Traefik to bump Alpine images to v3.20

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -3,53 +3,53 @@ Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <j
 Tags: v3.0.1-windowsservercore-ltsc2022, 3.0.1-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
-Directory: windows/servercore-ltsc2022
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v3.0/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: v3.0.1-windowsservercore-1809, 3.0.1-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
-Directory: windows/1809
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v3.0/windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v3.0.1-nanoserver-ltsc2022, 3.0.1-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
-Directory: windows/nanoserver-ltsc2022
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v3.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: v3.0.1, 3.0.1, v3.0, 3.0, beaufort, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 2caca4e184cbc99169ad4043d35e3482548c3410
-Directory: alpine
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v3.0/alpine
 
 Tags: v2.11.3-windowsservercore-ltsc2022, 2.11.3-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
-Directory: windows/servercore-ltsc2022
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: v2.11.3-windowsservercore-1809, 2.11.3-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
-Directory: windows/1809
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
 Tags: v2.11.3-nanoserver-ltsc2022, 2.11.3-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
-Directory: windows/nanoserver-ltsc2022
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: v2.11.3, 2.11.3, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 98edda3a6008ef1b658911e757b68bd06ea2ed8d
-Directory: alpine
+GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik manifest to bump Alpine images to v3.20

/cc @mmatur @rtribotte @kevinpollet

Cheers
