### PR TITLE
Update apache/spark 3.4 from 3.4.1 to 3.4.2

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -61,22 +61,22 @@ Architectures: amd64, arm64v8
 GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.2/scala2.12-java11-python3-r-ubuntu
 
-Tags: 3.4.1-scala2.12-java11-python3-ubuntu, 3.4.1-python3, 3.4.1
-Architectures: amd64,arm64v8
-GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
-Directory: ./3.4.1/scala2.12-java11-python3-ubuntu
+Tags: 3.4.2-scala2.12-java11-python3-ubuntu, 3.4.2-python3, 3.4.2
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.4.2/scala2.12-java11-python3-ubuntu
 
-Tags: 3.4.1-scala2.12-java11-r-ubuntu, 3.4.1-r
-Architectures: amd64,arm64v8
-GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
-Directory: ./3.4.1/scala2.12-java11-r-ubuntu
+Tags: 3.4.2-scala2.12-java11-r-ubuntu, 3.4.2-r
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.4.2/scala2.12-java11-r-ubuntu
 
-Tags: 3.4.1-scala2.12-java11-ubuntu, 3.4.1-scala
-Architectures: amd64,arm64v8
-GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
-Directory: ./3.4.1/scala2.12-java11-ubuntu
+Tags: 3.4.2-scala2.12-java11-ubuntu, 3.4.2-scala
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.4.2/scala2.12-java11-ubuntu
 
-Tags: 3.4.1-scala2.12-java11-python3-r-ubuntu
-Architectures: amd64,arm64v8
-GitCommit: 58d288546e8419d229f14b62b6a653999e0390f1
-Directory: ./3.4.1/scala2.12-java11-python3-r-ubuntu
+Tags: 3.4.2-scala2.12-java11-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
+Directory: ./3.4.2/scala2.12-java11-python3-r-ubuntu


### PR DESCRIPTION
https://spark.apache.org/news/spark-3-4-2-released.html

https://github.com/apache/spark-docker/tree/master/3.4.2