### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 7ebf445be0a2847cfe94cf1cee3f3b9df891f0d1
 Directory: 5.0
 
-Tags: 4.1.5, 4.1, 4, latest, 4.1.5-jammy, 4.1-jammy, 4-jammy, jammy
+Tags: 4.1.6, 4.1, 4, latest, 4.1.6-jammy, 4.1-jammy, 4-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7ae558bbbbfa3f07eaaecae0ff84a4537d37c570
+GitCommit: 72bda687322eef86992681e21ce54bd2351c2573
 Directory: 4.1
 
 Tags: 4.0.13, 4.0, 4.0.13-jammy, 4.0-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/72bda68: Update 4.1 to 4.1.6
- https://github.com/docker-library/cassandra/commit/73821ac: Merge pull request https://github.com/docker-library/cassandra/pull/284 from infosiftr/noble-fallout
- https://github.com/docker-library/cassandra/commit/6c7cbe9: Lock all versions to "jammy" (no "noble" auto-upgrade)