### PR TITLE
Bump Traefik to v3.1.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,4 +1,31 @@
-Maintainers: Ludovic Fernandez <ludovic@traefik.io> (@ldez), Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
+Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
+
+Tags: v3.1.0-rc2-windowsservercore-ltsc2022, 3.1.0-rc2-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+Directory: v3.1/windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: v3.1.0-rc2-windowsservercore-1809, 3.1.0-rc2-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+Directory: v3.1/windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v3.1.0-rc2-nanoserver-ltsc2022, 3.1.0-rc2-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+Directory: v3.1/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: v3.1.0-rc2, 3.1.0-rc2, v3.1, 3.1, comte
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+Directory: v3.1/alpine
 
 Tags: v3.0.3-windowsservercore-ltsc2022, 3.0.3-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.1.0-rc2](https://github.com/traefik/traefik/releases/tag/v3.1.0-rc2) and updates the maintainer list according to https://github.com/traefik/traefik/pull/10827. 

/cc @nmengin @emilevauge @mmatur @rtribotte @juliens

Cheers