### PR TITLE
fix(kong): rm 2.8 arm64 variants

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -29,10 +29,10 @@ Tags: 2.8.4-alpine, 2.8.4, 2.8
 GitCommit: 1c31704cdc9bbd2c0a20e5479eb307140339582b
 GitFetch: refs/tags/2.8.4
 Directory: alpine
-Architectures: amd64, arm64v8
+Architectures: amd64
 
 Tags: 2.8.4-ubuntu, 2.8-ubuntu
 GitCommit: 1c31704cdc9bbd2c0a20e5479eb307140339582b
 GitFetch: refs/tags/2.8.4
 Directory: ubuntu
-Architectures: amd64, arm64v8
+Architectures: amd64


### PR DESCRIPTION
This PR removes the 2.8 arm64 variants. This is a Product decisions being made so that our Community Edition (OSS) product matches the platforms supported by our Enterprise Edition (without exceeding them).