### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev4, 3.1-dev, 3.1-dev4-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev5, 3.1-dev, 3.1-dev5-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 027eb3e20eacc457cfd53a54982823aadebcfa4e
+GitCommit: aa204b15e00e1e32e56efd4b92cceded52b41db5
 Directory: 3.1
 
-Tags: 3.1-dev4-alpine, 3.1-dev-alpine, 3.1-dev4-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev5-alpine, 3.1-dev-alpine, 3.1-dev5-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 027eb3e20eacc457cfd53a54982823aadebcfa4e
+GitCommit: aa204b15e00e1e32e56efd4b92cceded52b41db5
 Directory: 3.1/alpine
 
 Tags: 3.0.3, 3.0, lts, latest, 3.0.3-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/aa204b1: Update 3.1 to 3.1-dev5