### PR TITLE
Remove i386 from Satosa

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -6,7 +6,7 @@ GitFetch: refs/heads/main
 
 Tags: 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, bookworm
 SharedTags: 8.4.0, 8.4, 8, latest
-Architectures: amd64, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 69038a84d541717d66420f3ad8ec7c9da22c91b4
 Directory: 8.4/bookworm
 


### PR DESCRIPTION
It's been failing to build for weeks with no fix in sight -- remove for now (happy to accept it back once the build failure is fixed).

See also https://github.com/IdentityPython/satosa-docker/issues/11#issuecomment-2245715396, https://github.com/docker-library/official-images/pull/16594