### PR TITLE
Update Clear Linux OS to 41960

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 68e01605e9214b1884687b702416befa1cfe74cb
-GitFetch: refs/heads/base-41850
+GitCommit: 1488533b57265100236f37b95475c355fdac8255
+GitFetch: refs/heads/base-41960


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 41960

@bryteise @djklimes @bryteise