### PR TITLE
Use keyword arguments in `python-sqlite3` test

### DIFF
--- a/test/tests/python-sqlite3/container.py
+++ b/test/tests/python-sqlite3/container.py
@@ -2,7 +2,7 @@ import sqlite3
 
 ver = sqlite3.sqlite_version
 
-con = sqlite3.connect(':memory:', 1, sqlite3.PARSE_DECLTYPES, None)
+con = sqlite3.connect(':memory:', timeout=1, detect_types=sqlite3.PARSE_DECLTYPES, isolation_level=None)
 cur = con.cursor()
 cur.execute('CREATE TABLE test (id INT, txt TEXT)')
 cur.execute('INSERT INTO test VALUES (?, ?)', (42, 'wut'))


### PR DESCRIPTION
    /tmp/test-dir/python-sqlite3/./container.py:5: DeprecationWarning: Passing more than 1 positional argument to sqlite3.connect() is deprecated. Parameters 'timeout', 'detect_types', 'isolation_level', 'check_same_thread', 'factory', 'cached_statements' and 'uri' will become keyword-only parameters in Python 3.15.

Tested successfully on Python 3.13rc1, 3.8, and PyPy's Python 2 implementation, for good measure.