### PR TITLE
archlinux: Release 20240811.0.253648

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240804.0.251467
-GitCommit: 01ae228c8051756518e072052944c489103e143f
-GitFetch: refs/tags/v20240804.0.251467
+Tags: latest, base, base-20240811.0.253648
+GitCommit: 7afc129a63ae475c411471f843c63cb3702a30c1
+GitFetch: refs/tags/v20240811.0.253648
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240804.0.251467
-GitCommit: 01ae228c8051756518e072052944c489103e143f
-GitFetch: refs/tags/v20240804.0.251467
+Tags: base-devel, base-devel-20240811.0.253648
+GitCommit: 7afc129a63ae475c411471f843c63cb3702a30c1
+GitFetch: refs/tags/v20240811.0.253648
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240804.0.251467
-GitCommit: 01ae228c8051756518e072052944c489103e143f
-GitFetch: refs/tags/v20240804.0.251467
+Tags: multilib-devel, multilib-devel-20240811.0.253648
+GitCommit: 7afc129a63ae475c411471f843c63cb3702a30c1
+GitFetch: refs/tags/v20240811.0.253648
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks