### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2024-3501

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 837a2c4210acabd7c040103b60c8240a7eefa9f0
+amd64-GitCommit: 9885780168f82868253bb3ecead4632f27bdb259
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 38b9ffe554cf130af2fb244115af17aedc60d159
+arm64v8-GitCommit: 337830cfed4e1ca54906c9d41b795596371dce25
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-28182,

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-3501.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
