### PR TITLE
Update Apache Flink to 1.20.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,17 +3,32 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.19.1-scala_2.12-java8, 1.19-scala_2.12-java8, scala_2.12-java8, 1.19.1-java8, 1.19-java8, java8
+Tags: 1.20.0-scala_2.12-java8, 1.20-scala_2.12-java8, scala_2.12-java8, 1.20.0-java8, 1.20-java8, java8
+Architectures: amd64,arm64v8
+GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
+Directory: ./1.20/scala_2.12-java8-ubuntu
+
+Tags: 1.20.0-scala_2.12-java17, 1.20-scala_2.12-java17, scala_2.12-java17, 1.20.0-java17, 1.20-java17, java17
+Architectures: amd64,arm64v8
+GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
+Directory: ./1.20/scala_2.12-java17-ubuntu
+
+Tags: 1.20.0-scala_2.12-java11, 1.20-scala_2.12-java11, scala_2.12-java11, 1.20.0-scala_2.12, 1.20-scala_2.12, scala_2.12, 1.20.0-java11, 1.20-java11, java11, 1.20.0, 1.20, latest
+Architectures: amd64,arm64v8
+GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
+Directory: ./1.20/scala_2.12-java11-ubuntu
+
+Tags: 1.19.1-scala_2.12-java8, 1.19-scala_2.12-java8, 1.19.1-java8, 1.19-java8
 Architectures: amd64,arm64v8
 GitCommit: f77b347d0a534da0482e692d80f559f47041829e
 Directory: ./1.19/scala_2.12-java8-ubuntu
 
-Tags: 1.19.1-scala_2.12-java17, 1.19-scala_2.12-java17, scala_2.12-java17, 1.19.1-java17, 1.19-java17, java17
+Tags: 1.19.1-scala_2.12-java17, 1.19-scala_2.12-java17, 1.19.1-java17, 1.19-java17
 Architectures: amd64,arm64v8
 GitCommit: f77b347d0a534da0482e692d80f559f47041829e
 Directory: ./1.19/scala_2.12-java17-ubuntu
 
-Tags: 1.19.1-scala_2.12-java11, 1.19-scala_2.12-java11, scala_2.12-java11, 1.19.1-scala_2.12, 1.19-scala_2.12, scala_2.12, 1.19.1-java11, 1.19-java11, java11, 1.19.1, 1.19, latest
+Tags: 1.19.1-scala_2.12-java11, 1.19-scala_2.12-java11, 1.19.1-scala_2.12, 1.19-scala_2.12, 1.19.1-java11, 1.19-java11, 1.19.1, 1.19
 Architectures: amd64,arm64v8
 GitCommit: f77b347d0a534da0482e692d80f559f47041829e
 Directory: ./1.19/scala_2.12-java11-ubuntu
@@ -32,13 +47,3 @@ Tags: 1.18.1-scala_2.12-java11, 1.18-scala_2.12-java11, 1.18.1-scala_2.12, 1.18-
 Architectures: amd64,arm64v8
 GitCommit: 883600747505c128d97e9d25c9326f0c6f1d31e4
 Directory: ./1.18/scala_2.12-java11-ubuntu
-
-Tags: 1.17.2-scala_2.12-java8, 1.17-scala_2.12-java8, 1.17.2-java8, 1.17-java8
-Architectures: amd64,arm64v8
-GitCommit: 883600747505c128d97e9d25c9326f0c6f1d31e4
-Directory: ./1.17/scala_2.12-java8-ubuntu
-
-Tags: 1.17.2-scala_2.12-java11, 1.17-scala_2.12-java11, 1.17.2-scala_2.12, 1.17-scala_2.12, 1.17.2-java11, 1.17-java11, 1.17.2, 1.17
-Architectures: amd64,arm64v8
-GitCommit: 883600747505c128d97e9d25c9326f0c6f1d31e4
-Directory: ./1.17/scala_2.12-java11-ubuntu


### PR DESCRIPTION
- Add new released `1.20.0`.
- Remove unsupported `1.17.2`.