### PR TITLE
Bump Traefik to v2.11.7

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 2f8afc4591f5faf2b4ec8279ed8128ffbb919e41
 Directory: v3.1/alpine
 
-Tags: v2.11.6-windowsservercore-ltsc2022, 2.11.6-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.7-windowsservercore-ltsc2022, 2.11.7-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
+GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.6-windowsservercore-1809, 2.11.6-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.7-windowsservercore-1809, 2.11.7-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
+GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.6-nanoserver-ltsc2022, 2.11.6-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.7-nanoserver-ltsc2022, 2.11.7-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
+GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.6, 2.11.6, v2.11, 2.11, mimolette
+Tags: v2.11.7, 2.11.7, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1e50ba91255ec5269abb2bf117a21e5ae7ffe2a9
+GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.7](https://github.com/traefik/traefik/releases/tag/v2.11.7).

/cc @emilevauge @ldez

Cheers
