### PR TITLE
haskell: add 9.6.6 images

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -11,3 +11,13 @@ Tags: 9.10.1-slim-bullseye, 9.10-slim-bullseye, 9-slim-bullseye, slim-bullseye, 
 Architectures: amd64, arm64v8
 GitCommit: 65b8848bc9e63d54f12ecf3f31d04621d62d761c
 Directory: 9.10/slim-bullseye
+
+Tags: 9.6.6-bullseye, 9.6-bullseye
+Architectures: amd64, arm64v8
+GitCommit: 45be610ef8bc3e4f844ff2fff1a66e6809d26dbf
+Directory: 9.6/bullseye
+
+Tags: 9.6.6-slim-bullseye, 9.6-slim-bullseye
+Architectures: amd64, arm64v8
+GitCommit: 45be610ef8bc3e4f844ff2fff1a66e6809d26dbf
+Directory: 9.6/slim-bullseye


### PR DESCRIPTION
aarch64 images use deb10 bindists, hope that's not a problem