### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.85.2, 5.85, 5, latest
+Tags: 5.86.2, 5.86, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7fb70a1525f7856d16542efe916bcb809cff366
+GitCommit: a74ffaa09a98dac2d6900957d7fab2c545e2dec1
 Directory: 5/debian
 
-Tags: 5.85.2-alpine, 5.85-alpine, 5-alpine, alpine
+Tags: 5.86.2-alpine, 5.86-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f7fb70a1525f7856d16542efe916bcb809cff366
+GitCommit: a74ffaa09a98dac2d6900957d7fab2c545e2dec1
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/a74ffaa: Update to 5.86.2, ghost-cli 1.26.0
- https://github.com/docker-library/ghost/commit/35ad2d4: Update to 5.86.1, ghost-cli 1.26.0
- https://github.com/docker-library/ghost/commit/230753a: Merge pull request https://github.com/docker-library/ghost/pull/417 from infosiftr/su-noexec
- https://github.com/docker-library/ghost/commit/b9cd69e: Update to 5.86.0, ghost-cli 1.26.0