### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-4252 ELSA-2024-4264

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ec5aa528ff05152e58b85e3d0a850ad8a627187c
+amd64-GitCommit: a08268e45e6baf5294d964ff9c51ac8be0e75c48
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 800918fa33925f2b36d2a69d2cf09f123263f2d2
+arm64v8-GitCommit: 835375fbd69f8d4afa213f4b05e882f9249d9cc9
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-28182, CVE-2023-2953, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-4252.html
https://linux.oracle.com/errata/ELSA-2024-4264.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
