### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.87.2, 5.87, 5, latest
+Tags: 5.87.3, 5.87, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 035db75f8de147549cc5b665ab8c97fa9f3ed2cb
+GitCommit: c3fca0fdd9e81fa47749134a751e6469366b6ea7
 Directory: 5/debian
 
-Tags: 5.87.2-alpine, 5.87-alpine, 5-alpine, alpine
+Tags: 5.87.3-alpine, 5.87-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 035db75f8de147549cc5b665ab8c97fa9f3ed2cb
+GitCommit: c3fca0fdd9e81fa47749134a751e6469366b6ea7
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/c3fca0f: Update to 5.87.3, ghost-cli 1.26.0