### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/97f7e4474e35d65268abe4a334d34eb9cb0b3608/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/a58bf7afbc5d6430d5720626e3db59f987ebb0a2/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 97f7e4474e35d65268abe4a334d34eb9cb0b3608
+GitCommit: a58bf7afbc5d6430d5720626e3db59f987ebb0a2
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 333060c8efc4ce573d8cf2a2b662d706d4b93f83
+amd64-GitCommit: 557fc6b60c652465f82bb915e7c55ab46984ceaf
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d40fbc880cf7abb46e0b9f141059e97a286ca26f
+arm32v5-GitCommit: 04c9c3d899194e73aded77726dcb5f6840b9295f
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 08320bc795bfbec362b41fc20b34857527d894e8
+arm32v6-GitCommit: 20fe3aba3b7a756b9f21cd1a8b1609bd9a5bcd63
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 6599aa8ff254dbc8f9af93d3fcb36f93e3ee25de
+arm32v7-GitCommit: 3964e0032165846da32b52031bab261044c3d920
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 9fac3af3a2904075993c11a1cc01c1f099c056b4
+arm64v8-GitCommit: 23b7350b8838ea73e848259895cfb5db626dab2e
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 9bbbface6b42d2aded8c8bfd6fe564eaa37ff146
+i386-GitCommit: f436118f42c1fc1d2b53f376991b06ccaea5e50f
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: b04e5fa7760b8618c43dfb9f166a6d9f680cf922
+mips64le-GitCommit: 15672b834b27c60e549c5a2363ed31470b3d11dd
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: f98c60b4114833d50df726b12bee69a3ef2abe07
+ppc64le-GitCommit: 2e75b39717f0cd2974f52db46179ea3d3fcc5ff8
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 3d364d09d0650e28ddd49e20c5a64867f8660ffa
+riscv64-GitCommit: 9051ab627c7402a4e6b3e3a56209d9965b51f1d8
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 7b2d9614b454abc42305ae250c7325b5c9c914d7
+s390x-GitCommit: f7a8f851869fa700b14d329cd9bbc7cb4414c7bf
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/a58bf7a: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/6f3c338: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/54e9044: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/bd0f292: Update metadata for i386
- https://github.com/docker-library/busybox/commit/c6a790d: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/bc8c404: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/5fb609b: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/50e03b3: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/a9f4f0d: Merge pull request https://github.com/docker-library/busybox/pull/199 from infosiftr/remove-cbq
- https://github.com/docker-library/busybox/commit/686bc28: Apply patch to remove CBQ functionality
- https://github.com/docker-library/busybox/commit/d40b612: Merge pull request https://github.com/docker-library/busybox/pull/197 from infosiftr/alpine3.20
- https://github.com/docker-library/busybox/commit/d43ba9b: Update to Alpine 3.20
- https://github.com/docker-library/busybox/commit/97f7e44: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/702e53e: Update metadata for i386
- https://github.com/docker-library/busybox/commit/3b0464c: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/95edf02: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/3c495cf: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/9a7aaf9: Merge pull request https://github.com/docker-library/busybox/pull/195 from infosiftr/buildroot-2024.02.2
- https://github.com/docker-library/busybox/commit/df272ca: Update amd64 metadata