### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/3937857e971639452447a00740cbe32b08bc5dca/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/41fc6f77fbd75362dfcbeb21a32610c0eec61e28/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0-rc2, 5.0, 5, 5.0-rc2-jammy, 5.0-jammy, 5-jammy
+Tags: 5.0.0, 5.0, 5, latest, 5.0.0-jammy, 5.0-jammy, 5-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 31cced8ff8e1ba9f7d7600a8d0f41c36fb3dc8a8
+GitCommit: cb4f6acadef77048615282871fd1480aee75f193
 Directory: 5.0
 
-Tags: 4.1.6, 4.1, 4, latest, 4.1.6-jammy, 4.1-jammy, 4-jammy, jammy
+Tags: 4.1.6, 4.1, 4, 4.1.6-jammy, 4.1-jammy, 4-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 72bda687322eef86992681e21ce54bd2351c2573
 Directory: 4.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/41fc6f7: Move "latest" to 5.0
- https://github.com/docker-library/cassandra/commit/cb4f6ac: Update 5.0 to 5.0.0