### PR TITLE
Update spark 3.4 from 3.4.2 to 3.4.3

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -61,22 +61,22 @@ Architectures: amd64, arm64v8
 GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
 Directory: ./3.5.2/scala2.12-java11-python3-r-ubuntu
 
-Tags: 3.4.2-scala2.12-java11-python3-ubuntu, 3.4.2-python3, 3.4.2
+Tags: 3.4.3-scala2.12-java11-python3-ubuntu, 3.4.3-python3, 3.4.3
 Architectures: amd64, arm64v8
-GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
-Directory: ./3.4.2/scala2.12-java11-python3-ubuntu
+GitCommit: 6f10acb452a360966ec9a971641280b7b4a3619a
+Directory: ./3.4.3/scala2.12-java11-python3-ubuntu
 
-Tags: 3.4.2-scala2.12-java11-r-ubuntu, 3.4.2-r
+Tags: 3.4.3-scala2.12-java11-r-ubuntu, 3.4.3-r
 Architectures: amd64, arm64v8
-GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
-Directory: ./3.4.2/scala2.12-java11-r-ubuntu
+GitCommit: 6f10acb452a360966ec9a971641280b7b4a3619a
+Directory: ./3.4.3/scala2.12-java11-r-ubuntu
 
-Tags: 3.4.2-scala2.12-java11-ubuntu, 3.4.2-scala
+Tags: 3.4.3-scala2.12-java11-ubuntu, 3.4.3-scala
 Architectures: amd64, arm64v8
-GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
-Directory: ./3.4.2/scala2.12-java11-ubuntu
+GitCommit: 6f10acb452a360966ec9a971641280b7b4a3619a
+Directory: ./3.4.3/scala2.12-java11-ubuntu
 
-Tags: 3.4.2-scala2.12-java11-python3-r-ubuntu
+Tags: 3.4.3-scala2.12-java11-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: b9f1f8e8ebed1959c2be3864a114b52f67519092
-Directory: ./3.4.2/scala2.12-java11-python3-r-ubuntu
+GitCommit: 6f10acb452a360966ec9a971641280b7b4a3619a
+Directory: ./3.4.3/scala2.12-java11-python3-r-ubuntu


### PR DESCRIPTION
https://spark.apache.org/news/spark-3-4-3-released.html
https://github.com/apache/spark-docker/tree/master/3.4.3

I apologize for frequently bothering all of you lately. I am attempting to restore the Docker release history of the Apache Spark 3.4 branch. Fortunately, this will be the last patch for all 3.4.x releases that have not been uploaded.

![image](https://github.com/user-attachments/assets/5ddc6aea-3b80-4a5e-86c9-37d1890cfaf8)

