### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240805.0
+Tags: 2023, latest, 2023.5.20240819.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 6d74be550141b91913144f2cbf3775f793082a37
+amd64-GitCommit: c29bfadba77a70adf176970bfb1f4d634c644871
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 827c1289fd0e66d597fac4c4c69053d2658dc34a
+arm64v8-GitCommit: 26976ae0b270ea4ae55c51421404208ee5112c5f
 
-Tags: 2, 2.0.20240719.0
+Tags: 2, 2.0.20240816.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 777bd118eac88f5da9cd43baee35bea52604def2
+amd64-GitCommit: 11e068c308c8aaee8a9484fa2381651f101c8ec9
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 54429931bd4b95501f396c3c79e5f88337fd7711
+arm64v8-GitCommit: 614e3a1d5be715018ac29c866b3402041738ee84
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- libarchive-3.7.4-2.amzn2023.0.1
- amazon-linux-repo-cdn-2023.5.20240819-0.amzn2023
- system-release-2023.5.20240819-0.amzn2023

### Updated Packages for Amazon Linux 2:
- openssl-libs-1.0.2k-24.amzn2.0.13
- cyrus-sasl-lib-2.1.26-24.amzn2.0.1
- ca-certificates-2023.2.68-1.amzn2.0.1 
### Packages addressing CVES:
- openssl-libs-1.0.2k-24.amzn2.0.13
  - [CVE-2024-5535](https://alas.aws.amazon.com/cve/html/CVE-2024-5535.html)
- ca-certificates-2023.2.68-1.amzn2.0.1
  - [CVE-2024-39689](https://alas.aws.amazon.com/cve/html/CVE-2024-39689.html)