### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -49,17 +49,17 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3f1a0cab9f2f938bbc57f5f92ec11eeea4511636
 Directory: latest/php8.3/fpm-alpine
 
-Tags: cli-2.10.0-php8.1, cli-2.10-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.11.0-php8.1, cli-2.11-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: f7e3d05cc365b12c38cdf7c2cfe5584a018bf9de
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.10.0, cli-2.10, cli-2, cli, cli-2.10.0-php8.2, cli-2.10-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.11.0, cli-2.11, cli-2, cli, cli-2.11.0-php8.2, cli-2.11-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: f7e3d05cc365b12c38cdf7c2cfe5584a018bf9de
 Directory: cli/php8.2/alpine
 
-Tags: cli-2.10.0-php8.3, cli-2.10-php8.3, cli-2-php8.3, cli-php8.3
+Tags: cli-2.11.0-php8.3, cli-2.11-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 509adb58cbc7463a03e317931df65868ec8a3e92
+GitCommit: f7e3d05cc365b12c38cdf7c2cfe5584a018bf9de
 Directory: cli/php8.3/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/f7e3d05: Update cli to 2.11.0