### PR TITLE
Releasing Neo4j 5.21.2

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -3,25 +3,25 @@ Maintainers: Jenny Owen <jenny.owen@neo4j.com> (@jennyowen),
              Eric Sporre <eric.sporre@neo4j.com> (@ericsporre)
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
-Tags: 5.21.0-community-bullseye, 5.21-community-bullseye, 5-community-bullseye, 5.21.0-community, 5.21-community, 5-community, 5.21.0-bullseye, 5.21-bullseye, 5-bullseye, 5.21.0, 5.21, 5, community-bullseye, community, bullseye, latest
+Tags: 5.21.2-community-bullseye, 5.21-community-bullseye, 5-community-bullseye, 5.21.2-community, 5.21-community, 5-community, 5.21.2-bullseye, 5.21-bullseye, 5-bullseye, 5.21.2, 5.21, 5, community-bullseye, community, bullseye, latest
 Architectures: amd64, arm64v8
-GitCommit: b1989e4b7222c257c56a1fc432b8bad090c159b8
-Directory: 5.21.0/bullseye/community
+GitCommit: ffbc64121d15ea1e1fa75115ab0d1dae0f729ffb
+Directory: 5.21.2/bullseye/community
 
-Tags: 5.21.0-enterprise-bullseye, 5.21-enterprise-bullseye, 5-enterprise-bullseye, 5.21.0-enterprise, 5.21-enterprise, 5-enterprise, enterprise-bullseye, enterprise
+Tags: 5.21.2-enterprise-bullseye, 5.21-enterprise-bullseye, 5-enterprise-bullseye, 5.21.2-enterprise, 5.21-enterprise, 5-enterprise, enterprise-bullseye, enterprise
 Architectures: amd64, arm64v8
-GitCommit: b1989e4b7222c257c56a1fc432b8bad090c159b8
-Directory: 5.21.0/bullseye/enterprise
+GitCommit: ffbc64121d15ea1e1fa75115ab0d1dae0f729ffb
+Directory: 5.21.2/bullseye/enterprise
 
-Tags: 5.21.0-community-ubi9, 5.21-community-ubi9, 5-community-ubi9, 5.21.0-ubi9, 5.21-ubi9, 5-ubi9, community-ubi9, ubi9
+Tags: 5.21.2-community-ubi9, 5.21-community-ubi9, 5-community-ubi9, 5.21.2-ubi9, 5.21-ubi9, 5-ubi9, community-ubi9, ubi9
 Architectures: amd64, arm64v8
-GitCommit: b1989e4b7222c257c56a1fc432b8bad090c159b8
-Directory: 5.21.0/ubi9/community
+GitCommit: ffbc64121d15ea1e1fa75115ab0d1dae0f729ffb
+Directory: 5.21.2/ubi9/community
 
-Tags: 5.21.0-enterprise-ubi9, 5.21-enterprise-ubi9, 5-enterprise-ubi9, enterprise-ubi9
+Tags: 5.21.2-enterprise-ubi9, 5.21-enterprise-ubi9, 5-enterprise-ubi9, enterprise-ubi9
 Architectures: amd64, arm64v8
-GitCommit: b1989e4b7222c257c56a1fc432b8bad090c159b8
-Directory: 5.21.0/ubi9/enterprise
+GitCommit: ffbc64121d15ea1e1fa75115ab0d1dae0f729ffb
+Directory: 5.21.2/ubi9/enterprise
 
 
 


### PR DESCRIPTION
We intentionally are skipping releasing a 5.21.1 version (it was no good), and are going straight from 5.21.0 to 5.21.2.
In case that looks weird :slightly_smiling_face: 

Thanks!