### PR TITLE
chore: Update to Rust version 1.79.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/e2c6ff15ac68eb3ca95d05c491a48127936b40bd/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/ea4aab0935fcafe4956d6206f3ecde84ffddf800/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-buster, 1.78-buster, 1.78.0-buster, buster
+Tags: 1-buster, 1.79-buster, 1.79.0-buster, buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/buster
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/buster
 
-Tags: 1-slim-buster, 1.78-slim-buster, 1.78.0-slim-buster, slim-buster
+Tags: 1-slim-buster, 1.79-slim-buster, 1.79.0-slim-buster, slim-buster
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/buster/slim
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/buster/slim
 
-Tags: 1-bullseye, 1.78-bullseye, 1.78.0-bullseye, bullseye
+Tags: 1-bullseye, 1.79-bullseye, 1.79.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/bullseye
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/bullseye
 
-Tags: 1-slim-bullseye, 1.78-slim-bullseye, 1.78.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.79-slim-bullseye, 1.79.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/bullseye/slim
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/bullseye/slim
 
-Tags: 1-bookworm, 1.78-bookworm, 1.78.0-bookworm, bookworm, 1, 1.78, 1.78.0, latest
+Tags: 1-bookworm, 1.79-bookworm, 1.79.0-bookworm, bookworm, 1, 1.79, 1.79.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/bookworm
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/bookworm
 
-Tags: 1-slim-bookworm, 1.78-slim-bookworm, 1.78.0-slim-bookworm, slim-bookworm, 1-slim, 1.78-slim, 1.78.0-slim, slim
+Tags: 1-slim-bookworm, 1.79-slim-bookworm, 1.79.0-slim-bookworm, slim-bookworm, 1-slim, 1.79-slim, 1.79.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/bookworm/slim
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/bookworm/slim
 
-Tags: 1-alpine3.19, 1.78-alpine3.19, 1.78.0-alpine3.19, alpine3.19
+Tags: 1-alpine3.19, 1.79-alpine3.19, 1.79.0-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: cc31986e1dfe94671c639231ecf0503942c121d9
-Directory: 1.78.0/alpine3.19
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/alpine3.19
 
-Tags: 1-alpine3.20, 1.78-alpine3.20, 1.78.0-alpine3.20, alpine3.20, 1-alpine, 1.78-alpine, 1.78.0-alpine, alpine
+Tags: 1-alpine3.20, 1.79-alpine3.20, 1.79.0-alpine3.20, alpine3.20, 1-alpine, 1.79-alpine, 1.79.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: e2c6ff15ac68eb3ca95d05c491a48127936b40bd
-Directory: 1.78.0/alpine3.20
+GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
+Directory: 1.79.0/alpine3.20


### PR DESCRIPTION
This bumps the Rust version to `1.79.0` and the underlying `rustup` version to `1.27.1`

- [Rust `1.79.0` Blog](https://blog.rust-lang.org/2024/06/13/Rust-1.79.0.html)
- [Rust `1.79.0` Release](https://github.com/rust-lang/rust/releases/tag/1.79.0)
- [`rustup` `1.27.1` Blog](https://blog.rust-lang.org/2024/05/06/Rustup-1.27.1.html)
- [`rustup` `1.27.1` Changelog](https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1271---2024-04-14)