### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,12 +12,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240624.0
+Tags: 2023, latest, 2023.5.20240701.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 79921b7f2b8ace2a04214cac4e2b2dd375f793af
+amd64-GitCommit: 3bbb9c330290a57dce82f86e126abfae5f158796
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: a3b9eaeda34f6decd23f62a16994f50b939511d6
+arm64v8-GitCommit: 91a3649d5b0de8b7691fd5f020fdf1e1aee37121
 
 Tags: 2, 2.0.20240620.0
 Architectures: amd64, arm64v8


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.5.20240701-0.amzn2023
- system-release-2023.5.20240701-0.amzn2023
#### Packages addressing CVES: