### PR TITLE
chore: Update to Rust version 1.80.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/7932cc837034e38e33566d7c4df0304314e7279f/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/3b6565cd3b0b7c9cb084f07461cb959f7cf77c16/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.80-bullseye, 1.80.0-bullseye, bullseye
+Tags: 1-bullseye, 1.80-bullseye, 1.80.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7932cc837034e38e33566d7c4df0304314e7279f
-Directory: 1.80.0/bullseye
+GitCommit: 3b6565cd3b0b7c9cb084f07461cb959f7cf77c16
+Directory: 1.80.1/bullseye
 
-Tags: 1-slim-bullseye, 1.80-slim-bullseye, 1.80.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.80-slim-bullseye, 1.80.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7932cc837034e38e33566d7c4df0304314e7279f
-Directory: 1.80.0/bullseye/slim
+GitCommit: 3b6565cd3b0b7c9cb084f07461cb959f7cf77c16
+Directory: 1.80.1/bullseye/slim
 
-Tags: 1-bookworm, 1.80-bookworm, 1.80.0-bookworm, bookworm, 1, 1.80, 1.80.0, latest
+Tags: 1-bookworm, 1.80-bookworm, 1.80.1-bookworm, bookworm, 1, 1.80, 1.80.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7932cc837034e38e33566d7c4df0304314e7279f
-Directory: 1.80.0/bookworm
+GitCommit: 3b6565cd3b0b7c9cb084f07461cb959f7cf77c16
+Directory: 1.80.1/bookworm
 
-Tags: 1-slim-bookworm, 1.80-slim-bookworm, 1.80.0-slim-bookworm, slim-bookworm, 1-slim, 1.80-slim, 1.80.0-slim, slim
+Tags: 1-slim-bookworm, 1.80-slim-bookworm, 1.80.1-slim-bookworm, slim-bookworm, 1-slim, 1.80-slim, 1.80.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7932cc837034e38e33566d7c4df0304314e7279f
-Directory: 1.80.0/bookworm/slim
+GitCommit: 3b6565cd3b0b7c9cb084f07461cb959f7cf77c16
+Directory: 1.80.1/bookworm/slim
 
-Tags: 1-alpine3.19, 1.80-alpine3.19, 1.80.0-alpine3.19, alpine3.19
+Tags: 1-alpine3.19, 1.80-alpine3.19, 1.80.1-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: 7932cc837034e38e33566d7c4df0304314e7279f
-Directory: 1.80.0/alpine3.19
+GitCommit: 3b6565cd3b0b7c9cb084f07461cb959f7cf77c16
+Directory: 1.80.1/alpine3.19
 
-Tags: 1-alpine3.20, 1.80-alpine3.20, 1.80.0-alpine3.20, alpine3.20, 1-alpine, 1.80-alpine, 1.80.0-alpine, alpine
+Tags: 1-alpine3.20, 1.80-alpine3.20, 1.80.1-alpine3.20, alpine3.20, 1-alpine, 1.80-alpine, 1.80.1-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 7932cc837034e38e33566d7c4df0304314e7279f
-Directory: 1.80.0/alpine3.20
+GitCommit: 3b6565cd3b0b7c9cb084f07461cb959f7cf77c16
+Directory: 1.80.1/alpine3.20


### PR DESCRIPTION
- [Blog](https://blog.rust-lang.org/2024/08/08/Rust-1.80.1.html)
- [Tag](https://github.com/rust-lang/rust/releases/tag/1.80.1)