### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2024-5529

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 53082608c83ad0df59197d2ac14f1c1403764bf6
+amd64-GitCommit: 5217ff6e8bb3152495c63a52c7790b1b88c33e39
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 584963be844e344c6b385c93ce2e3399c65207b4
+arm64v8-GitCommit: 29363a7f01e55f6c08a9fe1a9272f78ecf24c5e4
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-2398, including slim and fips images.

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-5529.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
