### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -7,34 +7,27 @@ GitRepo: https://github.com/docker-library/gcc.git
 # Last Modified: 2024-05-07
 Tags: 14.1.0, 14.1, 14, latest, 14.1.0-bookworm, 14.1-bookworm, 14-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
+GitCommit: dfd9a5f296cd45762afd9b9e098d293b12dc5193
 Directory: 14
 # Docker EOL: 2025-11-07
 
 # Last Modified: 2024-05-21
 Tags: 13.3.0, 13.3, 13, 13.3.0-bookworm, 13.3-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6f09c34227daae15e71f398f0073e31f3ef74234
+GitCommit: dfd9a5f296cd45762afd9b9e098d293b12dc5193
 Directory: 13
 # Docker EOL: 2025-11-21
 
-# Last Modified: 2023-05-08
-Tags: 12.3.0, 12.3, 12, 12.3.0-bookworm, 12.3-bookworm, 12-bookworm
+# Last Modified: 2024-06-20
+Tags: 12.4.0, 12.4, 12, 12.4.0-bookworm, 12.4-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
+GitCommit: 4a0eb64954fed9990b723b618fa13f6b8f7762e3
 Directory: 12
-# Docker EOL: 2024-11-08
+# Docker EOL: 2025-12-20
 
 # Last Modified: 2023-05-29
 Tags: 11.4.0, 11.4, 11, 11.4.0-bullseye, 11.4-bullseye, 11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
+GitCommit: dfd9a5f296cd45762afd9b9e098d293b12dc5193
 Directory: 11
 # Docker EOL: 2024-11-29
-
-# Last Modified: 2023-07-07
-Tags: 10.5.0, 10.5, 10, 10.5.0-bullseye, 10.5-bullseye, 10-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b1e7fc69e4021bab505d420fddc57002ef04939e
-Directory: 10
-# Docker EOL: 2025-01-07


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/4a0eb64: Update 12 to 12.4.0
- https://github.com/docker-library/gcc/commit/ba14e97: Merge pull request https://github.com/docker-library/gcc/pull/107 from infosiftr/10-eol
- https://github.com/docker-library/gcc/commit/7c21417: Remove 10 (end of life)
- https://github.com/docker-library/gcc/commit/df37ca5: Merge pull request https://github.com/docker-library/gcc/pull/106 from infosiftr/mirrors
- https://github.com/docker-library/gcc/commit/dfd9a5f: Switch to upstream mirror for scraping version numbers