### PR TITLE
Fix `build-order` calculation inside `diff-pr.sh`

### DIFF
--- a/diff-pr.sh
+++ b/diff-pr.sh
@@ -345,7 +345,12 @@ _metadata-files() {
 
 		"$diffDir/_bashbrew-cat-sorted.sh" "$@" 2>>temp/_bashbrew.err > temp/_bashbrew-cat || :
 
-		bashbrew cat --format "$templateLastTags" "$@" \
+		# piping "bashbrew list" first so that .TagEntries is filled up (keeping "templateLastTags" simpler)
+		# sorting that by version number so it's ~stable
+		# then doing --build-order on that, which is a "stable sort"
+		# then redoing that list back into "templateLastTags" so we get the tags we want listed (not the tags "--uniq" chooses)
+		bashbrew list --uniq "$@" \
+			| xargs -r bashbrew cat --format "$templateLastTags" \
 			| sort -V \
 			| xargs -r bashbrew list --uniq --build-order 2>>temp/_bashbrew.err \
 			| xargs -r bashbrew cat --format "$templateLastTags" 2>>temp/_bashbrew.err \
@@ -359,6 +364,9 @@ _metadata-files() {
 		( eval "$script" | tar -xiC tar )
 		copy-tar tar temp
 		rm -rf tar
+
+		# TODO we should *also* validate that our lists ended up non-empty 😬
+		cat >&2 temp/_bashbrew.err
 	fi
 
 	if [ -n "$externalPins" ] && command -v crane &> /dev/null; then


### PR DESCRIPTION
I noticed this while reviewing the recent `kong` diff (https://github.com/docker-library/official-images/pull/17067#issuecomment-2195301809) and seeing this odd bit:

```diff
diff --git a/_bashbrew-list-build-order b/kong_2/kong.tar.gz
similarity index 100%
copy from _bashbrew-list-build-order
copy to kong_2/kong.tar.gz
```

Knowing that `kong.tar.gz` is supposed to be an empty file, I wondered why `_bashbrew-list-build-order` was apparently empty, and discovered that it's because `.TagEntries` is only available/valid when we're actually passing _tags_ to `bashbrew`. 😅

The relevant portion of the diff there with this change applied becomes:

```diff
diff --git a/_bashbrew-list-build-order b/_bashbrew-list-build-order
index 3d1a096..dafab4e 100644
--- a/_bashbrew-list-build-order
+++ b/_bashbrew-list-build-order
@@ -1,4 +1,4 @@
-kong:2.8
+kong:2
 kong:2.8-ubuntu
 kong:3.4
 kong:3.5
```