### PR TITLE
Bump Traefik to v2.11.4 and v3.0.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.1-windowsservercore-ltsc2022, 3.0.1-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.0.2-windowsservercore-ltsc2022, 3.0.2-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
 Directory: v3.0/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.0.1-windowsservercore-1809, 3.0.1-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
+Tags: v3.0.2-windowsservercore-1809, 3.0.2-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
 Directory: v3.0/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.1-nanoserver-ltsc2022, 3.0.1-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.0.2-nanoserver-ltsc2022, 3.0.2-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
 Directory: v3.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.0.1, 3.0.1, v3.0, 3.0, beaufort, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Tags: v3.0.2, 3.0.2, v3.0, 3.0, beaufort, latest
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
 Directory: v3.0/alpine
 
 Tags: v2.11.4-windowsservercore-ltsc2022, 2.11.4-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
@@ -46,7 +46,7 @@ Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
 Directory: v2.11/windows/nanoserver-ltsc2022
-Constraints: windowsservercore-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: v2.11.4, 2.11.4, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x

--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
 Directory: v3.0/alpine
 
-Tags: v2.11.3-windowsservercore-ltsc2022, 2.11.3-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.4-windowsservercore-ltsc2022, 2.11.4-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.3-windowsservercore-1809, 2.11.3-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.4-windowsservercore-1809, 2.11.4-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.3-nanoserver-ltsc2022, 2.11.3-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.4-nanoserver-ltsc2022, 2.11.4-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
 Directory: v2.11/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.3, 2.11.3, v2.11, 2.11, mimolette
-Architectures: amd64, arm32v6, arm64v8, ppc64le, s390x
+Tags: v2.11.4, 2.11.4, v2.11, 2.11, mimolette
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: bebc5478c3fe376e918db45bc59cc864fd943feb
+GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.4](https://github.com/traefik/traefik/releases/tag/v2.11.4).

/cc @ldez @mmatur @rtribotte

Cheers
