### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0-rc1, 5.0, 5, 5.0-rc1-jammy, 5.0-jammy, 5-jammy
+Tags: 5.0-rc2, 5.0, 5, 5.0-rc2-jammy, 5.0-jammy, 5-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 7ebf445be0a2847cfe94cf1cee3f3b9df891f0d1
+GitCommit: 31cced8ff8e1ba9f7d7600a8d0f41c36fb3dc8a8
 Directory: 5.0
 
 Tags: 4.1.6, 4.1, 4, latest, 4.1.6-jammy, 4.1-jammy, 4-jammy, jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/31cced8: Update 5.0 to 5.0-rc2