### PR TITLE
nginx maintenance updates

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -5,7 +5,7 @@ GitRepo: https://github.com/nginxinc/docker-nginx.git
 
 Tags: 1.27.0, mainline, 1, 1.27, latest, 1.27.0-bookworm, mainline-bookworm, 1-bookworm, 1.27-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: a6f7d140744f8b15ff4314b8718b3f022efc7f43
 Directory: mainline/debian
 
 Tags: 1.27.0-perl, mainline-perl, 1-perl, 1.27-perl, perl, 1.27.0-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.27-bookworm-perl, bookworm-perl
@@ -20,27 +20,27 @@ Directory: mainline/debian-otel
 
 Tags: 1.27.0-alpine, mainline-alpine, 1-alpine, 1.27-alpine, alpine, 1.27.0-alpine3.19, mainline-alpine3.19, 1-alpine3.19, 1.27-alpine3.19, alpine3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: mainline/alpine
 
 Tags: 1.27.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.27-alpine-perl, alpine-perl, 1.27.0-alpine3.19-perl, mainline-alpine3.19-perl, 1-alpine3.19-perl, 1.27-alpine3.19-perl, alpine3.19-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: mainline/alpine-perl
 
 Tags: 1.27.0-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.27-alpine-slim, alpine-slim, 1.27.0-alpine3.19-slim, mainline-alpine3.19-slim, 1-alpine3.19-slim, 1.27-alpine3.19-slim, alpine3.19-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: mainline/alpine-slim
 
 Tags: 1.27.0-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.27-alpine-otel, alpine-otel, 1.27.0-alpine3.19-otel, mainline-alpine3.19-otel, 1-alpine3.19-otel, 1.27-alpine3.19-otel, alpine3.19-otel
 Architectures: amd64, arm64v8
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: mainline/alpine-otel
 
 Tags: 1.26.1, stable, 1.26, 1.26.1-bookworm, stable-bookworm, 1.26-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: a6f7d140744f8b15ff4314b8718b3f022efc7f43
 Directory: stable/debian
 
 Tags: 1.26.1-perl, stable-perl, 1.26-perl, 1.26.1-bookworm-perl, stable-bookworm-perl, 1.26-bookworm-perl
@@ -55,20 +55,20 @@ Directory: stable/debian-otel
 
 Tags: 1.26.1-alpine, stable-alpine, 1.26-alpine, 1.26.1-alpine3.19, stable-alpine3.19, 1.26-alpine3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: stable/alpine
 
 Tags: 1.26.1-alpine-perl, stable-alpine-perl, 1.26-alpine-perl, 1.26.1-alpine3.19-perl, stable-alpine3.19-perl, 1.26-alpine3.19-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: stable/alpine-perl
 
 Tags: 1.26.1-alpine-slim, stable-alpine-slim, 1.26-alpine-slim, 1.26.1-alpine3.19-slim, stable-alpine3.19-slim, 1.26-alpine3.19-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: stable/alpine-slim
 
 Tags: 1.26.1-alpine-otel, stable-alpine-otel, 1.26-alpine-otel, 1.26.1-alpine3.19-otel, stable-alpine3.19-otel, 1.26-alpine3.19-otel
 Architectures: amd64, arm64v8
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
 Directory: stable/alpine-otel


### PR DESCRIPTION
No tag updates, just a couple of fixes:

 - compatibility with Alpine's apk-tools 2.14.2+ when signing self-built packages, fixing the codepath where binary packages are built from source.

 - new gpg signing keys for debian-based images, fixing an expired key issue for downstreams.

I initially thought a gpg issue is best fixed by dropping the keys from the resulting image altogether; but then I thought that our next step would be to introduce another set of keys for the future releases;  and that will undoubtedly cause even more confusion to downstreams.   So let's keep the keys as they are and update them properly.