### PR TITLE
diff-pr: ADD/COPY enumberate full list of options

### DIFF
--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -257,9 +257,7 @@ copy-tar() {
 					if ($i ~ /^--(keep-git-dir|checksum)=/) {
 						continue
 					}
-					print $i
-					while (i < NF) {
-						i++
+					for ( ; i < NF; i++) {
 						print $i
 					}
 				}

--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -249,7 +249,17 @@ copy-tar() {
 					if ($i ~ /^--from=/) {
 						next
 					}
-					if ($i !~ /^--chown=/) {
+					# COPY and ADD options
+					if ($i ~ /^--(chown|chmod|link|parents|exclude)=/) {
+						continue
+					}
+					# additional ADD options
+					if ($i ~ /^--(keep-git-dir|checksum)=/) {
+						continue
+					}
+					print $i
+					while (i < NF) {
+						i++
 						print $i
 					}
 				}


### PR DESCRIPTION
Buildkit has many more options on ADD/COPY than just chown

Lets exclude all of them.

ref:
* https://docs.docker.com/reference/dockerfile/#add
* https://docs.docker.com/reference/dockerfile/#copy