### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.86.2, 5.86, 5, latest
+Tags: 5.87.0, 5.87, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a74ffaa09a98dac2d6900957d7fab2c545e2dec1
+GitCommit: 1b2bf3e790b799e4e9b232ad8bc4b6622e466c76
 Directory: 5/debian
 
-Tags: 5.86.2-alpine, 5.86-alpine, 5-alpine, alpine
+Tags: 5.87.0-alpine, 5.87-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: a74ffaa09a98dac2d6900957d7fab2c545e2dec1
+GitCommit: 1b2bf3e790b799e4e9b232ad8bc4b6622e466c76
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1b2bf3e: Update to 5.87.0, ghost-cli 1.26.0