### PR TITLE
Add Java 22 images

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -6,77 +6,92 @@ GitRepo: https://github.com/keeganwitt/docker-gradle.git
 
 Tags: 8.8.0-jdk8, 8.8-jdk8, 8-jdk8, jdk8, 8.8.0-jdk8-jammy, 8.8-jdk8-jammy, 8-jdk8-jammy, jdk8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk8
 
 Tags: 8.8.0-jdk8-focal, 8.8-jdk8-focal, 8-jdk8-focal, jdk8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk8-focal
 
 Tags: 8.8.0-jdk11, 8.8-jdk11, 8-jdk11, jdk11, 8.8.0-jdk11-jammy, 8.8-jdk11-jammy, 8-jdk11-jammy, jdk11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk11
 
 Tags: 8.8.0-jdk11-focal, 8.8-jdk11-focal, 8-jdk11-focal, jdk11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk11-focal
 
 Tags: 8.8.0-jdk11-alpine, 8.8-jdk11-alpine, 8-jdk11-alpine, jdk11-alpine
 Architectures: amd64
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk11-alpine
 
 Tags: 8.8.0-jdk17, 8.8-jdk17, 8-jdk17, jdk17, 8.8.0-jdk17-jammy, 8.8-jdk17-jammy, 8-jdk17-jammy, jdk17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk17
 
 Tags: 8.8.0-jdk17-focal, 8.8-jdk17-focal, 8-jdk17-focal, jdk17-focal, 8.8.0-jdk-focal, 8.8-jdk-focal, 8-jdk-focal, jdk-focal, 8.8.0-focal, 8.8-focal, 8-focal, focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk17-focal
 
 Tags: 8.8.0-jdk17-alpine, 8.8-jdk17-alpine, 8-jdk17-alpine, jdk17-alpine, 8.8.0-jdk-alpine, 8.8-jdk-alpine
 Architectures: amd64
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk17-alpine
 
 Tags: 8.8.0-jdk17-graal, 8.8-jdk17-graal, 8-jdk17-graal, jdk17-graal, 8.8.0-jdk-graal, 8.8-jdk-graal, 8-jdk-graal, jdk-graal, 8.8.0-graal, 8.8-graal, 8-graal, graal, 8.8.0-jdk17-graal-jammy, 8.8-jdk17-graal-jammy, 8-jdk17-graal-jammy, jdk17-graal-jammy, 8.8.0-jdk-graal-jammy, 8.8-jdk-graal-jammy, 8-jdk-graal-jammy, jdk-graal-jammy, 8.8.0-graal-jammy, 8.8-graal-jammy, 8-graal-jammy, graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk17-graal
 
 Tags: 8.8.0-jdk21, 8.8-jdk21, 8-jdk21, jdk21, 8.8.0-jdk21-jammy, 8.8-jdk21-jammy, 8-jdk21-jammy, jdk21-jammy, latest, 8.8.0-jdk, 8.8-jdk, 8-jdk, jdk, 8.8.0, 8.8, 8, 8.8.0-jdk-jammy, 8.8-jdk-jammy, 8-jdk-jammy, jdk-jammy, 8.8.0-jammy, 8.8-jammy, 8-jammy, jammy
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk21
 
 Tags: 8.8.0-jdk21-alpine, 8.8-jdk21-alpine, 8-jdk21-alpine, jdk21-alpine, 8-jdk-alpine, jdk-alpine, 8.8.0-alpine, 8.8-alpine, 8-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk21-alpine
 
 Tags: 8.8.0-jdk21-graal, 8.8-jdk21-graal, 8-jdk21-graal, jdk21-graal, 8.8.0-jdk21-graal-jammy, 8.8-jdk21-graal-jammy, 8-jdk21-graal-jammy, jdk21-graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk21-graal
+
+Tags: 8.8.0-jdk22, 8.8-jdk22, 8-jdk22, jdk22, 8.8.0-jdk22-jammy, 8.8-jdk22-jammy, 8-jdk22-jammy, jdk22-jammy
+Architectures: amd64, arm64v8
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
+Directory: jdk22
+
+Tags: 8.8.0-jdk22-alpine, 8.8-jdk22-alpine, 8-jdk22-alpine, jdk22-alpine
+Architectures: amd64, arm64v8
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
+Directory: jdk22-alpine
+
+Tags: 8.8.0-jdk22-graal, 8.8-jdk22-graal, 8-jdk22-graal, jdk22-graal
+Architectures: amd64, arm64v8
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
+Directory: jdk22-graal
 
 Tags: 8.8.0-jdk-lts-and-current, 8.8-jdk-lts-and-current, 8-jdk-lts-and-current, jdk-lts-and-current, 8.8.0-jdk-lts-and-current-jammy, 8.8-jdk-lts-and-current-jammy, 8-jdk-lts-and-current-jammy, jdk-lts-and-current-jammy,8.8.0-jdk-21-and-22, 8.8-jdk-21-and-22, 8-jdk-21-and-22, jdk-21-and-22, 8.8.0-jdk-21-and-22-jammy, 8.8-jdk-21-and-22-jammy, 8-jdk-21-and-22-jammy, jdk-21-and-22-jammy
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk-lts-and-current
 
 Tags: 8.8.0-jdk-lts-and-current-alpine, 8.8-jdk-lts-and-current-alpine, 8-jdk-lts-and-current-alpine, jdk-lts-and-current-alpine,8.8.0-jdk-21-and-22-alpine, 8.8-jdk-21-and-22-alpine, 8-jdk-21-and-22-alpine, jdk-21-and-22-alpine
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk-lts-and-current-alpine
 
 Tags: 8.8.0-jdk-lts-and-current-graal, 8.8-jdk-lts-and-current-graal, 8-jdk-lts-and-current-graal, jdk-lts-and-current-graal, 8.8.0-jdk-lts-and-current-graal-jammy, 8.8-jdk-lts-and-current-graal-jammy, 8-jdk-lts-and-current-graal-jammy, jdk-lts-and-current-graal-jammy,8.8.0-jdk-21-and-22-graal, 8.8-jdk-21-and-22-graal, 8-jdk-21-and-22-graal, jdk-21-and-22-graal, 8.8.0-jdk-21-and-22-graal-jammy, 8.8-jdk-21-and-22-graal-jammy, 8-jdk-21-and-22-graal-jammy, jdk-21-and-22-graal-jammy
 Architectures: amd64, arm64v8
-GitCommit: 90ea9aab95d2d1cef922939cd7e9a623510e9d8a
+GitCommit: 1f0a6db274bded26d03d8d3a405003e4eddbd1f9
 Directory: jdk-lts-and-current-graal
 
 


### PR DESCRIPTION
Gradle 8.8 [added](https://docs.gradle.org/8.8/release-notes.html#full-java-22-support) full Java 22 support, so we should have added Java 22 images when we updated to Gradle 8.8. Adding them now.