### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,20 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 8.4.0, 8.4, 8, lts, latest, innovation, 8.4.0-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, oraclelinux9, innovation-oraclelinux9, 8.4.0-oracle, 8.4-oracle, 8-oracle, lts-oracle, oracle, innovation-oracle
+Tags: 9.0.0, 9.0, 9, innovation, latest, 9.0.0-oraclelinux9, 9.0-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.0.0-oracle, 9.0-oracle, 9-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 319db566ac7fef45c22f3df15ee5e194a7c43259
+GitCommit: 3d11822710789e82f64f08c578162a5b804d2f2f
+Directory: innovation
+File: Dockerfile.oracle
+
+Tags: 8.4.1, 8.4, 8, lts, 8.4.1-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.1-oracle, 8.4-oracle, 8-oracle, lts-oracle
+Architectures: amd64, arm64v8
+GitCommit: efa7479ffbb00139f6f1f0b0fe70985f20ee0456
 Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.37, 8.0, 8.0.37-oraclelinux9, 8.0-oraclelinux9, 8.0.37-oracle, 8.0-oracle
+Tags: 8.0.38, 8.0, 8.0.38-oraclelinux9, 8.0-oraclelinux9, 8.0.38-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 319db566ac7fef45c22f3df15ee5e194a7c43259
+GitCommit: db7daba00da79773c594b94bd91c9deeca1c9c88
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.37-bookworm, 8.0-bookworm, 8.0.37-debian, 8.0-debian
+Tags: 8.0.38-bookworm, 8.0-bookworm, 8.0.38-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 319db566ac7fef45c22f3df15ee5e194a7c43259
+GitCommit: db7daba00da79773c594b94bd91c9deeca1c9c88
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/939fe2f: Merge pull request https://github.com/docker-library/mysql/pull/1076 from jnoordsij/innovation-oraclelinux9
- https://github.com/docker-library/mysql/commit/3d11822: Use Oracle Linux 9 as base image for innovation image
- https://github.com/docker-library/mysql/commit/9585da1: Update innovation to mysql-shell 9.0.0-1.el8
- https://github.com/docker-library/mysql/commit/efa7479: Update 8.4 to 8.4.1, oracle 8.4.1-1.el9, mysql-shell 8.4.1-1.el9
- https://github.com/docker-library/mysql/commit/db7daba: Update 8.0 to 8.0.38, debian 8.0.38-1debian12, oracle 8.0.38-1.el9, mysql-shell 8.0.38-1.el9