### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-5312

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b99233acc86d93ff471c861cdc4ccbd5f83f91e9
+amd64-GitCommit: ebd9ccbe2d59c8b0c99767e1a59367e102e726d8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0969fa7de591a09867f2b93792d85876a7c4e395
+arm64v8-GitCommit: 448f7e0fe048c20a408292a73f6b6eb3621c52a2
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-37370, CVE-2024-37371, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-5312.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
