### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 24-ea-12-jdk-oraclelinux9, 24-ea-12-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-12-jdk-oracle, 24-ea-12-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-12-jdk, 24-ea-12, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-13-jdk-oraclelinux9, 24-ea-13-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-13-jdk-oracle, 24-ea-13-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-13-jdk, 24-ea-13, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-12-jdk-oraclelinux8, 24-ea-12-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-13-jdk-oraclelinux8, 24-ea-13-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-12-jdk-bookworm, 24-ea-12-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-13-jdk-bookworm, 24-ea-13-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-12-jdk-slim-bookworm, 24-ea-12-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-12-jdk-slim, 24-ea-12-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-13-jdk-slim-bookworm, 24-ea-13-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-13-jdk-slim, 24-ea-13-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-12-jdk-bullseye, 24-ea-12-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-13-jdk-bullseye, 24-ea-13-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-12-jdk-slim-bullseye, 24-ea-12-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-13-jdk-slim-bullseye, 24-ea-13-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-12-jdk-windowsservercore-ltsc2022, 24-ea-12-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-12-jdk-windowsservercore, 24-ea-12-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-12-jdk, 24-ea-12, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-13-jdk-windowsservercore-ltsc2022, 24-ea-13-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-13-jdk-windowsservercore, 24-ea-13-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-13-jdk, 24-ea-13, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-12-jdk-windowsservercore-1809, 24-ea-12-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-12-jdk-windowsservercore, 24-ea-12-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-12-jdk, 24-ea-12, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-13-jdk-windowsservercore-1809, 24-ea-13-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-13-jdk-windowsservercore, 24-ea-13-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-13-jdk, 24-ea-13, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-12-jdk-nanoserver-1809, 24-ea-12-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-12-jdk-nanoserver, 24-ea-12-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-13-jdk-nanoserver-1809, 24-ea-13-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-13-jdk-nanoserver, 24-ea-13-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: ef60330192dff999f2c31baee403a4833eb9fc0f
+GitCommit: f4265cce2ccb18d4725840d9b318e7d253c60562
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/f4265cc: Update 24 to 24-ea+13