### PR TITLE
Update Clear Linux OS to 42280

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: fad5d1c7fde5e79b117a07303cca5d8a6c4f8acb
-GitFetch: refs/heads/base-42210
+GitCommit: d6004a4ca03779b1aca721fd1376e9cfa48a414c
+GitFetch: refs/heads/base-42280


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42280

@bryteise @djklimes @bryteise