### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.89.5, 5.89, 5, latest
+Tags: 5.89.6, 5.89, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4ca6282eef820248e7b4d51c8688e4ac48a112ee
+GitCommit: 4ad5419396fce318c13714f205bf8e8829c6a9f9
 Directory: 5/debian
 
-Tags: 5.89.5-alpine, 5.89-alpine, 5-alpine, alpine
+Tags: 5.89.6-alpine, 5.89-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4ca6282eef820248e7b4d51c8688e4ac48a112ee
+GitCommit: 4ad5419396fce318c13714f205bf8e8829c6a9f9
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4ad5419: Update to 5.89.6, ghost-cli 1.26.1