### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2024-05-07
-Tags: 14.1.0, 14.1, 14, latest, 14.1.0-bookworm, 14.1-bookworm, 14-bookworm, bookworm
+# Last Modified: 2024-08-01
+Tags: 14.2.0, 14.2, 14, latest, 14.2.0-bookworm, 14.2-bookworm, 14-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b5055bcc1551a7e271af315158e1c260c212409c
+GitCommit: 22c26a9e4edb4ce4f7676dfa100afc80fc2ccbea
 Directory: 14
-# Docker EOL: 2025-11-07
+# Docker EOL: 2026-02-01
 
 # Last Modified: 2024-05-21
 Tags: 13.3.0, 13.3, 13, 13.3.0-bookworm, 13.3-bookworm, 13-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/22c26a9: Update 14 to 14.2.0