### PR TITLE
Update Bonita base alpine image version to 3.20

### DIFF
--- a/library/bonita
+++ b/library/bonita
@@ -1,5 +1,4 @@
-Maintainers: Danila Mazour <danila.mazour@bonitasoft.org> (@danila-m),
-             Emmanuel Duchastenier <emmanuel.duchastenier@bonitasoft.org> (@educhastenier),
+Maintainers: Emmanuel Duchastenier <emmanuel.duchastenier@bonitasoft.org> (@educhastenier),
              Pascal Garcia <pascal.garcia@bonitasoft.org> (@passga),
              Anthony Birembaut <anthony.birembaut@bonitasoft.org> (@abirembaut),
              Romain Bioteau <romain.bioteau@bonitasoft.org> (@rbioteau)
@@ -7,18 +6,14 @@ Architectures: amd64, arm64v8, ppc64le
 GitRepo: https://github.com/bonitasoft/bonita-distrib.git
 Directory: docker
 
-Tags: 2022.1-u0, 2022.1, 7.14.0, 7.14
-GitFetch: refs/heads/docker/2022.1
-GitCommit: 4cdeb1c385b981e7074ce19cc685c08028d7149d
-
 Tags: 2022.2-u0, 2022.2, 7.15.0, 7.15
 GitFetch: refs/heads/docker/2022.2
-GitCommit: 607a6a3885df35979e0946611af4f7c858f9c989
+GitCommit: 0fbc47d8fcb6629b943b4c1e00052ca14c3d1e1b
 
 Tags: 2023.1-u0, 2023.1, 8.0.0, 8.0
 GitFetch: refs/heads/docker/2023.1
-GitCommit: 814cc8cc0a6e8b02c827cb1dfeabb1bb4569a865
+GitCommit: 31dcebbf22ebcce11f8e3a9b9444802136c36c03
 
 Tags: 2023.2-u0, 2023.2, 9.0.0, 9.0, latest
 GitFetch: refs/heads/docker/2023.2
-GitCommit: a8f0abf47fa8f7b96cb010e7d80b032ae96720ca
+GitCommit: 397824cf4f302c37f3534908728a2b8321a31565


### PR DESCRIPTION
* Remove EOL Bonita 2022.1 version
* Update all Bonita version base image to alpine 3.20
* Remove a maintainer
* Fix deprecated `ENV` assignment format

Related to https://github.com/docker-library/official-images/pull/16801#issuecomment-2211490133