### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -6,25 +6,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Tanu Rampal (@trampal),
              Sam Thornton (@mrthornazon),
              Preston Carpenter (@timidger),
-             Miriam Clark (@mgclark001),
              Ade Adetayo (@dadetayo),
-             Jason Jiannuo Pei (@peijiannuo)
+             Jason Jiannuo Pei (@peijiannuo),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.4.20240611.0
+Tags: 2023, latest, 2023.5.20240624.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 77f7a5d15a41a4c43d477351a84d065377b10cb1
+amd64-GitCommit: 79921b7f2b8ace2a04214cac4e2b2dd375f793af
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 65645a38f8fa08616c27293fe2a5a5bbe842360c
+arm64v8-GitCommit: a3b9eaeda34f6decd23f62a16994f50b939511d6
 
-Tags: 2, 2.0.20240610.1
+Tags: 2, 2.0.20240620.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 252f954fcdd02be858931219147aebcf9099e86c
+amd64-GitCommit: 3940ec6a9ed3bbb1dd7ccca2fcfcc4a28213588a
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: de4f24369de1cf4f5bd88a06d86b33b2a88ca719
+arm64v8-GitCommit: 77c258e7b8f058d3a4d5f53ee6135eca78d5fdd7
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.5.20240624-0.amzn2023
- system-release-2023.5.20240624-0.amzn2023