### PR TITLE
Update Clear Linux OS to 42030

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 1488533b57265100236f37b95475c355fdac8255
-GitFetch: refs/heads/base-41960
+GitCommit: f4043e617e4ffc33dff4ce58b0a7bf9ad85f9b41
+GitFetch: refs/heads/base-42030


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42030

@bryteise @djklimes @bryteise