### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-3626

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 05516ffa72fcae6f01a00f7ac010d918d6ef8738
+amd64-GitCommit: 71c5c9c3d2c2d9b31b50b366e51256333a63e44a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 107981111f3b4511cd22458e3e900927a26a0128
+arm64v8-GitCommit: 51d7162d97ff89fda7a305a7bbb64d1ee2ef53ce
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-25062

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-3626.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>