### PR TITLE
[oraclelinux] Updating 9 for ELSA-2024-4779

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c84482379fe634b0b9db34cddc5555557bd4c514
+amd64-GitCommit: b99233acc86d93ff471c861cdc4ccbd5f83f91e9
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: de0cfacd1fa6a79c0edf8ae75aead800775bc6ae
+arm64v8-GitCommit: 0969fa7de591a09867f2b93792d85876a7c4e395
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-4032, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-4779.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
