### PR TITLE
Update Clear Linux OS to 41850

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 94674a75fcbd61b721ac1332cf3893e7f1979ba6
-GitFetch: refs/heads/base-41780
+GitCommit: 68e01605e9214b1884687b702416befa1cfe74cb
+GitFetch: refs/heads/base-41850


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41850

@bryteise @djklimes @bryteise