### PR TITLE
Update julia

### DIFF
--- a/library/julia
+++ b/library/julia
@@ -4,39 +4,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/julia.git
 
-Tags: 1.11.0-rc2-bookworm, 1.11-rc-bookworm, rc-bookworm
-SharedTags: 1.11.0-rc2, 1.11-rc, rc
+Tags: 1.11.0-rc3-bookworm, 1.11-rc-bookworm, rc-bookworm
+SharedTags: 1.11.0-rc3, 1.11-rc, rc
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 2a287596074016d7736988340a0d5351cce19a4a
+GitCommit: d3171d95ff7ff459684cadc387a57c1c06eae506
 Directory: 1.11-rc/bookworm
 
-Tags: 1.11.0-rc2-bullseye, 1.11-rc-bullseye, rc-bullseye
+Tags: 1.11.0-rc3-bullseye, 1.11-rc-bullseye, rc-bullseye
 Architectures: amd64, arm64v8, i386, ppc64le
-GitCommit: 2a287596074016d7736988340a0d5351cce19a4a
+GitCommit: d3171d95ff7ff459684cadc387a57c1c06eae506
 Directory: 1.11-rc/bullseye
 
-Tags: 1.11.0-rc2-alpine3.20, 1.11-rc-alpine3.20, rc-alpine3.20, 1.11.0-rc2-alpine, 1.11-rc-alpine, rc-alpine
-Architectures: amd64
-GitCommit: 2a287596074016d7736988340a0d5351cce19a4a
-Directory: 1.11-rc/alpine3.20
-
-Tags: 1.11.0-rc2-alpine3.19, 1.11-rc-alpine3.19, rc-alpine3.19
-Architectures: amd64
-GitCommit: 2a287596074016d7736988340a0d5351cce19a4a
-Directory: 1.11-rc/alpine3.19
-
-Tags: 1.11.0-rc2-windowsservercore-ltsc2022, 1.11-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 1.11.0-rc2, 1.11-rc, rc, 1.11.0-rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
+Tags: 1.11.0-rc3-windowsservercore-ltsc2022, 1.11-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 1.11.0-rc3, 1.11-rc, rc, 1.11.0-rc3-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 2a287596074016d7736988340a0d5351cce19a4a
+GitCommit: d3171d95ff7ff459684cadc387a57c1c06eae506
 Directory: 1.11-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 1.11.0-rc2-windowsservercore-1809, 1.11-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 1.11.0-rc2, 1.11-rc, rc, 1.11.0-rc2-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
+Tags: 1.11.0-rc3-windowsservercore-1809, 1.11-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 1.11.0-rc3, 1.11-rc, rc, 1.11.0-rc3-windowsservercore, 1.11-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 2a287596074016d7736988340a0d5351cce19a4a
+GitCommit: d3171d95ff7ff459684cadc387a57c1c06eae506
 Directory: 1.11-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/julia/commit/d3171d9: Update 1.11-rc to 1.11.0-rc3

https://discourse.julialang.org/t/julia-v1-11-0-rc3-is-now-available/118653/1, especially:

> Unfortunately, musl Linux binaries are not currently available for this release.