### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev1, 3.1-dev, 3.1-dev1-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev3, 3.1-dev, 3.1-dev3-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 90192f6c7f183049e1ac746438584e7aa5dc3c2e
+GitCommit: da5603561f715baf0d19d0857224a715b899f126
 Directory: 3.1
 
-Tags: 3.1-dev1-alpine, 3.1-dev-alpine, 3.1-dev1-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev3-alpine, 3.1-dev-alpine, 3.1-dev3-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90192f6c7f183049e1ac746438584e7aa5dc3c2e
+GitCommit: da5603561f715baf0d19d0857224a715b899f126
 Directory: 3.1/alpine
 
 Tags: 3.0.2, 3.0, lts, latest, 3.0.2-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/da56035: Update 3.1 to 3.1-dev3
- https://github.com/docker-library/haproxy/commit/99a218b: Update to actions/checkout@v4 🙃