### PR TITLE
Update clojure to include git in all images

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: arm64v8, amd64
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 22167afbc6b9ab69c814f6de120e7ea953c7c277
+GitCommit: 6a8d5b5094a2fd6a1c89781ad0b2f4d41b2f7bc6
 
 
 Tags: latest


### PR DESCRIPTION
Includes this: https://github.com/Quantisan/docker-clojure/pull/234 

CC @cap10morgan.