### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 24-ea-9-jdk-oraclelinux9, 24-ea-9-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-9-jdk-oracle, 24-ea-9-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-9-jdk, 24-ea-9, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-10-jdk-oraclelinux9, 24-ea-10-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-10-jdk-oracle, 24-ea-10-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-10-jdk, 24-ea-10, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-9-jdk-oraclelinux8, 24-ea-9-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-10-jdk-oraclelinux8, 24-ea-10-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-9-jdk-bookworm, 24-ea-9-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-10-jdk-bookworm, 24-ea-10-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-9-jdk-slim-bookworm, 24-ea-9-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-9-jdk-slim, 24-ea-9-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-10-jdk-slim-bookworm, 24-ea-10-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-10-jdk-slim, 24-ea-10-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-9-jdk-bullseye, 24-ea-9-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-10-jdk-bullseye, 24-ea-10-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-9-jdk-slim-bullseye, 24-ea-9-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-10-jdk-slim-bullseye, 24-ea-10-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-9-jdk-windowsservercore-ltsc2022, 24-ea-9-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-9-jdk-windowsservercore, 24-ea-9-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-9-jdk, 24-ea-9, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-10-jdk-windowsservercore-ltsc2022, 24-ea-10-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-10-jdk-windowsservercore, 24-ea-10-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-10-jdk, 24-ea-10, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-9-jdk-windowsservercore-1809, 24-ea-9-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-9-jdk-windowsservercore, 24-ea-9-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-9-jdk, 24-ea-9, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-10-jdk-windowsservercore-1809, 24-ea-10-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-10-jdk-windowsservercore, 24-ea-10-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-10-jdk, 24-ea-10, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-9-jdk-nanoserver-1809, 24-ea-9-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-9-jdk-nanoserver, 24-ea-9-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-10-jdk-nanoserver-1809, 24-ea-10-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-10-jdk-nanoserver, 24-ea-10-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 944b40b29945baac42fc7eefb513c63120d03745
+GitCommit: 63e05f7bcba2416fc4c008b055d5f436ef9ad952
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 23-ea-35-jdk-oraclelinux9, 23-ea-35-oraclelinux9, 23-ea-jdk-oraclelinux9, 23-ea-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-ea-35-jdk-oracle, 23-ea-35-oracle, 23-ea-jdk-oracle, 23-ea-oracle, 23-jdk-oracle, 23-oracle
-SharedTags: 23-ea-35-jdk, 23-ea-35, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-rc-jdk-oraclelinux9, 23-rc-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-rc-jdk-oracle, 23-rc-oracle, 23-jdk-oracle, 23-oracle
+SharedTags: 23-rc-jdk, 23-rc, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/oraclelinux9
 
-Tags: 23-ea-35-jdk-oraclelinux8, 23-ea-35-oraclelinux8, 23-ea-jdk-oraclelinux8, 23-ea-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
+Tags: 23-rc-jdk-oraclelinux8, 23-rc-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/oraclelinux8
 
-Tags: 23-ea-35-jdk-bookworm, 23-ea-35-bookworm, 23-ea-jdk-bookworm, 23-ea-bookworm, 23-jdk-bookworm, 23-bookworm
+Tags: 23-rc-jdk-bookworm, 23-rc-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/bookworm
 
-Tags: 23-ea-35-jdk-slim-bookworm, 23-ea-35-slim-bookworm, 23-ea-jdk-slim-bookworm, 23-ea-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-ea-35-jdk-slim, 23-ea-35-slim, 23-ea-jdk-slim, 23-ea-slim, 23-jdk-slim, 23-slim
+Tags: 23-rc-jdk-slim-bookworm, 23-rc-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-rc-jdk-slim, 23-rc-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/slim-bookworm
 
-Tags: 23-ea-35-jdk-bullseye, 23-ea-35-bullseye, 23-ea-jdk-bullseye, 23-ea-bullseye, 23-jdk-bullseye, 23-bullseye
+Tags: 23-rc-jdk-bullseye, 23-rc-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/bullseye
 
-Tags: 23-ea-35-jdk-slim-bullseye, 23-ea-35-slim-bullseye, 23-ea-jdk-slim-bullseye, 23-ea-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
+Tags: 23-rc-jdk-slim-bullseye, 23-rc-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/slim-bullseye
 
-Tags: 23-ea-35-jdk-windowsservercore-ltsc2022, 23-ea-35-windowsservercore-ltsc2022, 23-ea-jdk-windowsservercore-ltsc2022, 23-ea-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23-ea-35-jdk-windowsservercore, 23-ea-35-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-35-jdk, 23-ea-35, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-rc-jdk-windowsservercore-ltsc2022, 23-rc-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
+SharedTags: 23-rc-jdk-windowsservercore, 23-rc-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-rc-jdk, 23-rc, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23-ea-35-jdk-windowsservercore-1809, 23-ea-35-windowsservercore-1809, 23-ea-jdk-windowsservercore-1809, 23-ea-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23-ea-35-jdk-windowsservercore, 23-ea-35-windowsservercore, 23-ea-jdk-windowsservercore, 23-ea-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-ea-35-jdk, 23-ea-35, 23-ea-jdk, 23-ea, 23-jdk, 23
+Tags: 23-rc-jdk-windowsservercore-1809, 23-rc-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
+SharedTags: 23-rc-jdk-windowsservercore, 23-rc-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-rc-jdk, 23-rc, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 23-ea-35-jdk-nanoserver-1809, 23-ea-35-nanoserver-1809, 23-ea-jdk-nanoserver-1809, 23-ea-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23-ea-35-jdk-nanoserver, 23-ea-35-nanoserver, 23-ea-jdk-nanoserver, 23-ea-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 23-rc-jdk-nanoserver-1809, 23-rc-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
+SharedTags: 23-rc-jdk-nanoserver, 23-rc-nanoserver, 23-jdk-nanoserver, 23-nanoserver
 Architectures: windows-amd64
-GitCommit: 8d131a7a1ec18ef121b02b568c6268816a349da7
+GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
 Directory: 23/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/63e05f7: Update 24 to 24-ea+10
- https://github.com/docker-library/openjdk/commit/ef6c71c: Update 23 to 23

(Reviewer's note: "23" here is the "Initial Release Candidate"; https://jdk.java.net/23/, https://openjdk.org/projects/jdk/23/, https://github.com/docker-library/openjdk/pull/511)