### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 4.0.0-beta.5, 4.0-rc
+Tags: 4.0.0-beta.6, 4.0-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 9d679df50f50556fbc2f0d973783c8348d4e23ca
+GitCommit: 8049e562768aa2f2ff8b3b84e03cd111cd212ba2
 Directory: 4.0-rc/ubuntu
 
-Tags: 4.0.0-beta.5-management, 4.0-rc-management
+Tags: 4.0.0-beta.6-management, 4.0-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 3881658e776314fb145db712981c91c52a3e25b8
 Directory: 4.0-rc/ubuntu/management
 
-Tags: 4.0.0-beta.5-alpine, 4.0-rc-alpine
+Tags: 4.0.0-beta.6-alpine, 4.0-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d679df50f50556fbc2f0d973783c8348d4e23ca
+GitCommit: 8049e562768aa2f2ff8b3b84e03cd111cd212ba2
 Directory: 4.0-rc/alpine
 
-Tags: 4.0.0-beta.5-management-alpine, 4.0-rc-management-alpine
+Tags: 4.0.0-beta.6-management-alpine, 4.0-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3881658e776314fb145db712981c91c52a3e25b8
 Directory: 4.0-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8049e56: Update 4.0-rc to 4.0.0-beta.6