### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -63,3 +63,48 @@ Tags: cli-2.10.0-php8.3, cli-2.10-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
 Directory: cli/php8.3/alpine
+
+Tags: beta-6.6.1-RC1-php8.1-apache, beta-6.6.1-php8.1-apache, beta-6.6-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.6.1-RC1-php8.1, beta-6.6.1-php8.1, beta-6.6-php8.1, beta-6-php8.1, beta-php8.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.1/apache
+
+Tags: beta-6.6.1-RC1-php8.1-fpm, beta-6.6.1-php8.1-fpm, beta-6.6-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.1/fpm
+
+Tags: beta-6.6.1-RC1-php8.1-fpm-alpine, beta-6.6.1-php8.1-fpm-alpine, beta-6.6-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.1/fpm-alpine
+
+Tags: beta-6.6.1-RC1-apache, beta-6.6.1-apache, beta-6.6-apache, beta-6-apache, beta-apache, beta-6.6.1-RC1, beta-6.6.1, beta-6.6, beta-6, beta, beta-6.6.1-RC1-php8.2-apache, beta-6.6.1-php8.2-apache, beta-6.6-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.6.1-RC1-php8.2, beta-6.6.1-php8.2, beta-6.6-php8.2, beta-6-php8.2, beta-php8.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.2/apache
+
+Tags: beta-6.6.1-RC1-fpm, beta-6.6.1-fpm, beta-6.6-fpm, beta-6-fpm, beta-fpm, beta-6.6.1-RC1-php8.2-fpm, beta-6.6.1-php8.2-fpm, beta-6.6-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.2/fpm
+
+Tags: beta-6.6.1-RC1-fpm-alpine, beta-6.6.1-fpm-alpine, beta-6.6-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.6.1-RC1-php8.2-fpm-alpine, beta-6.6.1-php8.2-fpm-alpine, beta-6.6-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.2/fpm-alpine
+
+Tags: beta-6.6.1-RC1-php8.3-apache, beta-6.6.1-php8.3-apache, beta-6.6-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.6.1-RC1-php8.3, beta-6.6.1-php8.3, beta-6.6-php8.3, beta-6-php8.3, beta-php8.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.3/apache
+
+Tags: beta-6.6.1-RC1-php8.3-fpm, beta-6.6.1-php8.3-fpm, beta-6.6-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.3/fpm
+
+Tags: beta-6.6.1-RC1-php8.3-fpm-alpine, beta-6.6.1-php8.3-fpm-alpine, beta-6.6-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2cb57ab7b6beab34aff0450f26eca2180b9dfaad
+Directory: beta/php8.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/2cb57ab: Update beta to 6.6.1-RC1