### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,44 +4,44 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev0, 3.1-dev, 3.1-dev0-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev1, 3.1-dev, 3.1-dev1-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9a4501c94ca45dc96a871b504d32a997db090707
+GitCommit: 90192f6c7f183049e1ac746438584e7aa5dc3c2e
 Directory: 3.1
 
-Tags: 3.1-dev0-alpine, 3.1-dev-alpine, 3.1-dev0-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev1-alpine, 3.1-dev-alpine, 3.1-dev1-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9a4501c94ca45dc96a871b504d32a997db090707
+GitCommit: 90192f6c7f183049e1ac746438584e7aa5dc3c2e
 Directory: 3.1/alpine
 
-Tags: 3.0.1, 3.0, lts, latest, 3.0.1-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.2, 3.0, lts, latest, 3.0.2-bookworm, 3.0-bookworm, lts-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fa44c97038614c4204f225f5b0fa80bfceb5791
+GitCommit: 12bf60c7685bdfa526057a0ccf89967291106b4c
 Directory: 3.0
 
-Tags: 3.0.1-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.1-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.2-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.2-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fa44c97038614c4204f225f5b0fa80bfceb5791
+GitCommit: 12bf60c7685bdfa526057a0ccf89967291106b4c
 Directory: 3.0/alpine
 
-Tags: 2.9.8, 2.9, 2.9.8-bookworm, 2.9-bookworm
+Tags: 2.9.9, 2.9, 2.9.9-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7a42aff80e0da2db2920bc4d338fc634ad4f8e85
+GitCommit: e85e5b3e506be4b05de5062f27cbbd3fde03f923
 Directory: 2.9
 
-Tags: 2.9.8-alpine, 2.9-alpine, 2.9.8-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.9-alpine, 2.9-alpine, 2.9.9-alpine3.20, 2.9-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7a42aff80e0da2db2920bc4d338fc634ad4f8e85
+GitCommit: e85e5b3e506be4b05de5062f27cbbd3fde03f923
 Directory: 2.9/alpine
 
-Tags: 2.8.9, 2.8, 2.8.9-bookworm, 2.8-bookworm
+Tags: 2.8.10, 2.8, 2.8.10-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: 01b3b0d48c75a815148d46ae86b409507e232e1c
 Directory: 2.8
 
-Tags: 2.8.9-alpine, 2.8-alpine, 2.8.9-alpine3.20, 2.8-alpine3.20
+Tags: 2.8.10-alpine, 2.8-alpine, 2.8.10-alpine3.20, 2.8-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
+GitCommit: 01b3b0d48c75a815148d46ae86b409507e232e1c
 Directory: 2.8/alpine
 
 Tags: 2.6.17, 2.6, 2.6.17-bookworm, 2.6-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/90192f6: Update 3.1 to 3.1-dev1
- https://github.com/docker-library/haproxy/commit/12bf60c: Update 3.0 to 3.0.2
- https://github.com/docker-library/haproxy/commit/e85e5b3: Update 2.9 to 2.9.9
- https://github.com/docker-library/haproxy/commit/01b3b0d: Update 2.8 to 2.8.10