### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3fa44c97038614c4204f225f5b0fa80bfceb5791
 Directory: 3.0/alpine
 
-Tags: 2.9.7, 2.9, 2.9.7-bookworm, 2.9-bookworm
+Tags: 2.9.8, 2.9, 2.9.8-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: 7a42aff80e0da2db2920bc4d338fc634ad4f8e85
 Directory: 2.9
 
-Tags: 2.9.7-alpine, 2.9-alpine, 2.9.7-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.8-alpine, 2.9-alpine, 2.9.8-alpine3.20, 2.9-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
+GitCommit: 7a42aff80e0da2db2920bc4d338fc634ad4f8e85
 Directory: 2.9/alpine
 
 Tags: 2.8.9, 2.8, 2.8.9-bookworm, 2.8-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7a42aff: Update 2.9 to 2.9.8