### PR TITLE
[oraclelinux] Updating 9 for ELSA-2024-6163 ELSA-2024-6166

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 91acb47147d3ee89e22741bece8f42e9e67180e2
+amd64-GitCommit: 5b4a86a64f379424f2c8de33264e63ca97649e2a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: bf6b944430798e21bd32c98c8f8a3b2016e7acc3
+arm64v8-GitCommit: 2c82af21e379d05f7d106e9a23322510b08ba3d4
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-6923, CVE-2024-37370, CVE-2024-37371, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-6163.html
https://linux.oracle.com/errata/ELSA-2024-6166.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
