### PR TITLE
Updated swipl stable to 9.2.6

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: debcf80f61dab217a2ade259a203a2b9e6f0a268
+GitCommit: 053b5508dfed21e7549947113893517c64494cce
 Architectures: amd64, arm32v7, arm64v8
 
 Tags: latest, 9.3.8
 Directory: 9.3.8/bookworm
 
-Tags: stable, 9.2.5
-Directory: 9.2.5/bookworm
+Tags: stable, 9.2.6
+Directory: 9.2.6/bookworm


### PR DESCRIPTION
Note that this also updates 9.3.8/bookworm/Dockerfile, which had its tag updated, but not the actual version.