### PR TITLE
[oraclelinux] Updating 8 and 9 for ELSA-2024-5534 ELSA-2024-5529 ELSA-2024-5530 ELSA-2024-5524

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -7,7 +7,7 @@ amd64-GitFetch: refs/heads/dist-amd64
 amd64-GitCommit: 53082608c83ad0df59197d2ac14f1c1403764bf6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 31a1708d05cf315d7200eae275ab891c152a522c
+arm64v8-GitCommit: 584963be844e344c6b385c93ce2e3399c65207b4
 
 Tags: 9
 Architectures: amd64, arm64v8

--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ebd9ccbe2d59c8b0c99767e1a59367e102e726d8
+amd64-GitCommit: 53082608c83ad0df59197d2ac14f1c1403764bf6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 448f7e0fe048c20a408292a73f6b6eb3621c52a2
+arm64v8-GitCommit: 31a1708d05cf315d7200eae275ab891c152a522c
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-6345, CVE-2024-2398, CVE-2024-1737, CVE-2024-1975

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-5530.html
https://linux.oracle.com/errata/ELSA-2024-5524.html
https://linux.oracle.com/errata/ELSA-2024-5534.html
https://linux.oracle.com/errata/ELSA-2024-5529.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
