### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.82.12, 5.82, 5, latest
+Tags: 5.83.0, 5.83, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a7b83c8d1c61cce86548725f2df3f0ede71a91cf
+GitCommit: 24c14ef74f056585dd20f61de0a6ae9a1c51a8e1
 Directory: 5/debian
 
-Tags: 5.82.12-alpine, 5.82-alpine, 5-alpine, alpine
+Tags: 5.83.0-alpine, 5.83-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: a7b83c8d1c61cce86548725f2df3f0ede71a91cf
+GitCommit: 24c14ef74f056585dd20f61de0a6ae9a1c51a8e1
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/24c14ef: Update to 5.83.0, ghost-cli 1.26.0