### PR TITLE
Update Clear Linux OS to 42210

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 4e64ac6abf04dad6c56178225b03c1bb4b667493
-GitFetch: refs/heads/base-42170
+GitCommit: fad5d1c7fde5e79b117a07303cca5d8a6c4f8acb
+GitFetch: refs/heads/base-42210


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42210

@bryteise @djklimes @bryteise