### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 9a4501c94ca45dc96a871b504d32a997db090707
 Directory: 3.1/alpine
 
-Tags: 3.0.0, 3.0, lts, latest, 3.0.0-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.1, 3.0, lts, latest, 3.0.1-bookworm, 3.0-bookworm, lts-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 25aca1c14ceb3d82c68404ddd2ef92d6df625966
+GitCommit: 3fa44c97038614c4204f225f5b0fa80bfceb5791
 Directory: 3.0
 
-Tags: 3.0.0-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.0-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.1-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.1-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 25aca1c14ceb3d82c68404ddd2ef92d6df625966
+GitCommit: 3fa44c97038614c4204f225f5b0fa80bfceb5791
 Directory: 3.0/alpine
 
 Tags: 2.9.7, 2.9, 2.9.7-bookworm, 2.9-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3fa44c9: Update 3.0 to 3.0.1