### PR TITLE
Bump Traefik to v2.11.8 and v3.1.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 422a4acd435b4e67d31da91ecfa4177f33cafe60
 Directory: v3.1/alpine
 
-Tags: v2.11.7-windowsservercore-ltsc2022, 2.11.7-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.8-windowsservercore-ltsc2022, 2.11.8-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
+GitCommit: 52b94a7d0570742c03de558db18cef6ca5267142
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.7-windowsservercore-1809, 2.11.7-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.8-windowsservercore-1809, 2.11.8-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
+GitCommit: 52b94a7d0570742c03de558db18cef6ca5267142
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.7-nanoserver-ltsc2022, 2.11.7-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.8-nanoserver-ltsc2022, 2.11.8-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
+GitCommit: 52b94a7d0570742c03de558db18cef6ca5267142
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.7, 2.11.7, v2.11, 2.11, mimolette
+Tags: v2.11.8, 2.11.8, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b84002647aa4a9dcc2750b8ba37206c2f9bc6c28
+GitCommit: 52b94a7d0570742c03de558db18cef6ca5267142
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.1.1-windowsservercore-ltsc2022, 3.1.1-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.1.2-windowsservercore-ltsc2022, 3.1.2-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 422a4acd435b4e67d31da91ecfa4177f33cafe60
+GitCommit: 15f17b50ee5f673098080de655caafa4f3dc77d8
 Directory: v3.1/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.1.1-windowsservercore-1809, 3.1.1-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
+Tags: v3.1.2-windowsservercore-1809, 3.1.2-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 422a4acd435b4e67d31da91ecfa4177f33cafe60
+GitCommit: 15f17b50ee5f673098080de655caafa4f3dc77d8
 Directory: v3.1/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.1.1-nanoserver-ltsc2022, 3.1.1-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.1.2-nanoserver-ltsc2022, 3.1.2-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 422a4acd435b4e67d31da91ecfa4177f33cafe60
+GitCommit: 15f17b50ee5f673098080de655caafa4f3dc77d8
 Directory: v3.1/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.1.1, 3.1.1, v3.1, 3.1, comte, latest
+Tags: v3.1.2, 3.1.2, v3.1, 3.1, comte, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 422a4acd435b4e67d31da91ecfa4177f33cafe60
+GitCommit: 15f17b50ee5f673098080de655caafa4f3dc77d8
 Directory: v3.1/alpine
 
 Tags: v2.11.8-windowsservercore-ltsc2022, 2.11.8-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.8](https://github.com/traefik/traefik/releases/tag/v2.11.8) and [v3.1.2](https://github.com/traefik/traefik/releases/tag/v3.1.2).

/cc @emilevauge @juliens @rtribotte

Cheers
