### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/790d59ba52b87071c9685b8c8790616741bc8795/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/5d682bddb261fbdc3b998c1b3e7bb41df7177146/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -65,7 +65,7 @@ GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie
 
 Tags: focal-curl, 20.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 93d6db0797f91ab674535553b7e0e762941a02d0
 Directory: ubuntu/focal/curl
 
@@ -80,31 +80,31 @@ GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: ubuntu/focal
 
 Tags: jammy-curl, 22.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 93d6db0797f91ab674535553b7e0e762941a02d0
 Directory: ubuntu/jammy/curl
 
 Tags: jammy-scm, 22.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: ubuntu/jammy/scm
 
 Tags: jammy, 22.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: ubuntu/jammy
 
 Tags: noble-curl, 24.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 60dc5f9555c521de086b2f5770514faf69ee2cc4
 Directory: ubuntu/noble/curl
 
 Tags: noble-scm, 24.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 60dc5f9555c521de086b2f5770514faf69ee2cc4
 Directory: ubuntu/noble/scm
 
 Tags: noble, 24.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 60dc5f9555c521de086b2f5770514faf69ee2cc4
 Directory: ubuntu/noble


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/5d682bd: Add back focal+risc64 bits removed in https://github.com/docker-library/buildpack-deps/pull/163

More `riscv64` on Ubuntu variants :eyes: