### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/4f766db54f5179aca1a841e4036d6d6746ac79d9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/790d59ba52b87071c9685b8c8790616741bc8795/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -50,7 +50,7 @@ GitCommit: 2b3a8b7d1f8875865034be3bab98ddd737e37d5e
 Directory: debian/sid
 
 Tags: trixie-curl, testing-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie/curl
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/dece9c6: Merge pull request https://github.com/docker-library/buildpack-deps/pull/163 from infosiftr/trixie-riscv64
- https://github.com/docker-library/buildpack-deps/commit/790d59b: Adjust trixie to avoid too much riscv64