### PR TITLE
Add Spark version 3.5.2 and 4.0.0-preiview1

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -1,44 +1,104 @@
 Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 3.5.1-scala2.12-java17-python3-ubuntu, 3.5.1-java17-python3, 3.5.1-java17, python3-java17
+Tags: 4.0.0-preview1-scala2.13-java17-python3-ubuntu, 4.0.0-preview1-python3, 4.0.0-preview1
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./4.0.0-preview1/scala2.13-java17-python3-ubuntu
+
+Tags: 4.0.0-preview1-scala2.13-java17-r-ubuntu, 4.0.0-preview1-r
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./4.0.0-preview1/scala2.13-java17-r-ubuntu
+
+Tags: 4.0.0-preview1-scala2.13-java17-ubuntu, 4.0.0-preview1-scala
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./4.0.0-preview1/scala2.13-java17-ubuntu
+
+Tags: 4.0.0-preview1-scala2.13-java17-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./4.0.0-preview1/scala2.13-java17-python3-r-ubuntu
+
+Tags: 3.5.2-scala2.12-java17-python3-ubuntu, 3.5.2-java17-python3, 3.5.2-java17, python3-java17
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java17-python3-ubuntu
+
+Tags: 3.5.2-scala2.12-java17-r-ubuntu, 3.5.2-java17-r
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java17-r-ubuntu
+
+Tags: 3.5.2-scala2.12-java17-ubuntu, 3.5.2-java17-scala
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java17-ubuntu
+
+Tags: 3.5.2-scala2.12-java17-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java17-python3-r-ubuntu
+
+Tags: 3.5.2-scala2.12-java11-python3-ubuntu, 3.5.2-python3, 3.5.2, python3, latest
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java11-python3-ubuntu
+
+Tags: 3.5.2-scala2.12-java11-r-ubuntu, 3.5.2-r, r
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java11-r-ubuntu
+
+Tags: 3.5.2-scala2.12-java11-ubuntu, 3.5.2-scala, scala
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java11-ubuntu
+
+Tags: 3.5.2-scala2.12-java11-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.5.2/scala2.12-java11-python3-r-ubuntu
+
+Tags: 3.5.1-scala2.12-java17-python3-ubuntu, 3.5.1-java17-python3, 3.5.1-java17
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java17-python3-ubuntu
 
 Tags: 3.5.1-scala2.12-java17-r-ubuntu, 3.5.1-java17-r
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java17-r-ubuntu
 
 Tags: 3.5.1-scala2.12-java17-ubuntu, 3.5.1-java17-scala
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java17-ubuntu
 
 Tags: 3.5.1-scala2.12-java17-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java17-python3-r-ubuntu
 
-Tags: 3.5.1-scala2.12-java11-python3-ubuntu, 3.5.1-python3, 3.5.1, python3, latest
+Tags: 3.5.1-scala2.12-java11-python3-ubuntu, 3.5.1-python3, 3.5.1
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java11-python3-ubuntu
 
-Tags: 3.5.1-scala2.12-java11-r-ubuntu, 3.5.1-r, r
+Tags: 3.5.1-scala2.12-java11-r-ubuntu, 3.5.1-r
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java11-r-ubuntu
 
-Tags: 3.5.1-scala2.12-java11-ubuntu, 3.5.1-scala, scala
+Tags: 3.5.1-scala2.12-java11-ubuntu, 3.5.1-scala
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java11-ubuntu
 
 Tags: 3.5.1-scala2.12-java11-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 4f2d96a415c89cfe0fde89a55e9034d095224c94
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.1/scala2.12-java11-python3-r-ubuntu
 
 Tags: 3.5.0-scala2.12-java17-python3-ubuntu, 3.5.0-java17-python3, 3.5.0-java17


### PR DESCRIPTION
This patch add 3.5.2 and 4.0.0-preiview1 versions for Apache Spark

[1] https://github.com/apache/spark-docker/commit/b9f1f8e8ebed1959c2be3864a114b52f67519092
[2] https://github.com/apache/spark-docker/commit/300ae7980492792c9717a2415159c4f9ac1d4b36