### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 Builder: buildkit
 
-Tags: 26.1.3-cli, 26.1-cli, 26-cli, cli, 26.1.3-cli-alpine3.20
+Tags: 26.1.4-cli, 26.1-cli, 26-cli, cli, 26.1.4-cli-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 234c02c685a0b966e6aae965924a70f29b216fe1
+GitCommit: 6ce7fe78a5a66dadf37e9226d8485e94e894814f
 Directory: 26/cli
 
-Tags: 26.1.3-dind, 26.1-dind, 26-dind, dind, 26.1.3-dind-alpine3.20, 26.1.3, 26.1, 26, latest, 26.1.3-alpine3.20
+Tags: 26.1.4-dind, 26.1-dind, 26-dind, dind, 26.1.4-dind-alpine3.20, 26.1.4, 26.1, 26, latest, 26.1.4-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 087521eb6c8c162b4ea538a0861df40ef0114059
+GitCommit: 6ce7fe78a5a66dadf37e9226d8485e94e894814f
 Directory: 26/dind
 
-Tags: 26.1.3-dind-rootless, 26.1-dind-rootless, 26-dind-rootless, dind-rootless
+Tags: 26.1.4-dind-rootless, 26.1-dind-rootless, 26-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 087521eb6c8c162b4ea538a0861df40ef0114059
+GitCommit: 6ce7fe78a5a66dadf37e9226d8485e94e894814f
 Directory: 26/dind-rootless
 
-Tags: 26.1.3-windowsservercore-ltsc2022, 26.1-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 26.1.3-windowsservercore, 26.1-windowsservercore, 26-windowsservercore, windowsservercore
+Tags: 26.1.4-windowsservercore-ltsc2022, 26.1-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 26.1.4-windowsservercore, 26.1-windowsservercore, 26-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 234c02c685a0b966e6aae965924a70f29b216fe1
+GitCommit: 6ce7fe78a5a66dadf37e9226d8485e94e894814f
 Directory: 26/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 26.1.3-windowsservercore-1809, 26.1-windowsservercore-1809, 26-windowsservercore-1809, windowsservercore-1809
-SharedTags: 26.1.3-windowsservercore, 26.1-windowsservercore, 26-windowsservercore, windowsservercore
+Tags: 26.1.4-windowsservercore-1809, 26.1-windowsservercore-1809, 26-windowsservercore-1809, windowsservercore-1809
+SharedTags: 26.1.4-windowsservercore, 26.1-windowsservercore, 26-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 234c02c685a0b966e6aae965924a70f29b216fe1
+GitCommit: 6ce7fe78a5a66dadf37e9226d8485e94e894814f
 Directory: 26/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/6ce7fe7: Update 26 to 26.1.4
- https://github.com/docker-library/docker/commit/9bfad19: Add `riscv64` mapping so we're automatically ready if binaries show up