### PR TITLE
fluentd: Update to Fluentd v1.16.6/v1.17.1

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,13 +3,27 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Alpine images
-Tags: v1.16.2-1.1, v1.16-1, latest
+Tags: v1.16.6-1.0, v1.16-1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: a4dd65768ec1819574e570716955276c9089326a
+GitFetch: refs/heads/v1.16
+GitCommit: ddb5019b433339f9eef991ca373445deb6e4d2b1
 Directory: v1.16/alpine
 
 # Debian images
-Tags: v1.16.2-debian-1.1, v1.16-debian-1
+Tags: v1.16.6-debian-1.0, v1.16-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a4dd65768ec1819574e570716955276c9089326a
+GitFetch: refs/heads/v1.16
+GitCommit: ddb5019b433339f9eef991ca373445deb6e4d2b1
 Directory: v1.16/debian
+
+# Alpine images
+Tags: v1.17.1-1.0, v1.17-1, latest
+Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
+GitCommit: 1055e528ef1acbb073028e0281b60bdaf9a23595
+Directory: v1.17/alpine
+
+# Debian images
+Tags: v1.17.1-debian-1.0, v1.17-debian-1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 1055e528ef1acbb073028e0281b60bdaf9a23595
+Directory: v1.17/debian


### PR DESCRIPTION
v1.16.x: stable branch (bundled for fluent-package LTS)

https://github.com/fluent/fluentd-docker-image/commit/ddb5019b433339f9eef991ca373445deb6e4d2b1

v1.17.x: latest branch

https://github.com/fluent/fluentd-docker-image/commit/1055e528ef1acbb073028e0281b60bdaf9a23595

