### PR TITLE
Remove several (persistently) failing builds

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,7 +1,7 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse/mosquitto.git
 GitCommit: f4400fa422eacac8417efbc45dd1284526dce8d4
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le
 
 Tags: 2.0.18, 2.0, 2, latest
 Directory: docker/2.0

--- a/library/plone
+++ b/library/plone
@@ -7,6 +7,6 @@ Maintainers: Alin Voinea <alin.voinea@gmail.com> (@avoinea),
 GitRepo: https://github.com/plone/plone.docker.git
 
 Tags: 5.2.14-python38, 5.2-python38, 5-python38, python38, 5.2.14, 5.2, 5, latest
-Architectures: amd64, arm64v8
+Architectures: amd64
 GitCommit: a3a9c7e0c5ca324f488fe7354f00a997398195f7
 Directory: 5.2/5.2.14/debian

--- a/library/satosa
+++ b/library/satosa
@@ -6,7 +6,7 @@ GitFetch: refs/heads/main
 
 Tags: 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, bookworm
 SharedTags: 8.4.0, 8.4, 8, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
+Architectures: amd64, arm64v8
 GitCommit: 69038a84d541717d66420f3ad8ec7c9da22c91b4
 Directory: 8.4/bookworm
 


### PR DESCRIPTION
Each of these has been failing for some period of time with no fix/mitigation forthcoming.  We're happy to see them re-enabled if they are fixed/updated.

- `eclipse-mosquitto`: https://github.com/eclipse/mosquitto/issues/3055
- `node`: ~https://github.com/docker-library/official-images/pull/16714#issuecomment-2096455085, https://github.com/nodejs/docker-node/issues/2107~ https://github.com/docker-library/official-images/pull/17394
- `plone`: https://github.com/plone/plone.docker/issues/161, https://github.com/docker-library/official-images/pull/12915#issuecomment-1426176158
- `rethinkdb`: ~https://github.com/rethinkdb/rethinkdb-dockerfiles/issues/67 (https://github.com/rethinkdb/rethinkdb/issues/7153)~ builds fixed
- `satosa`: https://github.com/IdentityPython/satosa-docker/issues/11#issuecomment-2270115644