### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -94,21 +94,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: ubuntu/jammy
 
-Tags: mantic-curl, 23.10-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6b4838ad208cd3447d2c8d6535827e0dfc74a145
-Directory: ubuntu/mantic/curl
-
-Tags: mantic-scm, 23.10-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
-Directory: ubuntu/mantic/scm
-
-Tags: mantic, 23.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
-Directory: ubuntu/mantic
-
 Tags: noble-curl, 24.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 60dc5f9555c521de086b2f5770514faf69ee2cc4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/2963e85: Merge pull request https://github.com/docker-library/buildpack-deps/pull/160 from infosiftr/bye-mantic
- https://github.com/docker-library/buildpack-deps/commit/fc4d075: Remove EOL Ubuntu 23.10 (aka mantic)
- https://github.com/docker-library/buildpack-deps/commit/d8e20a1: Update to actions/checkout@v4 🙃