### PR TITLE
Bump Alpine version from 3.19 to 3.20

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -9,28 +9,28 @@ Builder: buildkit
 #------------------------------v8 images---------------------------------
 Tags: 8u412-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jdk/alpine
 
 Tags: 8u412-b08-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u412-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
 SharedTags: 8u412-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u412-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jdk/centos
 
 Tags: 8u412-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u412-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
@@ -67,28 +67,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u412-b08-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jre/alpine
 
 Tags: 8u412-b08-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u412-b08-jre-jammy, 8-jre-jammy
 SharedTags: 8u412-b08-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u412-b08-jre-centos7, 8-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jre/centos
 
 Tags: 8u412-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u412-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
@@ -127,28 +127,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.23_9-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jdk/alpine
 
 Tags: 11.0.23_9-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.23_9-jdk-jammy, 11-jdk-jammy, 11-jammy
 SharedTags: 11.0.23_9-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.23_9-jdk-centos7, 11-jdk-centos7, 11-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jdk/centos
 
 Tags: 11.0.23_9-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.23_9-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
@@ -185,28 +185,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.23_9-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jre/alpine
 
 Tags: 11.0.23_9-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.23_9-jre-jammy, 11-jre-jammy
 SharedTags: 11.0.23_9-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.23_9-jre-centos7, 11-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jre/centos
 
 Tags: 11.0.23_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.23_9-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
@@ -245,28 +245,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.11_9-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jdk/alpine
 
 Tags: 17.0.11_9-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jdk/ubuntu/focal
 
 Tags: 17.0.11_9-jdk-jammy, 17-jdk-jammy, 17-jammy
 SharedTags: 17.0.11_9-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jdk/ubuntu/jammy
 
 Tags: 17.0.11_9-jdk-centos7, 17-jdk-centos7, 17-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jdk/centos
 
 Tags: 17.0.11_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jdk/ubi/ubi9-minimal
 
 Tags: 17.0.11_9-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
@@ -303,28 +303,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.11_9-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jre/alpine
 
 Tags: 17.0.11_9-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.11_9-jre-jammy, 17-jre-jammy
 SharedTags: 17.0.11_9-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jre/ubuntu/jammy
 
 Tags: 17.0.11_9-jre-centos7, 17-jre-centos7
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jre/centos
 
 Tags: 17.0.11_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 17/jre/ubi/ubi9-minimal
 
 Tags: 17.0.11_9-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
@@ -363,18 +363,18 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v21 images---------------------------------
 Tags: 21.0.3_9-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 21/jdk/alpine
 
 Tags: 21.0.3_9-jdk-jammy, 21-jdk-jammy, 21-jammy
 SharedTags: 21.0.3_9-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.3_9-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.3_9-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
@@ -411,18 +411,18 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.3_9-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 21/jre/alpine
 
 Tags: 21.0.3_9-jre-jammy, 21-jre-jammy
 SharedTags: 21.0.3_9-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.3_9-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.3_9-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
@@ -461,18 +461,18 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v22 images---------------------------------
 Tags: 22.0.1_8-jdk-alpine, 22-jdk-alpine, 22-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 22/jdk/alpine
 
 Tags: 22.0.1_8-jdk-jammy, 22-jdk-jammy, 22-jammy
 SharedTags: 22.0.1_8-jdk, 22-jdk, 22
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 22/jdk/ubuntu/jammy
 
 Tags: 22.0.1_8-jdk-ubi9-minimal, 22-jdk-ubi9-minimal, 22-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 22/jdk/ubi/ubi9-minimal
 
 Tags: 22.0.1_8-jdk-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
@@ -509,18 +509,18 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 22.0.1_8-jre-alpine, 22-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 22/jre/alpine
 
 Tags: 22.0.1_8-jre-jammy, 22-jre-jammy
 SharedTags: 22.0.1_8-jre, 22-jre
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 22/jre/ubuntu/jammy
 
 Tags: 22.0.1_8-jre-ubi9-minimal, 22-jre-ubi9-minimal
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: c4da73f6fbec30bfead9462a74192f2ede8ca29a
 Directory: 22/jre/ubi/ubi9-minimal
 
 Tags: 22.0.1_8-jre-windowsservercore-ltsc2022, 22-jre-windowsservercore-ltsc2022
@@ -554,4 +554,3 @@ GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 22/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
-


### PR DESCRIPTION
Updating Eclipse Temuriun Docker images bumped with alpine version 3.20 to fix the busybox vulnerabilities