### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -4,107 +4,72 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/pypy.git
 
-Tags: 3.10-7.3.16-bookworm, 3.10-7.3-bookworm, 3.10-7-bookworm, 3.10-bookworm, 3-7.3.16-bookworm, 3-7.3-bookworm, 3-7-bookworm, 3-bookworm, bookworm
+Tags: 3.10-7.3.17-bookworm, 3.10-7.3-bookworm, 3.10-7-bookworm, 3.10-bookworm, 3-7.3.17-bookworm, 3-7.3-bookworm, 3-7-bookworm, 3-bookworm, bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: 7fd4974ceb6228a380d1c759bb6bfbb9bb7a6686
+GitCommit: 122ac4d9f832a77e6ee2261984ba5c6a7c5cbe75
 Directory: 3.10/bookworm
 
-Tags: 3.10-7.3.16-slim-bookworm, 3.10-7.3-slim-bookworm, 3.10-7-slim-bookworm, 3.10-slim-bookworm, 3-7.3.16-slim-bookworm, 3-7.3-slim-bookworm, 3-7-slim-bookworm, 3-slim-bookworm, slim-bookworm
+Tags: 3.10-7.3.17-slim-bookworm, 3.10-7.3-slim-bookworm, 3.10-7-slim-bookworm, 3.10-slim-bookworm, 3-7.3.17-slim-bookworm, 3-7.3-slim-bookworm, 3-7-slim-bookworm, 3-slim-bookworm, slim-bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: 7fd4974ceb6228a380d1c759bb6bfbb9bb7a6686
+GitCommit: 122ac4d9f832a77e6ee2261984ba5c6a7c5cbe75
 Directory: 3.10/slim-bookworm
 
-Tags: 3.10-7.3.16-bullseye, 3.10-7.3-bullseye, 3.10-7-bullseye, 3.10-bullseye, 3-7.3.16-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
-SharedTags: 3.10-7.3.16, 3.10-7.3, 3.10-7, 3.10, 3-7.3.16, 3-7.3, 3-7, 3, latest
+Tags: 3.10-7.3.17-bullseye, 3.10-7.3-bullseye, 3.10-7-bullseye, 3.10-bullseye, 3-7.3.17-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
+SharedTags: 3.10-7.3.17, 3.10-7.3, 3.10-7, 3.10, 3-7.3.17, 3-7.3, 3-7, 3, latest
 Architectures: amd64, arm64v8, i386
-GitCommit: 7fd4974ceb6228a380d1c759bb6bfbb9bb7a6686
+GitCommit: 122ac4d9f832a77e6ee2261984ba5c6a7c5cbe75
 Directory: 3.10/bullseye
 
-Tags: 3.10-7.3.16-slim, 3.10-7.3-slim, 3.10-7-slim, 3.10-slim, 3-7.3.16-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.10-7.3.16-slim-bullseye, 3.10-7.3-slim-bullseye, 3.10-7-slim-bullseye, 3.10-slim-bullseye, 3-7.3.16-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.10-7.3.17-slim, 3.10-7.3-slim, 3.10-7-slim, 3.10-slim, 3-7.3.17-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.10-7.3.17-slim-bullseye, 3.10-7.3-slim-bullseye, 3.10-7-slim-bullseye, 3.10-slim-bullseye, 3-7.3.17-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: 7fd4974ceb6228a380d1c759bb6bfbb9bb7a6686
+GitCommit: 122ac4d9f832a77e6ee2261984ba5c6a7c5cbe75
 Directory: 3.10/slim-bullseye
 
-Tags: 3.10-7.3.16-windowsservercore-ltsc2022, 3.10-7.3-windowsservercore-ltsc2022, 3.10-7-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-7.3.16-windowsservercore-ltsc2022, 3-7.3-windowsservercore-ltsc2022, 3-7-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 3.10-7.3.16, 3.10-7.3, 3.10-7, 3.10, 3-7.3.16, 3-7.3, 3-7, 3, latest, 3.10-7.3.16-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.16-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.10-7.3.17-windowsservercore-ltsc2022, 3.10-7.3-windowsservercore-ltsc2022, 3.10-7-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-7.3.17-windowsservercore-ltsc2022, 3-7.3-windowsservercore-ltsc2022, 3-7-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 3.10-7.3.17, 3.10-7.3, 3.10-7, 3.10, 3-7.3.17, 3-7.3, 3-7, 3, latest, 3.10-7.3.17-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.17-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 7fd4974ceb6228a380d1c759bb6bfbb9bb7a6686
+GitCommit: 122ac4d9f832a77e6ee2261984ba5c6a7c5cbe75
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 3.10-7.3.16-windowsservercore-1809, 3.10-7.3-windowsservercore-1809, 3.10-7-windowsservercore-1809, 3.10-windowsservercore-1809, 3-7.3.16-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.10-7.3.16, 3.10-7.3, 3.10-7, 3.10, 3-7.3.16, 3-7.3, 3-7, 3, latest, 3.10-7.3.16-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.16-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
+Tags: 3.10-7.3.17-windowsservercore-1809, 3.10-7.3-windowsservercore-1809, 3.10-7-windowsservercore-1809, 3.10-windowsservercore-1809, 3-7.3.17-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.10-7.3.17, 3.10-7.3, 3.10-7, 3.10, 3-7.3.17, 3-7.3, 3-7, 3, latest, 3.10-7.3.17-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.17-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 7fd4974ceb6228a380d1c759bb6bfbb9bb7a6686
+GitCommit: 122ac4d9f832a77e6ee2261984ba5c6a7c5cbe75
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 3.9-7.3.16-bookworm, 3.9-7.3-bookworm, 3.9-7-bookworm, 3.9-bookworm
+Tags: 2.7-7.3.17-bookworm, 2.7-7.3-bookworm, 2.7-7-bookworm, 2.7-bookworm, 2-7.3.17-bookworm, 2-7.3-bookworm, 2-7-bookworm, 2-bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: 86c243284bdb4df9a673aa3f3c837edeed8449cb
-Directory: 3.9/bookworm
-
-Tags: 3.9-7.3.16-slim-bookworm, 3.9-7.3-slim-bookworm, 3.9-7-slim-bookworm, 3.9-slim-bookworm
-Architectures: amd64, arm64v8, i386
-GitCommit: 86c243284bdb4df9a673aa3f3c837edeed8449cb
-Directory: 3.9/slim-bookworm
-
-Tags: 3.9-7.3.16-bullseye, 3.9-7.3-bullseye, 3.9-7-bullseye, 3.9-bullseye
-SharedTags: 3.9-7.3.16, 3.9-7.3, 3.9-7, 3.9
-Architectures: amd64, arm64v8, i386
-GitCommit: 86c243284bdb4df9a673aa3f3c837edeed8449cb
-Directory: 3.9/bullseye
-
-Tags: 3.9-7.3.16-slim, 3.9-7.3-slim, 3.9-7-slim, 3.9-slim, 3.9-7.3.16-slim-bullseye, 3.9-7.3-slim-bullseye, 3.9-7-slim-bullseye, 3.9-slim-bullseye
-Architectures: amd64, arm64v8, i386
-GitCommit: 86c243284bdb4df9a673aa3f3c837edeed8449cb
-Directory: 3.9/slim-bullseye
-
-Tags: 3.9-7.3.16-windowsservercore-ltsc2022, 3.9-7.3-windowsservercore-ltsc2022, 3.9-7-windowsservercore-ltsc2022, 3.9-windowsservercore-ltsc2022
-SharedTags: 3.9-7.3.16, 3.9-7.3, 3.9-7, 3.9, 3.9-7.3.16-windowsservercore, 3.9-7.3-windowsservercore, 3.9-7-windowsservercore, 3.9-windowsservercore
-Architectures: windows-amd64
-GitCommit: 86c243284bdb4df9a673aa3f3c837edeed8449cb
-Directory: 3.9/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 3.9-7.3.16-windowsservercore-1809, 3.9-7.3-windowsservercore-1809, 3.9-7-windowsservercore-1809, 3.9-windowsservercore-1809
-SharedTags: 3.9-7.3.16, 3.9-7.3, 3.9-7, 3.9, 3.9-7.3.16-windowsservercore, 3.9-7.3-windowsservercore, 3.9-7-windowsservercore, 3.9-windowsservercore
-Architectures: windows-amd64
-GitCommit: 86c243284bdb4df9a673aa3f3c837edeed8449cb
-Directory: 3.9/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-
-Tags: 2.7-7.3.16-bookworm, 2.7-7.3-bookworm, 2.7-7-bookworm, 2.7-bookworm, 2-7.3.16-bookworm, 2-7.3-bookworm, 2-7-bookworm, 2-bookworm
-Architectures: amd64, arm64v8, i386
-GitCommit: da7ff7031b87e70e4d1eb089a5bea20c3cd8ff96
+GitCommit: b28e10b0636684622326bf8e7b731eb96e3615d2
 Directory: 2.7/bookworm
 
-Tags: 2.7-7.3.16-slim-bookworm, 2.7-7.3-slim-bookworm, 2.7-7-slim-bookworm, 2.7-slim-bookworm, 2-7.3.16-slim-bookworm, 2-7.3-slim-bookworm, 2-7-slim-bookworm, 2-slim-bookworm
+Tags: 2.7-7.3.17-slim-bookworm, 2.7-7.3-slim-bookworm, 2.7-7-slim-bookworm, 2.7-slim-bookworm, 2-7.3.17-slim-bookworm, 2-7.3-slim-bookworm, 2-7-slim-bookworm, 2-slim-bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: da7ff7031b87e70e4d1eb089a5bea20c3cd8ff96
+GitCommit: b28e10b0636684622326bf8e7b731eb96e3615d2
 Directory: 2.7/slim-bookworm
 
-Tags: 2.7-7.3.16-bullseye, 2.7-7.3-bullseye, 2.7-7-bullseye, 2.7-bullseye, 2-7.3.16-bullseye, 2-7.3-bullseye, 2-7-bullseye, 2-bullseye
-SharedTags: 2.7-7.3.16, 2.7-7.3, 2.7-7, 2.7, 2-7.3.16, 2-7.3, 2-7, 2
+Tags: 2.7-7.3.17-bullseye, 2.7-7.3-bullseye, 2.7-7-bullseye, 2.7-bullseye, 2-7.3.17-bullseye, 2-7.3-bullseye, 2-7-bullseye, 2-bullseye
+SharedTags: 2.7-7.3.17, 2.7-7.3, 2.7-7, 2.7, 2-7.3.17, 2-7.3, 2-7, 2
 Architectures: amd64, arm64v8, i386
-GitCommit: da7ff7031b87e70e4d1eb089a5bea20c3cd8ff96
+GitCommit: b28e10b0636684622326bf8e7b731eb96e3615d2
 Directory: 2.7/bullseye
 
-Tags: 2.7-7.3.16-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.16-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.16-slim-bullseye, 2.7-7.3-slim-bullseye, 2.7-7-slim-bullseye, 2.7-slim-bullseye, 2-7.3.16-slim-bullseye, 2-7.3-slim-bullseye, 2-7-slim-bullseye, 2-slim-bullseye
+Tags: 2.7-7.3.17-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.17-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.17-slim-bullseye, 2.7-7.3-slim-bullseye, 2.7-7-slim-bullseye, 2.7-slim-bullseye, 2-7.3.17-slim-bullseye, 2-7.3-slim-bullseye, 2-7-slim-bullseye, 2-slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: da7ff7031b87e70e4d1eb089a5bea20c3cd8ff96
+GitCommit: b28e10b0636684622326bf8e7b731eb96e3615d2
 Directory: 2.7/slim-bullseye
 
-Tags: 2.7-7.3.16-windowsservercore-ltsc2022, 2.7-7.3-windowsservercore-ltsc2022, 2.7-7-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-7.3.16-windowsservercore-ltsc2022, 2-7.3-windowsservercore-ltsc2022, 2-7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
-SharedTags: 2.7-7.3.16, 2.7-7.3, 2.7-7, 2.7, 2-7.3.16, 2-7.3, 2-7, 2, 2.7-7.3.16-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.16-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
+Tags: 2.7-7.3.17-windowsservercore-ltsc2022, 2.7-7.3-windowsservercore-ltsc2022, 2.7-7-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-7.3.17-windowsservercore-ltsc2022, 2-7.3-windowsservercore-ltsc2022, 2-7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
+SharedTags: 2.7-7.3.17, 2.7-7.3, 2.7-7, 2.7, 2-7.3.17, 2-7.3, 2-7, 2, 2.7-7.3.17-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.17-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: da7ff7031b87e70e4d1eb089a5bea20c3cd8ff96
+GitCommit: b28e10b0636684622326bf8e7b731eb96e3615d2
 Directory: 2.7/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.7-7.3.16-windowsservercore-1809, 2.7-7.3-windowsservercore-1809, 2.7-7-windowsservercore-1809, 2.7-windowsservercore-1809, 2-7.3.16-windowsservercore-1809, 2-7.3-windowsservercore-1809, 2-7-windowsservercore-1809, 2-windowsservercore-1809
-SharedTags: 2.7-7.3.16, 2.7-7.3, 2.7-7, 2.7, 2-7.3.16, 2-7.3, 2-7, 2, 2.7-7.3.16-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.16-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
+Tags: 2.7-7.3.17-windowsservercore-1809, 2.7-7.3-windowsservercore-1809, 2.7-7-windowsservercore-1809, 2.7-windowsservercore-1809, 2-7.3.17-windowsservercore-1809, 2-7.3-windowsservercore-1809, 2-7-windowsservercore-1809, 2-windowsservercore-1809
+SharedTags: 2.7-7.3.17, 2.7-7.3, 2.7-7, 2.7, 2-7.3.17, 2-7.3, 2-7, 2, 2.7-7.3.17-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.17-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: da7ff7031b87e70e4d1eb089a5bea20c3cd8ff96
+GitCommit: b28e10b0636684622326bf8e7b731eb96e3615d2
 Directory: 2.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/b53c361: Remove 3.9 (no longer supported upstream)
- https://github.com/docker-library/pypy/commit/122ac4d: Update 3.10 to 7.3.17
- https://github.com/docker-library/pypy/commit/b28e10b: Update 2.7 to 7.3.17
- https://github.com/docker-library/pypy/commit/14d9352: Update to actions/checkout@v4 🙃