### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/python/blob/7eefa0c4911bcf998ff5f880df51dc7f8bbf6dec/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/python/blob/8acd7b13be23c0a9829764f759a6f314e5b063f5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -8,38 +8,38 @@ Builder: buildkit
 Tags: 3.13.0b3-bookworm, 3.13-rc-bookworm
 SharedTags: 3.13.0b3, 3.13-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/bookworm
 
 Tags: 3.13.0b3-slim-bookworm, 3.13-rc-slim-bookworm, 3.13.0b3-slim, 3.13-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/slim-bookworm
 
 Tags: 3.13.0b3-bullseye, 3.13-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/bullseye
 
 Tags: 3.13.0b3-slim-bullseye, 3.13-rc-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/slim-bullseye
 
 Tags: 3.13.0b3-alpine3.20, 3.13-rc-alpine3.20, 3.13.0b3-alpine, 3.13-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/alpine3.20
 
 Tags: 3.13.0b3-alpine3.19, 3.13-rc-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/alpine3.19
 
 Tags: 3.13.0b3-windowsservercore-ltsc2022, 3.13-rc-windowsservercore-ltsc2022
 SharedTags: 3.13.0b3-windowsservercore, 3.13-rc-windowsservercore, 3.13.0b3, 3.13-rc
 Architectures: windows-amd64
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -47,7 +47,7 @@ Builder: classic
 Tags: 3.13.0b3-windowsservercore-1809, 3.13-rc-windowsservercore-1809
 SharedTags: 3.13.0b3-windowsservercore, 3.13-rc-windowsservercore, 3.13.0b3, 3.13-rc
 Architectures: windows-amd64
-GitCommit: a2520ad1af2f65e0cf23e8f53c4a20e6502a4032
+GitCommit: 569c82f764bd2b39c3aab2610a080220efd53778
 Directory: 3.13-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
@@ -55,38 +55,38 @@ Builder: classic
 Tags: 3.12.4-bookworm, 3.12-bookworm, 3-bookworm, bookworm
 SharedTags: 3.12.4, 3.12, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/bookworm
 
 Tags: 3.12.4-slim-bookworm, 3.12-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.12.4-slim, 3.12-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/slim-bookworm
 
 Tags: 3.12.4-bullseye, 3.12-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/bullseye
 
 Tags: 3.12.4-slim-bullseye, 3.12-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/slim-bullseye
 
 Tags: 3.12.4-alpine3.20, 3.12-alpine3.20, 3-alpine3.20, alpine3.20, 3.12.4-alpine, 3.12-alpine, 3-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/alpine3.20
 
 Tags: 3.12.4-alpine3.19, 3.12-alpine3.19, 3-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/alpine3.19
 
 Tags: 3.12.4-windowsservercore-ltsc2022, 3.12-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.12.4-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.4, 3.12, 3, latest
 Architectures: windows-amd64
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -94,7 +94,7 @@ Builder: classic
 Tags: 3.12.4-windowsservercore-1809, 3.12-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.12.4-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.4, 3.12, 3, latest
 Architectures: windows-amd64
-GitCommit: 3c2ae4b9e0a400a7d1378ff121152d66e3df491e
+GitCommit: 5ed2758efb58d9acaafa90515caa43edbcfe4c4e
 Directory: 3.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
@@ -102,38 +102,38 @@ Builder: classic
 Tags: 3.11.9-bookworm, 3.11-bookworm
 SharedTags: 3.11.9, 3.11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/bookworm
 
 Tags: 3.11.9-slim-bookworm, 3.11-slim-bookworm, 3.11.9-slim, 3.11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/slim-bookworm
 
 Tags: 3.11.9-bullseye, 3.11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/bullseye
 
 Tags: 3.11.9-slim-bullseye, 3.11-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/slim-bullseye
 
 Tags: 3.11.9-alpine3.20, 3.11-alpine3.20, 3.11.9-alpine, 3.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/alpine3.20
 
 Tags: 3.11.9-alpine3.19, 3.11-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/alpine3.19
 
 Tags: 3.11.9-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022
 SharedTags: 3.11.9-windowsservercore, 3.11-windowsservercore, 3.11.9, 3.11
 Architectures: windows-amd64
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -141,7 +141,7 @@ Builder: classic
 Tags: 3.11.9-windowsservercore-1809, 3.11-windowsservercore-1809
 SharedTags: 3.11.9-windowsservercore, 3.11-windowsservercore, 3.11.9, 3.11
 Architectures: windows-amd64
-GitCommit: 20b3773ebc8443d9249bb1bd7fd4b4ac6f4269a2
+GitCommit: de17a909b9143e7715550ce85023fee87c48c7d6
 Directory: 3.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
@@ -149,92 +149,92 @@ Builder: classic
 Tags: 3.10.14-bookworm, 3.10-bookworm
 SharedTags: 3.10.14, 3.10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7f0ac802a9c6bd2ec5ae6213ab57ba7ec71c147
+GitCommit: cb3ed4c9ff44fb15611034ae4d579ef82a6d12e5
 Directory: 3.10/bookworm
 
 Tags: 3.10.14-slim-bookworm, 3.10-slim-bookworm, 3.10.14-slim, 3.10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7f0ac802a9c6bd2ec5ae6213ab57ba7ec71c147
+GitCommit: cb3ed4c9ff44fb15611034ae4d579ef82a6d12e5
 Directory: 3.10/slim-bookworm
 
 Tags: 3.10.14-bullseye, 3.10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7f0ac802a9c6bd2ec5ae6213ab57ba7ec71c147
+GitCommit: cb3ed4c9ff44fb15611034ae4d579ef82a6d12e5
 Directory: 3.10/bullseye
 
 Tags: 3.10.14-slim-bullseye, 3.10-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7f0ac802a9c6bd2ec5ae6213ab57ba7ec71c147
+GitCommit: cb3ed4c9ff44fb15611034ae4d579ef82a6d12e5
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.14-alpine3.20, 3.10-alpine3.20, 3.10.14-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f7f0ac802a9c6bd2ec5ae6213ab57ba7ec71c147
+GitCommit: cb3ed4c9ff44fb15611034ae4d579ef82a6d12e5
 Directory: 3.10/alpine3.20
 
 Tags: 3.10.14-alpine3.19, 3.10-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f7f0ac802a9c6bd2ec5ae6213ab57ba7ec71c147
+GitCommit: cb3ed4c9ff44fb15611034ae4d579ef82a6d12e5
 Directory: 3.10/alpine3.19
 
 Tags: 3.9.19-bookworm, 3.9-bookworm
 SharedTags: 3.9.19, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d8eb2b33ad9b0afec34e3edf184f809c3012cb60
+GitCommit: 70b9507c0503d4dab77c0d898c4faaa67e555907
 Directory: 3.9/bookworm
 
 Tags: 3.9.19-slim-bookworm, 3.9-slim-bookworm, 3.9.19-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d8eb2b33ad9b0afec34e3edf184f809c3012cb60
+GitCommit: 70b9507c0503d4dab77c0d898c4faaa67e555907
 Directory: 3.9/slim-bookworm
 
 Tags: 3.9.19-bullseye, 3.9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d8eb2b33ad9b0afec34e3edf184f809c3012cb60
+GitCommit: 70b9507c0503d4dab77c0d898c4faaa67e555907
 Directory: 3.9/bullseye
 
 Tags: 3.9.19-slim-bullseye, 3.9-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d8eb2b33ad9b0afec34e3edf184f809c3012cb60
+GitCommit: 70b9507c0503d4dab77c0d898c4faaa67e555907
 Directory: 3.9/slim-bullseye
 
 Tags: 3.9.19-alpine3.20, 3.9-alpine3.20, 3.9.19-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d8eb2b33ad9b0afec34e3edf184f809c3012cb60
+GitCommit: 70b9507c0503d4dab77c0d898c4faaa67e555907
 Directory: 3.9/alpine3.20
 
 Tags: 3.9.19-alpine3.19, 3.9-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: d8eb2b33ad9b0afec34e3edf184f809c3012cb60
+GitCommit: 70b9507c0503d4dab77c0d898c4faaa67e555907
 Directory: 3.9/alpine3.19
 
 Tags: 3.8.19-bookworm, 3.8-bookworm
 SharedTags: 3.8.19, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 78bf492e6a793c950e2b6f678763453f9276f5c0
+GitCommit: e835636db72db5f0b9ab192362992c763af60260
 Directory: 3.8/bookworm
 
 Tags: 3.8.19-slim-bookworm, 3.8-slim-bookworm, 3.8.19-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 78bf492e6a793c950e2b6f678763453f9276f5c0
+GitCommit: e835636db72db5f0b9ab192362992c763af60260
 Directory: 3.8/slim-bookworm
 
 Tags: 3.8.19-bullseye, 3.8-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 78bf492e6a793c950e2b6f678763453f9276f5c0
+GitCommit: e835636db72db5f0b9ab192362992c763af60260
 Directory: 3.8/bullseye
 
 Tags: 3.8.19-slim-bullseye, 3.8-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 78bf492e6a793c950e2b6f678763453f9276f5c0
+GitCommit: e835636db72db5f0b9ab192362992c763af60260
 Directory: 3.8/slim-bullseye
 
 Tags: 3.8.19-alpine3.20, 3.8-alpine3.20, 3.8.19-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 78bf492e6a793c950e2b6f678763453f9276f5c0
+GitCommit: e835636db72db5f0b9ab192362992c763af60260
 Directory: 3.8/alpine3.20
 
 Tags: 3.8.19-alpine3.19, 3.8-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 78bf492e6a793c950e2b6f678763453f9276f5c0
+GitCommit: e835636db72db5f0b9ab192362992c763af60260
 Directory: 3.8/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/9602fc7: Merge pull request https://github.com/docker-library/python/pull/935 from infosiftr/less-riscv
- https://github.com/docker-library/python/commit/8acd7b1: Remove riscv64 from python versions that are too slow to build
- https://github.com/docker-library/python/commit/9d2a9a2: Update to actions/checkout@v4 🙃
- https://github.com/docker-library/python/commit/70b9507: Update 3.9 to get-pip https://github.com/pypa/get-pip/commit/e03e1607ad60522cf34a92e834138eb89f57667c
- https://github.com/docker-library/python/commit/e835636: Update 3.8 to get-pip https://github.com/pypa/get-pip/commit/e03e1607ad60522cf34a92e834138eb89f57667c
- https://github.com/docker-library/python/commit/569c82f: Update 3.13-rc to get-pip https://github.com/pypa/get-pip/commit/e03e1607ad60522cf34a92e834138eb89f57667c
- https://github.com/docker-library/python/commit/5ed2758: Update 3.12 to get-pip https://github.com/pypa/get-pip/commit/e03e1607ad60522cf34a92e834138eb89f57667c
- https://github.com/docker-library/python/commit/de17a90: Update 3.11 to get-pip https://github.com/pypa/get-pip/commit/e03e1607ad60522cf34a92e834138eb89f57667c
- https://github.com/docker-library/python/commit/cb3ed4c: Update 3.10 to get-pip https://github.com/pypa/get-pip/commit/e03e1607ad60522cf34a92e834138eb89f57667c