### PR TITLE
archlinux: Release 20240714.0.246936

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240101.0.204074
-GitCommit: 4caef241ef62b1e01362a6d0c7eab7f6149aa3be
-GitFetch: refs/tags/v20240101.0.204074
+Tags: latest, base, base-20240714.0.246936
+GitCommit: 4a92dba2124ec21c3971c3b247880ce153c97fb5
+GitFetch: refs/tags/v20240714.0.246936
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240101.0.204074
-GitCommit: 4caef241ef62b1e01362a6d0c7eab7f6149aa3be
-GitFetch: refs/tags/v20240101.0.204074
+Tags: base-devel, base-devel-20240714.0.246936
+GitCommit: 4a92dba2124ec21c3971c3b247880ce153c97fb5
+GitFetch: refs/tags/v20240714.0.246936
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240101.0.204074
-GitCommit: 4caef241ef62b1e01362a6d0c7eab7f6149aa3be
-GitFetch: refs/tags/v20240101.0.204074
+Tags: multilib-devel, multilib-devel-20240714.0.246936
+GitCommit: 4a92dba2124ec21c3971c3b247880ce153c97fb5
+GitFetch: refs/tags/v20240714.0.246936
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks