### PR TITLE
Remove tags from deprecated images

### DIFF
--- a/library/consul
+++ b/library/consul
@@ -1,20 +1,5 @@
 Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
-
-Tags: 1.15.4, 1.15
-Architectures: amd64, arm32v6, arm64v8, i386
 GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: aedd0844f06e9eac9c4e130206219b1ff044a8c4
-Directory: 0.X
 
-Tags: 1.14.8, 1.14
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: 7c095b8e988517c239526c0137caeb837c490807
-Directory: 0.X
-
-Tags: 1.13.9, 1.13
-Architectures: amd64, arm32v6, arm64v8, i386
-GitRepo: https://github.com/hashicorp/docker-consul.git
-GitCommit: ae00ef4e7ff1cf68afd391838993bc53234cf5e6
-Directory: 0.X
-
+# https://github.com/docker-library/docs/pull/2283
+# https://github.com/docker-library/official-images/pull/14949

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,7 +1,4 @@
 Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
 GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
 
-Tags: 1.x, 1.16.x, 1.16.11, latest
-Architectures: arm64v8, amd64, ppc64le, s390x
-GitCommit: fa2707c3b24bbd99710a100d7859566fa28817b8
-Directory: alpine
+# https://github.com/docker-library/docs/pull/2138

--- a/library/jobber
+++ b/library/jobber
@@ -1,8 +1,5 @@
 Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
 GitRepo: https://github.com/dshearer/jobber-docker.git
 
-Tags: 1.4.4-alpine3.11, 1.4-alpine3.11, 1-alpine3.11, latest
-GitCommit: cd07d76987097b5389aa9be5f48df041aa74d699
-GitFetch: refs/heads/maint-1.4
-Directory: alpine3.11
-
+# https://github.com/docker-library/docs/pull/2148
+# https://github.com/dshearer/jobber/pull/334

--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,26 +1,5 @@
 Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-GitFetch: refs/heads/main
-GitCommit: b58b5957ac6c7e2349e52a01ec61fb0afb376ac5
 
-Tags: 0.25.6-alpine3.18, 0.25-alpine3.18, alpine3.18, 0.25.6-alpine, 0.25-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.25.6/alpine3.18
-
-Tags: 0.25.6-scratch, 0.25-scratch, scratch, 0.25.6-linux, 0.25-linux, linux
-SharedTags: 0.25.6, 0.25, latest
-Architectures: amd64, arm32v6, arm32v7, arm64v8
-Directory: 0.25.6/scratch
-
-Tags: 0.25.6-windowsservercore-1809, 0.25-windowsservercore-1809, windowsservercore-1809
-SharedTags: 0.25.6-windowsservercore, 0.25-windowsservercore, windowsservercore
-Architectures: windows-amd64
-Directory: 0.25.6/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 0.25.6-nanoserver-1809, 0.25-nanoserver-1809, nanoserver-1809
-SharedTags: 0.25.6-nanoserver, 0.25-nanoserver, nanoserver, 0.25.6, 0.25, latest
-Architectures: windows-amd64
-Directory: 0.25.6/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
+# https://github.com/docker-library/docs/pull/2084

--- a/library/vault
+++ b/library/vault
@@ -2,19 +2,6 @@ Maintainers: Meggie Ladlow <meggie@hashicorp.com> (@mladlow),
              Calvin Leung Huang <calvin@hashicorp.com> (@calvn),
              Nick Cabatoff <ncabatoff@hashicorp.com> (@ncabatoff)
 GitRepo: https://github.com/hashicorp/docker-vault.git
-GitFetch: refs/heads/main
 
-Tags: 1.13.3
-Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: 152f49d818b2764c437ee1fd20ee4d13791a8296 
-Directory: 0.X
-
-Tags: 1.12.7
-Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: 48d258c844d65814e16c123f8d3750a4e73e4350 
-Directory: 0.X
-
-Tags: 1.11.11
-Architectures: amd64, arm64v8, arm32v6, i386
-GitCommit: e90ed0d020018291fabd520e9c36196c1e58f049
-Directory: 0.X
+# https://github.com/docker-library/docs/pull/2291
+# https://github.com/docker-library/official-images/pull/14940


### PR DESCRIPTION
This removes all tags from the `consul`, `express-gateway`, `jobber`, `nats-streaming`, and `vault` images. Each of them has had a "DEPRECATED" notice on their Docker Hub readme page for months to years. This will begin to remove the images from Docker Official Images by removing the tags from the "supported set" and prevent anyone from trying to propose an image `FROM` them.

---

Thank you to the maintainers of these images. We are grateful for all that you did for your users over the years. ❤️ Our door is open for helping bring these back into Docker Official Images should you desire (though I understand that some of these projects are fully deprecated, so we wish you luck in your other endeavors ❤️🍀💯).

So, what does this PR mean for these images:
 - the images will no longer be rebuilt when its base image is updated
 - the Docker Hub readme pages will be updated to no longer reference these tags, but instead show "No supported tags" (like https://hub.docker.com/_/sentry)
 -  the images will remain as-is on Docker Hub, so users can continue to pull the old versions of the software

We hope that these changes will increase the clarity of them being not supported since they already have a "Deprecated" notice.

Feel free to reach out of you'd like other changes to the Docker Hub readme pages (https://github.com/docker-library/docs), we're happy to help.

---

Related deprecation notices:
- `consul`: https://github.com/docker-library/docs/pull/2283
- `express-gateway`: https://github.com/docker-library/docs/pull/2138
- `jobber`: https://github.com/docker-library/docs/pull/2148
- `nats-streaming`: https://github.com/docker-library/docs/pull/2084
- `vault`: https://github.com/docker-library/docs/pull/2291