### PR TITLE
[oraclelinux]: Release Oracle Linux 8 Update 10,  8, 8-slim, 8-slim-fips, 9, 9-slim and 9-slim-fips for multiple errata.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c107874aaa8980a697bf8258c85a0f60aa415c17
+amd64-GitCommit: 05516ffa72fcae6f01a00f7ac010d918d6ef8738
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4f14cd7084170191044db0afeaaef12c670a4626
+arm64v8-GitCommit: 107981111f3b4511cd22458e3e900927a26a0128
 
 Tags: 9
 Architectures: amd64, arm64v8
@@ -21,7 +21,7 @@ Tags: 9-slim-fips
 Architectures: amd64, arm64v8
 Directory: 9-slim-fips
 
-Tags: 8.9, 8
+Tags: 8.10, 8
 Architectures: amd64, arm64v8
 Directory: 8
 


### PR DESCRIPTION
This update incorporates fixes for:

Oracle Linux 8 Update 10
https://docs.oracle.com/en/operating-systems/oracle-linux/8/relnotes8.10/

Oracle Linux 8:
CVE-2023-4408, CVE-2023-50387, CVE-2023-50868, CVE-2024-26458, CVE-2024-26461,
CVE-2023-6597, CVE-2024-0450, CVE-2024-33599, CVE-2024-33600, CVE-2024-33601, CVE-2024-33602, 

See the following for details:
https://linux.oracle.com/errata/ELSA-2024-3271.html
https://linux.oracle.com/errata/ELSA-2024-3268.html
https://linux.oracle.com/errata/ELSA-2024-3347.html
https://linux.oracle.com/errata/ELSA-2024-3344.html

Oracle Linux 9:
CVE-2024-2961, CVE-2024-33599, CVE-2024-33600, CVE-2024-33601, CVE-2024-33602.

See the following for details:
https://linux.oracle.com/errata/ELSA-2024-3339.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>