### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 54937702396000e9b7ef8494896e749ea96aa6aa
 Directory: 3.1/alpine
 
-Tags: 3.0.3, 3.0, lts, latest, 3.0.3-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.4, 3.0, lts, latest, 3.0.4-bookworm, 3.0-bookworm, lts-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: bc729b362307822861331c816b73f863332d4b11
+GitCommit: 217149de5f069af7a540918e71ba6a3d967598c1
 Directory: 3.0
 
-Tags: 3.0.3-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.3-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.4-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.4-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bc729b362307822861331c816b73f863332d4b11
+GitCommit: 217149de5f069af7a540918e71ba6a3d967598c1
 Directory: 3.0/alpine
 
-Tags: 2.9.9, 2.9, 2.9.9-bookworm, 2.9-bookworm
+Tags: 2.9.10, 2.9, 2.9.10-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e85e5b3e506be4b05de5062f27cbbd3fde03f923
+GitCommit: 9f4709d9c692b7b4ef2999cf689ba947e07e1394
 Directory: 2.9
 
-Tags: 2.9.9-alpine, 2.9-alpine, 2.9.9-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.10-alpine, 2.9-alpine, 2.9.10-alpine3.20, 2.9-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e85e5b3e506be4b05de5062f27cbbd3fde03f923
+GitCommit: 9f4709d9c692b7b4ef2999cf689ba947e07e1394
 Directory: 2.9/alpine
 
 Tags: 2.8.10, 2.8, 2.8.10-bookworm, 2.8-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/217149d: Update 3.0 to 3.0.4
- https://github.com/docker-library/haproxy/commit/9f4709d: Update 2.9 to 2.9.10