### PR TITLE
Add official image for Apache Kafka

### DIFF
--- a/library/kafka
+++ b/library/kafka
@@ -1,0 +1,8 @@
+# This file is generated via https://github.com/apache/kafka/blob/2432a1866e7bd270f1073cea7c9594e111aed78b/docker/generate_kafka_pr_template.py
+Maintainers: The Apache Kafka Project <dev@kafka.apache.org> (@ApacheKafka)
+GitRepo: https://github.com/apache/kafka.git
+
+Tags: 3.7.0, latest
+Architectures: amd64,arm64v8
+GitCommit: b7dcae44ffb29f854385cef959519a3d0baad55e
+Directory: ./docker/docker_official_images/3.7.0/jvm 


### PR DESCRIPTION
Hi there, this aims to introduce a Docker Official Image for [Apache Kafka](https://kafka.apache.org/).

Apache Kafka is an open-source distributed event streaming platform used by thousands of companies for high-performance data pipelines, streaming analytics, data integration, and mission-critical applications.
To know more about Apache Kafka, please read the [documentation](https://kafka.apache.org/documentation/).

# Checklist for Review
-	[ ] associated with or contacted upstream?
-	[ ] available under [an OSI-approved license](https://opensource.org/licenses)?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)
