### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.22.3-bookworm, 1.22-bookworm, 1-bookworm, bookworm
-SharedTags: 1.22.3, 1.22, 1, latest
+Tags: 1.22.4-bookworm, 1.22-bookworm, 1-bookworm, bookworm
+SharedTags: 1.22.4, 1.22, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/bookworm
 
-Tags: 1.22.3-bullseye, 1.22-bullseye, 1-bullseye, bullseye
+Tags: 1.22.4-bullseye, 1.22-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/bullseye
 
-Tags: 1.22.3-alpine3.20, 1.22-alpine3.20, 1-alpine3.20, alpine3.20, 1.22.3-alpine, 1.22-alpine, 1-alpine, alpine
+Tags: 1.22.4-alpine3.20, 1.22-alpine3.20, 1-alpine3.20, alpine3.20, 1.22.4-alpine, 1.22-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cf7a37dedf1fd5a25ca72075645368d1e3c30c4a
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/alpine3.20
 
-Tags: 1.22.3-alpine3.19, 1.22-alpine3.19, 1-alpine3.19, alpine3.19
+Tags: 1.22.4-alpine3.19, 1.22-alpine3.19, 1-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/alpine3.19
 
-Tags: 1.22.3-windowsservercore-ltsc2022, 1.22-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.22.3-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.3, 1.22, 1, latest
+Tags: 1.22.4-windowsservercore-ltsc2022, 1.22-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.22.4-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.4, 1.22, 1, latest
 Architectures: windows-amd64
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.22.3-windowsservercore-1809, 1.22-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.22.3-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.3, 1.22, 1, latest
+Tags: 1.22.4-windowsservercore-1809, 1.22-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.22.4-windowsservercore, 1.22-windowsservercore, 1-windowsservercore, windowsservercore, 1.22.4, 1.22, 1, latest
 Architectures: windows-amd64
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.22.3-nanoserver-ltsc2022, 1.22-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.22.3-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.22.4-nanoserver-ltsc2022, 1.22-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.22.4-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.22.3-nanoserver-1809, 1.22-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.22.3-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.22.4-nanoserver-1809, 1.22-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.22.4-nanoserver, 1.22-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: eb57429622f401af7c5afffeb3cd88022c9b9782
+GitCommit: 58bc678a838d467ca5afb7e0ee636cf5b8459da2
 Directory: 1.22/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.21.10-bookworm, 1.21-bookworm
-SharedTags: 1.21.10, 1.21
+Tags: 1.21.11-bookworm, 1.21-bookworm
+SharedTags: 1.21.11, 1.21
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/bookworm
 
-Tags: 1.21.10-bullseye, 1.21-bullseye
+Tags: 1.21.11-bullseye, 1.21-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/bullseye
 
-Tags: 1.21.10-alpine3.20, 1.21-alpine3.20, 1.21.10-alpine, 1.21-alpine
+Tags: 1.21.11-alpine3.20, 1.21-alpine3.20, 1.21.11-alpine, 1.21-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cf7a37dedf1fd5a25ca72075645368d1e3c30c4a
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/alpine3.20
 
-Tags: 1.21.10-alpine3.19, 1.21-alpine3.19
+Tags: 1.21.11-alpine3.19, 1.21-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/alpine3.19
 
-Tags: 1.21.10-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022
-SharedTags: 1.21.10-windowsservercore, 1.21-windowsservercore, 1.21.10, 1.21
+Tags: 1.21.11-windowsservercore-ltsc2022, 1.21-windowsservercore-ltsc2022
+SharedTags: 1.21.11-windowsservercore, 1.21-windowsservercore, 1.21.11, 1.21
 Architectures: windows-amd64
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.21.10-windowsservercore-1809, 1.21-windowsservercore-1809
-SharedTags: 1.21.10-windowsservercore, 1.21-windowsservercore, 1.21.10, 1.21
+Tags: 1.21.11-windowsservercore-1809, 1.21-windowsservercore-1809
+SharedTags: 1.21.11-windowsservercore, 1.21-windowsservercore, 1.21.11, 1.21
 Architectures: windows-amd64
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.21.10-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022
-SharedTags: 1.21.10-nanoserver, 1.21-nanoserver
+Tags: 1.21.11-nanoserver-ltsc2022, 1.21-nanoserver-ltsc2022
+SharedTags: 1.21.11-nanoserver, 1.21-nanoserver
 Architectures: windows-amd64
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.21.10-nanoserver-1809, 1.21-nanoserver-1809
-SharedTags: 1.21.10-nanoserver, 1.21-nanoserver
+Tags: 1.21.11-nanoserver-1809, 1.21-nanoserver-1809
+SharedTags: 1.21.11-nanoserver, 1.21-nanoserver
 Architectures: windows-amd64
-GitCommit: 777111946489bad416e54e378d580f2518632a82
+GitCommit: d92abc1f4a90239f955653f24f69a023d5d1d749
 Directory: 1.21/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/58bc678: Update 1.22 to 1.22.4
- https://github.com/docker-library/golang/commit/d92abc1: Update 1.21 to 1.21.11