### PR TITLE
bump kong to 3.7

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -1,7 +1,13 @@
 Maintainers: Kong Docker Maintainers <team-gateway@konghq.com> (@team-gateway-bot)
 GitRepo: https://github.com/Kong/docker-kong.git
 
-Tags: 3.6.1-ubuntu, 3.6-ubuntu, 3.6.1, 3.6, 3, latest, ubuntu
+Tags: 3.7.0-ubuntu, 3.7-ubuntu, 3.7.0, 3.7, 3, latest, ubuntu
+GitCommit: 7c1f670b717d308affd4843c8cf2f5c4402b6794
+GitFetch: refs/tags/3.7.0
+Directory: ubuntu
+Architectures: amd64, arm64v8
+
+Tags: 3.6.1-ubuntu, 3.6-ubuntu, 3.6.1, 3.6
 GitCommit: 4dec46ee7e14ddd3a10692814728ff85adb77f25
 GitFetch: refs/tags/3.6.1
 Directory: ubuntu
@@ -19,18 +25,6 @@ GitFetch: refs/tags/3.4.2
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 3.3.1-alpine, alpine
-GitCommit: 2207aa20530f8a04290c82c9c2258717f7795080
-GitFetch: refs/tags/3.3.1
-File: Dockerfile.apk
-Architectures: amd64
-
-Tags: 3.3.1-ubuntu, 3.3-ubuntu, 3.3.1, 3.3
-GitCommit: 2207aa20530f8a04290c82c9c2258717f7795080
-GitFetch: refs/tags/3.3.1
-Directory: ubuntu
-Architectures: amd64, arm64v8
-
 Tags: 2.8.4-alpine, 2.8.4, 2.8
 GitCommit: 1c31704cdc9bbd2c0a20e5479eb307140339582b
 GitFetch: refs/tags/2.8.4
@@ -42,4 +36,3 @@ GitCommit: 1c31704cdc9bbd2c0a20e5479eb307140339582b
 GitFetch: refs/tags/2.8.4
 Directory: ubuntu
 Architectures: amd64, arm64v8
-


### PR DESCRIPTION
This is a retry of https://github.com/docker-library/official-images/pull/16876 ,  done in order to force a new build after we retagged.

Explanation https://github.com/docker-library/official-images/pull/16876#issuecomment-2144590491