### PR TITLE
Update Clear Linux OS to 42080

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: f4043e617e4ffc33dff4ce58b0a7bf9ad85f9b41
-GitFetch: refs/heads/base-42030
+GitCommit: 65dba8369447f9bc5cbb9569a7c780e8a653ca9c
+GitFetch: refs/heads/base-42080


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42080

@bryteise @djklimes @bryteise