### PR TITLE
archlinux: Release 20240825.0.257728

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240818.0.255804
-GitCommit: 35a4506c22ecbf3790338472872c8370b63e7400
-GitFetch: refs/tags/v20240818.0.255804
+Tags: latest, base, base-20240825.0.257728
+GitCommit: a915cdf3e8ae85bb9675c1d018151de0f86de624
+GitFetch: refs/tags/v20240825.0.257728
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240818.0.255804
-GitCommit: 35a4506c22ecbf3790338472872c8370b63e7400
-GitFetch: refs/tags/v20240818.0.255804
+Tags: base-devel, base-devel-20240825.0.257728
+GitCommit: a915cdf3e8ae85bb9675c1d018151de0f86de624
+GitFetch: refs/tags/v20240825.0.257728
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240818.0.255804
-GitCommit: 35a4506c22ecbf3790338472872c8370b63e7400
-GitFetch: refs/tags/v20240818.0.255804
+Tags: multilib-devel, multilib-devel-20240825.0.257728
+GitCommit: a915cdf3e8ae85bb9675c1d018151de0f86de624
+GitFetch: refs/tags/v20240825.0.257728
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks