### PR TITLE
[oraclelinux] Updating 8, 8-slim, 8-slim-fips, 9, 9-slim, 9-slim-fips for ELSA-2024-5654 and ca-certificates.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5217ff6e8bb3152495c63a52c7790b1b88c33e39
+amd64-GitCommit: 91acb47147d3ee89e22741bece8f42e9e67180e2
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 29363a7f01e55f6c08a9fe1a9272f78ecf24c5e4
+arm64v8-GitCommit: bf6b944430798e21bd32c98c8f8a3b2016e7acc3
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-2398 and ca-certificates update.

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-5654.html
https://linux.oracle.com/errata/ELSA-2024-5691.html
https://linux.oracle.com/errata/ELSA-2024-5736.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
