### PR TITLE
arangodb 3.12.2

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -7,7 +7,7 @@ Architectures: amd64, arm64v8
 GitCommit: ce25dfe5cb8cc8658b031136b262bd8d2be7e679
 Directory: alpine/3.11.10.1
 
-Tags: 3.12, 3.12.1, latest
+Tags: 3.12, 3.12.2, latest
 Architectures: amd64, arm64v8
-GitCommit: eb4312a4f2e7974dc798d4e6585281b24b283e06
-Directory: alpine/3.12.1
+GitCommit: ba430694881c65dc95aaf47e0250e501ead0f5b5
+Directory: alpine/3.12.2


### PR DESCRIPTION
Updated ArangoDB 3.12 to 3.12.2.