### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,122 +4,122 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.2.0-alpha3-php8.1-apache, 5.2-php8.1-apache, 5.2.alpha-php8.1-apache, 5.2.0-alpha-php8.1-apache
+Tags: 5.2.0-beta1-php8.1-apache, 5.2-php8.1-apache, 5.2.beta-php8.1-apache, 5.2.0-beta-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.1/apache
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.1/apache
 
-Tags: 5.2.0-alpha3-php8.1-fpm-alpine, 5.2-php8.1-fpm-alpine, 5.2.alpha-php8.1-fpm-alpine, 5.2.0-alpha-php8.1-fpm-alpine
+Tags: 5.2.0-beta1-php8.1-fpm-alpine, 5.2-php8.1-fpm-alpine, 5.2.beta-php8.1-fpm-alpine, 5.2.0-beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.1/fpm-alpine
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.1/fpm-alpine
 
-Tags: 5.2.0-alpha3-php8.1-fpm, 5.2-php8.1-fpm, 5.2.alpha-php8.1-fpm, 5.2.0-alpha-php8.1-fpm
+Tags: 5.2.0-beta1-php8.1-fpm, 5.2-php8.1-fpm, 5.2.beta-php8.1-fpm, 5.2.0-beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.1/fpm
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.1/fpm
 
-Tags: 5.2.0-alpha3, 5.2, 5.2.alpha, 5.2.0-alpha, 5.2.0-alpha3-apache, 5.2-apache, 5.2.alpha-apache, 5.2.0-alpha-apache, 5.2.0-alpha3-php8.2, 5.2-php8.2, 5.2.alpha-php8.2, 5.2.0-alpha-php8.2, 5.2.0-alpha3-php8.2-apache, 5.2-php8.2-apache, 5.2.alpha-php8.2-apache, 5.2.0-alpha-php8.2-apache
+Tags: 5.2.0-beta1, 5.2, 5.2.beta, 5.2.0-beta, 5.2.0-beta1-apache, 5.2-apache, 5.2.beta-apache, 5.2.0-beta-apache, 5.2.0-beta1-php8.2, 5.2-php8.2, 5.2.beta-php8.2, 5.2.0-beta-php8.2, 5.2.0-beta1-php8.2-apache, 5.2-php8.2-apache, 5.2.beta-php8.2-apache, 5.2.0-beta-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.2/apache
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.2/apache
 
-Tags: 5.2.0-alpha3-php8.2-fpm-alpine, 5.2-php8.2-fpm-alpine, 5.2.alpha-php8.2-fpm-alpine, 5.2.0-alpha-php8.2-fpm-alpine
+Tags: 5.2.0-beta1-php8.2-fpm-alpine, 5.2-php8.2-fpm-alpine, 5.2.beta-php8.2-fpm-alpine, 5.2.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.2/fpm-alpine
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.2/fpm-alpine
 
-Tags: 5.2.0-alpha3-php8.2-fpm, 5.2-php8.2-fpm, 5.2.alpha-php8.2-fpm, 5.2.0-alpha-php8.2-fpm
+Tags: 5.2.0-beta1-php8.2-fpm, 5.2-php8.2-fpm, 5.2.beta-php8.2-fpm, 5.2.0-beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.2/fpm
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.2/fpm
 
-Tags: 5.2.0-alpha3-php8.3-apache, 5.2-php8.3-apache, 5.2.alpha-php8.3-apache, 5.2.0-alpha-php8.3-apache
+Tags: 5.2.0-beta1-php8.3-apache, 5.2-php8.3-apache, 5.2.beta-php8.3-apache, 5.2.0-beta-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.3/apache
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.3/apache
 
-Tags: 5.2.0-alpha3-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5.2.alpha-php8.3-fpm-alpine, 5.2.0-alpha-php8.3-fpm-alpine
+Tags: 5.2.0-beta1-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5.2.beta-php8.3-fpm-alpine, 5.2.0-beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.3/fpm-alpine
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.3/fpm-alpine
 
-Tags: 5.2.0-alpha3-php8.3-fpm, 5.2-php8.3-fpm, 5.2.alpha-php8.3-fpm, 5.2.0-alpha-php8.3-fpm
+Tags: 5.2.0-beta1-php8.3-fpm, 5.2-php8.3-fpm, 5.2.beta-php8.3-fpm, 5.2.0-beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: de23e987f57789644dd2c9cd1da823c3784d5925
-Directory: 5.2.alpha/php8.3/fpm
+GitCommit: 450bc595e4c4b1ea207a178188b41e09c30704c9
+Directory: 5.2.beta/php8.3/fpm
 
-Tags: 5.1.2-php8.1-apache, 5.1-php8.1-apache, 5-php8.1-apache, php8.1-apache
+Tags: 5.1.3-php8.1-apache, 5.1-php8.1-apache, 5-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.1/apache
 
-Tags: 5.1.2-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 5.1.3-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.1/fpm-alpine
 
-Tags: 5.1.2-php8.1-fpm, 5.1-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
+Tags: 5.1.3-php8.1-fpm, 5.1-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.1/fpm
 
-Tags: 5.1.2, 5.1, 5, latest, 5.1.2-apache, 5.1-apache, 5-apache, apache, 5.1.2-php8.2, 5.1-php8.2, 5-php8.2, php8.2, 5.1.2-php8.2-apache, 5.1-php8.2-apache, 5-php8.2-apache, php8.2-apache
+Tags: 5.1.3, 5.1, 5, latest, 5.1.3-apache, 5.1-apache, 5-apache, apache, 5.1.3-php8.2, 5.1-php8.2, 5-php8.2, php8.2, 5.1.3-php8.2-apache, 5.1-php8.2-apache, 5-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.2/apache
 
-Tags: 5.1.2-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 5.1.3-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.2/fpm-alpine
 
-Tags: 5.1.2-php8.2-fpm, 5.1-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
+Tags: 5.1.3-php8.2-fpm, 5.1-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.2/fpm
 
-Tags: 5.1.2-php8.3-apache, 5.1-php8.3-apache, 5-php8.3-apache, php8.3-apache
+Tags: 5.1.3-php8.3-apache, 5.1-php8.3-apache, 5-php8.3-apache, php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.3/apache
 
-Tags: 5.1.2-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 5.1.3-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.3/fpm-alpine
 
-Tags: 5.1.2-php8.3-fpm, 5.1-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
+Tags: 5.1.3-php8.3-fpm, 5.1-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 5.1/php8.3/fpm
 
-Tags: 4.4.6, 4.4, 4, 4.4.6-apache, 4.4-apache, 4-apache, 4.4.6-php8.1, 4.4-php8.1, 4-php8.1, 4.4.6-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
+Tags: 4.4.7, 4.4, 4, 4.4.7-apache, 4.4-apache, 4-apache, 4.4.7-php8.1, 4.4-php8.1, 4-php8.1, 4.4.7-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 4.4/php8.1/apache
 
-Tags: 4.4.6-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
+Tags: 4.4.7-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 4.4/php8.1/fpm-alpine
 
-Tags: 4.4.6-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
+Tags: 4.4.7-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 4.4/php8.1/fpm
 
-Tags: 4.4.6-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
+Tags: 4.4.7-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 4.4/php8.2/apache
 
-Tags: 4.4.6-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
+Tags: 4.4.7-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 4.4/php8.2/fpm-alpine
 
-Tags: 4.4.6-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
+Tags: 4.4.7-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60f3895dc2f34ca3b7ffceef019c73a1fbf0b7e
+GitCommit: cf97c38cdff7a89422685bc1b1699d516f2050df
 Directory: 4.4/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@cf97c38: Update Joomla 5.1.2 to 5.1.3 and Joomla 4.4.6 to 4.4.7
- joomla-docker/docker-joomla@450bc59: Add Joomla 5.2.0-beta build
- joomla-docker/docker-joomla@ecbbb1d: Remove Joomla 5.2.0-alpha build