### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -59,45 +59,45 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 23-rc-jdk-oraclelinux9, 23-rc-oraclelinux9, 23-jdk-oraclelinux9, 23-oraclelinux9, 23-rc-jdk-oracle, 23-rc-oracle, 23-jdk-oracle, 23-oracle
 SharedTags: 23-rc-jdk, 23-rc, 23-jdk, 23
 Architectures: amd64, arm64v8
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/oraclelinux9
 
 Tags: 23-rc-jdk-oraclelinux8, 23-rc-oraclelinux8, 23-jdk-oraclelinux8, 23-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/oraclelinux8
 
 Tags: 23-rc-jdk-bookworm, 23-rc-bookworm, 23-jdk-bookworm, 23-bookworm
 Architectures: amd64, arm64v8
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/bookworm
 
 Tags: 23-rc-jdk-slim-bookworm, 23-rc-slim-bookworm, 23-jdk-slim-bookworm, 23-slim-bookworm, 23-rc-jdk-slim, 23-rc-slim, 23-jdk-slim, 23-slim
 Architectures: amd64, arm64v8
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/slim-bookworm
 
 Tags: 23-rc-jdk-bullseye, 23-rc-bullseye, 23-jdk-bullseye, 23-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/bullseye
 
 Tags: 23-rc-jdk-slim-bullseye, 23-rc-slim-bullseye, 23-jdk-slim-bullseye, 23-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/slim-bullseye
 
 Tags: 23-rc-jdk-windowsservercore-ltsc2022, 23-rc-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
 SharedTags: 23-rc-jdk-windowsservercore, 23-rc-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-rc-jdk, 23-rc, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 23-rc-jdk-windowsservercore-1809, 23-rc-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
 SharedTags: 23-rc-jdk-windowsservercore, 23-rc-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23-rc-jdk, 23-rc, 23-jdk, 23
 Architectures: windows-amd64
-GitCommit: ef6c71c79148fdbac029ee6924626699ca5cd8c1
+GitCommit: 9561b4fda40bd1525d1c05244474e52778737678
 Directory: 23/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/9561b4f: Update 23

According to the schedule this should be the "Final Release Candidate" for 23: https://openjdk.org/projects/jdk/23/. That means this will likely be the final 23 available in the `openjdk` tags since we only continue to provide them for pre-releases.

Reminder to use one of the other Official Images for GA releases: https://github.com/docker-library/docs/blob/f80da10a27ea507d6e916d33267c3217b5905d8a/openjdk/README.md#deprecation-notice