### PR TITLE
Test that setuptools and wheel are installed (or not)

### DIFF
--- a/test/tests/python-imports/container.py
+++ b/test/tests/python-imports/container.py
@@ -1,8 +1,8 @@
-import platform
+import platform, sys
 
 isWindows = platform.system() == 'Windows'
 isNotPypy = platform.python_implementation() != 'PyPy'
-isCaveman = platform.python_version_tuple()[0] == '2'
+isCaveman = sys.version_info[0] == 2
 
 if not isWindows:
     import curses
@@ -23,3 +23,11 @@ assert(zlib.decompress(zlib.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WOR
 if not isCaveman:
     import lzma
     assert(lzma.decompress(lzma.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
+
+    # https://github.com/docker-library/python/pull/954
+    shouldHaveSetuptoolsAndWheel = sys.version_info[0] == 3 and sys.version_info[1] < 12
+    import importlib.util
+    hasSetuptools = importlib.util.find_spec('setuptools') is not None
+    hasWheel = importlib.util.find_spec('wheel') is not None
+    assert(hasSetuptools == shouldHaveSetuptoolsAndWheel)
+    assert(hasWheel == shouldHaveSetuptoolsAndWheel)


### PR DESCRIPTION
In Python 3.12+, setuptools and wheel should be removed (but should be present in older versions).

Technically this should be tested on Python 2 as well, but I opted not to because the interfaces for doing so are different and that only exists in a single variant of PyPy (that frankly I don't care too much about verifying the "correctness" of as much).

https://github.com/docker-library/python/pull/954