### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240819.0
+Tags: 2023, latest, 2023.5.20240903.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: c29bfadba77a70adf176970bfb1f4d634c644871
+amd64-GitCommit: e3615dc9e73e50ddb9bf7bcf1fd76807878014cf
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 26976ae0b270ea4ae55c51421404208ee5112c5f
+arm64v8-GitCommit: be8956c8f811c17bf77b6cbe33d06ab1a120ad8a
 
-Tags: 2, 2.0.20240816.0
+Tags: 2, 2.0.20240903.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 11e068c308c8aaee8a9484fa2381651f101c8ec9
+amd64-GitCommit: 2433b42c5ba17a2c73fa604deece91cd73b40d56
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 614e3a1d5be715018ac29c866b3402041738ee84
+arm64v8-GitCommit: 6a90510af507dfde9368f82688afa4bcbc5ae45e
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
#### Packages addressing CVES:

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.5.20240903-0.amzn2023
- system-release-2023.5.20240903-0.amzn2023
#### Packages addressing CVES: