### PR TITLE
eclipse-temurin: update JDK11 and 22

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -115,108 +115,118 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.23_9-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.24_8-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/alpine
 
-Tags: 11.0.23_9-jdk-focal, 11-jdk-focal, 11-focal
+Tags: 11.0.24_8-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/ubuntu/focal
 
-Tags: 11.0.23_9-jdk-jammy, 11-jdk-jammy, 11-jammy
-SharedTags: 11.0.23_9-jdk, 11-jdk, 11
+Tags: 11.0.24_8-jdk-jammy, 11-jdk-jammy, 11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/ubuntu/jammy
 
-Tags: 11.0.23_9-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Tags: 11.0.24_8-jdk-noble, 11-jdk-noble, 11-noble
+SharedTags: 11.0.24_8-jdk, 11-jdk, 11
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+Directory: 11/jdk/ubuntu/noble
+
+Tags: 11.0.24_8-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/ubi/ubi9-minimal
 
-Tags: 11.0.23_9-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.23_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.23_9-jdk, 11-jdk, 11
+Tags: 11.0.24_8-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.24_8-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.24_8-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.23_9-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.23_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.24_8-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.24_8-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.23_9-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
-SharedTags: 11.0.23_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.23_9-jdk, 11-jdk, 11
+Tags: 11.0.24_8-jdk-windowsservercore-1809, 11-jdk-windowsservercore-1809, 11-windowsservercore-1809
+SharedTags: 11.0.24_8-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.24_8-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 11.0.23_9-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
-SharedTags: 11.0.23_9-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.24_8-jdk-nanoserver-1809, 11-jdk-nanoserver-1809, 11-nanoserver-1809
+SharedTags: 11.0.24_8-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 11.0.23_9-jre-alpine, 11-jre-alpine
+Tags: 11.0.24_8-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/alpine
 
-Tags: 11.0.23_9-jre-focal, 11-jre-focal
+Tags: 11.0.24_8-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/ubuntu/focal
 
-Tags: 11.0.23_9-jre-jammy, 11-jre-jammy
-SharedTags: 11.0.23_9-jre, 11-jre
+Tags: 11.0.24_8-jre-jammy, 11-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/ubuntu/jammy
 
-Tags: 11.0.23_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Tags: 11.0.24_8-jre-noble, 11-jre-noble
+SharedTags: 11.0.24_8-jre, 11-jre
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+Directory: 11/jre/ubuntu/noble
+
+Tags: 11.0.24_8-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/ubi/ubi9-minimal
 
-Tags: 11.0.23_9-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.23_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.23_9-jre, 11-jre
+Tags: 11.0.24_8-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.24_8-jre-windowsservercore, 11-jre-windowsservercore, 11.0.24_8-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.23_9-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.23_9-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.24_8-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.24_8-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.23_9-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
-SharedTags: 11.0.23_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.23_9-jre, 11-jre
+Tags: 11.0.24_8-jre-windowsservercore-1809, 11-jre-windowsservercore-1809
+SharedTags: 11.0.24_8-jre-windowsservercore, 11-jre-windowsservercore, 11.0.24_8-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 11.0.23_9-jre-nanoserver-1809, 11-jre-nanoserver-1809
-SharedTags: 11.0.23_9-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.24_8-jre-nanoserver-1809, 11-jre-nanoserver-1809
+SharedTags: 11.0.24_8-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 11/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -449,98 +459,108 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 
 #------------------------------v22 images---------------------------------
-Tags: 22.0.1_8-jdk-alpine, 22-jdk-alpine, 22-alpine
+Tags: 22.0.2_9-jdk-alpine, 22-jdk-alpine, 22-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/alpine
 
-Tags: 22.0.1_8-jdk-jammy, 22-jdk-jammy, 22-jammy
-SharedTags: 22.0.1_8-jdk, 22-jdk, 22
+Tags: 22.0.2_9-jdk-jammy, 22-jdk-jammy, 22-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/ubuntu/jammy
 
-Tags: 22.0.1_8-jdk-ubi9-minimal, 22-jdk-ubi9-minimal, 22-ubi9-minimal
+Tags: 22.0.2_9-jdk-noble, 22-jdk-noble, 22-noble
+SharedTags: 22.0.2_9-jdk, 22-jdk, 22
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+Directory: 22/jdk/ubuntu/noble
+
+Tags: 22.0.2_9-jdk-ubi9-minimal, 22-jdk-ubi9-minimal, 22-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/ubi/ubi9-minimal
 
-Tags: 22.0.1_8-jdk-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
-SharedTags: 22.0.1_8-jdk-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22.0.1_8-jdk, 22-jdk, 22
+Tags: 22.0.2_9-jdk-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
+SharedTags: 22.0.2_9-jdk-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22.0.2_9-jdk, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22.0.1_8-jdk-nanoserver-ltsc2022, 22-jdk-nanoserver-ltsc2022, 22-nanoserver-ltsc2022
-SharedTags: 22.0.1_8-jdk-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22.0.2_9-jdk-nanoserver-ltsc2022, 22-jdk-nanoserver-ltsc2022, 22-nanoserver-ltsc2022
+SharedTags: 22.0.2_9-jdk-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 22.0.1_8-jdk-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
-SharedTags: 22.0.1_8-jdk-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22.0.1_8-jdk, 22-jdk, 22
+Tags: 22.0.2_9-jdk-windowsservercore-1809, 22-jdk-windowsservercore-1809, 22-windowsservercore-1809
+SharedTags: 22.0.2_9-jdk-windowsservercore, 22-jdk-windowsservercore, 22-windowsservercore, 22.0.2_9-jdk, 22-jdk, 22
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 22.0.1_8-jdk-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
-SharedTags: 22.0.1_8-jdk-nanoserver, 22-jdk-nanoserver, 22-nanoserver
+Tags: 22.0.2_9-jdk-nanoserver-1809, 22-jdk-nanoserver-1809, 22-nanoserver-1809
+SharedTags: 22.0.2_9-jdk-nanoserver, 22-jdk-nanoserver, 22-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 22.0.1_8-jre-alpine, 22-jre-alpine
+Tags: 22.0.2_9-jre-alpine, 22-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/alpine
 
-Tags: 22.0.1_8-jre-jammy, 22-jre-jammy
-SharedTags: 22.0.1_8-jre, 22-jre
+Tags: 22.0.2_9-jre-jammy, 22-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/ubuntu/jammy
 
-Tags: 22.0.1_8-jre-ubi9-minimal, 22-jre-ubi9-minimal
+Tags: 22.0.2_9-jre-noble, 22-jre-noble
+SharedTags: 22.0.2_9-jre, 22-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+Directory: 22/jre/ubuntu/noble
+
+Tags: 22.0.2_9-jre-ubi9-minimal, 22-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/ubi/ubi9-minimal
 
-Tags: 22.0.1_8-jre-windowsservercore-ltsc2022, 22-jre-windowsservercore-ltsc2022
-SharedTags: 22.0.1_8-jre-windowsservercore, 22-jre-windowsservercore, 22.0.1_8-jre, 22-jre
+Tags: 22.0.2_9-jre-windowsservercore-ltsc2022, 22-jre-windowsservercore-ltsc2022
+SharedTags: 22.0.2_9-jre-windowsservercore, 22-jre-windowsservercore, 22.0.2_9-jre, 22-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 22.0.1_8-jre-nanoserver-ltsc2022, 22-jre-nanoserver-ltsc2022
-SharedTags: 22.0.1_8-jre-nanoserver, 22-jre-nanoserver
+Tags: 22.0.2_9-jre-nanoserver-ltsc2022, 22-jre-nanoserver-ltsc2022
+SharedTags: 22.0.2_9-jre-nanoserver, 22-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 22.0.1_8-jre-windowsservercore-1809, 22-jre-windowsservercore-1809
-SharedTags: 22.0.1_8-jre-windowsservercore, 22-jre-windowsservercore, 22.0.1_8-jre, 22-jre
+Tags: 22.0.2_9-jre-windowsservercore-1809, 22-jre-windowsservercore-1809
+SharedTags: 22.0.2_9-jre-windowsservercore, 22-jre-windowsservercore, 22.0.2_9-jre, 22-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 22.0.1_8-jre-nanoserver-1809, 22-jre-nanoserver-1809
-SharedTags: 22.0.1_8-jre-nanoserver, 22-jre-nanoserver
+Tags: 22.0.2_9-jre-nanoserver-1809, 22-jre-nanoserver-1809
+SharedTags: 22.0.2_9-jre-nanoserver, 22-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
 Directory: 22/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
JDK8 will be available soon