### PR TITLE
[oraclelinux] Updating 7 for ELSA-2024-3741

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a44abc66997043061e72468c12ee26dcb11930b4
+amd64-GitCommit: 837a2c4210acabd7c040103b60c8240a7eefa9f0
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5f1f99b66d77e494098dd7a11d409e71dc9b5690
+arm64v8-GitCommit: 38b9ffe554cf130af2fb244115af17aedc60d159
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-4408, CVE-2023-50387, CVE-2023-50868

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-3741.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>