### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,30 +6,30 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 5.1.3, 5.1, 5, latest, 5.1.3-bookworm, 5.1-bookworm, 5-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 00027a1ffc5010efeb4ee8562afdf20635844bd9
+GitCommit: f44d7a06e867841594aaaf45fddf59a77fad5337
 Directory: 5.1/bookworm
 
 Tags: 5.1.3-alpine3.20, 5.1-alpine3.20, 5-alpine3.20, alpine3.20, 5.1.3-alpine, 5.1-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00027a1ffc5010efeb4ee8562afdf20635844bd9
+GitCommit: f44d7a06e867841594aaaf45fddf59a77fad5337
 Directory: 5.1/alpine3.20
 
 Tags: 5.1.3-alpine3.19, 5.1-alpine3.19, 5-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 00027a1ffc5010efeb4ee8562afdf20635844bd9
+GitCommit: f44d7a06e867841594aaaf45fddf59a77fad5337
 Directory: 5.1/alpine3.19
 
 Tags: 5.0.9, 5.0, 5.0.9-bookworm, 5.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01b89cb313c07c154f99f95362a0b4baa6cf71d0
+GitCommit: f44d7a06e867841594aaaf45fddf59a77fad5337
 Directory: 5.0/bookworm
 
 Tags: 5.0.9-alpine3.20, 5.0-alpine3.20, 5.0.9-alpine, 5.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 01b89cb313c07c154f99f95362a0b4baa6cf71d0
+GitCommit: f44d7a06e867841594aaaf45fddf59a77fad5337
 Directory: 5.0/alpine3.20
 
 Tags: 5.0.9-alpine3.19, 5.0-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 01b89cb313c07c154f99f95362a0b4baa6cf71d0
+GitCommit: f44d7a06e867841594aaaf45fddf59a77fad5337
 Directory: 5.0/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/957f1e0: Merge pull request https://github.com/docker-library/redmine/pull/333 from infosiftr/su-noexec
- https://github.com/docker-library/redmine/commit/f44d7a0: Replace `su-exec` with `gosu`