### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -47,14 +47,14 @@ Directory: 7.0
 Tags: 7.0.14-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022, 7-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 7.0.14-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, windowsservercore, 7.0.14, 7.0, 7, latest
 Architectures: windows-amd64
-GitCommit: c738ec82e4036ccc7269415b221e6bf6313cc77a
+GitCommit: f026329ba338f77401005d637716572837102972
 Directory: 7.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 7.0.14-windowsservercore-1809, 7.0-windowsservercore-1809, 7-windowsservercore-1809, windowsservercore-1809
 SharedTags: 7.0.14-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, windowsservercore, 7.0.14, 7.0, 7, latest
 Architectures: windows-amd64
-GitCommit: c738ec82e4036ccc7269415b221e6bf6313cc77a
+GitCommit: f026329ba338f77401005d637716572837102972
 Directory: 7.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/f026329: Update 7.0

Extrapolating from https://github.com/mongodb/homebrew-brew/pull/217#issuecomment-2316161741, then it seems that the `.msi` installer was also affected.