### PR TITLE
Bump Traefik to v2.11.6, v3.0.4, and v3.1.0-rc3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,82 +1,82 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.1.0-rc2-windowsservercore-ltsc2022, 3.1.0-rc2-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022
+Tags: v3.1.0-rc3-windowsservercore-ltsc2022, 3.1.0-rc3-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
 Directory: v3.1/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.1.0-rc2-windowsservercore-1809, 3.1.0-rc2-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809
+Tags: v3.1.0-rc3-windowsservercore-1809, 3.1.0-rc3-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
 Directory: v3.1/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.1.0-rc2-nanoserver-ltsc2022, 3.1.0-rc2-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022
+Tags: v3.1.0-rc3-nanoserver-ltsc2022, 3.1.0-rc3-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
 Directory: v3.1/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.1.0-rc2, 3.1.0-rc2, v3.1, 3.1, comte
+Tags: v3.1.0-rc3, 3.1.0-rc3, v3.1, 3.1, comte
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e8e43baa0a336e4ab03ffcaa02377b446c146274
+GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
 Directory: v3.1/alpine
 
-Tags: v3.0.3-windowsservercore-ltsc2022, 3.0.3-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.0.4-windowsservercore-ltsc2022, 3.0.4-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
+GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
 Directory: v3.0/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.0.3-windowsservercore-1809, 3.0.3-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
+Tags: v3.0.4-windowsservercore-1809, 3.0.4-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
+GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
 Directory: v3.0/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.0.3-nanoserver-ltsc2022, 3.0.3-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.0.4-nanoserver-ltsc2022, 3.0.4-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
+GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
 Directory: v3.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.0.3, 3.0.3, v3.0, 3.0, beaufort, latest
+Tags: v3.0.4, 3.0.4, v3.0, 3.0, beaufort, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e4bd02cde037ae1002cbb2de6358a2e067158d84
+GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
 Directory: v3.0/alpine
 
-Tags: v2.11.5-windowsservercore-ltsc2022, 2.11.5-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.6-windowsservercore-ltsc2022, 2.11.6-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
+GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.5-windowsservercore-1809, 2.11.5-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.6-windowsservercore-1809, 2.11.6-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
+GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.5-nanoserver-ltsc2022, 2.11.5-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.6-nanoserver-ltsc2022, 2.11.6-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
+GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.5, 2.11.5, v2.11, 2.11, mimolette
+Tags: v2.11.6, 2.11.6, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 796345ea7521aa8635afbb42f4b9e27b1abb3928
+GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.6](https://github.com/traefik/traefik/releases/tag/v2.11.6), [v3.0.4](https://github.com/traefik/traefik/releases/tag/v3.0.4), and [v3.1.0-rc3](https://github.com/traefik/traefik/releases/tag/v3.1.0-rc3). 

/cc @nmengin @emilevauge @mmatur @rtribotte @juliens

Cheers