### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.93.0, 5.93, 5, latest
+Tags: 5.94.0, 5.94, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5236e173d960a865740b39cfb2a2a1ee5cb19375
+GitCommit: 4f86cc1e82deaf7843b8fe4086c8b3ecc5bdf3ce
 Directory: 5/debian
 
-Tags: 5.93.0-alpine, 5.93-alpine, 5-alpine, alpine
+Tags: 5.94.0-alpine, 5.94-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 5236e173d960a865740b39cfb2a2a1ee5cb19375
+GitCommit: 4f86cc1e82deaf7843b8fe4086c8b3ecc5bdf3ce
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4f86cc1: Update to 5.94.0, ghost-cli 1.26.1