### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 3.13.3, 3.13, 3, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 83604b7ec3bda015495dda883fe3b471f206d562
+GitCommit: 013a76f659c4c5e379f80507b100a85fffb95552
 Directory: 3.13/ubuntu
 
 Tags: 3.13.3-management, 3.13-management, 3-management, management
@@ -17,7 +17,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.3-alpine, 3.13-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 83604b7ec3bda015495dda883fe3b471f206d562
+GitCommit: 013a76f659c4c5e379f80507b100a85fffb95552
 Directory: 3.13/alpine
 
 Tags: 3.13.3-management-alpine, 3.13-management-alpine, 3-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/013a76f: Update 3.13 to otp 26.2.5.1