### PR TITLE
MariaDB - bug fix - healthcheck.sh

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -8,65 +8,65 @@ Builder: buildkit
 
 Tags: 11.6.1-ubi9-rc, 11.6-ubi9-rc, 11.6.1-ubi-rc, 11.6-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: b34b76eb883ea262db762517947e2cb2776f112b
+GitCommit: 275297af91e85af864e70c70ce2a650ec128db9c
 Directory: 11.6-ubi
 
 Tags: 11.6.1-noble-rc, 11.6-noble-rc, 11.6.1-rc, 11.6-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b34b76eb883ea262db762517947e2cb2776f112b
+GitCommit: 275297af91e85af864e70c70ce2a650ec128db9c
 Directory: 11.6
 
 Tags: 11.5.2-ubi9, 11.5-ubi9, 11-ubi9, 11.5.2-ubi, 11.5-ubi, 11-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: b34b76eb883ea262db762517947e2cb2776f112b
+GitCommit: 275297af91e85af864e70c70ce2a650ec128db9c
 Directory: 11.5-ubi
 
 Tags: 11.5.2-noble, 11.5-noble, 11-noble, noble, 11.5.2, 11.5, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: b34b76eb883ea262db762517947e2cb2776f112b
+GitCommit: 275297af91e85af864e70c70ce2a650ec128db9c
 Directory: 11.5
 
 Tags: 11.4.3-ubi9, 11.4-ubi9, lts-ubi9, 11.4.3-ubi, 11.4-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 11.4-ubi
 
 Tags: 11.4.3-noble, 11.4-noble, lts-noble, 11.4.3, 11.4, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 11.4
 
 Tags: 11.2.5-jammy, 11.2-jammy, 11.2.5, 11.2
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 11.2
 
 Tags: 11.1.6-jammy, 11.1-jammy, 11.1.6, 11.1
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 11.1
 
 Tags: 10.11.9-ubi9, 10.11-ubi9, 10-ubi9, 10.11.9-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 10.11-ubi
 
 Tags: 10.11.9-jammy, 10.11-jammy, 10-jammy, 10.11.9, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 10.11
 
 Tags: 10.6.19-ubi9, 10.6-ubi9, 10.6.19-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 10.6-ubi
 
 Tags: 10.6.19-focal, 10.6-focal, 10.6.19, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 10.6
 
 Tags: 10.5.26-focal, 10.5-focal, 10.5.26, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 8b9a47d0544826a8fb7c01b4308b400c3f6e529f
+GitCommit: ee80a97d5cc2fd4f8779dbfedeb8fc8c47941812
 Directory: 10.5


### PR DESCRIPTION
healthcheck.sh had some code paths where an incorrect healthy status could have been returned.

Also correct a noisy install where the messages didn't relate to the container release.