### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.87.0, 5.87, 5, latest
+Tags: 5.87.1, 5.87, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 1b2bf3e790b799e4e9b232ad8bc4b6622e466c76
+GitCommit: 5018c52524d50890500bdde0194d4443ccf7305f
 Directory: 5/debian
 
-Tags: 5.87.0-alpine, 5.87-alpine, 5-alpine, alpine
+Tags: 5.87.1-alpine, 5.87-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 1b2bf3e790b799e4e9b232ad8bc4b6622e466c76
+GitCommit: 5018c52524d50890500bdde0194d4443ccf7305f
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/5018c52: Update to 5.87.1, ghost-cli 1.26.0