### PR TITLE
haxe: haxe 4.3.5 and neko 2.4.0

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -1,60 +1,60 @@
 Maintainers: Andy Li <andy@onthewings.net> (@andyli)
 GitRepo: https://github.com/HaxeFoundation/docker-library-haxe.git
 
-Tags: 4.3.4-bookworm, 4.3-bookworm
-SharedTags: 4.3.4, 4.3, latest
+Tags: 4.3.5-bookworm, 4.3-bookworm
+SharedTags: 4.3.5, 4.3, latest
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1cff33784d835b54074b7befa1ee159877ede9bf
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/bookworm
 
-Tags: 4.3.4-bullseye, 4.3-bullseye
+Tags: 4.3.5-bullseye, 4.3-bullseye
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 882ff89f78244a8a5b05faaf7d4fe9933528f6ca
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/bullseye
 
-Tags: 4.3.4-windowsservercore-ltsc2022, 4.3-windowsservercore-ltsc2022
-SharedTags: 4.3.4-windowsservercore, 4.3-windowsservercore, 4.3.4, 4.3, latest
+Tags: 4.3.5-windowsservercore-ltsc2022, 4.3-windowsservercore-ltsc2022
+SharedTags: 4.3.5-windowsservercore, 4.3-windowsservercore, 4.3.5, 4.3, latest
 Architectures: windows-amd64
-GitCommit: 882ff89f78244a8a5b05faaf7d4fe9933528f6ca
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 4.3.4-windowsservercore-1809, 4.3-windowsservercore-1809
-SharedTags: 4.3.4-windowsservercore, 4.3-windowsservercore, 4.3.4, 4.3, latest
+Tags: 4.3.5-windowsservercore-1809, 4.3-windowsservercore-1809
+SharedTags: 4.3.5-windowsservercore, 4.3-windowsservercore, 4.3.5, 4.3, latest
 Architectures: windows-amd64
-GitCommit: 882ff89f78244a8a5b05faaf7d4fe9933528f6ca
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 4.3.4-alpine3.20, 4.3-alpine3.20, 4.3.4-alpine, 4.3-alpine
+Tags: 4.3.5-alpine3.20, 4.3-alpine3.20, 4.3.5-alpine, 4.3-alpine
 Architectures: amd64, arm64v8
-GitCommit: c678f34e8951bdb1359e08021276df5d38ac83df
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/alpine3.20
 
-Tags: 4.3.4-alpine3.19, 4.3-alpine3.19
+Tags: 4.3.5-alpine3.19, 4.3-alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: 882ff89f78244a8a5b05faaf7d4fe9933528f6ca
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/alpine3.19
 
-Tags: 4.3.4-alpine3.18, 4.3-alpine3.18
+Tags: 4.3.5-alpine3.18, 4.3-alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: 882ff89f78244a8a5b05faaf7d4fe9933528f6ca
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/alpine3.18
 
-Tags: 4.3.4-alpine3.17, 4.3-alpine3.17
+Tags: 4.3.5-alpine3.17, 4.3-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 882ff89f78244a8a5b05faaf7d4fe9933528f6ca
+GitCommit: 06c07a989caa62b8e178a84b15f9e03bfa9b31e6
 Directory: 4.3/alpine3.17
 
 Tags: 4.2.5-bookworm, 4.2-bookworm
 SharedTags: 4.2.5, 4.2
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 1cff33784d835b54074b7befa1ee159877ede9bf
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.2/bookworm
 
 Tags: 4.2.5-bullseye, 4.2-bullseye
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 5a0bf6fd06e6c8ec052cf0a2bbd83b39932a1839
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.2/bullseye
 
 Tags: 4.2.5-windowsservercore-ltsc2022, 4.2-windowsservercore-ltsc2022
@@ -73,28 +73,28 @@ Constraints: windowsservercore-1809
 
 Tags: 4.2.5-alpine3.20, 4.2-alpine3.20, 4.2.5-alpine, 4.2-alpine
 Architectures: amd64, arm64v8
-GitCommit: c678f34e8951bdb1359e08021276df5d38ac83df
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.2/alpine3.20
 
 Tags: 4.2.5-alpine3.19, 4.2-alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: b7f47ba7340373d40202dfb77621de1ed3ba3677
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.2/alpine3.19
 
 Tags: 4.2.5-alpine3.18, 4.2-alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: b7003bc3280e69dc057ef0e6e8dfb8fd44ce4741
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.2/alpine3.18
 
 Tags: 4.2.5-alpine3.17, 4.2-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 5a0bf6fd06e6c8ec052cf0a2bbd83b39932a1839
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.2/alpine3.17
 
 Tags: 4.1.5-bullseye, 4.1-bullseye
 SharedTags: 4.1.5, 4.1
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 5a0bf6fd06e6c8ec052cf0a2bbd83b39932a1839
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.1/bullseye
 
 Tags: 4.1.5-windowsservercore-ltsc2022, 4.1-windowsservercore-ltsc2022
@@ -113,28 +113,28 @@ Constraints: windowsservercore-1809
 
 Tags: 4.1.5-alpine3.20, 4.1-alpine3.20, 4.1.5-alpine, 4.1-alpine
 Architectures: amd64, arm64v8
-GitCommit: c678f34e8951bdb1359e08021276df5d38ac83df
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.1/alpine3.20
 
 Tags: 4.1.5-alpine3.19, 4.1-alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: b7f47ba7340373d40202dfb77621de1ed3ba3677
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.1/alpine3.19
 
 Tags: 4.1.5-alpine3.18, 4.1-alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: b7003bc3280e69dc057ef0e6e8dfb8fd44ce4741
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.1/alpine3.18
 
 Tags: 4.1.5-alpine3.17, 4.1-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 5a0bf6fd06e6c8ec052cf0a2bbd83b39932a1839
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.1/alpine3.17
 
 Tags: 4.0.5-bullseye, 4.0-bullseye
 SharedTags: 4.0.5, 4.0
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 5a0bf6fd06e6c8ec052cf0a2bbd83b39932a1839
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.0/bullseye
 
 Tags: 4.0.5-windowsservercore-ltsc2022, 4.0-windowsservercore-ltsc2022
@@ -153,21 +153,21 @@ Constraints: windowsservercore-1809
 
 Tags: 4.0.5-alpine3.20, 4.0-alpine3.20, 4.0.5-alpine, 4.0-alpine
 Architectures: amd64, arm64v8
-GitCommit: c678f34e8951bdb1359e08021276df5d38ac83df
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.0/alpine3.20
 
 Tags: 4.0.5-alpine3.19, 4.0-alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: b7f47ba7340373d40202dfb77621de1ed3ba3677
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.0/alpine3.19
 
 Tags: 4.0.5-alpine3.18, 4.0-alpine3.18
 Architectures: amd64, arm64v8
-GitCommit: b7003bc3280e69dc057ef0e6e8dfb8fd44ce4741
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.0/alpine3.18
 
 Tags: 4.0.5-alpine3.17, 4.0-alpine3.17
 Architectures: amd64, arm64v8
-GitCommit: 5a0bf6fd06e6c8ec052cf0a2bbd83b39932a1839
+GitCommit: 28b986eccdcf136c1a6f705cab132abf63e88a56
 Directory: 4.0/alpine3.17
 


### PR DESCRIPTION
* Updated Haxe to 4.3.5.
* Updated Haxe's dependency Neko to 2.4.0 for applicable variants.