### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.84.1, 5.84, 5, latest
+Tags: 5.84.2, 5.84, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ae70d15aa2110df03e1301b276d627a3a9575566
+GitCommit: caef43845c6a453fb47c923bae50698d870268ba
 Directory: 5/debian
 
-Tags: 5.84.1-alpine, 5.84-alpine, 5-alpine, alpine
+Tags: 5.84.2-alpine, 5.84-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: ae70d15aa2110df03e1301b276d627a3a9575566
+GitCommit: caef43845c6a453fb47c923bae50698d870268ba
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/caef438: Update to 5.84.2, ghost-cli 1.26.0