### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 24-ea-1-jdk-oraclelinux9, 24-ea-1-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-1-jdk-oracle, 24-ea-1-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-1-jdk, 24-ea-1, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-2-jdk-oraclelinux9, 24-ea-2-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-2-jdk-oracle, 24-ea-2-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-2-jdk, 24-ea-2, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-1-jdk-oraclelinux8, 24-ea-1-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-2-jdk-oraclelinux8, 24-ea-2-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-1-jdk-bookworm, 24-ea-1-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-2-jdk-bookworm, 24-ea-2-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-1-jdk-slim-bookworm, 24-ea-1-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-1-jdk-slim, 24-ea-1-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-2-jdk-slim-bookworm, 24-ea-2-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-2-jdk-slim, 24-ea-2-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-1-jdk-bullseye, 24-ea-1-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-2-jdk-bullseye, 24-ea-2-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-1-jdk-slim-bullseye, 24-ea-1-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-2-jdk-slim-bullseye, 24-ea-2-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-1-jdk-windowsservercore-ltsc2022, 24-ea-1-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-1-jdk-windowsservercore, 24-ea-1-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-1-jdk, 24-ea-1, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-2-jdk-windowsservercore-ltsc2022, 24-ea-2-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-2-jdk-windowsservercore, 24-ea-2-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-2-jdk, 24-ea-2, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-1-jdk-windowsservercore-1809, 24-ea-1-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-1-jdk-windowsservercore, 24-ea-1-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-1-jdk, 24-ea-1, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-2-jdk-windowsservercore-1809, 24-ea-2-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-2-jdk-windowsservercore, 24-ea-2-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-2-jdk, 24-ea-2, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-1-jdk-nanoserver-1809, 24-ea-1-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-1-jdk-nanoserver, 24-ea-1-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-2-jdk-nanoserver-1809, 24-ea-2-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-2-jdk-nanoserver, 24-ea-2-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: e655fc6aa19ab37eb541ed05646b5e79747d39f4
+GitCommit: 3deeddad83128e99b0c299f9867d467e465ce0be
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 23-ea-26-jdk-oraclelinux9, 23-ea-26-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-26-jdk-oracle, 23-ea-26-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-26-jdk, 23-ea-26, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-27-jdk-oraclelinux9, 23-ea-27-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-27-jdk-oracle, 23-ea-27-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-ea-27-jdk, 23-ea-27, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/oraclelinux9
 
-Tags: 23-ea-26-jdk-oraclelinux8, 23-ea-26-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
+Tags: 23-ea-27-jdk-oraclelinux8, 23-ea-27-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-26-jdk-bookworm, 23-ea-26-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-ea-27-jdk-bookworm, 23-ea-27-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-26-jdk-slim-bookworm, 23-ea-26-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-26-jdk-slim, 23-ea-26-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-ea-27-jdk-slim-bookworm, 23-ea-27-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-27-jdk-slim, 23-ea-27-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-26-jdk-bullseye, 23-ea-26-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-ea-27-jdk-bullseye, 23-ea-27-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-26-jdk-slim-bullseye, 23-ea-26-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-ea-27-jdk-slim-bullseye, 23-ea-27-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-26-jdk-windowsservercore-ltsc2022, 23-ea-26-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-26-jdk-windowsservercore, 23-ea-26-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-26-jdk, 23-ea-26, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-27-jdk-windowsservercore-ltsc2022, 23-ea-27-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-ea-27-jdk-windowsservercore, 23-ea-27-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-27-jdk, 23-ea-27, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-26-jdk-windowsservercore-1809, 23-ea-26-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-26-jdk-windowsservercore, 23-ea-26-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-26-jdk, 23-ea-26, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-ea-27-jdk-windowsservercore-1809, 23-ea-27-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-ea-27-jdk-windowsservercore, 23-ea-27-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-27-jdk, 23-ea-27, 23-ea-jdk, 23-ea, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-26-jdk-nanoserver-1809, 23-ea-26-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-26-jdk-nanoserver, 23-ea-26-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-ea-27-jdk-nanoserver-1809, 23-ea-27-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-ea-27-jdk-nanoserver, 23-ea-27-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 766b1164e567bb1017eea224f7c910bc9668af92
+GitCommit: 3f5dee9cd178b3fdb3fc5f7bb96688d0bec6a4aa
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/3deedda: Update 24 to 24-ea+2
- https://github.com/docker-library/openjdk/commit/3f5dee9: Update 23 to 23-ea+27
- https://github.com/docker-library/openjdk/commit/30a79e3: Merge pull request https://github.com/docker-library/openjdk/pull/539 from marchof/update-checkout