### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.85.1, 5.85, 5, latest
+Tags: 5.85.2, 5.85, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e33d9bde68a1fc6ce5087c6e32706f6a4a8d2636
+GitCommit: f7fb70a1525f7856d16542efe916bcb809cff366
 Directory: 5/debian
 
-Tags: 5.85.1-alpine, 5.85-alpine, 5-alpine, alpine
+Tags: 5.85.2-alpine, 5.85-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: e33d9bde68a1fc6ce5087c6e32706f6a4a8d2636
+GitCommit: f7fb70a1525f7856d16542efe916bcb809cff366
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/f7fb70a: Update to 5.85.2, ghost-cli 1.26.0