### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -8,38 +8,38 @@ Builder: buildkit
 Tags: 3.13.0rc1-bookworm, 3.13-rc-bookworm
 SharedTags: 3.13.0rc1, 3.13-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/bookworm
 
 Tags: 3.13.0rc1-slim-bookworm, 3.13-rc-slim-bookworm, 3.13.0rc1-slim, 3.13-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/slim-bookworm
 
 Tags: 3.13.0rc1-bullseye, 3.13-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/bullseye
 
 Tags: 3.13.0rc1-slim-bullseye, 3.13-rc-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/slim-bullseye
 
 Tags: 3.13.0rc1-alpine3.20, 3.13-rc-alpine3.20, 3.13.0rc1-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/alpine3.20
 
 Tags: 3.13.0rc1-alpine3.19, 3.13-rc-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/alpine3.19
 
 Tags: 3.13.0rc1-windowsservercore-ltsc2022, 3.13-rc-windowsservercore-ltsc2022
 SharedTags: 3.13.0rc1-windowsservercore, 3.13-rc-windowsservercore, 3.13.0rc1, 3.13-rc
 Architectures: windows-amd64
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -47,7 +47,7 @@ Builder: classic
 Tags: 3.13.0rc1-windowsservercore-1809, 3.13-rc-windowsservercore-1809
 SharedTags: 3.13.0rc1-windowsservercore, 3.13-rc-windowsservercore, 3.13.0rc1, 3.13-rc
 Architectures: windows-amd64
-GitCommit: 16e96e15aa5c7fec8ca41436159d62b22a733daf
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.13-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
@@ -55,38 +55,38 @@ Builder: classic
 Tags: 3.12.5-bookworm, 3.12-bookworm, 3-bookworm, bookworm
 SharedTags: 3.12.5, 3.12, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/bookworm
 
 Tags: 3.12.5-slim-bookworm, 3.12-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.12.5-slim, 3.12-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/slim-bookworm
 
 Tags: 3.12.5-bullseye, 3.12-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/bullseye
 
 Tags: 3.12.5-slim-bullseye, 3.12-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/slim-bullseye
 
 Tags: 3.12.5-alpine3.20, 3.12-alpine3.20, 3-alpine3.20, alpine3.20, 3.12.5-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/alpine3.20
 
 Tags: 3.12.5-alpine3.19, 3.12-alpine3.19, 3-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/alpine3.19
 
 Tags: 3.12.5-windowsservercore-ltsc2022, 3.12-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.12.5-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.5, 3.12, 3, latest
 Architectures: windows-amd64
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -94,7 +94,7 @@ Builder: classic
 Tags: 3.12.5-windowsservercore-1809, 3.12-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.12.5-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.5, 3.12, 3, latest
 Architectures: windows-amd64
-GitCommit: cc2cf19f2c9a440706d17b5937bf104052eef967
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
@@ -102,38 +102,38 @@ Builder: classic
 Tags: 3.11.9-bookworm, 3.11-bookworm
 SharedTags: 3.11.9, 3.11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/bookworm
 
 Tags: 3.11.9-slim-bookworm, 3.11-slim-bookworm, 3.11.9-slim, 3.11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/slim-bookworm
 
 Tags: 3.11.9-bullseye, 3.11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/bullseye
 
 Tags: 3.11.9-slim-bullseye, 3.11-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/slim-bullseye
 
 Tags: 3.11.9-alpine3.20, 3.11-alpine3.20, 3.11.9-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/alpine3.20
 
 Tags: 3.11.9-alpine3.19, 3.11-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/alpine3.19
 
 Tags: 3.11.9-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022
 SharedTags: 3.11.9-windowsservercore, 3.11-windowsservercore, 3.11.9, 3.11
 Architectures: windows-amd64
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -141,7 +141,7 @@ Builder: classic
 Tags: 3.11.9-windowsservercore-1809, 3.11-windowsservercore-1809
 SharedTags: 3.11.9-windowsservercore, 3.11-windowsservercore, 3.11.9, 3.11
 Architectures: windows-amd64
-GitCommit: 290f525cf67ff5a27410408ca3b7972d46b9203f
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
@@ -149,92 +149,92 @@ Builder: classic
 Tags: 3.10.14-bookworm, 3.10-bookworm
 SharedTags: 3.10.14, 3.10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1980d7b46875e86518a0fb1fff9da4c39f5261ea
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.10/bookworm
 
 Tags: 3.10.14-slim-bookworm, 3.10-slim-bookworm, 3.10.14-slim, 3.10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1980d7b46875e86518a0fb1fff9da4c39f5261ea
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.10/slim-bookworm
 
 Tags: 3.10.14-bullseye, 3.10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1980d7b46875e86518a0fb1fff9da4c39f5261ea
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.10/bullseye
 
 Tags: 3.10.14-slim-bullseye, 3.10-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1980d7b46875e86518a0fb1fff9da4c39f5261ea
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10.14-alpine3.20, 3.10-alpine3.20, 3.10.14-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1980d7b46875e86518a0fb1fff9da4c39f5261ea
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.10/alpine3.20
 
 Tags: 3.10.14-alpine3.19, 3.10-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1980d7b46875e86518a0fb1fff9da4c39f5261ea
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.10/alpine3.19
 
 Tags: 3.9.19-bookworm, 3.9-bookworm
 SharedTags: 3.9.19, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 352e474bd8665590dc7075ceefe4624aac3228ca
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.9/bookworm
 
 Tags: 3.9.19-slim-bookworm, 3.9-slim-bookworm, 3.9.19-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 352e474bd8665590dc7075ceefe4624aac3228ca
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.9/slim-bookworm
 
 Tags: 3.9.19-bullseye, 3.9-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 352e474bd8665590dc7075ceefe4624aac3228ca
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.9/bullseye
 
 Tags: 3.9.19-slim-bullseye, 3.9-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 352e474bd8665590dc7075ceefe4624aac3228ca
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.9/slim-bullseye
 
 Tags: 3.9.19-alpine3.20, 3.9-alpine3.20, 3.9.19-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 352e474bd8665590dc7075ceefe4624aac3228ca
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.9/alpine3.20
 
 Tags: 3.9.19-alpine3.19, 3.9-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 352e474bd8665590dc7075ceefe4624aac3228ca
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.9/alpine3.19
 
 Tags: 3.8.19-bookworm, 3.8-bookworm
 SharedTags: 3.8.19, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0489af60eafa1bc93807a7e96bbd77bdc363e04
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.8/bookworm
 
 Tags: 3.8.19-slim-bookworm, 3.8-slim-bookworm, 3.8.19-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0489af60eafa1bc93807a7e96bbd77bdc363e04
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.8/slim-bookworm
 
 Tags: 3.8.19-bullseye, 3.8-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0489af60eafa1bc93807a7e96bbd77bdc363e04
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.8/bullseye
 
 Tags: 3.8.19-slim-bullseye, 3.8-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0489af60eafa1bc93807a7e96bbd77bdc363e04
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.8/slim-bullseye
 
 Tags: 3.8.19-alpine3.20, 3.8-alpine3.20, 3.8.19-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b0489af60eafa1bc93807a7e96bbd77bdc363e04
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.8/alpine3.20
 
 Tags: 3.8.19-alpine3.19, 3.8-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b0489af60eafa1bc93807a7e96bbd77bdc363e04
+GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
 Directory: 3.8/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/811625e: Merge pull request https://github.com/docker-library/python/pull/954 from infosiftr/really-no-setuptools-or-wheel
- https://github.com/docker-library/python/commit/a8ec33a: Stop installing setuptools in python 3.12+
- https://github.com/docker-library/python/commit/5ee49c2: Update 3.9 to get-pip https://github.com/pypa/get-pip/commit/def4aec84b261b939137dd1c69eff0aabb4a7bf4
- https://github.com/docker-library/python/commit/0dabaf3: Update 3.8 to get-pip https://github.com/pypa/get-pip/commit/def4aec84b261b939137dd1c69eff0aabb4a7bf4
- https://github.com/docker-library/python/commit/14e03d8: Update 3.13-rc to get-pip https://github.com/pypa/get-pip/commit/def4aec84b261b939137dd1c69eff0aabb4a7bf4
- https://github.com/docker-library/python/commit/109e83a: Update 3.12 to get-pip https://github.com/pypa/get-pip/commit/def4aec84b261b939137dd1c69eff0aabb4a7bf4
- https://github.com/docker-library/python/commit/625a0a3: Update 3.11 to get-pip https://github.com/pypa/get-pip/commit/def4aec84b261b939137dd1c69eff0aabb4a7bf4
- https://github.com/docker-library/python/commit/e84c3f7: Update 3.10 to get-pip https://github.com/pypa/get-pip/commit/def4aec84b261b939137dd1c69eff0aabb4a7bf4