### PR TITLE
[oraclelinux] Updating 7, 7-slim and 7-slim-fips for ELSA-2024-3588

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 71c5c9c3d2c2d9b31b50b366e51256333a63e44a
+amd64-GitCommit: a44abc66997043061e72468c12ee26dcb11930b4
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 51d7162d97ff89fda7a305a7bbb64d1ee2ef53ce
+arm64v8-GitCommit: 5f1f99b66d77e494098dd7a11d409e71dc9b5690
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-2961, CVE-2024-33599, CVE-2024-33600, CVE-2024-33601, CVE-2024-33602, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-3588.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>