### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.3, 3.13, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 344a1c142ddc8f7e9163d2aef1985d24f72b2483
+GitCommit: 83604b7ec3bda015495dda883fe3b471f206d562
 Directory: 3.13/ubuntu
 
 Tags: 3.13.3-management, 3.13-management, 3-management, management
@@ -17,7 +17,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.3-alpine, 3.13-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 344a1c142ddc8f7e9163d2aef1985d24f72b2483
+GitCommit: 83604b7ec3bda015495dda883fe3b471f206d562
 Directory: 3.13/alpine
 
 Tags: 3.13.3-management-alpine, 3.13-management-alpine, 3-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 3.13/alpine/management
 
 Tags: 3.12.14, 3.12
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4482825c6f2c929cd26157c59018ef43455e4288
+GitCommit: 62d163ace25f2a4b3c9affd3f6328e4629df1b37
 Directory: 3.12/ubuntu
 
 Tags: 3.12.14-management, 3.12-management
@@ -37,7 +37,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.14-alpine, 3.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4482825c6f2c929cd26157c59018ef43455e4288
+GitCommit: 62d163ace25f2a4b3c9affd3f6328e4629df1b37
 Directory: 3.12/alpine
 
 Tags: 3.12.14-management-alpine, 3.12-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/83604b7: Update 3.13 to openssl 3.1.6
- https://github.com/docker-library/rabbitmq/commit/62d163a: Update 3.12 to openssl 3.1.6