### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.88.1, 5.88, 5, latest
+Tags: 5.88.2, 5.88, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 48d24c4edaf68ca606dc7d90e97ee57bff31bac4
+GitCommit: 22f52c7dce218c90e39ca9d24490564929f4043a
 Directory: 5/debian
 
-Tags: 5.88.1-alpine, 5.88-alpine, 5-alpine, alpine
+Tags: 5.88.2-alpine, 5.88-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 48d24c4edaf68ca606dc7d90e97ee57bff31bac4
+GitCommit: 22f52c7dce218c90e39ca9d24490564929f4043a
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/22f52c7: Update to 5.88.2, ghost-cli 1.26.0