### PR TITLE
[Swift] Add Swift 5.10.1 with additional platforms

### DIFF
--- a/library/swift
+++ b/library/swift
@@ -6,57 +6,77 @@ Maintainers: Ted Kremenek <kremenek@apple.com> (@tkremenek),
 GitRepo: https://github.com/apple/swift-docker.git
 GitFetch: refs/heads/main
 
-Tags: 5.10.0, 5.10, 5.10.0-jammy, 5.10-jammy, jammy, latest
+Tags: 5.10.1, 5.10, 5.10.1-jammy, 5.10-jammy, jammy, latest
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/ubuntu/22.04
 
-Tags: 5.10.0-slim, 5.10-slim, 5.10.0-jammy-slim, 5.10-jammy-slim, jammy-slim, slim
+Tags: 5.10.1-slim, 5.10-slim, 5.10.1-jammy-slim, 5.10-jammy-slim, jammy-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/ubuntu/22.04/slim
 
-Tags: 5.10.0-focal-slim, 5.10-focal-slim, focal-slim
+Tags: 5.10.1-focal-slim, 5.10-focal-slim, focal-slim
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/ubuntu/20.04/slim
 
-Tags: 5.10.0-focal, 5.10-focal, focal
+Tags: 5.10.1-focal, 5.10-focal, focal
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/ubuntu/20.04
 
-Tags: 5.10.0-amazonlinux2, 5.10-amazonlinux2, amazonlinux2
+Tags: 5.10.1-mantic, 5.10-mantic, mantic
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
+Directory: 5.10/ubuntu/23.10
+
+Tags: 5.10.1-noble, 5.10-noble, noble
+Architectures: amd64, arm64v8
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
+Directory: 5.10/ubuntu/24.04
+
+Tags: 5.10.1-bookworm, 5.10-bookworm, bookworm
+Architectures: amd64, arm64v8
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
+Directory: 5.10/debian/12
+
+Tags: 5.10.1-fedora39, 5.10-fedora39, fedora39
+Architectures: amd64, arm64v8
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
+Directory: 5.10/fedora/39
+
+Tags: 5.10.1-amazonlinux2, 5.10-amazonlinux2, amazonlinux2
+Architectures: amd64, arm64v8
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/amazonlinux/2
 
-Tags: 5.10.0-amazonlinux2-slim, 5.10-amazonlinux2-slim, amazonlinux2-slim
+Tags: 5.10.1-amazonlinux2-slim, 5.10-amazonlinux2-slim, amazonlinux2-slim
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/amazonlinux/2/slim
 
-Tags: 5.10.0-centos7, 5.10-centos7, centos7
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+Tags: 5.10.1-centos7, 5.10-centos7, centos7
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/centos/7
 
-Tags: 5.10.0-centos7-slim, 5.10-centos7-slim, centos7-slim
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+Tags: 5.10.1-centos7-slim, 5.10-centos7-slim, centos7-slim
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/centos/7/slim
 
-Tags: 5.10.0-rhel-ubi9, 5.10-rhel-ubi9, rhel-ubi9
+Tags: 5.10.1-rhel-ubi9, 5.10-rhel-ubi9, rhel-ubi9
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/rhel-ubi/9
 
-Tags: 5.10.0-rhel-ubi9-slim, 5.10-rhel-ubi9-slim, rhel-ubi9-slim
+Tags: 5.10.1-rhel-ubi9-slim, 5.10-rhel-ubi9-slim, rhel-ubi9-slim
 Architectures: amd64, arm64v8
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/rhel-ubi/9/slim
 
-Tags: 5.10.0-windowsservercore-ltsc2022, 5.10-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: 5.10.1-windowsservercore-ltsc2022, 5.10-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
-GitCommit: ea035798755cce4ec41e0c6dbdd320904cef0421
+GitCommit: 53c4d44e4b556d7bab6ff94c80e5bd0444cdc17d
 Directory: 5.10/windows/LTSC2022
 Constraints: windowsservercore-ltsc2022
 
@@ -250,75 +270,3 @@ Directory: 5.5/centos/7
 Tags: 5.5.3-centos7-slim, 5.5-centos7-slim
 GitCommit: 9394b31e064cf0d80eaab08b692a2886c7aea8fe
 Directory: 5.5/centos/7/slim
-
-Tags: 5.4.3-focal-slim, 5.4-focal-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.4/ubuntu/20.04/slim
-
-Tags: 5.4.3-focal, 5.4-focal
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.4/ubuntu/20.04
-
-Tags: 5.4.3-amazonlinux2, 5.4-amazonlinux2
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.4/amazonlinux/2
-
-Tags: 5.4.3-amazonlinux2-slim, 5.4-amazonlinux2-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.4/amazonlinux/2/slim
-
-Tags: 5.4.3-centos7, 5.4-centos7
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.4/centos/7
-
-Tags: 5.4.3-centos7-slim, 5.4-centos7-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.4/centos/7/slim
-
-Tags: 5.3.3-focal-slim, 5.3-focal-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.3/ubuntu/20.04/slim
-
-Tags: 5.3.3-focal, 5.3-focal
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.3/ubuntu/20.04
-
-Tags: 5.3.3-amazonlinux2, 5.3-amazonlinux2
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.3/amazonlinux/2
-
-Tags: 5.3.3-amazonlinux2-slim, 5.3-amazonlinux2-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.3/amazonlinux/2/slim
-
-Tags: 5.3.3-centos7, 5.3-centos7
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.3/centos/7
-
-Tags: 5.3.3-centos7-slim, 5.3-centos7-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.3/centos/7/slim
-
-Tags: 5.2.5-focal-slim, 5.2-focal-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.2/ubuntu/20.04/slim
-
-Tags: 5.2.5-focal, 5.2-focal
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.2/ubuntu/20.04
-
-Tags: 5.2.5-amazonlinux2, 5.2-amazonlinux2
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.2/amazonlinux/2
-
-Tags: 5.2.5-amazonlinux2-slim, 5.2-amazonlinux2-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.2/amazonlinux/2/slim
-
-Tags: 5.2.5-centos7, 5.2-centos7
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.2/centos/7
-
-Tags: 5.2.5-centos7-slim, 5.2-centos7-slim
-GitCommit: 2d2c2fb89fe6ecfd8885157eb1666ed2686503a0
-Directory: 5.2/centos/7/slim


### PR DESCRIPTION
* Adding 5.10.1 with Ubuntu 24.04, Ubuntu 23.10, Debian 12 and Fedora 39
* Removing 5.4.3, 5.3.3 and 5.2.5