### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.4.20240416.0
+Tags: 2023, latest, 2023.4.20240528.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: ccf125ba9199e9dc53a614df2df2c5be14ab95fe
+amd64-GitCommit: 3f70daba787f52e24ac044292a45f80bde40d68c
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 93e4923abc8fbf8729277207b9e4be904dd7ab35
+arm64v8-GitCommit: 9d8a9b8c45fb865ed3a01a25ba57130be47c19be
 
-Tags: 2, 2.0.20240412.0
+Tags: 2, 2.0.20240529.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 8935e6e622c058e7c41af69ae2929be8e6a3a892
+amd64-GitCommit: 4e2e2fd3a7f437964ba551048908e6a5ce819bf5
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 6bab03f3e5c498f95771f73ca0fea3f4f3cf94ad
+arm64v8-GitCommit: 9b67b534fa1b8612e093f51a7e82192eb38530e4
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.4.20240528-0.amzn2023
- system-release-2023.4.20240528-0.amzn2023