### PR TITLE
archlinux: Release 20240901.0.259499

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240825.0.257728
-GitCommit: a915cdf3e8ae85bb9675c1d018151de0f86de624
-GitFetch: refs/tags/v20240825.0.257728
+Tags: latest, base, base-20240901.0.259499
+GitCommit: f59f5b268aac1459c2513e4971704dd940400260
+GitFetch: refs/tags/v20240901.0.259499
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240825.0.257728
-GitCommit: a915cdf3e8ae85bb9675c1d018151de0f86de624
-GitFetch: refs/tags/v20240825.0.257728
+Tags: base-devel, base-devel-20240901.0.259499
+GitCommit: f59f5b268aac1459c2513e4971704dd940400260
+GitFetch: refs/tags/v20240901.0.259499
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240825.0.257728
-GitCommit: a915cdf3e8ae85bb9675c1d018151de0f86de624
-GitFetch: refs/tags/v20240825.0.257728
+Tags: multilib-devel, multilib-devel-20240901.0.259499
+GitCommit: f59f5b268aac1459c2513e4971704dd940400260
+GitFetch: refs/tags/v20240901.0.259499
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks