### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 4.0.0-beta.4, 4.0-rc
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7f88620e423c04f76b240bf3ab64e321c9d5fd9e
+Tags: 4.0.0-beta.5, 4.0-rc
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 9d679df50f50556fbc2f0d973783c8348d4e23ca
 Directory: 4.0-rc/ubuntu
 
-Tags: 4.0.0-beta.4-management, 4.0-rc-management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Tags: 4.0.0-beta.5-management, 4.0-rc-management
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 3881658e776314fb145db712981c91c52a3e25b8
 Directory: 4.0-rc/ubuntu/management
 
-Tags: 4.0.0-beta.4-alpine, 4.0-rc-alpine
+Tags: 4.0.0-beta.5-alpine, 4.0-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7f88620e423c04f76b240bf3ab64e321c9d5fd9e
+GitCommit: 9d679df50f50556fbc2f0d973783c8348d4e23ca
 Directory: 4.0-rc/alpine
 
-Tags: 4.0.0-beta.4-management-alpine, 4.0-rc-management-alpine
+Tags: 4.0.0-beta.5-management-alpine, 4.0-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3881658e776314fb145db712981c91c52a3e25b8
 Directory: 4.0-rc/alpine/management
 
 Tags: 3.13.6, 3.13, 3, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: fc362c970aa152f8c0d596f5a81cfc453a2e5eec
 Directory: 3.13/ubuntu
 
 Tags: 3.13.6-management, 3.13-management, 3-management, management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 6cc0f66ec13b06c153a7527c033cf1ad59a97ef3
 Directory: 3.13/ubuntu/management
 
@@ -46,12 +46,12 @@ GitCommit: 6cc0f66ec13b06c153a7527c033cf1ad59a97ef3
 Directory: 3.13/alpine/management
 
 Tags: 3.12.14, 3.12
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: fc362c970aa152f8c0d596f5a81cfc453a2e5eec
 Directory: 3.12/ubuntu
 
 Tags: 3.12.14-management, 3.12-management
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: c30652127ae871535b7ec8ecda8046948a52ab79
 Directory: 3.12/ubuntu/management
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/9d679df: Update 4.0-rc to 4.0.0-beta.5

(also, `riscv64` thanks to Ubuntu updates :eyes:)