### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 17beta2, 17beta2-bookworm
+Tags: 17beta3, 17beta3-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9bf5a6d620a90158d8192ee0dba05acc4464d002
+GitCommit: 805329e7a64fad212a5d4b07abd11238a9beab75
 Directory: 17/bookworm
 
-Tags: 17beta2-bullseye
+Tags: 17beta3-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9bf5a6d620a90158d8192ee0dba05acc4464d002
+GitCommit: 805329e7a64fad212a5d4b07abd11238a9beab75
 Directory: 17/bullseye
 
-Tags: 17beta2-alpine3.20, 17beta2-alpine
+Tags: 17beta3-alpine3.20, 17beta3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9bf5a6d620a90158d8192ee0dba05acc4464d002
+GitCommit: 805329e7a64fad212a5d4b07abd11238a9beab75
 Directory: 17/alpine3.20
 
-Tags: 17beta2-alpine3.19
+Tags: 17beta3-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9bf5a6d620a90158d8192ee0dba05acc4464d002
+GitCommit: 805329e7a64fad212a5d4b07abd11238a9beab75
 Directory: 17/alpine3.19
 
-Tags: 16.3, 16, latest, 16.3-bookworm, 16-bookworm, bookworm
+Tags: 16.4, 16, latest, 16.4-bookworm, 16-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d08757ccb56ee047efd76c41dbc148e2e2c4f68f
+GitCommit: 3a94d965ecbe08f4b1b255d3ed9ccae671a7a984
 Directory: 16/bookworm
 
-Tags: 16.3-bullseye, 16-bullseye, bullseye
+Tags: 16.4-bullseye, 16-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d08757ccb56ee047efd76c41dbc148e2e2c4f68f
+GitCommit: 3a94d965ecbe08f4b1b255d3ed9ccae671a7a984
 Directory: 16/bullseye
 
-Tags: 16.3-alpine3.20, 16-alpine3.20, alpine3.20, 16.3-alpine, 16-alpine, alpine
+Tags: 16.4-alpine3.20, 16-alpine3.20, alpine3.20, 16.4-alpine, 16-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: 3a94d965ecbe08f4b1b255d3ed9ccae671a7a984
 Directory: 16/alpine3.20
 
-Tags: 16.3-alpine3.19, 16-alpine3.19, alpine3.19
+Tags: 16.4-alpine3.19, 16-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: 3a94d965ecbe08f4b1b255d3ed9ccae671a7a984
 Directory: 16/alpine3.19
 
-Tags: 15.7, 15, 15.7-bookworm, 15-bookworm
+Tags: 15.8, 15, 15.8-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8a0b96710d917d1c3b32a5fe5b66687ad83827da
+GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
 Directory: 15/bookworm
 
-Tags: 15.7-bullseye, 15-bullseye
+Tags: 15.8-bullseye, 15-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8a0b96710d917d1c3b32a5fe5b66687ad83827da
+GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
 Directory: 15/bullseye
 
-Tags: 15.7-alpine3.20, 15-alpine3.20, 15.7-alpine, 15-alpine
+Tags: 15.8-alpine3.20, 15-alpine3.20, 15.8-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
 Directory: 15/alpine3.20
 
-Tags: 15.7-alpine3.19, 15-alpine3.19
+Tags: 15.8-alpine3.19, 15-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
 Directory: 15/alpine3.19
 
-Tags: 14.12, 14, 14.12-bookworm, 14-bookworm
+Tags: 14.13, 14, 14.13-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 662dbe5225f4d404364bdcf5e49dd5d88357ed31
+GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
 Directory: 14/bookworm
 
-Tags: 14.12-bullseye, 14-bullseye
+Tags: 14.13-bullseye, 14-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 662dbe5225f4d404364bdcf5e49dd5d88357ed31
+GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
 Directory: 14/bullseye
 
-Tags: 14.12-alpine3.20, 14-alpine3.20, 14.12-alpine, 14-alpine
+Tags: 14.13-alpine3.20, 14-alpine3.20, 14.13-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
 Directory: 14/alpine3.20
 
-Tags: 14.12-alpine3.19, 14-alpine3.19
+Tags: 14.13-alpine3.19, 14-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
 Directory: 14/alpine3.19
 
-Tags: 13.15, 13, 13.15-bookworm, 13-bookworm
+Tags: 13.16, 13, 13.16-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f3ab8c6db63e2986453e0a4fae2c5f372dd4f05e
+GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
 Directory: 13/bookworm
 
-Tags: 13.15-bullseye, 13-bullseye
+Tags: 13.16-bullseye, 13-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f3ab8c6db63e2986453e0a4fae2c5f372dd4f05e
+GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
 Directory: 13/bullseye
 
-Tags: 13.15-alpine3.20, 13-alpine3.20, 13.15-alpine, 13-alpine
+Tags: 13.16-alpine3.20, 13-alpine3.20, 13.16-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
 Directory: 13/alpine3.20
 
-Tags: 13.15-alpine3.19, 13-alpine3.19
+Tags: 13.16-alpine3.19, 13-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
 Directory: 13/alpine3.19
 
-Tags: 12.19, 12, 12.19-bookworm, 12-bookworm
+Tags: 12.20, 12, 12.20-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ccf4f2289a1e59ddf74a5d1e6eb7693b7f464b54
+GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
 Directory: 12/bookworm
 
-Tags: 12.19-bullseye, 12-bullseye
+Tags: 12.20-bullseye, 12-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ccf4f2289a1e59ddf74a5d1e6eb7693b7f464b54
+GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
 Directory: 12/bullseye
 
-Tags: 12.19-alpine3.20, 12-alpine3.20, 12.19-alpine, 12-alpine
+Tags: 12.20-alpine3.20, 12-alpine3.20, 12.20-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
 Directory: 12/alpine3.20
 
-Tags: 12.19-alpine3.19, 12-alpine3.19
+Tags: 12.20-alpine3.19, 12-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3e9b4eaaebf00d7a8ece67f02e2d6546402f4de7
+GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
 Directory: 12/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/805329e: Update 17 to 17beta3, bookworm 17~beta3-1.pgdg120+1, bullseye 17~beta3-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/3a94d96: Update 16 to 16.4, bookworm 16.4-1.pgdg120+1, bullseye 16.4-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/8cce578: Update 15 to 15.8, bookworm 15.8-1.pgdg120+1, bullseye 15.8-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/e324d93: Update 14 to 14.13, bookworm 14.13-1.pgdg120+1, bullseye 14.13-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/ce54cce: Update 13 to 13.16, bookworm 13.16-1.pgdg120+1, bullseye 13.16-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/62f99df: Update 12 to 12.20, bookworm 12.20-1.pgdg120+1, bullseye 12.20-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/66da384: Merge pull request https://github.com/docker-library/postgres/pull/1258 from infosiftr/install
- https://github.com/docker-library/postgres/commit/a09f1c4: Use `install` instead of `mkdir && chown && chmod`