### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev6, 3.1-dev, 3.1-dev6-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev7, 3.1-dev, 3.1-dev7-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 54937702396000e9b7ef8494896e749ea96aa6aa
+GitCommit: e15bc9b51aa03402fbdf832e0e041ed75f70bed5
 Directory: 3.1
 
-Tags: 3.1-dev6-alpine, 3.1-dev-alpine, 3.1-dev6-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev7-alpine, 3.1-dev-alpine, 3.1-dev7-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 54937702396000e9b7ef8494896e749ea96aa6aa
+GitCommit: e15bc9b51aa03402fbdf832e0e041ed75f70bed5
 Directory: 3.1/alpine
 
 Tags: 3.0.4, 3.0, lts, latest, 3.0.4-bookworm, 3.0-bookworm, lts-bookworm, bookworm
@@ -65,6 +65,6 @@ GitCommit: c72a79f8fe0a0db91b36645220409c08d11cc0a6
 Directory: 2.4/alpine
 
 Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
 Directory: 2.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e15bc9b: Update 3.1 to 3.1-dev7