### PR TITLE
[oraclelinux] Updating 9 for ELSA-2024-4078

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9885780168f82868253bb3ecead4632f27bdb259
+amd64-GitCommit: ec5aa528ff05152e58b85e3d0a850ad8a627187c
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 337830cfed4e1ca54906c9d41b795596371dce25
+arm64v8-GitCommit: 800918fa33925f2b36d2a69d2cf09f123263f2d2
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2023-6597, CVE-2024-0450, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-4078.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
