### PR TITLE
eclipse-temurin: add JDK8

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,108 +7,118 @@ GitFetch: refs/heads/main
 Builder: buildkit
 
 #------------------------------v8 images---------------------------------
-Tags: 8u412-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u422-b05-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/alpine
 
-Tags: 8u412-b08-jdk-focal, 8-jdk-focal, 8-focal
+Tags: 8u422-b05-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/ubuntu/focal
 
-Tags: 8u412-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
-SharedTags: 8u412-b08-jdk, 8-jdk, 8
+Tags: 8u422-b05-jdk-jammy, 8-jdk-jammy, 8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/ubuntu/jammy
 
-Tags: 8u412-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Tags: 8u422-b05-jdk-noble, 8-jdk-noble, 8-noble
+SharedTags: 8u422-b05-jdk, 8-jdk, 8
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+Directory: 8/jdk/ubuntu/noble
+
+Tags: 8u422-b05-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/ubi/ubi9-minimal
 
-Tags: 8u412-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u412-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u412-b08-jdk, 8-jdk, 8
+Tags: 8u422-b05-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u422-b05-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u422-b05-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u412-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
-SharedTags: 8u412-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u422-b05-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
+SharedTags: 8u422-b05-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u412-b08-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
-SharedTags: 8u412-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u412-b08-jdk, 8-jdk, 8
+Tags: 8u422-b05-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
+SharedTags: 8u422-b05-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u422-b05-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 8u412-b08-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
-SharedTags: 8u412-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u422-b05-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
+SharedTags: 8u422-b05-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 8u412-b08-jre-alpine, 8-jre-alpine
+Tags: 8u422-b05-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/alpine
 
-Tags: 8u412-b08-jre-focal, 8-jre-focal
+Tags: 8u422-b05-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/ubuntu/focal
 
-Tags: 8u412-b08-jre-jammy, 8-jre-jammy
-SharedTags: 8u412-b08-jre, 8-jre
+Tags: 8u422-b05-jre-jammy, 8-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/ubuntu/jammy
 
-Tags: 8u412-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Tags: 8u422-b05-jre-noble, 8-jre-noble
+SharedTags: 8u422-b05-jre, 8-jre
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+Directory: 8/jre/ubuntu/noble
+
+Tags: 8u422-b05-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/ubi/ubi9-minimal
 
-Tags: 8u412-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u412-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u412-b08-jre, 8-jre
+Tags: 8u422-b05-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u422-b05-jre-windowsservercore, 8-jre-windowsservercore, 8u422-b05-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u412-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
-SharedTags: 8u412-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u422-b05-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
+SharedTags: 8u422-b05-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u412-b08-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
-SharedTags: 8u412-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u412-b08-jre, 8-jre
+Tags: 8u422-b05-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
+SharedTags: 8u422-b05-jre-windowsservercore, 8-jre-windowsservercore, 8u422-b05-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 8u412-b08-jre-nanoserver-1809, 8-jre-nanoserver-1809
-SharedTags: 8u412-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u422-b05-jre-nanoserver-1809, 8-jre-nanoserver-1809
+SharedTags: 8u422-b05-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 057e5aa7581e96b8a2334290e750b329d62abfdf
+GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
 Directory: 8/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -9,34 +9,34 @@ Builder: buildkit
 #------------------------------v8 images---------------------------------
 Tags: 8u422-b05-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/alpine
 
 Tags: 8u422-b05-jdk-focal, 8-jdk-focal, 8-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/ubuntu/focal
 
 Tags: 8u422-b05-jdk-jammy, 8-jdk-jammy, 8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/ubuntu/jammy
 
 Tags: 8u422-b05-jdk-noble, 8-jdk-noble, 8-noble
 SharedTags: 8u422-b05-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/ubuntu/noble
 
 Tags: 8u422-b05-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u422-b05-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
 SharedTags: 8u422-b05-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u422-b05-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
@@ -44,7 +44,7 @@ Constraints: windowsservercore-ltsc2022
 Tags: 8u422-b05-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
 SharedTags: 8u422-b05-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
@@ -52,7 +52,7 @@ Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 Tags: 8u422-b05-jdk-windowsservercore-1809, 8-jdk-windowsservercore-1809, 8-windowsservercore-1809
 SharedTags: 8u422-b05-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u422-b05-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
@@ -60,41 +60,41 @@ Constraints: windowsservercore-1809
 Tags: 8u422-b05-jdk-nanoserver-1809, 8-jdk-nanoserver-1809, 8-nanoserver-1809
 SharedTags: 8u422-b05-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 8u422-b05-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/alpine
 
 Tags: 8u422-b05-jre-focal, 8-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/ubuntu/focal
 
 Tags: 8u422-b05-jre-jammy, 8-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/ubuntu/jammy
 
 Tags: 8u422-b05-jre-noble, 8-jre-noble
 SharedTags: 8u422-b05-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/ubuntu/noble
 
 Tags: 8u422-b05-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u422-b05-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
 SharedTags: 8u422-b05-jre-windowsservercore, 8-jre-windowsservercore, 8u422-b05-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
@@ -102,7 +102,7 @@ Constraints: windowsservercore-ltsc2022
 Tags: 8u422-b05-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
 SharedTags: 8u422-b05-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
@@ -110,7 +110,7 @@ Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 Tags: 8u422-b05-jre-windowsservercore-1809, 8-jre-windowsservercore-1809
 SharedTags: 8u422-b05-jre-windowsservercore, 8-jre-windowsservercore, 8u422-b05-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
@@ -118,7 +118,7 @@ Constraints: windowsservercore-1809
 Tags: 8u422-b05-jre-nanoserver-1809, 8-jre-nanoserver-1809
 SharedTags: 8u422-b05-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: bbda8ccd2cb51b5c46028a40a4072e8158e2403a
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 8/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
@@ -127,28 +127,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v11 images---------------------------------
 Tags: 11.0.24_8-jdk-alpine, 11-jdk-alpine, 11-alpine
 Architectures: amd64
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jdk/alpine
 
 Tags: 11.0.24_8-jdk-focal, 11-jdk-focal, 11-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jdk/ubuntu/focal
 
 Tags: 11.0.24_8-jdk-jammy, 11-jdk-jammy, 11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jdk/ubuntu/jammy
 
 Tags: 11.0.24_8-jdk-noble, 11-jdk-noble, 11-noble
 SharedTags: 11.0.24_8-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jdk/ubuntu/noble
 
 Tags: 11.0.24_8-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.24_8-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
@@ -185,28 +185,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 11.0.24_8-jre-alpine, 11-jre-alpine
 Architectures: amd64
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jre/alpine
 
 Tags: 11.0.24_8-jre-focal, 11-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.24_8-jre-jammy, 11-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jre/ubuntu/jammy
 
 Tags: 11.0.24_8-jre-noble, 11-jre-noble
 SharedTags: 11.0.24_8-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jre/ubuntu/noble
 
 Tags: 11.0.24_8-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.24_8-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
@@ -245,28 +245,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v17 images---------------------------------
 Tags: 17.0.12_7-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jdk/alpine
 
 Tags: 17.0.12_7-jdk-focal, 17-jdk-focal, 17-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jdk/ubuntu/focal
 
 Tags: 17.0.12_7-jdk-jammy, 17-jdk-jammy, 17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jdk/ubuntu/jammy
 
 Tags: 17.0.12_7-jdk-noble, 17-jdk-noble, 17-noble
 SharedTags: 17.0.12_7-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jdk/ubuntu/noble
 
 Tags: 17.0.12_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jdk/ubi/ubi9-minimal
 
 Tags: 17.0.12_7-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
@@ -303,28 +303,28 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 17.0.12_7-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jre/alpine
 
 Tags: 17.0.12_7-jre-focal, 17-jre-focal
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.12_7-jre-jammy, 17-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jre/ubuntu/jammy
 
 Tags: 17.0.12_7-jre-noble, 17-jre-noble
 SharedTags: 17.0.12_7-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jre/ubuntu/noble
 
 Tags: 17.0.12_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: f7ce125dc28d8c0d065d94829e63094daa018ca3
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 17/jre/ubi/ubi9-minimal
 
 Tags: 17.0.12_7-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
@@ -363,23 +363,23 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v21 images---------------------------------
 Tags: 21.0.4_7-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jdk/alpine
 
 Tags: 21.0.4_7-jdk-jammy, 21-jdk-jammy, 21-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jdk/ubuntu/jammy
 
 Tags: 21.0.4_7-jdk-noble, 21-jdk-noble, 21-noble
 SharedTags: 21.0.4_7-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jdk/ubuntu/noble
 
 Tags: 21.0.4_7-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.4_7-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
@@ -416,23 +416,23 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 21.0.4_7-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jre/alpine
 
 Tags: 21.0.4_7-jre-jammy, 21-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jre/ubuntu/jammy
 
 Tags: 21.0.4_7-jre-noble, 21-jre-noble
 SharedTags: 21.0.4_7-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jre/ubuntu/noble
 
 Tags: 21.0.4_7-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6e6c1cc0d915b330e3c474a9bf21d92fc4e5f157
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.4_7-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
@@ -471,23 +471,23 @@ Constraints: nanoserver-1809, windowsservercore-1809
 #------------------------------v22 images---------------------------------
 Tags: 22.0.2_9-jdk-alpine, 22-jdk-alpine, 22-alpine
 Architectures: amd64, arm64v8
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jdk/alpine
 
 Tags: 22.0.2_9-jdk-jammy, 22-jdk-jammy, 22-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jdk/ubuntu/jammy
 
 Tags: 22.0.2_9-jdk-noble, 22-jdk-noble, 22-noble
 SharedTags: 22.0.2_9-jdk, 22-jdk, 22
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jdk/ubuntu/noble
 
 Tags: 22.0.2_9-jdk-ubi9-minimal, 22-jdk-ubi9-minimal, 22-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jdk/ubi/ubi9-minimal
 
 Tags: 22.0.2_9-jdk-windowsservercore-ltsc2022, 22-jdk-windowsservercore-ltsc2022, 22-windowsservercore-ltsc2022
@@ -524,23 +524,23 @@ Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 22.0.2_9-jre-alpine, 22-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jre/alpine
 
 Tags: 22.0.2_9-jre-jammy, 22-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jre/ubuntu/jammy
 
 Tags: 22.0.2_9-jre-noble, 22-jre-noble
 SharedTags: 22.0.2_9-jre, 22-jre
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jre/ubuntu/noble
 
 Tags: 22.0.2_9-jre-ubi9-minimal, 22-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 48ce959533cd2146eb94d626938b683b5b013cfc
+GitCommit: 43fcefc483338727126a5263d7110f5711ad8506
 Directory: 22/jre/ubi/ubi9-minimal
 
 Tags: 22.0.2_9-jre-windowsservercore-ltsc2022, 22-jre-windowsservercore-ltsc2022


### PR DESCRIPTION
This closes out our July release cycle

Also contains the rootless CA certs changes made in https://github.com/adoptium/containers/pull/572