### PR TITLE
fix(kong): retags to source pkgs from cloudsmith

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -8,19 +8,19 @@ Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 3.6.1-ubuntu, 3.6-ubuntu, 3.6.1, 3.6
-GitCommit: 4dec46ee7e14ddd3a10692814728ff85adb77f25
+GitCommit: 8791499ad78381aff75b4763ea944b0141851089
 GitFetch: refs/tags/3.6.1
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 3.5.0-ubuntu, 3.5-ubuntu, 3.5.0, 3.5
-GitCommit: e4ba2e351f3da34727fd016409a2669004b3fce0
+GitCommit: 8814c97a408d76ed004b05ea96f0d9eadf9b36be
 GitFetch: refs/tags/3.5.0
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
 Tags: 3.4.2-ubuntu, 3.4-ubuntu, 3.4.2, 3.4
-GitCommit: 2ccc1a4cc237f2cbe85e9226c8d0fa1e70f1d612
+GitCommit: e07de903edf213445a0540172d51529ac344b448
 GitFetch: refs/tags/3.4.2
 Directory: ubuntu
 Architectures: amd64, arm64v8


### PR DESCRIPTION
These changes represent a "backport" of the changes to the Kong Dockerfiles that cause packages to be sourced from our new package hosting solution, Cloudsmith (aka https://packages.konghq.com).

This is in response to the ci failures surfaced in https://github.com/docker-library/official-images/pull/16962