### PR TITLE
Update Clear Linux OS to 42110

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c636a7e6fc5d0dac37a7b86608068cef48da9aa1
-GitFetch: refs/heads/base-42090
+GitCommit: 451c2b4f2c6bbea1b527e58342836427b27581a4
+GitFetch: refs/heads/base-42110


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42110

@bryteise @djklimes @bryteise