### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -6,60 +6,75 @@ GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
 Tags: 5.1.1-php8.1-apache, 5.1-php8.1-apache, 5-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 5.1/php8.1/apache
 
 Tags: 5.1.1-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 5.1/php8.1/fpm-alpine
 
 Tags: 5.1.1-php8.1-fpm, 5.1-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 5.1/php8.1/fpm
 
 Tags: 5.1.1, 5.1, 5, latest, 5.1.1-apache, 5.1-apache, 5-apache, apache, 5.1.1-php8.2, 5.1-php8.2, 5-php8.2, php8.2, 5.1.1-php8.2-apache, 5.1-php8.2-apache, 5-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 5.1/php8.2/apache
 
 Tags: 5.1.1-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 5.1/php8.2/fpm-alpine
 
 Tags: 5.1.1-php8.2-fpm, 5.1-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 5.1/php8.2/fpm
+
+Tags: 5.1.1-php8.3-apache, 5.1-php8.3-apache, 5-php8.3-apache, php8.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: d5366538dc03894ead790646fb35761d35735b6f
+Directory: 5.1/php8.3/apache
+
+Tags: 5.1.1-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: d5366538dc03894ead790646fb35761d35735b6f
+Directory: 5.1/php8.3/fpm-alpine
+
+Tags: 5.1.1-php8.3-fpm, 5.1-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: d5366538dc03894ead790646fb35761d35735b6f
+Directory: 5.1/php8.3/fpm
 
 Tags: 4.4.5, 4.4, 4, 4.4.5-apache, 4.4-apache, 4-apache, 4.4.5-php8.1, 4.4-php8.1, 4-php8.1, 4.4.5-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 4.4/php8.1/apache
 
 Tags: 4.4.5-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 4.4/php8.1/fpm-alpine
 
 Tags: 4.4.5-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 4.4/php8.1/fpm
 
 Tags: 4.4.5-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 4.4/php8.2/apache
 
 Tags: 4.4.5-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 4.4/php8.2/fpm-alpine
 
 Tags: 4.4.5-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b72519094ce8ea4df7c3f07035c12191ed78f526
+GitCommit: d3713dc96c3bb1fd08be4239dab19a6ad78e867d
 Directory: 4.4/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@d536653: Add PHP 8.3 images for Joomla 5.1
- joomla-docker/docker-joomla@d3713dc: Update imagick package to 3.7.0 Also apply hack patch for preprocessor build failures