### PR TITLE
[Friendica] update 2024.09-dev

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -36,15 +36,15 @@ Directory: 2024.08/fpm-alpine
 
 Tags: 2024.09-dev-apache, dev-apache, 2024.09-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 69adf85d8791b5b149476ca7e434c17a19192767
+GitCommit: c6a6c0684a228c7915a92c5ce3a7444f12536ae3
 Directory: 2024.09-dev/apache
 
 Tags: 2024.09-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 69adf85d8791b5b149476ca7e434c17a19192767
+GitCommit: c6a6c0684a228c7915a92c5ce3a7444f12536ae3
 Directory: 2024.09-dev/fpm
 
 Tags: 2024.09-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 69adf85d8791b5b149476ca7e434c17a19192767
+GitCommit: a007cb41702e73120ce4faf2a5f1c1e9ddc296aa
 Directory: 2024.09-dev/fpm-alpine


### PR DESCRIPTION
update 2024.09-dev 
 - revert from bookworm to bullseye due to problems with dependency
