### PR TITLE
Remove EOL CentOS versions of IBM Semeru Runtimes

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -18,12 +18,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u412-b08-jdk-centos7, open-8-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 8/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-8u412-b08-jre-focal, open-8-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -35,12 +29,6 @@ SharedTags: open-8u412-b08-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 8/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-8u412-b08-jre-centos7, open-8-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 8/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
@@ -57,12 +45,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.23_9-jdk-centos7, open-11-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 11/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-11.0.23_9-jre-focal, open-11-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -74,12 +56,6 @@ SharedTags: open-11.0.23_9-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 11/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-11.0.23_9-jre-centos7, open-11-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 11/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
@@ -96,12 +72,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.11_9-jdk-centos7, open-17-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 17/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-17.0.11_9-jre-focal, open-17-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -113,12 +83,6 @@ SharedTags: open-17.0.11_9-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 17/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-17.0.11_9-jre-centos7, open-17-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 17/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v21 images---------------------------------
@@ -135,12 +99,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 21/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.3_9-jdk-centos7, open-21-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 21/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-21.0.3_9-jre-focal, open-21-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -152,12 +110,6 @@ SharedTags: open-21.0.3_9-jre, open-21-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 21/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-21.0.3_9-jre-centos7, open-21-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 21/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v22 images---------------------------------
@@ -174,12 +126,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 22/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-22.0.1_8-jdk-centos7, open-22-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 22/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-22.0.1_8-jre-focal, open-22-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -191,10 +137,4 @@ SharedTags: open-22.0.1_8-jre, open-22-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 22/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-22.0.1_8-jre-centos7, open-22-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 22/jre/centos
 File: Dockerfile.open.releases.full


### PR DESCRIPTION
This is in response to https://github.com/docker-library/official-images/pull/17094#issuecomment-2201439800, in order to drop CentOS-based IBM Semeru Runtimes images since the CentOS 7 image has been dropped from Docker Official Images.