### PR TITLE
Apache Storm 2.6.3: Update Hash to remove upstream added "ubuntu" user for JRE 11

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -5,7 +5,7 @@ GitRepo: https://github.com/apache/storm-docker.git
 Architectures: amd64, arm64v8
 
 Tags: 2.6.3, 2.6, latest
-GitCommit: e7117105eb207e0ffad071d429e7c3de8c0864ce
+GitCommit: adb8344286f15872ecebb2796ad7ee0791f09883
 Directory: 2.6.3
 
 Tags: 2.6.3-jre17, 2.6-jre17


### PR DESCRIPTION
cf. https://github.com/docker-library/official-images/pull/17231#issuecomment-2251432207