### PR TITLE
IBM Semeru updated to drop CentOS images

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -7,54 +7,54 @@ GitFetch: refs/heads/ibm
 #-----------------------------openj9 v8 images---------------------------------
 Tags: open-8u412-b08-jdk-focal, open-8-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-8u412-b08-jdk-jammy, open-8-jdk-jammy
 SharedTags: open-8u412-b08-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-8u412-b08-jre-focal, open-8-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-8u412-b08-jre-jammy, open-8-jre-jammy
 SharedTags: open-8u412-b08-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
 Tags: open-11.0.23_9-jdk-focal, open-11-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.23_9-jdk-jammy, open-11-jdk-jammy
 SharedTags: open-11.0.23_9-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.23_9-jre-focal, open-11-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-11.0.23_9-jre-jammy, open-11-jre-jammy
 SharedTags: open-11.0.23_9-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
@@ -62,27 +62,27 @@ File: Dockerfile.open.releases.full
 #-----------------------------openj9 v17 images---------------------------------
 Tags: open-17.0.11_9-jdk-focal, open-17-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.11_9-jdk-jammy, open-17-jdk-jammy
 SharedTags: open-17.0.11_9-jdk, open-17-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.11_9-jre-focal, open-17-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-17.0.11_9-jre-jammy, open-17-jre-jammy
 SharedTags: open-17.0.11_9-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
@@ -90,27 +90,27 @@ File: Dockerfile.open.releases.full
 #-----------------------------openj9 v21 images---------------------------------
 Tags: open-21.0.3_9-jdk-focal, open-21-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 21/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-21.0.3_9-jdk-jammy, open-21-jdk-jammy
 SharedTags: open-21.0.3_9-jdk, open-21-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 21/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-21.0.3_9-jre-focal, open-21-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 21/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-21.0.3_9-jre-jammy, open-21-jre-jammy
 SharedTags: open-21.0.3_9-jre, open-21-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 21/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
@@ -118,27 +118,27 @@ File: Dockerfile.open.releases.full
 #-----------------------------openj9 v22 images---------------------------------
 Tags: open-22.0.1_8-jdk-focal, open-22-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 22/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-22.0.1_8-jdk-jammy, open-22-jdk-jammy
 SharedTags: open-22.0.1_8-jdk, open-22-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 22/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
 Tags: open-22.0.1_8-jre-focal, open-22-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 22/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
 Tags: open-22.0.1_8-jre-jammy, open-22-jre-jammy
 SharedTags: open-22.0.1_8-jre, open-22-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
+GitCommit: 85c863fc29210104181c7b8ef9d24f3e52fcc87e
 Directory: 22/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 

--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -18,12 +18,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u412-b08-jdk-centos7, open-8-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 8/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-8u412-b08-jre-focal, open-8-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -35,12 +29,6 @@ SharedTags: open-8u412-b08-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 8/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-8u412-b08-jre-centos7, open-8-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 8/jre/centos
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
@@ -57,12 +45,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.23_9-jdk-centos7, open-11-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 11/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-11.0.23_9-jre-focal, open-11-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -76,11 +58,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.23_9-jre-centos7, open-11-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 11/jre/centos
-File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
 Tags: open-17.0.11_9-jdk-focal, open-17-jdk-focal
@@ -96,12 +73,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.11_9-jdk-centos7, open-17-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 17/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-17.0.11_9-jre-focal, open-17-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -115,11 +86,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.11_9-jre-centos7, open-17-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 17/jre/centos
-File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v21 images---------------------------------
 Tags: open-21.0.3_9-jdk-focal, open-21-jdk-focal
@@ -135,12 +101,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 21/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.3_9-jdk-centos7, open-21-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 21/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-21.0.3_9-jre-focal, open-21-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -154,11 +114,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 21/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.3_9-jre-centos7, open-21-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 21/jre/centos
-File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v22 images---------------------------------
 Tags: open-22.0.1_8-jdk-focal, open-22-jdk-focal
@@ -174,12 +129,6 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 22/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-22.0.1_8-jdk-centos7, open-22-jdk-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 22/jdk/centos
-File: Dockerfile.open.releases.full
-
 Tags: open-22.0.1_8-jre-focal, open-22-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
 GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
@@ -193,8 +142,3 @@ GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
 Directory: 22/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-22.0.1_8-jre-centos7, open-22-jre-centos7
-Architectures: amd64, ppc64le, arm64v8
-GitCommit: a3c82d720a98bbdd4cb70f1db22eb27060af2164
-Directory: 22/jre/centos
-File: Dockerfile.open.releases.full


### PR DESCRIPTION
This PR is for dropping CentOS-based IBM Semeru Runtimes images since the CentOS 7 image has been deprecated and reached End of Life. 

