### PR TITLE
Pin Ubuntu to jammy for Zookeeper 3.7.2, 3.7, 3.7.2-jre-11, 3.7-jre-11

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -4,7 +4,7 @@ Architectures: amd64, arm64v8, s390x, ppc64le
 
 Tags: 3.7.2, 3.7, 3.7.2-jre-11, 3.7-jre-11
 GitCommit: c03e4eea773bb3406fed38bdda15bf0bdfb1b35b
-Directory: 3.7.2
+Directory: 3.7.2-jre11
 
 Tags: 3.7.2-jre-17, 3.7-jre-17
 GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -3,7 +3,7 @@ GitRepo: https://github.com/31z4/zookeeper-docker.git
 Architectures: amd64, arm64v8, s390x, ppc64le
 
 Tags: 3.7.2, 3.7, 3.7.2-jre-11, 3.7-jre-11
-GitCommit: dd520cb108da9eafe6914dce4e5dbd4877dd2411
+GitCommit: c03e4eea773bb3406fed38bdda15bf0bdfb1b35b
 Directory: 3.7.2
 
 Tags: 3.7.2-jre-17, 3.7-jre-17


### PR DESCRIPTION
Adresses https://github.com/31z4/zookeeper-docker/issues/166