### PR TITLE
Bump Traefik to v2.11.5 and v3.0.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.0.2-windowsservercore-ltsc2022, 3.0.2-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.0.3-windowsservercore-ltsc2022, 3.0.3-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
+GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
 Directory: v3.0/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.0.2-windowsservercore-1809, 3.0.2-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
+Tags: v3.0.3-windowsservercore-1809, 3.0.3-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
+GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
 Directory: v3.0/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.2-nanoserver-ltsc2022, 3.0.2-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.0.3-nanoserver-ltsc2022, 3.0.3-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
+GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
 Directory: v3.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.0.2, 3.0.2, v3.0, 3.0, beaufort, latest
+Tags: v3.0.3, 3.0.3, v3.0, 3.0, beaufort, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
+GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
 Directory: v3.0/alpine
 
 Tags: v2.11.5-windowsservercore-ltsc2022, 2.11.5-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022

--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 42b189eacc3f995fb07ff3093f24e2936aebbbd1
 Directory: v3.0/alpine
 
-Tags: v2.11.4-windowsservercore-ltsc2022, 2.11.4-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.5-windowsservercore-ltsc2022, 2.11.5-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
+GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.4-windowsservercore-1809, 2.11.4-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.5-windowsservercore-1809, 2.11.5-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
+GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.4-nanoserver-ltsc2022, 2.11.4-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.5-nanoserver-ltsc2022, 2.11.5-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
+GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.4, 2.11.4, v2.11, 2.11, mimolette
+Tags: v2.11.5, 2.11.5, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8dfac0ac639317b2e8f2908a4b9ab91d88c062a5
+GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.5](https://github.com/traefik/traefik/releases/tag/v2.11.5) and [v3.0.3](https://github.com/traefik/traefik/releases/tag/v3.0.3).

/cc @ldez @mmatur @rtribotte

Cheers
