### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: cc3a452953d734499bb98275a0a71a3f41895112
+GitCommit: 72b605d4755c0e13098e59442882ee8e6a708227
 Directory: dockerfiles-generated
 
 Tags: 0.29.0-python3.12-bookworm, 0.29-python3.12-bookworm, 0-python3.12-bookworm, python3.12-bookworm, 0.29.0-bookworm, 0.29-bookworm, 0-bookworm, bookworm
@@ -12,13 +12,25 @@ Tags: 0.29.0-python3.12-bullseye, 0.29-python3.12-bullseye, 0-python3.12-bullsey
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.12-bullseye
 
-Tags: 0.29.0-python3.12-alpine3.20, 0.29-python3.12-alpine3.20, 0-python3.12-alpine3.20, python3.12-alpine3.20, 0.29.0-alpine3.20, 0.29-alpine3.20, 0-alpine3.20, alpine3.20
+Tags: 0.29.0-python3.12-alpine3.20, 0.29-python3.12-alpine3.20, 0-python3.12-alpine3.20, python3.12-alpine3.20, 0.29.0-alpine3.20, 0.29-alpine3.20, 0-alpine3.20, alpine3.20, 0.29.0-python3.12-alpine, 0.29-python3.12-alpine, 0-python3.12-alpine, python3.12-alpine, 0.29.0-alpine, 0.29-alpine, 0-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.12-alpine3.20
 
-Tags: 0.29.0-python3.12-alpine3.19, 0.29-python3.12-alpine3.19, 0-python3.12-alpine3.19, python3.12-alpine3.19, 0.29.0-alpine3.19, 0.29-alpine3.19, 0-alpine3.19, alpine3.19, 0.29.0-python3.12-alpine, 0.29-python3.12-alpine, 0-python3.12-alpine, python3.12-alpine, 0.29.0-alpine, 0.29-alpine, 0-alpine, alpine
+Tags: 0.29.0-python3.12-alpine3.19, 0.29-python3.12-alpine3.19, 0-python3.12-alpine3.19, python3.12-alpine3.19, 0.29.0-alpine3.19, 0.29-alpine3.19, 0-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.12-alpine3.19
+
+Tags: 0.29.0-python3.12-windowsservercore-ltsc2022, 0.29-python3.12-windowsservercore-ltsc2022, 0-python3.12-windowsservercore-ltsc2022, python3.12-windowsservercore-ltsc2022, 0.29.0-windowsservercore-ltsc2022, 0.29-windowsservercore-ltsc2022, 0-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 0.29.0-python3.12, 0.29-python3.12, 0-python3.12, python3.12, 0.29.0, 0.29, 0, latest
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+File: Dockerfile.python3.12-windowsservercore-ltsc2022
+
+Tags: 0.29.0-python3.12-windowsservercore-1809, 0.29-python3.12-windowsservercore-1809, 0-python3.12-windowsservercore-1809, python3.12-windowsservercore-1809, 0.29.0-windowsservercore-1809, 0.29-windowsservercore-1809, 0-windowsservercore-1809, windowsservercore-1809
+SharedTags: 0.29.0-python3.12, 0.29-python3.12, 0-python3.12, python3.12, 0.29.0, 0.29, 0, latest
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+File: Dockerfile.python3.12-windowsservercore-1809
 
 Tags: 0.29.0-python3.11-bookworm, 0.29-python3.11-bookworm, 0-python3.11-bookworm, python3.11-bookworm
 SharedTags: 0.29.0-python3.11, 0.29-python3.11, 0-python3.11, python3.11
@@ -29,13 +41,25 @@ Tags: 0.29.0-python3.11-bullseye, 0.29-python3.11-bullseye, 0-python3.11-bullsey
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.11-bullseye
 
-Tags: 0.29.0-python3.11-alpine3.20, 0.29-python3.11-alpine3.20, 0-python3.11-alpine3.20, python3.11-alpine3.20
+Tags: 0.29.0-python3.11-alpine3.20, 0.29-python3.11-alpine3.20, 0-python3.11-alpine3.20, python3.11-alpine3.20, 0.29.0-python3.11-alpine, 0.29-python3.11-alpine, 0-python3.11-alpine, python3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.11-alpine3.20
 
-Tags: 0.29.0-python3.11-alpine3.19, 0.29-python3.11-alpine3.19, 0-python3.11-alpine3.19, python3.11-alpine3.19, 0.29.0-python3.11-alpine, 0.29-python3.11-alpine, 0-python3.11-alpine, python3.11-alpine
+Tags: 0.29.0-python3.11-alpine3.19, 0.29-python3.11-alpine3.19, 0-python3.11-alpine3.19, python3.11-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.11-alpine3.19
+
+Tags: 0.29.0-python3.11-windowsservercore-ltsc2022, 0.29-python3.11-windowsservercore-ltsc2022, 0-python3.11-windowsservercore-ltsc2022, python3.11-windowsservercore-ltsc2022
+SharedTags: 0.29.0-python3.11, 0.29-python3.11, 0-python3.11, python3.11
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+File: Dockerfile.python3.11-windowsservercore-ltsc2022
+
+Tags: 0.29.0-python3.11-windowsservercore-1809, 0.29-python3.11-windowsservercore-1809, 0-python3.11-windowsservercore-1809, python3.11-windowsservercore-1809
+SharedTags: 0.29.0-python3.11, 0.29-python3.11, 0-python3.11, python3.11
+Architectures: windows-amd64
+Constraints: windowsservercore-1809
+File: Dockerfile.python3.11-windowsservercore-1809
 
 Tags: 0.29.0-python3.10-bookworm, 0.29-python3.10-bookworm, 0-python3.10-bookworm, python3.10-bookworm
 SharedTags: 0.29.0-python3.10, 0.29-python3.10, 0-python3.10, python3.10
@@ -46,11 +70,11 @@ Tags: 0.29.0-python3.10-bullseye, 0.29-python3.10-bullseye, 0-python3.10-bullsey
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-bullseye
 
-Tags: 0.29.0-python3.10-alpine3.20, 0.29-python3.10-alpine3.20, 0-python3.10-alpine3.20, python3.10-alpine3.20
+Tags: 0.29.0-python3.10-alpine3.20, 0.29-python3.10-alpine3.20, 0-python3.10-alpine3.20, python3.10-alpine3.20, 0.29.0-python3.10-alpine, 0.29-python3.10-alpine, 0-python3.10-alpine, python3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.10-alpine3.20
 
-Tags: 0.29.0-python3.10-alpine3.19, 0.29-python3.10-alpine3.19, 0-python3.10-alpine3.19, python3.10-alpine3.19, 0.29.0-python3.10-alpine, 0.29-python3.10-alpine, 0-python3.10-alpine, python3.10-alpine
+Tags: 0.29.0-python3.10-alpine3.19, 0.29-python3.10-alpine3.19, 0-python3.10-alpine3.19, python3.10-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-alpine3.19
 
@@ -63,11 +87,11 @@ Tags: 0.29.0-python3.9-bullseye, 0.29-python3.9-bullseye, 0-python3.9-bullseye, 
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.9-bullseye
 
-Tags: 0.29.0-python3.9-alpine3.20, 0.29-python3.9-alpine3.20, 0-python3.9-alpine3.20, python3.9-alpine3.20
+Tags: 0.29.0-python3.9-alpine3.20, 0.29-python3.9-alpine3.20, 0-python3.9-alpine3.20, python3.9-alpine3.20, 0.29.0-python3.9-alpine, 0.29-python3.9-alpine, 0-python3.9-alpine, python3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.9-alpine3.20
 
-Tags: 0.29.0-python3.9-alpine3.19, 0.29-python3.9-alpine3.19, 0-python3.9-alpine3.19, python3.9-alpine3.19, 0.29.0-python3.9-alpine, 0.29-python3.9-alpine, 0-python3.9-alpine, python3.9-alpine
+Tags: 0.29.0-python3.9-alpine3.19, 0.29-python3.9-alpine3.19, 0-python3.9-alpine3.19, python3.9-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.9-alpine3.19
 
@@ -80,11 +104,11 @@ Tags: 0.29.0-python3.8-bullseye, 0.29-python3.8-bullseye, 0-python3.8-bullseye, 
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.8-bullseye
 
-Tags: 0.29.0-python3.8-alpine3.20, 0.29-python3.8-alpine3.20, 0-python3.8-alpine3.20, python3.8-alpine3.20
+Tags: 0.29.0-python3.8-alpine3.20, 0.29-python3.8-alpine3.20, 0-python3.8-alpine3.20, python3.8-alpine3.20, 0.29.0-python3.8-alpine, 0.29-python3.8-alpine, 0-python3.8-alpine, python3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.8-alpine3.20
 
-Tags: 0.29.0-python3.8-alpine3.19, 0.29-python3.8-alpine3.19, 0-python3.8-alpine3.19, python3.8-alpine3.19, 0.29.0-python3.8-alpine, 0.29-python3.8-alpine, 0-python3.8-alpine, python3.8-alpine
+Tags: 0.29.0-python3.8-alpine3.19, 0.29-python3.8-alpine3.19, 0-python3.8-alpine3.19, python3.8-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.8-alpine3.19
 
@@ -97,23 +121,14 @@ Tags: 0.29.0-pypy3.10-bullseye, 0.29-pypy3.10-bullseye, 0-pypy3.10-bullseye, pyp
 Architectures: amd64, arm64v8, i386
 File: Dockerfile.pypy3.10-bullseye
 
-Tags: 0.29.0-pypy3.9-bookworm, 0.29-pypy3.9-bookworm, 0-pypy3.9-bookworm, pypy3.9-bookworm
-SharedTags: 0.29.0-pypy3.9, 0.29-pypy3.9, 0-pypy3.9, pypy3.9
-Architectures: amd64, arm64v8, i386
-File: Dockerfile.pypy3.9-bookworm
-
-Tags: 0.29.0-pypy3.9-bullseye, 0.29-pypy3.9-bullseye, 0-pypy3.9-bullseye, pypy3.9-bullseye
-Architectures: amd64, arm64v8, i386
-File: Dockerfile.pypy3.9-bullseye
-
-Tags: 0.29.0-pypy3.9-windowsservercore-ltsc2022, 0.29-pypy3.9-windowsservercore-ltsc2022, 0-pypy3.9-windowsservercore-ltsc2022, pypy3.9-windowsservercore-ltsc2022
-SharedTags: 0.29.0-pypy3.9, 0.29-pypy3.9, 0-pypy3.9, pypy3.9
+Tags: 0.29.0-pypy3.10-windowsservercore-ltsc2022, 0.29-pypy3.10-windowsservercore-ltsc2022, 0-pypy3.10-windowsservercore-ltsc2022, pypy3.10-windowsservercore-ltsc2022, 0.29.0-pypy-windowsservercore-ltsc2022, 0.29-pypy-windowsservercore-ltsc2022, 0-pypy-windowsservercore-ltsc2022, pypy-windowsservercore-ltsc2022
+SharedTags: 0.29.0-pypy3.10, 0.29-pypy3.10, 0-pypy3.10, pypy3.10, 0.29.0-pypy, 0.29-pypy, 0-pypy, pypy
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
-File: Dockerfile.pypy3.9-windowsservercore-ltsc2022
+File: Dockerfile.pypy3.10-windowsservercore-ltsc2022
 
-Tags: 0.29.0-pypy3.9-windowsservercore-1809, 0.29-pypy3.9-windowsservercore-1809, 0-pypy3.9-windowsservercore-1809, pypy3.9-windowsservercore-1809
-SharedTags: 0.29.0-pypy3.9, 0.29-pypy3.9, 0-pypy3.9, pypy3.9
+Tags: 0.29.0-pypy3.10-windowsservercore-1809, 0.29-pypy3.10-windowsservercore-1809, 0-pypy3.10-windowsservercore-1809, pypy3.10-windowsservercore-1809, 0.29.0-pypy-windowsservercore-1809, 0.29-pypy-windowsservercore-1809, 0-pypy-windowsservercore-1809, pypy-windowsservercore-1809
+SharedTags: 0.29.0-pypy3.10, 0.29-pypy3.10, 0-pypy3.10, pypy3.10, 0.29.0-pypy, 0.29-pypy, 0-pypy, pypy
 Architectures: windows-amd64
 Constraints: windowsservercore-1809
-File: Dockerfile.pypy3.9-windowsservercore-1809
+File: Dockerfile.pypy3.10-windowsservercore-1809


### PR DESCRIPTION
👋 bye pypy 3.9

Changes:

- https://github.com/hylang/docker-hylang/commit/72b605d: Add back Windows variants 🚀
- https://github.com/hylang/docker-hylang/commit/5e78df9: Adjust ordering to make Windows exclusion more obvious/clear
- https://github.com/hylang/docker-hylang/commit/5097255: Make Alpine 3.20 the default for Alpine variants
- https://github.com/hylang/docker-hylang/commit/fb043ad: Actually remove pypy3.9