### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,24 +44,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 01b3b0d48c75a815148d46ae86b409507e232e1c
 Directory: 2.8/alpine
 
-Tags: 2.6.17, 2.6, 2.6.17-bookworm, 2.6-bookworm
+Tags: 2.6.18, 2.6, 2.6.18-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: af88bbc9186ea2ea09fa59dc77ae9437cad687b4
 Directory: 2.6
 
-Tags: 2.6.17-alpine, 2.6-alpine, 2.6.17-alpine3.20, 2.6-alpine3.20
+Tags: 2.6.18-alpine, 2.6-alpine, 2.6.18-alpine3.20, 2.6-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
+GitCommit: af88bbc9186ea2ea09fa59dc77ae9437cad687b4
 Directory: 2.6/alpine
 
-Tags: 2.4.26, 2.4, 2.4.26-bookworm, 2.4-bookworm
+Tags: 2.4.27, 2.4, 2.4.27-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: c72a79f8fe0a0db91b36645220409c08d11cc0a6
 Directory: 2.4
 
-Tags: 2.4.26-alpine, 2.4-alpine, 2.4.26-alpine3.20, 2.4-alpine3.20
+Tags: 2.4.27-alpine, 2.4-alpine, 2.4.27-alpine3.20, 2.4-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 58040965047f8cc37eedbaa4d3180c6313b88440
+GitCommit: c72a79f8fe0a0db91b36645220409c08d11cc0a6
 Directory: 2.4/alpine
 
 Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/af88bbc: Update 2.6 to 2.6.18
- https://github.com/docker-library/haproxy/commit/c72a79f: Update 2.4 to 2.4.27