### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,122 +4,122 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.2.0-alpha2-php8.1-apache, 5.2-php8.1-apache, 5.2.alpha-php8.1-apache, 5.2.0-alpha-php8.1-apache
+Tags: 5.2.0-alpha3-php8.1-apache, 5.2-php8.1-apache, 5.2.alpha-php8.1-apache, 5.2.0-alpha-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fc2531d198816fd4ab1089d0991763d39657fa5
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.1/apache
 
-Tags: 5.2.0-alpha2-php8.1-fpm-alpine, 5.2-php8.1-fpm-alpine, 5.2.alpha-php8.1-fpm-alpine, 5.2.0-alpha-php8.1-fpm-alpine
+Tags: 5.2.0-alpha3-php8.1-fpm-alpine, 5.2-php8.1-fpm-alpine, 5.2.alpha-php8.1-fpm-alpine, 5.2.0-alpha-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc2531d198816fd4ab1089d0991763d39657fa5
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.1/fpm-alpine
 
-Tags: 5.2.0-alpha2-php8.1-fpm, 5.2-php8.1-fpm, 5.2.alpha-php8.1-fpm, 5.2.0-alpha-php8.1-fpm
+Tags: 5.2.0-alpha3-php8.1-fpm, 5.2-php8.1-fpm, 5.2.alpha-php8.1-fpm, 5.2.0-alpha-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fc2531d198816fd4ab1089d0991763d39657fa5
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.1/fpm
 
-Tags: 5.2.0-alpha2, 5.2, 5.2.alpha, 5.2.0-alpha, 5.2.0-alpha2-apache, 5.2-apache, 5.2.alpha-apache, 5.2.0-alpha-apache, 5.2.0-alpha2-php8.2, 5.2-php8.2, 5.2.alpha-php8.2, 5.2.0-alpha-php8.2, 5.2.0-alpha2-php8.2-apache, 5.2-php8.2-apache, 5.2.alpha-php8.2-apache, 5.2.0-alpha-php8.2-apache
+Tags: 5.2.0-alpha3, 5.2, 5.2.alpha, 5.2.0-alpha, 5.2.0-alpha3-apache, 5.2-apache, 5.2.alpha-apache, 5.2.0-alpha-apache, 5.2.0-alpha3-php8.2, 5.2-php8.2, 5.2.alpha-php8.2, 5.2.0-alpha-php8.2, 5.2.0-alpha3-php8.2-apache, 5.2-php8.2-apache, 5.2.alpha-php8.2-apache, 5.2.0-alpha-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fc2531d198816fd4ab1089d0991763d39657fa5
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.2/apache
 
-Tags: 5.2.0-alpha2-php8.2-fpm-alpine, 5.2-php8.2-fpm-alpine, 5.2.alpha-php8.2-fpm-alpine, 5.2.0-alpha-php8.2-fpm-alpine
+Tags: 5.2.0-alpha3-php8.2-fpm-alpine, 5.2-php8.2-fpm-alpine, 5.2.alpha-php8.2-fpm-alpine, 5.2.0-alpha-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc2531d198816fd4ab1089d0991763d39657fa5
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.2/fpm-alpine
 
-Tags: 5.2.0-alpha2-php8.2-fpm, 5.2-php8.2-fpm, 5.2.alpha-php8.2-fpm, 5.2.0-alpha-php8.2-fpm
+Tags: 5.2.0-alpha3-php8.2-fpm, 5.2-php8.2-fpm, 5.2.alpha-php8.2-fpm, 5.2.0-alpha-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3fc2531d198816fd4ab1089d0991763d39657fa5
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.2/fpm
 
-Tags: 5.2.0-alpha2-php8.3-apache, 5.2-php8.3-apache, 5.2.alpha-php8.3-apache, 5.2.0-alpha-php8.3-apache
+Tags: 5.2.0-alpha3-php8.3-apache, 5.2-php8.3-apache, 5.2.alpha-php8.3-apache, 5.2.0-alpha-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 360f6bd96c80f72b020d2d9c8aae9daa6bca2887
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.3/apache
 
-Tags: 5.2.0-alpha2-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5.2.alpha-php8.3-fpm-alpine, 5.2.0-alpha-php8.3-fpm-alpine
+Tags: 5.2.0-alpha3-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5.2.alpha-php8.3-fpm-alpine, 5.2.0-alpha-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 360f6bd96c80f72b020d2d9c8aae9daa6bca2887
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.3/fpm-alpine
 
-Tags: 5.2.0-alpha2-php8.3-fpm, 5.2-php8.3-fpm, 5.2.alpha-php8.3-fpm, 5.2.0-alpha-php8.3-fpm
+Tags: 5.2.0-alpha3-php8.3-fpm, 5.2-php8.3-fpm, 5.2.alpha-php8.3-fpm, 5.2.0-alpha-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 360f6bd96c80f72b020d2d9c8aae9daa6bca2887
+GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
 Directory: 5.2.alpha/php8.3/fpm
 
 Tags: 5.1.2-php8.1-apache, 5.1-php8.1-apache, 5-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.1/apache
 
 Tags: 5.1.2-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.1/fpm-alpine
 
 Tags: 5.1.2-php8.1-fpm, 5.1-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.1/fpm
 
 Tags: 5.1.2, 5.1, 5, latest, 5.1.2-apache, 5.1-apache, 5-apache, apache, 5.1.2-php8.2, 5.1-php8.2, 5-php8.2, php8.2, 5.1.2-php8.2-apache, 5.1-php8.2-apache, 5-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.2/apache
 
 Tags: 5.1.2-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.2/fpm-alpine
 
 Tags: 5.1.2-php8.2-fpm, 5.1-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.2/fpm
 
 Tags: 5.1.2-php8.3-apache, 5.1-php8.3-apache, 5-php8.3-apache, php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.3/apache
 
 Tags: 5.1.2-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.3/fpm-alpine
 
 Tags: 5.1.2-php8.3-fpm, 5.1-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 5.1/php8.3/fpm
 
 Tags: 4.4.6, 4.4, 4, 4.4.6-apache, 4.4-apache, 4-apache, 4.4.6-php8.1, 4.4-php8.1, 4-php8.1, 4.4.6-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 4.4/php8.1/apache
 
 Tags: 4.4.6-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 4.4/php8.1/fpm-alpine
 
 Tags: 4.4.6-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 4.4/php8.1/fpm
 
 Tags: 4.4.6-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 4.4/php8.2/apache
 
 Tags: 4.4.6-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 4.4/php8.2/fpm-alpine
 
 Tags: 4.4.6-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 60bdaae5a96b191d1a229b92e0cecf5e0bd1552a
+GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
 Directory: 4.4/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@de23e98: Update Joomla 5.2.0-alpha2 to 5.2.0-alpha3
- joomla-docker/docker-joomla@f60f389: Update all images with the PostgreSQL connection fix
- joomla-docker/docker-joomla@56e8a0f: Add postgres dbname to connection of pgsql
- joomla-docker/docker-joomla@73dbbce: Update makedb.php