### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.4.20240528.0
+Tags: 2023, latest, 2023.4.20240611.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 3f70daba787f52e24ac044292a45f80bde40d68c
+amd64-GitCommit: 77f7a5d15a41a4c43d477351a84d065377b10cb1
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 9d8a9b8c45fb865ed3a01a25ba57130be47c19be
+arm64v8-GitCommit: 65645a38f8fa08616c27293fe2a5a5bbe842360c
 
-Tags: 2, 2.0.20240529.0
+Tags: 2, 2.0.20240610.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 4e2e2fd3a7f437964ba551048908e6a5ce819bf5
+amd64-GitCommit: 252f954fcdd02be858931219147aebcf9099e86c
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 9b67b534fa1b8612e093f51a7e82192eb38530e4
+arm64v8-GitCommit: de4f24369de1cf4f5bd88a06d86b33b2a88ca719
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
#### Packages addressing CVES:

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.4.20240611-1.amzn2023
- system-release-2023.4.20240611-1.amzn2023
- openssl-libs-3.0.8-1.amzn2023.0.12
#### Packages addressing CVES:
- openssl-libs-3.0.8-1.amzn2023.0.12
  - [CVE-2024-2511](https://alas.aws.amazon.com/cve/html/CVE-2024-2511.html)