### PR TITLE
archlinux: Release 20240728.0.249973

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240721.0.248532
-GitCommit: 482302c0f1d228555036ec4d36088afdc635c589
-GitFetch: refs/tags/v20240721.0.248532
+Tags: latest, base, base-20240728.0.249973
+GitCommit: 99788745914e8ad11d9d2c8157d0a71e82a6fa29
+GitFetch: refs/tags/v20240728.0.249973
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240721.0.248532
-GitCommit: 482302c0f1d228555036ec4d36088afdc635c589
-GitFetch: refs/tags/v20240721.0.248532
+Tags: base-devel, base-devel-20240728.0.249973
+GitCommit: 99788745914e8ad11d9d2c8157d0a71e82a6fa29
+GitFetch: refs/tags/v20240728.0.249973
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240721.0.248532
-GitCommit: 482302c0f1d228555036ec4d36088afdc635c589
-GitFetch: refs/tags/v20240721.0.248532
+Tags: multilib-devel, multilib-devel-20240728.0.249973
+GitCommit: 99788745914e8ad11d9d2c8157d0a71e82a6fa29
+GitFetch: refs/tags/v20240728.0.249973
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks