### PR TITLE
Update Clear Linux OS to 42170

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 2796025d007ea6237915b070547a5fd096eb7703
-GitFetch: refs/heads/base-42150
+GitCommit: 4e64ac6abf04dad6c56178225b03c1bb4b667493
+GitFetch: refs/heads/base-42170


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42170

@bryteise @djklimes @bryteise