### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240708.0
+Tags: 2023, latest, 2023.5.20240722.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 9aa5efdadd1dbd202f24e6425831f550a005700d
+amd64-GitCommit: 5ab742374d78d507f5ddb156396cb7b08c6c032a
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2a7677fce501b2e2a85037893d820e52e568fa5c
+arm64v8-GitCommit: e83b7c7830244b9c18efbb763fed1196a0af7e5d
 
-Tags: 2, 2.0.20240709.1
+Tags: 2, 2.0.20240719.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 658e36f64d9196707f00b3e5082ce8a54d65ed26
+amd64-GitCommit: 777bd118eac88f5da9cd43baee35bea52604def2
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 1d95bd6790901e72acb5f016e931ddde6fb82599
+arm64v8-GitCommit: 54429931bd4b95501f396c3c79e5f88337fd7711
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
== Updated Packages for Amazon Linux 2 ==
- krb5-libs-1.15.1-55.amzn2.2.8

== Packages addressing CVES ==
- krb5-libs-1.15.1-55.amzn2.2.8
  - [CVE-2024-37370](https://alas.aws.amazon.com/cve/html/CVE-2024-37370.html)
  - [CVE-2024-37371](https://alas.aws.amazon.com/cve/html/CVE-2024-37371.html)

== Updated Packages for Amazon Linux 2023 ==
- amazon-linux-repo-cdn-2023.5.20240722-0.amzn2023
- system-release-2023.5.20240722-0.amzn2023

== Packages addressing CVES ==
- N/A