### PR TITLE
Bump Traefik to v3.1.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,58 +1,31 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.1.0-rc3-windowsservercore-ltsc2022, 3.1.0-rc3-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022
+Tags: v3.1.0-windowsservercore-ltsc2022, 3.1.0-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
+GitCommit: 2f8afc4591f5faf2b4ec8279ed8128ffbb919e41
 Directory: v3.1/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.1.0-rc3-windowsservercore-1809, 3.1.0-rc3-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809
+Tags: v3.1.0-windowsservercore-1809, 3.1.0-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
+GitCommit: 2f8afc4591f5faf2b4ec8279ed8128ffbb919e41
 Directory: v3.1/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.1.0-rc3-nanoserver-ltsc2022, 3.1.0-rc3-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022
+Tags: v3.1.0-nanoserver-ltsc2022, 3.1.0-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
+GitCommit: 2f8afc4591f5faf2b4ec8279ed8128ffbb919e41
 Directory: v3.1/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.1.0-rc3, 3.1.0-rc3, v3.1, 3.1, comte
+Tags: v3.1.0, 3.1.0, v3.1, 3.1, comte, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 30b5ca403f1a1caef4c6b91112616eec405c4d95
+GitCommit: 2f8afc4591f5faf2b4ec8279ed8128ffbb919e41
 Directory: v3.1/alpine
-
-Tags: v3.0.4-windowsservercore-ltsc2022, 3.0.4-windowsservercore-ltsc2022, v3.0-windowsservercore-ltsc2022, 3.0-windowsservercore-ltsc2022, beaufort-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
-Directory: v3.0/windows/servercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: v3.0.4-windowsservercore-1809, 3.0.4-windowsservercore-1809, v3.0-windowsservercore-1809, 3.0-windowsservercore-1809, beaufort-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
-Directory: v3.0/windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v3.0.4-nanoserver-ltsc2022, 3.0.4-nanoserver-ltsc2022, v3.0-nanoserver-ltsc2022, 3.0-nanoserver-ltsc2022, beaufort-nanoserver-ltsc2022, nanoserver-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
-Directory: v3.0/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: v3.0.4, 3.0.4, v3.0, 3.0, beaufort, latest
-Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 10af0cbf05f6af64df7062738a2d612bd95a5e3b
-Directory: v3.0/alpine
 
 Tags: v2.11.6-windowsservercore-ltsc2022, 2.11.6-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.1.0](https://github.com/traefik/traefik/releases/tag/v3.1.0).

/cc @mmatur @kevinpollet

Cheers
