### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: da5603561f715baf0d19d0857224a715b899f126
 Directory: 3.1/alpine
 
-Tags: 3.0.2, 3.0, lts, latest, 3.0.2-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.3, 3.0, lts, latest, 3.0.3-bookworm, 3.0-bookworm, lts-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 12bf60c7685bdfa526057a0ccf89967291106b4c
+GitCommit: bc729b362307822861331c816b73f863332d4b11
 Directory: 3.0
 
-Tags: 3.0.2-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.2-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.3-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.3-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 12bf60c7685bdfa526057a0ccf89967291106b4c
+GitCommit: bc729b362307822861331c816b73f863332d4b11
 Directory: 3.0/alpine
 
 Tags: 2.9.9, 2.9, 2.9.9-bookworm, 2.9-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bc729b3: Update 3.0 to 3.0.3