### PR TITLE
 Update Jetty to 9.4.56, 10.0.23, 11.0.23 & 12.0.12

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,517 +4,367 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 9.4.55-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.55-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
+Tags: 9.4.56-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.56-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre8-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre8, 9.4-jre8, 9-jre8, 9.4.55-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
+Tags: 9.4.56-jre8, 9.4-jre8, 9-jre8, 9.4.56-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre8
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.55-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
+Tags: 9.4.56-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.56-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre21, 9.4-jre21, 9-jre21, 9.4.55-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
+Tags: 9.4.56-jre21, 9.4-jre21, 9-jre21, 9.4.56-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.55-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
+Tags: 9.4.56-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.56-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre17, 9.4-jre17, 9-jre17, 9.4.55-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
+Tags: 9.4.56-jre17, 9.4-jre17, 9-jre17, 9.4.56-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.55-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
+Tags: 9.4.56-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.56-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jre11, 9.4-jre11, 9-jre11, 9.4.55-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
+Tags: 9.4.56-jre11, 9.4-jre11, 9-jre11, 9.4.56-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk8, 9.4-jdk8, 9-jdk8, 9.4.55-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
+Tags: 9.4.56-jdk8, 9.4-jdk8, 9-jdk8, 9.4.56-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.55-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
+Tags: 9.4.56-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.56-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55, 9.4, 9, 9.4.55-jdk21, 9.4-jdk21, 9-jdk21, 9.4.55-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.55-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
+Tags: 9.4.56, 9.4, 9, 9.4.56-jdk21, 9.4-jdk21, 9-jdk21, 9.4.56-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.56-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.55-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
+Tags: 9.4.56-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.56-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk17, 9.4-jdk17, 9-jdk17, 9.4.55-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
+Tags: 9.4.56-jdk17, 9.4-jdk17, 9-jdk17, 9.4.56-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.55-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
+Tags: 9.4.56-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.56-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk11, 9.4-jdk11, 9-jdk11, 9.4.55-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
+Tags: 9.4.56-jdk11, 9.4-jdk11, 9-jdk11, 9.4.56-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.11-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.12-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.12-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jre21, 12.0-jre21, 12-jre21, 12.0.11-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.12-jre21, 12.0-jre21, 12-jre21, 12.0.12-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.11-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.12-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.12-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jre17, 12.0-jre17, 12-jre17, 12.0.11-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.12-jre17, 12.0-jre17, 12-jre17, 12.0.12-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.11-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.12-jdk22-alpine, 12.0-jdk22-alpine, 12-jdk22-alpine, 12.0.12-jdk22-alpine-eclipse-temurin, 12.0-jdk22-alpine-eclipse-temurin, 12-jdk22-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.0/jdk22-alpine
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+
+Tags: 12.0.12-jdk22, 12.0-jdk22, 12-jdk22, 12.0.12-jdk22-eclipse-temurin, 12.0-jdk22-eclipse-temurin, 12-jdk22-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.0/jdk22
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+
+Tags: 12.0.12-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.12-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11, 12.0, 12, 12.0.11-jdk21, 12.0-jdk21, 12-jdk21, 12.0.11-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.11-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.12, 12.0, 12, 12.0.12-jdk21, 12.0-jdk21, 12-jdk21, 12.0.12-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.12-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.11-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.12-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.12-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jdk17, 12.0-jdk17, 12-jdk17, 12.0.11-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.12-jdk17, 12.0-jdk17, 12-jdk17, 12.0.12-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.10-jre21-alpine, 12.0.10-jre21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/12.0.10/jre21-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10-jre21, 12.0.10-jre21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/12.0.10/jre21
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10-jre17-alpine, 12.0.10-jre17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/12.0.10/jre17-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10-jre17, 12.0.10-jre17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/12.0.10/jre17
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10-jdk21-alpine, 12.0.10-jdk21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/12.0.10/jdk21-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10, 12.0.10-jdk21, 12.0.10-eclipse-temurin, 12.0.10-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/12.0.10/jdk21
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10-jdk17-alpine, 12.0.10-jdk17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/12.0.10/jdk17-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 12.0.10-jdk17, 12.0.10-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/12.0.10/jdk17
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.22-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.22-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
+Tags: 11.0.23-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.23-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jre21, 11.0-jre21, 11-jre21, 11.0.22-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
+Tags: 11.0.23-jre21, 11.0-jre21, 11-jre21, 11.0.23-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.22-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
+Tags: 11.0.23-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.23-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jre17, 11.0-jre17, 11-jre17, 11.0.22-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
+Tags: 11.0.23-jre17, 11.0-jre17, 11-jre17, 11.0.23-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.22-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
+Tags: 11.0.23-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.23-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jre11, 11.0-jre11, 11-jre11, 11.0.22-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
+Tags: 11.0.23-jre11, 11.0-jre11, 11-jre11, 11.0.23-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.22-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
+Tags: 11.0.23-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.23-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22, 11.0, 11, 11.0.22-jdk21, 11.0-jdk21, 11-jdk21, 11.0.22-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.22-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
+Tags: 11.0.23, 11.0, 11, 11.0.23-jdk21, 11.0-jdk21, 11-jdk21, 11.0.23-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.23-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.22-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.23-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.23-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk17, 11.0-jdk17, 11-jdk17, 11.0.22-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.23-jdk17, 11.0-jdk17, 11-jdk17, 11.0.23-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.22-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.23-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.23-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk11, 11.0-jdk11, 11-jdk11, 11.0.22-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.23-jdk11, 11.0-jdk11, 11-jdk11, 11.0.23-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.21-jre21-alpine, 11.0.21-jre21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0.21/jre21-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jre21, 11.0.21-jre21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0.21/jre21
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jre17-alpine, 11.0.21-jre17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0.21/jre17-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jre17, 11.0.21-jre17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0.21/jre17
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jre11-alpine, 11.0.21-jre11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0.21/jre11-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jre11, 11.0.21-jre11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0.21/jre11
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jdk21-alpine, 11.0.21-jdk21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0.21/jdk21-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21, 11.0.21-jdk21, 11.0.21-eclipse-temurin, 11.0.21-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0.21/jdk21
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jdk17-alpine, 11.0.21-jdk17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0.21/jdk17-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jdk17, 11.0.21-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0.21/jdk17
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jdk11-alpine, 11.0.21-jdk11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0.21/jdk11-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 11.0.21-jdk11, 11.0.21-jdk11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0.21/jdk11
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.22-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.22-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
+Tags: 10.0.23-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.23-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jre21, 10.0-jre21, 10-jre21, 10.0.22-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
+Tags: 10.0.23-jre21, 10.0-jre21, 10-jre21, 10.0.23-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.22-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
+Tags: 10.0.23-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.23-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jre17, 10.0-jre17, 10-jre17, 10.0.22-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
+Tags: 10.0.23-jre17, 10.0-jre17, 10-jre17, 10.0.23-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.22-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
+Tags: 10.0.23-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.23-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jre11, 10.0-jre11, 10-jre11, 10.0.22-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
+Tags: 10.0.23-jre11, 10.0-jre11, 10-jre11, 10.0.23-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.22-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
+Tags: 10.0.23-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.23-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22, 10.0, 10, 10.0.22-jdk21, 10.0-jdk21, 10-jdk21, 10.0.22-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.22-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
+Tags: 10.0.23, 10.0, 10, 10.0.23-jdk21, 10.0-jdk21, 10-jdk21, 10.0.23-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.23-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.22-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.23-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.23-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk17, 10.0-jdk17, 10-jdk17, 10.0.22-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.23-jdk17, 10.0-jdk17, 10-jdk17, 10.0.23-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.22-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.23-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.23-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk11, 10.0-jdk11, 10-jdk11, 10.0.22-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.23-jdk11, 10.0-jdk11, 10-jdk11, 10.0.23-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.21-jre21-alpine, 10.0.21-jre21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0.21/jre21-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jre21, 10.0.21-jre21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0.21/jre21
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jre17-alpine, 10.0.21-jre17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0.21/jre17-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jre17, 10.0.21-jre17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0.21/jre17
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jre11-alpine, 10.0.21-jre11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0.21/jre11-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jre11, 10.0.21-jre11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0.21/jre11
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jdk21-alpine, 10.0.21-jdk21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0.21/jdk21-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21, 10.0.21-jdk21, 10.0.21-eclipse-temurin, 10.0.21-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0.21/jdk21
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jdk17-alpine, 10.0.21-jdk17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0.21/jdk17-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jdk17, 10.0.21-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0.21/jdk17
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jdk11-alpine, 10.0.21-jdk11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0.21/jdk11-alpine
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 10.0.21-jdk11, 10.0.21-jdk11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0.21/jdk11
-GitCommit: ca69d374a1c300d36d75973007e15ca0fd77f2e2
-
-Tags: 9.4.55-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
+Tags: 9.4.56-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
+Tags: 9.4.56-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
+Tags: 9.4.56-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.55-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
+Tags: 9.4.56-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.56-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
+Tags: 9.4.56-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
+Tags: 9.4.56-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
+Tags: 9.4.56-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 9.4.55-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
+Tags: 9.4.56-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.12-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.11-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.12-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.12-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.12-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.11-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.12-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
+Tags: 11.0.23-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.22-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
+Tags: 11.0.23-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.23-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.23-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.23-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.23-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 11.0.22-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.23-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
+Tags: 10.0.23-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.22-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
+Tags: 10.0.23-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.23-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.23-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.23-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.23-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 10.0.22-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.23-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: 65b114c0ee20b162c7df650bb1b95a0949bea68f
+GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451


### PR DESCRIPTION
 ## Update Jetty Versions
- `9.4.55` -> `9.4.56`
- `10.0.22` -> `10.0.23`
- `11.0.22` -> `11.0.23`
- `12.0.11` -> `12.0.12`

Removed the temporary tags for `10.0.21`, `11.0.21` & `12.0.10`.