### PR TITLE
Update Clear Linux OS to 42150

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 451c2b4f2c6bbea1b527e58342836427b27581a4
-GitFetch: refs/heads/base-42110
+GitCommit: 2796025d007ea6237915b070547a5fd096eb7703
+GitFetch: refs/heads/base-42150


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42150

@bryteise @djklimes @bryteise