### PR TITLE
library/perl: patch cpanm to use --no-lwp by default

### DIFF
--- a/library/perl
+++ b/library/perl
@@ -1,7 +1,7 @@
 Maintainers: Peter Martini <PeterCMartini@GMail.com> (@PeterMartini),
              Zak B. Elep <zakame@cpan.org> (@zakame)
 GitRepo: https://github.com/perl/docker-perl.git
-GitCommit: d78befa15ec5827f5aa5bbe4e97e7a30e7960daa
+GitCommit: fa9f0515f305a323bc34204cda600a745e901356
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 
 Tags: 5.40.0, 5.40, 5, latest, stable, 5.40.0-bookworm, 5.40-bookworm, 5-bookworm, bookworm, stable-bookworm

--- a/library/perl
+++ b/library/perl
@@ -8,94 +8,110 @@ Tags: 5.40.0, 5.40, 5, latest, stable, 5.40.0-bookworm, 5.40-bookworm, 5-bookwor
 Directory: 5.040.000-main-bookworm
 
 Tags: 5.40.0-bullseye, 5.40-bullseye, 5-bullseye, bullseye, stable-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.040.000-main-bullseye
 
 Tags: 5.40.0-slim, 5.40-slim, 5-slim, slim, stable-slim, 5.40.0-slim-bookworm, 5.40-slim-bookworm, 5-slim-bookworm, slim-bookworm, stable-slim-bookworm
 Directory: 5.040.000-slim-bookworm
 
 Tags: 5.40.0-slim-bullseye, 5.40-slim-bullseye, 5-slim-bullseye, slim-bullseye, stable-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.040.000-slim-bullseye
 
 Tags: 5.40.0-threaded, 5.40-threaded, 5-threaded, threaded, stable-threaded, 5.40.0-threaded-bookworm, 5.40-threaded-bookworm, 5-threaded-bookworm, threaded-bookworm, stable-threaded-bookworm
 Directory: 5.040.000-main,threaded-bookworm
 
 Tags: 5.40.0-threaded-bullseye, 5.40-threaded-bullseye, 5-threaded-bullseye, threaded-bullseye, stable-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.040.000-main,threaded-bullseye
 
 Tags: 5.40.0-slim-threaded, 5.40-slim-threaded, 5-slim-threaded, slim-threaded, stable-slim-threaded, 5.40.0-slim-threaded-bookworm, 5.40-slim-threaded-bookworm, 5-slim-threaded-bookworm, slim-threaded-bookworm, stable-slim-threaded-bookworm
 Directory: 5.040.000-slim,threaded-bookworm
 
 Tags: 5.40.0-slim-threaded-bullseye, 5.40-slim-threaded-bullseye, 5-slim-threaded-bullseye, slim-threaded-bullseye, stable-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.040.000-slim,threaded-bullseye
 
 Tags: 5.38.2, 5.38, 5.38.2-bookworm, 5.38-bookworm
 Directory: 5.038.002-main-bookworm
 
 Tags: 5.38.2-bullseye, 5.38-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.038.002-main-bullseye
 
 Tags: 5.38.2-slim, 5.38-slim, 5.38.2-slim-bookworm, 5.38-slim-bookworm
 Directory: 5.038.002-slim-bookworm
 
 Tags: 5.38.2-slim-bullseye, 5.38-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.038.002-slim-bullseye
 
 Tags: 5.38.2-threaded, 5.38-threaded, 5.38.2-threaded-bookworm, 5.38-threaded-bookworm
 Directory: 5.038.002-main,threaded-bookworm
 
 Tags: 5.38.2-threaded-bullseye, 5.38-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.038.002-main,threaded-bullseye
 
 Tags: 5.38.2-slim-threaded, 5.38-slim-threaded, 5.38.2-slim-threaded-bookworm, 5.38-slim-threaded-bookworm
 Directory: 5.038.002-slim,threaded-bookworm
 
 Tags: 5.38.2-slim-threaded-bullseye, 5.38-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.038.002-slim,threaded-bullseye
 
 Tags: 5.36.3, 5.36, 5.36.3-bookworm, 5.36-bookworm
 Directory: 5.036.003-main-bookworm
 
 Tags: 5.36.3-bullseye, 5.36-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.036.003-main-bullseye
 
 Tags: 5.36.3-slim, 5.36-slim, 5.36.3-slim-bookworm, 5.36-slim-bookworm
 Directory: 5.036.003-slim-bookworm
 
 Tags: 5.36.3-slim-bullseye, 5.36-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.036.003-slim-bullseye
 
 Tags: 5.36.3-threaded, 5.36-threaded, 5.36.3-threaded-bookworm, 5.36-threaded-bookworm
 Directory: 5.036.003-main,threaded-bookworm
 
 Tags: 5.36.3-threaded-bullseye, 5.36-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.036.003-main,threaded-bullseye
 
 Tags: 5.36.3-slim-threaded, 5.36-slim-threaded, 5.36.3-slim-threaded-bookworm, 5.36-slim-threaded-bookworm
 Directory: 5.036.003-slim,threaded-bookworm
 
 Tags: 5.36.3-slim-threaded-bullseye, 5.36-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.036.003-slim,threaded-bullseye
 
 Tags: 5.41.3, 5.41, devel, 5.41.3-bookworm, 5.41-bookworm, devel-bookworm
 Directory: 5.041.003-main-bookworm
 
 Tags: 5.41.3-bullseye, 5.41-bullseye, devel-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.041.003-main-bullseye
 
 Tags: 5.41.3-slim, 5.41-slim, devel-slim, 5.41.3-slim-bookworm, 5.41-slim-bookworm, devel-slim-bookworm
 Directory: 5.041.003-slim-bookworm
 
 Tags: 5.41.3-slim-bullseye, 5.41-slim-bullseye, devel-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.041.003-slim-bullseye
 
 Tags: 5.41.3-threaded, 5.41-threaded, devel-threaded, 5.41.3-threaded-bookworm, 5.41-threaded-bookworm, devel-threaded-bookworm
 Directory: 5.041.003-main,threaded-bookworm
 
 Tags: 5.41.3-threaded-bullseye, 5.41-threaded-bullseye, devel-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.041.003-main,threaded-bullseye
 
 Tags: 5.41.3-slim-threaded, 5.41-slim-threaded, devel-slim-threaded, 5.41.3-slim-threaded-bookworm, 5.41-slim-threaded-bookworm, devel-slim-threaded-bookworm
 Directory: 5.041.003-slim,threaded-bookworm
 
 Tags: 5.41.3-slim-threaded-bullseye, 5.41-slim-threaded-bullseye, devel-slim-threaded-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: 5.041.003-slim,threaded-bullseye


### PR DESCRIPTION
- Fixes https://github.com/Perl/docker-perl/pull/169 via https://github.com/Perl/docker-perl/pull/170
- Also drop `mips64le` on bullseye (per https://github.com/docker-library/official-images/pull/17486#issuecomment-2329807333