### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,12 +12,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240730.0
+Tags: 2023, latest, 2023.5.20240805.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 7a6b2fcfccde9bc1e30ca7a82f339032334222e8
+amd64-GitCommit: 6d74be550141b91913144f2cbf3775f793082a37
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 4269f9427804e66072ecb1a4af0ef362349b19c7
+arm64v8-GitCommit: 827c1289fd0e66d597fac4c4c69053d2658dc34a
 
 Tags: 2, 2.0.20240719.0
 Architectures: amd64, arm64v8


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- python3-setuptools-wheel-59.6.0-2.amzn2023.0.5
- glibc-common-2.34-52.amzn2023.0.11
- ca-certificates-2023.2.68-1.0.amzn2023.0.1
- python3-libs-3.9.16-1.amzn2023.0.9
- amazon-linux-repo-cdn-2023.5.20240805-0.amzn2023
- system-release-2023.5.20240805-0.amzn2023
- glibc-minimal-langpack-2.34-52.amzn2023.0.11
- glibc-2.34-52.amzn2023.0.11
- openssl-libs-3.0.8-1.amzn2023.0.14
- krb5-libs-1.21.3-1.amzn2023.0.1
- python3-3.9.16-1.amzn2023.0.9
#### Packages addressing CVES:
- python3-setuptools-wheel-59.6.0-2.amzn2023.0.5
  - [CVE-2024-6345](https://alas.aws.amazon.com/cve/html/CVE-2024-6345.html)
- ca-certificates-2023.2.68-1.0.amzn2023.0.1
  - [CVE-2024-39689](https://alas.aws.amazon.com/cve/html/CVE-2024-39689.html)
- python3-libs-3.9.16-1.amzn2023.0.9, python3-3.9.16-1.amzn2023.0.9
  - [CVE-2024-0397](https://alas.aws.amazon.com/cve/html/CVE-2024-0397.html)
- openssl-libs-3.0.8-1.amzn2023.0.14
  - [CVE-2024-4603](https://alas.aws.amazon.com/cve/html/CVE-2024-4603.html)
  - [CVE-2024-4741](https://alas.aws.amazon.com/cve/html/CVE-2024-4741.html)
  - [CVE-2024-5535](https://alas.aws.amazon.com/cve/html/CVE-2024-5535.html)
- krb5-libs-1.21.3-1.amzn2023.0.1
  - [CVE-2024-37370](https://alas.aws.amazon.com/cve/html/CVE-2024-37370.html)
  - [CVE-2024-37371](https://alas.aws.amazon.com/cve/html/CVE-2024-37371.html)
