### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.84.2, 5.84, 5, latest
+Tags: 5.85.0, 5.85, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: caef43845c6a453fb47c923bae50698d870268ba
+GitCommit: 59e8917dd3a05049dfc80e663462abb7427dfdec
 Directory: 5/debian
 
-Tags: 5.84.2-alpine, 5.84-alpine, 5-alpine, alpine
+Tags: 5.85.0-alpine, 5.85-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: caef43845c6a453fb47c923bae50698d870268ba
+GitCommit: 59e8917dd3a05049dfc80e663462abb7427dfdec
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/59e8917: Update to 5.85.0, ghost-cli 1.26.0