### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.23.0-bookworm, 1.23-bookworm, 1-bookworm, bookworm
-SharedTags: 1.23.0, 1.23, 1, latest
+Tags: 1.23.1-bookworm, 1.23-bookworm, 1-bookworm, bookworm
+SharedTags: 1.23.1, 1.23, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/bookworm
 
-Tags: 1.23.0-bullseye, 1.23-bullseye, 1-bullseye, bullseye
+Tags: 1.23.1-bullseye, 1.23-bullseye, 1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/bullseye
 
-Tags: 1.23.0-alpine3.20, 1.23-alpine3.20, 1-alpine3.20, alpine3.20, 1.23.0-alpine, 1.23-alpine, 1-alpine, alpine
+Tags: 1.23.1-alpine3.20, 1.23-alpine3.20, 1-alpine3.20, alpine3.20, 1.23.1-alpine, 1.23-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/alpine3.20
 
-Tags: 1.23.0-alpine3.19, 1.23-alpine3.19, 1-alpine3.19, alpine3.19
+Tags: 1.23.1-alpine3.19, 1.23-alpine3.19, 1-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/alpine3.19
 
-Tags: 1.23.0-windowsservercore-ltsc2022, 1.23-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.23.0-windowsservercore, 1.23-windowsservercore, 1-windowsservercore, windowsservercore, 1.23.0, 1.23, 1, latest
+Tags: 1.23.1-windowsservercore-ltsc2022, 1.23-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.23.1-windowsservercore, 1.23-windowsservercore, 1-windowsservercore, windowsservercore, 1.23.1, 1.23, 1, latest
 Architectures: windows-amd64
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.23.0-windowsservercore-1809, 1.23-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
-SharedTags: 1.23.0-windowsservercore, 1.23-windowsservercore, 1-windowsservercore, windowsservercore, 1.23.0, 1.23, 1, latest
+Tags: 1.23.1-windowsservercore-1809, 1.23-windowsservercore-1809, 1-windowsservercore-1809, windowsservercore-1809
+SharedTags: 1.23.1-windowsservercore, 1.23-windowsservercore, 1-windowsservercore, windowsservercore, 1.23.1, 1.23, 1, latest
 Architectures: windows-amd64
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.23.0-nanoserver-ltsc2022, 1.23-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.23.0-nanoserver, 1.23-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.23.1-nanoserver-ltsc2022, 1.23-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.23.1-nanoserver, 1.23-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.23.0-nanoserver-1809, 1.23-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
-SharedTags: 1.23.0-nanoserver, 1.23-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.23.1-nanoserver-1809, 1.23-nanoserver-1809, 1-nanoserver-1809, nanoserver-1809
+SharedTags: 1.23.1-nanoserver, 1.23-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: b663973a9386bafc16023b41b0d94cc80f80cd7a
+GitCommit: 724988cd7e877c42252631f262420cc7d97abc9e
 Directory: 1.23/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 1.22.6-bookworm, 1.22-bookworm
-SharedTags: 1.22.6, 1.22
+Tags: 1.22.7-bookworm, 1.22-bookworm
+SharedTags: 1.22.7, 1.22
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/bookworm
 
-Tags: 1.22.6-bullseye, 1.22-bullseye
+Tags: 1.22.7-bullseye, 1.22-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/bullseye
 
-Tags: 1.22.6-alpine3.20, 1.22-alpine3.20, 1.22.6-alpine, 1.22-alpine
+Tags: 1.22.7-alpine3.20, 1.22-alpine3.20, 1.22.7-alpine, 1.22-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/alpine3.20
 
-Tags: 1.22.6-alpine3.19, 1.22-alpine3.19
+Tags: 1.22.7-alpine3.19, 1.22-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/alpine3.19
 
-Tags: 1.22.6-windowsservercore-ltsc2022, 1.22-windowsservercore-ltsc2022
-SharedTags: 1.22.6-windowsservercore, 1.22-windowsservercore, 1.22.6, 1.22
+Tags: 1.22.7-windowsservercore-ltsc2022, 1.22-windowsservercore-ltsc2022
+SharedTags: 1.22.7-windowsservercore, 1.22-windowsservercore, 1.22.7, 1.22
 Architectures: windows-amd64
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.22.6-windowsservercore-1809, 1.22-windowsservercore-1809
-SharedTags: 1.22.6-windowsservercore, 1.22-windowsservercore, 1.22.6, 1.22
+Tags: 1.22.7-windowsservercore-1809, 1.22-windowsservercore-1809
+SharedTags: 1.22.7-windowsservercore, 1.22-windowsservercore, 1.22.7, 1.22
 Architectures: windows-amd64
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.22.6-nanoserver-ltsc2022, 1.22-nanoserver-ltsc2022
-SharedTags: 1.22.6-nanoserver, 1.22-nanoserver
+Tags: 1.22.7-nanoserver-ltsc2022, 1.22-nanoserver-ltsc2022
+SharedTags: 1.22.7-nanoserver, 1.22-nanoserver
 Architectures: windows-amd64
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.22.6-nanoserver-1809, 1.22-nanoserver-1809
-SharedTags: 1.22.6-nanoserver, 1.22-nanoserver
+Tags: 1.22.7-nanoserver-1809, 1.22-nanoserver-1809
+SharedTags: 1.22.7-nanoserver, 1.22-nanoserver
 Architectures: windows-amd64
-GitCommit: 3187a722bf31fb8b91df2b8c929fee4af9332460
+GitCommit: 9e123d9969e8e6bd266c50ab3a44920719902c49
 Directory: 1.22/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/724988c: Update 1.23 to 1.23.1
- https://github.com/docker-library/golang/commit/9e123d9: Update 1.22 to 1.22.7
- https://github.com/docker-library/golang/commit/bb910a3: Merge pull request https://github.com/docker-library/golang/pull/530 from infosiftr/GOARM64-GORISCV64
- https://github.com/docker-library/golang/commit/8d99221: Add GOARM64 and GORISCV64 values to our `versions.json`