### PR TITLE
Updated nginx to latest versions

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,72 +3,72 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
 GitRepo: https://github.com/nginxinc/docker-nginx.git
 
-Tags: 1.27.0, mainline, 1, 1.27, latest, 1.27.0-bookworm, mainline-bookworm, 1-bookworm, 1.27-bookworm, bookworm
+Tags: 1.27.1, mainline, 1, 1.27, latest, 1.27.1-bookworm, mainline-bookworm, 1-bookworm, 1.27-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a6f7d140744f8b15ff4314b8718b3f022efc7f43
+GitCommit: e78cf70ce7b73a0c9ea734c9cf8aaaa283c1cc5a
 Directory: mainline/debian
 
-Tags: 1.27.0-perl, mainline-perl, 1-perl, 1.27-perl, perl, 1.27.0-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.27-bookworm-perl, bookworm-perl
+Tags: 1.27.1-perl, mainline-perl, 1-perl, 1.27-perl, perl, 1.27.1-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.27-bookworm-perl, bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: e78cf70ce7b73a0c9ea734c9cf8aaaa283c1cc5a
 Directory: mainline/debian-perl
 
-Tags: 1.27.0-otel, mainline-otel, 1-otel, 1.27-otel, otel, 1.27.0-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.27-bookworm-otel, bookworm-otel
+Tags: 1.27.1-otel, mainline-otel, 1-otel, 1.27-otel, otel, 1.27.1-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.27-bookworm-otel, bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: e78cf70ce7b73a0c9ea734c9cf8aaaa283c1cc5a
 Directory: mainline/debian-otel
 
-Tags: 1.27.0-alpine, mainline-alpine, 1-alpine, 1.27-alpine, alpine, 1.27.0-alpine3.19, mainline-alpine3.19, 1-alpine3.19, 1.27-alpine3.19, alpine3.19
+Tags: 1.27.1-alpine, mainline-alpine, 1-alpine, 1.27-alpine, alpine, 1.27.1-alpine3.20, mainline-alpine3.20, 1-alpine3.20, 1.27-alpine3.20, alpine3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: mainline/alpine
 
-Tags: 1.27.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.27-alpine-perl, alpine-perl, 1.27.0-alpine3.19-perl, mainline-alpine3.19-perl, 1-alpine3.19-perl, 1.27-alpine3.19-perl, alpine3.19-perl
+Tags: 1.27.1-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.27-alpine-perl, alpine-perl, 1.27.1-alpine3.20-perl, mainline-alpine3.20-perl, 1-alpine3.20-perl, 1.27-alpine3.20-perl, alpine3.20-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: mainline/alpine-perl
 
-Tags: 1.27.0-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.27-alpine-slim, alpine-slim, 1.27.0-alpine3.19-slim, mainline-alpine3.19-slim, 1-alpine3.19-slim, 1.27-alpine3.19-slim, alpine3.19-slim
+Tags: 1.27.1-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.27-alpine-slim, alpine-slim, 1.27.1-alpine3.20-slim, mainline-alpine3.20-slim, 1-alpine3.20-slim, 1.27-alpine3.20-slim, alpine3.20-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: mainline/alpine-slim
 
-Tags: 1.27.0-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.27-alpine-otel, alpine-otel, 1.27.0-alpine3.19-otel, mainline-alpine3.19-otel, 1-alpine3.19-otel, 1.27-alpine3.19-otel, alpine3.19-otel
+Tags: 1.27.1-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.27-alpine-otel, alpine-otel, 1.27.1-alpine3.20-otel, mainline-alpine3.20-otel, 1-alpine3.20-otel, 1.27-alpine3.20-otel, alpine3.20-otel
 Architectures: amd64, arm64v8
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: mainline/alpine-otel
 
-Tags: 1.26.1, stable, 1.26, 1.26.1-bookworm, stable-bookworm, 1.26-bookworm
+Tags: 1.26.2, stable, 1.26, 1.26.2-bookworm, stable-bookworm, 1.26-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a6f7d140744f8b15ff4314b8718b3f022efc7f43
+GitCommit: e78cf70ce7b73a0c9ea734c9cf8aaaa283c1cc5a
 Directory: stable/debian
 
-Tags: 1.26.1-perl, stable-perl, 1.26-perl, 1.26.1-bookworm-perl, stable-bookworm-perl, 1.26-bookworm-perl
+Tags: 1.26.2-perl, stable-perl, 1.26-perl, 1.26.2-bookworm-perl, stable-bookworm-perl, 1.26-bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: e78cf70ce7b73a0c9ea734c9cf8aaaa283c1cc5a
 Directory: stable/debian-perl
 
-Tags: 1.26.1-otel, stable-otel, 1.26-otel, 1.26.1-bookworm-otel, stable-bookworm-otel, 1.26-bookworm-otel
+Tags: 1.26.2-otel, stable-otel, 1.26-otel, 1.26.2-bookworm-otel, stable-bookworm-otel, 1.26-bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: 3180cdbec313dc4a9f6dd1109ae66adaf98f11fb
+GitCommit: e78cf70ce7b73a0c9ea734c9cf8aaaa283c1cc5a
 Directory: stable/debian-otel
 
-Tags: 1.26.1-alpine, stable-alpine, 1.26-alpine, 1.26.1-alpine3.19, stable-alpine3.19, 1.26-alpine3.19
+Tags: 1.26.2-alpine, stable-alpine, 1.26-alpine, 1.26.2-alpine3.20, stable-alpine3.20, 1.26-alpine3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: stable/alpine
 
-Tags: 1.26.1-alpine-perl, stable-alpine-perl, 1.26-alpine-perl, 1.26.1-alpine3.19-perl, stable-alpine3.19-perl, 1.26-alpine3.19-perl
+Tags: 1.26.2-alpine-perl, stable-alpine-perl, 1.26-alpine-perl, 1.26.2-alpine3.20-perl, stable-alpine3.20-perl, 1.26-alpine3.20-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: stable/alpine-perl
 
-Tags: 1.26.1-alpine-slim, stable-alpine-slim, 1.26-alpine-slim, 1.26.1-alpine3.19-slim, stable-alpine3.19-slim, 1.26-alpine3.19-slim
+Tags: 1.26.2-alpine-slim, stable-alpine-slim, 1.26-alpine-slim, 1.26.2-alpine3.20-slim, stable-alpine3.20-slim, 1.26-alpine3.20-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 1c99bf1406f95d5fbddb4c9f246e67ad07f79642
 Directory: stable/alpine-slim
 
-Tags: 1.26.1-alpine-otel, stable-alpine-otel, 1.26-alpine-otel, 1.26.1-alpine3.19-otel, stable-alpine3.19-otel, 1.26-alpine3.19-otel
+Tags: 1.26.2-alpine-otel, stable-alpine-otel, 1.26-alpine-otel, 1.26.2-alpine3.20-otel, stable-alpine3.20-otel, 1.26-alpine3.20-otel
 Architectures: amd64, arm64v8
-GitCommit: 94a27ac42d45670d941a55334d89e80760f7cc8e
+GitCommit: 239684923b2c652b0767540d180de7f7e84bd9fa
 Directory: stable/alpine-otel


### PR DESCRIPTION
mainline gets updated to 1.27.1
stable gets updated to 1.26.2

while at it, Alpine is bumped for both mainline and stable to 3.20

also implemented a way to specify a different dynamic module packaging release version (1 vs 2) to workaround currently published packaging sources;  might likely come in handy in the future when we'd need to bump nginx "base" package independently of all other modules.