### PR TITLE
SONAR-22607 Restore the usage of Ubuntu Jammy in the base image

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -3,7 +3,7 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Davi Koscianski Vidal <davi.koscianski-vidal@sonarsource.com> (@davividal)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: c46099ea4f748bc1bfea76bfc928b935a4e07430
+GitCommit: 29b65682b4f8dbb38bd303b35b3ceaa3a39a0e40
 
 Tags: 9.9.6-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Dear team,

as described in [our public ticket](https://sonarsource.atlassian.net/browse/SONAR-22607), the `eclipse-temurin:17-jre` tag started to resolve to `eclipse-temurin:17-jre-noble `instead of `eclipse-temurin:17-jre-jammy`. 

This makes it impossible to build our docker images due to conflicting UIDs. Therefore, we updated the base image tag in our Dockerfiles and would like to update the commit sha used in the DockerHub build process.