### PR TITLE
Reinstate Kong Alpine 2.8.5 as the main version

### DIFF
--- a/library/kong
+++ b/library/kong
@@ -25,8 +25,16 @@ GitFetch: refs/tags/3.4.2
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 2.8.5-ubuntu, 2.8-ubuntu, 2.8.5, 2.8, 2
-GitCommit: 3fe94ba928bf75b385bd98aa2d5ad07b86fd3eb8
+Tags: 2.8.5-alpine, 2.8-alpine, 2.8.5, 2.8, 2
+GitCommit: cdf93ae2106f998a2245a3eee6814b1ae68781af
+GitFetch: refs/tags/2.8.5
+Directory: alpine
+Architectures: amd64
+
+Tags: 2.8.5-ubuntu, 2.8-ubuntu
+GitCommit: cdf93ae2106f998a2245a3eee6814b1ae68781af
 GitFetch: refs/tags/2.8.5
 Directory: ubuntu
 Architectures: amd64
+
+


### PR DESCRIPTION
There was some confusion during the release of kong 2.8.5. While on the 3.x series we no longer maintain Alpine, it is still maintained in 2.x

As such, this PR reinstates Alpine as the head for 2.8.x.

The change in the Ubuntu SHA is due to the fact that we had to add a new commit to the branch in order to rebuild alpine. The ubuntu files are otherwise unchanged