### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -34,21 +34,6 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: debian/bullseye
 
-Tags: buster-curl, oldoldstable-curl
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 93d6db0797f91ab674535553b7e0e762941a02d0
-Directory: debian/buster/curl
-
-Tags: buster-scm, oldoldstable-scm
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
-Directory: debian/buster/scm
-
-Tags: buster, oldoldstable
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
-Directory: debian/buster
-
 Tags: sid-curl, unstable-curl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 GitCommit: 2b3a8b7d1f8875865034be3bab98ddd737e37d5e


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/766f7f6: Merge pull request https://github.com/docker-library/buildpack-deps/pull/159 from infosiftr/buster-eol
- https://github.com/docker-library/buildpack-deps/commit/e6c3ed0: Remove (now EOL) Debian Buster variants