### PR TITLE
Update Clear Linux OS to 41780

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: de7b43d93c25cda5141e1329b7dea0c0e810dd75
-GitFetch: refs/heads/base-41760
+GitCommit: 94674a75fcbd61b721ac1332cf3893e7f1979ba6
+GitFetch: refs/heads/base-41780


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41780

@bryteise @djklimes @bryteise