### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,120 +6,120 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 3.4.0-preview1-bookworm, 3.4-rc-bookworm, 3.4.0-preview1, 3.4-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bfd3f474cdaef7cf5ed6741bef80355c62e9ba2f
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.4-rc/bookworm
 
 Tags: 3.4.0-preview1-slim-bookworm, 3.4-rc-slim-bookworm, 3.4.0-preview1-slim, 3.4-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bfd3f474cdaef7cf5ed6741bef80355c62e9ba2f
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.4-rc/slim-bookworm
 
 Tags: 3.4.0-preview1-bullseye, 3.4-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bfd3f474cdaef7cf5ed6741bef80355c62e9ba2f
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.4-rc/bullseye
 
 Tags: 3.4.0-preview1-slim-bullseye, 3.4-rc-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bfd3f474cdaef7cf5ed6741bef80355c62e9ba2f
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.4-rc/slim-bullseye
 
 Tags: 3.4.0-preview1-alpine3.20, 3.4-rc-alpine3.20, 3.4.0-preview1-alpine, 3.4-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a4c6c26df171630eca259b1254a8b374c2eb0a43
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.4-rc/alpine3.20
 
 Tags: 3.4.0-preview1-alpine3.19, 3.4-rc-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bfd3f474cdaef7cf5ed6741bef80355c62e9ba2f
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.4-rc/alpine3.19
 
-Tags: 3.3.3-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.3, 3.3, 3, latest
+Tags: 3.3.4-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.4, 3.3, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8b0053a92b4f7232fe28c45e44a469c032affe2
+GitCommit: 2e432fc966a291fa241b14637557710d33a05b42
 Directory: 3.3/bookworm
 
-Tags: 3.3.3-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.3-slim, 3.3-slim, 3-slim, slim
+Tags: 3.3.4-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.4-slim, 3.3-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8b0053a92b4f7232fe28c45e44a469c032affe2
+GitCommit: 2e432fc966a291fa241b14637557710d33a05b42
 Directory: 3.3/slim-bookworm
 
-Tags: 3.3.3-bullseye, 3.3-bullseye, 3-bullseye, bullseye
+Tags: 3.3.4-bullseye, 3.3-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8b0053a92b4f7232fe28c45e44a469c032affe2
+GitCommit: 2e432fc966a291fa241b14637557710d33a05b42
 Directory: 3.3/bullseye
 
-Tags: 3.3.3-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.3.4-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8b0053a92b4f7232fe28c45e44a469c032affe2
+GitCommit: 2e432fc966a291fa241b14637557710d33a05b42
 Directory: 3.3/slim-bullseye
 
-Tags: 3.3.3-alpine3.20, 3.3-alpine3.20, 3-alpine3.20, alpine3.20, 3.3.3-alpine, 3.3-alpine, 3-alpine, alpine
+Tags: 3.3.4-alpine3.20, 3.3-alpine3.20, 3-alpine3.20, alpine3.20, 3.3.4-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8b0053a92b4f7232fe28c45e44a469c032affe2
+GitCommit: 2e432fc966a291fa241b14637557710d33a05b42
 Directory: 3.3/alpine3.20
 
-Tags: 3.3.3-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19
+Tags: 3.3.4-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b8b0053a92b4f7232fe28c45e44a469c032affe2
+GitCommit: 2e432fc966a291fa241b14637557710d33a05b42
 Directory: 3.3/alpine3.19
 
 Tags: 3.2.4-bookworm, 3.2-bookworm, 3.2.4, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.2/bookworm
 
 Tags: 3.2.4-slim-bookworm, 3.2-slim-bookworm, 3.2.4-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.2/slim-bookworm
 
 Tags: 3.2.4-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.2/bullseye
 
 Tags: 3.2.4-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.2/slim-bullseye
 
 Tags: 3.2.4-alpine3.20, 3.2-alpine3.20, 3.2.4-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a4c6c26df171630eca259b1254a8b374c2eb0a43
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.2/alpine3.20
 
 Tags: 3.2.4-alpine3.19, 3.2-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 53646d3dc96008bd20218a4d9aeb5695619fb4f7
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.2/alpine3.19
 
 Tags: 3.1.6-bookworm, 3.1-bookworm, 3.1.6, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74a48e2248ff94c6ebf93958070bafaf5cbdffcc
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.1/bookworm
 
 Tags: 3.1.6-slim-bookworm, 3.1-slim-bookworm, 3.1.6-slim, 3.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74a48e2248ff94c6ebf93958070bafaf5cbdffcc
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.1/slim-bookworm
 
 Tags: 3.1.6-bullseye, 3.1-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74a48e2248ff94c6ebf93958070bafaf5cbdffcc
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.1/bullseye
 
 Tags: 3.1.6-slim-bullseye, 3.1-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 74a48e2248ff94c6ebf93958070bafaf5cbdffcc
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.1/slim-bullseye
 
 Tags: 3.1.6-alpine3.20, 3.1-alpine3.20, 3.1.6-alpine, 3.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 74a48e2248ff94c6ebf93958070bafaf5cbdffcc
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.1/alpine3.20
 
 Tags: 3.1.6-alpine3.19, 3.1-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 74a48e2248ff94c6ebf93958070bafaf5cbdffcc
+GitCommit: f69cac9888c7909b402a1bc21a87331429318aae
 Directory: 3.1/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/2e432fc: Update 3.3 to 3.3.4
- https://github.com/docker-library/ruby/commit/c069afc: Merge pull request https://github.com/docker-library/ruby/pull/463 from infosiftr/mkdir-gem-home
- https://github.com/docker-library/ruby/commit/f69cac9: Add more defensive `mkdir` for `GEM_HOME`