### PR TITLE
Empty recent deprecated images, delete older

### DIFF
--- a/library/adminer
+++ b/library/adminer
@@ -3,14 +3,4 @@
 Maintainers: Tim Düsterhus <tim@bastelstu.be> (@TimWolla)
 GitRepo: https://github.com/TimWolla/docker-adminer.git
 
-Tags: 4.8.1-standalone, 4-standalone, standalone, 4.8.1, 4, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c9c54b18f79a66409a3153a94f629ea68f08647c
-GitFetch: refs/heads/debian-packages
-Directory: 4
-
-Tags: 4.8.1-fastcgi, 4-fastcgi, fastcgi
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c9c54b18f79a66409a3153a94f629ea68f08647c
-GitFetch: refs/heads/debian-packages
-Directory: 4/fastcgi
+# https://github.com/docker-library/docs/pull/2476

--- a/library/centos
+++ b/library/centos
@@ -1,3 +1,0 @@
-Maintainers: The CentOS Project <cloud-ops@centos.org> (@CentOS)
-GitRepo: https://github.com/CentOS/sig-cloud-instance-images.git
-Directory: docker

--- a/library/clefos
+++ b/library/clefos
@@ -1,7 +1,4 @@
 Maintainers: The ClefOS Project <neale@sinenomine.net> (@nealef)
 GitRepo: https://github.com/nealef/clefos.git
 
-Tags: 7, 7.7.1908, latest 
-GitFetch: refs/heads/7.4.1708
-GitCommit: 1aa7d3771b2ced8b8b5cdc9a1a1752d93c56a60e
-Architectures: s390x
+# https://github.com/docker-library/docs/pull/2477

--- a/library/consul
+++ b/library/consul
@@ -1,5 +1,0 @@
-Maintainers: Consul Team <consul@hashicorp.com> (@hashicorp/consul)
-GitRepo: https://github.com/hashicorp/docker-consul.git
-
-# https://github.com/docker-library/docs/pull/2283
-# https://github.com/docker-library/official-images/pull/14949

--- a/library/express-gateway
+++ b/library/express-gateway
@@ -1,4 +1,0 @@
-Maintainers: The Express-Gateway Team <info@express-gateway.io> (@express_gateway)
-GitRepo: https://github.com/ExpressGateway/docker-express-gateway.git
-
-# https://github.com/docker-library/docs/pull/2138

--- a/library/jobber
+++ b/library/jobber
@@ -1,5 +1,0 @@
-Maintainers: C. Dylan Shearer <dylan@nekonya.info> (@dshearer)
-GitRepo: https://github.com/dshearer/jobber-docker.git
-
-# https://github.com/docker-library/docs/pull/2148
-# https://github.com/dshearer/jobber/pull/334

--- a/library/nats-streaming
+++ b/library/nats-streaming
@@ -1,5 +1,0 @@
-Maintainers: Ivan Kozlovic <ivan@synadia.com> (@kozlovic),
-             Phil Pennock <pdp@synadia.com> (@philpennock)
-GitRepo: https://github.com/nats-io/nats-streaming-docker.git
-
-# https://github.com/docker-library/docs/pull/2084

--- a/library/php-zendserver
+++ b/library/php-zendserver
@@ -3,14 +3,4 @@ Maintainers: Heigo Sinilind <hsinilind@perforce.com> (@hsinilind),
 GitRepo: https://github.com/zendtech/php-zendserver-docker.git
 GitCommit: bcd65b82acb4f3b5b67f8c657c52f08bc52d8789
 
-Tags: 8.5, 8.5-php5.6, 5.6 
-Directory: 8.5/5.6
-
-Tags: 9.1
-Directory: 9.1/7.1
-
-Tags: 2019.0
-Directory: 2019.0
-
-Tags: 2021.0, latest
-Directory: 2021.0
+# https://github.com/docker-library/docs/pull/2475

--- a/library/vault
+++ b/library/vault
@@ -1,7 +1,0 @@
-Maintainers: Meggie Ladlow <meggie@hashicorp.com> (@mladlow),
-             Calvin Leung Huang <calvin@hashicorp.com> (@calvn),
-             Nick Cabatoff <ncabatoff@hashicorp.com> (@ncabatoff)
-GitRepo: https://github.com/hashicorp/docker-vault.git
-
-# https://github.com/docker-library/docs/pull/2291
-# https://github.com/docker-library/official-images/pull/14940


### PR DESCRIPTION
Emptying these files of "tag entries" will empty the list of "Supported Tags" on Docker Hub so that we can remove them completely from the set.