### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2024-4312

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a08268e45e6baf5294d964ff9c51ac8be0e75c48
+amd64-GitCommit: 13d3ed67efbee3ff5de5bb595100a9bde7237ea9
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 835375fbd69f8d4afa213f4b05e882f9249d9cc9
+arm64v8-GitCommit: 7b228ca6294b6953d8f85ef70d230e38ead0f23e
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-6387.

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-4312.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>