### PR TITLE
eclipse-temurin: bump JDK17 and 21

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -361,98 +361,108 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v21 images---------------------------------
-Tags: 21.0.3_9-jdk-alpine, 21-jdk-alpine, 21-alpine
+Tags: 21.0.4_7-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/alpine
 
-Tags: 21.0.3_9-jdk-jammy, 21-jdk-jammy, 21-jammy
-SharedTags: 21.0.3_9-jdk, 21-jdk, 21, latest
+Tags: 21.0.4_7-jdk-jammy, 21-jdk-jammy, 21-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/ubuntu/jammy
 
-Tags: 21.0.3_9-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Tags: 21.0.4_7-jdk-noble, 21-jdk-noble, 21-noble
+SharedTags: 21.0.4_7-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+Directory: 21/jdk/ubuntu/noble
+
+Tags: 21.0.4_7-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/ubi/ubi9-minimal
 
-Tags: 21.0.3_9-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21.0.3_9-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.3_9-jdk, 21-jdk, 21, latest
+Tags: 21.0.4_7-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21.0.4_7-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.4_7-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.3_9-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
-SharedTags: 21.0.3_9-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.4_7-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
+SharedTags: 21.0.4_7-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.3_9-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
-SharedTags: 21.0.3_9-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.3_9-jdk, 21-jdk, 21, latest
+Tags: 21.0.4_7-jdk-windowsservercore-1809, 21-jdk-windowsservercore-1809, 21-windowsservercore-1809
+SharedTags: 21.0.4_7-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.4_7-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 21.0.3_9-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
-SharedTags: 21.0.3_9-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.4_7-jdk-nanoserver-1809, 21-jdk-nanoserver-1809, 21-nanoserver-1809
+SharedTags: 21.0.4_7-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 21.0.3_9-jre-alpine, 21-jre-alpine
+Tags: 21.0.4_7-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/alpine
 
-Tags: 21.0.3_9-jre-jammy, 21-jre-jammy
-SharedTags: 21.0.3_9-jre, 21-jre
+Tags: 21.0.4_7-jre-jammy, 21-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/ubuntu/jammy
 
-Tags: 21.0.3_9-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Tags: 21.0.4_7-jre-noble, 21-jre-noble
+SharedTags: 21.0.4_7-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+Directory: 21/jre/ubuntu/noble
+
+Tags: 21.0.4_7-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/ubi/ubi9-minimal
 
-Tags: 21.0.3_9-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
-SharedTags: 21.0.3_9-jre-windowsservercore, 21-jre-windowsservercore, 21.0.3_9-jre, 21-jre
+Tags: 21.0.4_7-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
+SharedTags: 21.0.4_7-jre-windowsservercore, 21-jre-windowsservercore, 21.0.4_7-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.3_9-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
-SharedTags: 21.0.3_9-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.4_7-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
+SharedTags: 21.0.4_7-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.3_9-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
-SharedTags: 21.0.3_9-jre-windowsservercore, 21-jre-windowsservercore, 21.0.3_9-jre, 21-jre
+Tags: 21.0.4_7-jre-windowsservercore-1809, 21-jre-windowsservercore-1809
+SharedTags: 21.0.4_7-jre-windowsservercore, 21-jre-windowsservercore, 21.0.4_7-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 21.0.3_9-jre-nanoserver-1809, 21-jre-nanoserver-1809
-SharedTags: 21.0.3_9-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.4_7-jre-nanoserver-1809, 21-jre-nanoserver-1809
+SharedTags: 21.0.4_7-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
 Directory: 21/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -23,11 +23,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 8/jdk/ubuntu/jammy
 
-Tags: 8u412-b08-jdk-centos7, 8-jdk-centos7, 8-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
-Directory: 8/jdk/centos
-
 Tags: 8u412-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
@@ -80,11 +75,6 @@ SharedTags: 8u412-b08-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 8/jre/ubuntu/jammy
-
-Tags: 8u412-b08-jre-centos7, 8-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
-Directory: 8/jre/centos
 
 Tags: 8u412-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
@@ -141,11 +131,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 11/jdk/ubuntu/jammy
 
-Tags: 11.0.23_9-jdk-centos7, 11-jdk-centos7, 11-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
-Directory: 11/jdk/centos
-
 Tags: 11.0.23_9-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
@@ -198,11 +183,6 @@ SharedTags: 11.0.23_9-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 11/jre/ubuntu/jammy
-
-Tags: 11.0.23_9-jre-centos7, 11-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
-Directory: 11/jre/centos
 
 Tags: 11.0.23_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
@@ -259,11 +239,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.11_9-jdk-centos7, 17-jdk-centos7, 17-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
-Directory: 17/jdk/centos
-
 Tags: 17.0.11_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
@@ -316,11 +291,6 @@ SharedTags: 17.0.11_9-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
 Directory: 17/jre/ubuntu/jammy
-
-Tags: 17.0.11_9-jre-centos7, 17-jre-centos7
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
-Directory: 17/jre/centos
 
 Tags: 17.0.11_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -223,108 +223,118 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.11_9-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.12_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/alpine
 
-Tags: 17.0.11_9-jdk-focal, 17-jdk-focal, 17-focal
+Tags: 17.0.12_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/ubuntu/focal
 
-Tags: 17.0.11_9-jdk-jammy, 17-jdk-jammy, 17-jammy
-SharedTags: 17.0.11_9-jdk, 17-jdk, 17
+Tags: 17.0.12_7-jdk-jammy, 17-jdk-jammy, 17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.11_9-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.12_7-jdk-noble, 17-jdk-noble, 17-noble
+SharedTags: 17.0.12_7-jdk, 17-jdk, 17
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+Directory: 17/jdk/ubuntu/noble
+
+Tags: 17.0.12_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.11_9-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.11_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.11_9-jdk, 17-jdk, 17
+Tags: 17.0.12_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.12_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.12_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.11_9-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.11_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.12_7-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.12_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.11_9-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
-SharedTags: 17.0.11_9-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.11_9-jdk, 17-jdk, 17
+Tags: 17.0.12_7-jdk-windowsservercore-1809, 17-jdk-windowsservercore-1809, 17-windowsservercore-1809
+SharedTags: 17.0.12_7-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.12_7-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 17.0.11_9-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
-SharedTags: 17.0.11_9-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.12_7-jdk-nanoserver-1809, 17-jdk-nanoserver-1809, 17-nanoserver-1809
+SharedTags: 17.0.12_7-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 17.0.11_9-jre-alpine, 17-jre-alpine
+Tags: 17.0.12_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/alpine
 
-Tags: 17.0.11_9-jre-focal, 17-jre-focal
+Tags: 17.0.12_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/ubuntu/focal
 
-Tags: 17.0.11_9-jre-jammy, 17-jre-jammy
-SharedTags: 17.0.11_9-jre, 17-jre
+Tags: 17.0.12_7-jre-jammy, 17-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/ubuntu/jammy
 
-Tags: 17.0.11_9-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.12_7-jre-noble, 17-jre-noble
+SharedTags: 17.0.12_7-jre, 17-jre
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+Directory: 17/jre/ubuntu/noble
+
+Tags: 17.0.12_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.11_9-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.11_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.11_9-jre, 17-jre
+Tags: 17.0.12_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.12_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.12_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.11_9-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.11_9-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.12_7-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.12_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.11_9-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
-SharedTags: 17.0.11_9-jre-windowsservercore, 17-jre-windowsservercore, 17.0.11_9-jre, 17-jre
+Tags: 17.0.12_7-jre-windowsservercore-1809, 17-jre-windowsservercore-1809
+SharedTags: 17.0.12_7-jre-windowsservercore, 17-jre-windowsservercore, 17.0.12_7-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 17.0.11_9-jre-nanoserver-1809, 17-jre-nanoserver-1809
-SharedTags: 17.0.11_9-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.12_7-jre-nanoserver-1809, 17-jre-nanoserver-1809
+SharedTags: 17.0.12_7-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
 Directory: 17/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Other versions will be available shortly.

Also removes the EOL Centos 7 images

Note the bump from Alpine 3.19 to 3.20