### PR TITLE
Add tags for skipped Jetty versions 10.0.21, 11.0.21 and 12.0.10

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -119,6 +119,46 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
 GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
 
+Tags: 12.0.10-jre21-alpine, 12.0.10-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0.10/jre21-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10-jre21, 12.0.10-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0.10/jre21
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10-jre17-alpine, 12.0.10-jre17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0.10/jre17-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10-jre17, 12.0.10-jre17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0.10/jre17
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10-jdk21-alpine, 12.0.10-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0.10/jdk21-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10, 12.0.10-jdk21, 12.0.10-eclipse-temurin, 12.0.10-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0.10/jdk21
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10-jdk17-alpine, 12.0.10-jdk17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0.10/jdk17-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 12.0.10-jdk17, 12.0.10-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0.10/jdk17
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
 Tags: 11.0.22-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.22-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
@@ -179,6 +219,66 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
 GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
 
+Tags: 11.0.21-jre21-alpine, 11.0.21-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0.21/jre21-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jre21, 11.0.21-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0.21/jre21
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jre17-alpine, 11.0.21-jre17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0.21/jre17-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jre17, 11.0.21-jre17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0.21/jre17
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jre11-alpine, 11.0.21-jre11-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0.21/jre11-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jre11, 11.0.21-jre11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0.21/jre11
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jdk21-alpine, 11.0.21-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0.21/jdk21-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21, 11.0.21-jdk21, 11.0.21-eclipse-temurin, 11.0.21-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0.21/jdk21
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jdk17-alpine, 11.0.21-jdk17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0.21/jdk17-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jdk17, 11.0.21-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0.21/jdk17
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jdk11-alpine, 11.0.21-jdk11-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/11.0.21/jdk11-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 11.0.21-jdk11, 11.0.21-jdk11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/11.0.21/jdk11
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
 Tags: 10.0.22-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.22-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
@@ -238,6 +338,66 @@ Tags: 10.0.22-jdk11, 10.0-jdk11, 10-jdk11, 10.0.22-jdk11-eclipse-temurin, 10.0-j
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
 GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+
+Tags: 10.0.21-jre21-alpine, 10.0.21-jre21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0.21/jre21-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jre21, 10.0.21-jre21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0.21/jre21
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jre17-alpine, 10.0.21-jre17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0.21/jre17-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jre17, 10.0.21-jre17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0.21/jre17
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jre11-alpine, 10.0.21-jre11-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0.21/jre11-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jre11, 10.0.21-jre11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0.21/jre11
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jdk21-alpine, 10.0.21-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0.21/jdk21-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21, 10.0.21-jdk21, 10.0.21-eclipse-temurin, 10.0.21-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0.21/jdk21
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jdk17-alpine, 10.0.21-jdk17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0.21/jdk17-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jdk17, 10.0.21-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0.21/jdk17
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jdk11-alpine, 10.0.21-jdk11-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/10.0.21/jdk11-alpine
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
+
+Tags: 10.0.21-jdk11, 10.0.21-jdk11-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/10.0.21/jdk11
+GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
 
 Tags: 9.4.55-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Add tags for Jetty versions `10.0.21`, `11.0.21`, `12.0.10` which were skipped in the previous PR where we upgraded straight to `10.0.22`, `11.0.22` & `12.0.11`.

see https://github.com/docker-library/official-images/pull/17138