### PR TITLE
chore(Rust): Remove Debian Buster support

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,18 +1,8 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/ea4aab0935fcafe4956d6206f3ecde84ffddf800/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/bccfc8f43eeeac8b9aecc6e734a228507e10de5b/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
-
-Tags: 1-buster, 1.79-buster, 1.79.0-buster, buster
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
-Directory: 1.79.0/buster
-
-Tags: 1-slim-buster, 1.79-slim-buster, 1.79.0-slim-buster, slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: ea4aab0935fcafe4956d6206f3ecde84ffddf800
-Directory: 1.79.0/buster/slim
 
 Tags: 1-bullseye, 1.79-bullseye, 1.79.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
This removes support for Debian Buster from the Rust Official Image.

See #17091