### PR TITLE
library/perl: 5.39.10 -> 5.41.1

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,7 +1,7 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: 310b7bc1e03fa38094922c1a2e2cbd608bd0b3a4
+GitCommit: d8d1d47872c9c76bff44200268569a1a756f1bbd
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 
 Tags: 5.40.0, 5.40, 5, latest, stable, 5.40.0-bookworm, 5.40-bookworm, 5-bookworm, bookworm, stable-bookworm
@@ -10,19 +10,11 @@ Directory: 5.040.000-main-bookworm
 Tags: 5.40.0-bullseye, 5.40-bullseye, 5-bullseye, bullseye, stable-bullseye
 Directory: 5.040.000-main-bullseye
 
-Tags: 5.40.0-buster, 5.40-buster, 5-buster, buster, stable-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.040.000-main-buster
-
 Tags: 5.40.0-slim, 5.40-slim, 5-slim, slim, stable-slim, 5.40.0-slim-bookworm, 5.40-slim-bookworm, 5-slim-bookworm, slim-bookworm, stable-slim-bookworm
 Directory: 5.040.000-slim-bookworm
 
 Tags: 5.40.0-slim-bullseye, 5.40-slim-bullseye, 5-slim-bullseye, slim-bullseye, stable-slim-bullseye
 Directory: 5.040.000-slim-bullseye
-
-Tags: 5.40.0-slim-buster, 5.40-slim-buster, 5-slim-buster, slim-buster, stable-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.040.000-slim-buster
 
 Tags: 5.40.0-threaded, 5.40-threaded, 5-threaded, threaded, stable-threaded, 5.40.0-threaded-bookworm, 5.40-threaded-bookworm, 5-threaded-bookworm, threaded-bookworm, stable-threaded-bookworm
 Directory: 5.040.000-main,threaded-bookworm
@@ -30,19 +22,11 @@ Directory: 5.040.000-main,threaded-bookworm
 Tags: 5.40.0-threaded-bullseye, 5.40-threaded-bullseye, 5-threaded-bullseye, threaded-bullseye, stable-threaded-bullseye
 Directory: 5.040.000-main,threaded-bullseye
 
-Tags: 5.40.0-threaded-buster, 5.40-threaded-buster, 5-threaded-buster, threaded-buster, stable-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.040.000-main,threaded-buster
-
 Tags: 5.40.0-slim-threaded, 5.40-slim-threaded, 5-slim-threaded, slim-threaded, stable-slim-threaded, 5.40.0-slim-threaded-bookworm, 5.40-slim-threaded-bookworm, 5-slim-threaded-bookworm, slim-threaded-bookworm, stable-slim-threaded-bookworm
 Directory: 5.040.000-slim,threaded-bookworm
 
 Tags: 5.40.0-slim-threaded-bullseye, 5.40-slim-threaded-bullseye, 5-slim-threaded-bullseye, slim-threaded-bullseye, stable-slim-threaded-bullseye
 Directory: 5.040.000-slim,threaded-bullseye
-
-Tags: 5.40.0-slim-threaded-buster, 5.40-slim-threaded-buster, 5-slim-threaded-buster, slim-threaded-buster, stable-slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.040.000-slim,threaded-buster
 
 Tags: 5.38.2, 5.38, 5.38.2-bookworm, 5.38-bookworm
 Directory: 5.038.002-main-bookworm
@@ -50,19 +34,11 @@ Directory: 5.038.002-main-bookworm
 Tags: 5.38.2-bullseye, 5.38-bullseye
 Directory: 5.038.002-main-bullseye
 
-Tags: 5.38.2-buster, 5.38-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.038.002-main-buster
-
 Tags: 5.38.2-slim, 5.38-slim, 5.38.2-slim-bookworm, 5.38-slim-bookworm
 Directory: 5.038.002-slim-bookworm
 
 Tags: 5.38.2-slim-bullseye, 5.38-slim-bullseye
 Directory: 5.038.002-slim-bullseye
-
-Tags: 5.38.2-slim-buster, 5.38-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.038.002-slim-buster
 
 Tags: 5.38.2-threaded, 5.38-threaded, 5.38.2-threaded-bookworm, 5.38-threaded-bookworm
 Directory: 5.038.002-main,threaded-bookworm
@@ -70,19 +46,11 @@ Directory: 5.038.002-main,threaded-bookworm
 Tags: 5.38.2-threaded-bullseye, 5.38-threaded-bullseye
 Directory: 5.038.002-main,threaded-bullseye
 
-Tags: 5.38.2-threaded-buster, 5.38-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.038.002-main,threaded-buster
-
 Tags: 5.38.2-slim-threaded, 5.38-slim-threaded, 5.38.2-slim-threaded-bookworm, 5.38-slim-threaded-bookworm
 Directory: 5.038.002-slim,threaded-bookworm
 
 Tags: 5.38.2-slim-threaded-bullseye, 5.38-slim-threaded-bullseye
 Directory: 5.038.002-slim,threaded-bullseye
-
-Tags: 5.38.2-slim-threaded-buster, 5.38-slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.038.002-slim,threaded-buster
 
 Tags: 5.36.3, 5.36, 5.36.3-bookworm, 5.36-bookworm
 Directory: 5.036.003-main-bookworm
@@ -90,19 +58,11 @@ Directory: 5.036.003-main-bookworm
 Tags: 5.36.3-bullseye, 5.36-bullseye
 Directory: 5.036.003-main-bullseye
 
-Tags: 5.36.3-buster, 5.36-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.036.003-main-buster
-
 Tags: 5.36.3-slim, 5.36-slim, 5.36.3-slim-bookworm, 5.36-slim-bookworm
 Directory: 5.036.003-slim-bookworm
 
 Tags: 5.36.3-slim-bullseye, 5.36-slim-bullseye
 Directory: 5.036.003-slim-bullseye
-
-Tags: 5.36.3-slim-buster, 5.36-slim-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.036.003-slim-buster
 
 Tags: 5.36.3-threaded, 5.36-threaded, 5.36.3-threaded-bookworm, 5.36-threaded-bookworm
 Directory: 5.036.003-main,threaded-bookworm
@@ -110,40 +70,32 @@ Directory: 5.036.003-main,threaded-bookworm
 Tags: 5.36.3-threaded-bullseye, 5.36-threaded-bullseye
 Directory: 5.036.003-main,threaded-bullseye
 
-Tags: 5.36.3-threaded-buster, 5.36-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.036.003-main,threaded-buster
-
 Tags: 5.36.3-slim-threaded, 5.36-slim-threaded, 5.36.3-slim-threaded-bookworm, 5.36-slim-threaded-bookworm
 Directory: 5.036.003-slim,threaded-bookworm
 
 Tags: 5.36.3-slim-threaded-bullseye, 5.36-slim-threaded-bullseye
 Directory: 5.036.003-slim,threaded-bullseye
 
-Tags: 5.36.3-slim-threaded-buster, 5.36-slim-threaded-buster
-Architectures: amd64, arm32v7, arm64v8, i386
-Directory: 5.036.003-slim,threaded-buster
+Tags: 5.41.1, 5.41, devel, 5.41.1-bookworm, 5.41-bookworm, devel-bookworm
+Directory: 5.041.001-main-bookworm
 
-Tags: 5.39.10, 5.39, devel, 5.39.10-bookworm, 5.39-bookworm, devel-bookworm
-Directory: 5.039.010-main-bookworm
+Tags: 5.41.1-bullseye, 5.41-bullseye, devel-bullseye
+Directory: 5.041.001-main-bullseye
 
-Tags: 5.39.10-bullseye, 5.39-bullseye, devel-bullseye
-Directory: 5.039.010-main-bullseye
+Tags: 5.41.1-slim, 5.41-slim, devel-slim, 5.41.1-slim-bookworm, 5.41-slim-bookworm, devel-slim-bookworm
+Directory: 5.041.001-slim-bookworm
 
-Tags: 5.39.10-slim, 5.39-slim, devel-slim, 5.39.10-slim-bookworm, 5.39-slim-bookworm, devel-slim-bookworm
-Directory: 5.039.010-slim-bookworm
+Tags: 5.41.1-slim-bullseye, 5.41-slim-bullseye, devel-slim-bullseye
+Directory: 5.041.001-slim-bullseye
 
-Tags: 5.39.10-slim-bullseye, 5.39-slim-bullseye, devel-slim-bullseye
-Directory: 5.039.010-slim-bullseye
+Tags: 5.41.1-threaded, 5.41-threaded, devel-threaded, 5.41.1-threaded-bookworm, 5.41-threaded-bookworm, devel-threaded-bookworm
+Directory: 5.041.001-main,threaded-bookworm
 
-Tags: 5.39.10-threaded, 5.39-threaded, devel-threaded, 5.39.10-threaded-bookworm, 5.39-threaded-bookworm, devel-threaded-bookworm
-Directory: 5.039.010-main,threaded-bookworm
+Tags: 5.41.1-threaded-bullseye, 5.41-threaded-bullseye, devel-threaded-bullseye
+Directory: 5.041.001-main,threaded-bullseye
 
-Tags: 5.39.10-threaded-bullseye, 5.39-threaded-bullseye, devel-threaded-bullseye
-Directory: 5.039.010-main,threaded-bullseye
+Tags: 5.41.1-slim-threaded, 5.41-slim-threaded, devel-slim-threaded, 5.41.1-slim-threaded-bookworm, 5.41-slim-threaded-bookworm, devel-slim-threaded-bookworm
+Directory: 5.041.001-slim,threaded-bookworm
 
-Tags: 5.39.10-slim-threaded, 5.39-slim-threaded, devel-slim-threaded, 5.39.10-slim-threaded-bookworm, 5.39-slim-threaded-bookworm, devel-slim-threaded-bookworm
-Directory: 5.039.010-slim,threaded-bookworm
-
-Tags: 5.39.10-slim-threaded-bullseye, 5.39-slim-threaded-bullseye, devel-slim-threaded-bullseye
-Directory: 5.039.010-slim,threaded-bullseye
+Tags: 5.41.1-slim-threaded-bullseye, 5.41-slim-threaded-bullseye, devel-slim-threaded-bullseye
+Directory: 5.041.001-slim,threaded-bullseye


### PR DESCRIPTION
Also removes Debian Buster builds.

- https://github.com/Perl/docker-perl/pull/165
- https://github.com/Perl/docker-perl/pull/163