### PR TITLE
[security] Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -5,236 +5,220 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 Builder: buildkit
 
-Tags: 3.13.0rc1-bookworm, 3.13-rc-bookworm
-SharedTags: 3.13.0rc1, 3.13-rc
+Tags: 3.13.0rc2-bookworm, 3.13-rc-bookworm
+SharedTags: 3.13.0rc2, 3.13-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/bookworm
 
-Tags: 3.13.0rc1-slim-bookworm, 3.13-rc-slim-bookworm, 3.13.0rc1-slim, 3.13-rc-slim
+Tags: 3.13.0rc2-slim-bookworm, 3.13-rc-slim-bookworm, 3.13.0rc2-slim, 3.13-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/slim-bookworm
 
-Tags: 3.13.0rc1-bullseye, 3.13-rc-bullseye
+Tags: 3.13.0rc2-bullseye, 3.13-rc-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/bullseye
 
-Tags: 3.13.0rc1-slim-bullseye, 3.13-rc-slim-bullseye
+Tags: 3.13.0rc2-slim-bullseye, 3.13-rc-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/slim-bullseye
 
-Tags: 3.13.0rc1-alpine3.20, 3.13-rc-alpine3.20, 3.13.0rc1-alpine, 3.13-rc-alpine
+Tags: 3.13.0rc2-alpine3.20, 3.13-rc-alpine3.20, 3.13.0rc2-alpine, 3.13-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/alpine3.20
 
-Tags: 3.13.0rc1-alpine3.19, 3.13-rc-alpine3.19
+Tags: 3.13.0rc2-alpine3.19, 3.13-rc-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/alpine3.19
 
-Tags: 3.13.0rc1-windowsservercore-ltsc2022, 3.13-rc-windowsservercore-ltsc2022
-SharedTags: 3.13.0rc1-windowsservercore, 3.13-rc-windowsservercore, 3.13.0rc1, 3.13-rc
+Tags: 3.13.0rc2-windowsservercore-ltsc2022, 3.13-rc-windowsservercore-ltsc2022
+SharedTags: 3.13.0rc2-windowsservercore, 3.13-rc-windowsservercore, 3.13.0rc2, 3.13-rc
 Architectures: windows-amd64
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 3.13.0rc1-windowsservercore-1809, 3.13-rc-windowsservercore-1809
-SharedTags: 3.13.0rc1-windowsservercore, 3.13-rc-windowsservercore, 3.13.0rc1, 3.13-rc
+Tags: 3.13.0rc2-windowsservercore-1809, 3.13-rc-windowsservercore-1809
+SharedTags: 3.13.0rc2-windowsservercore, 3.13-rc-windowsservercore, 3.13.0rc2, 3.13-rc
 Architectures: windows-amd64
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 551060c0ee78d7a73a8b46c6234954b5760d5c74
 Directory: 3.13-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
 
-Tags: 3.12.5-bookworm, 3.12-bookworm, 3-bookworm, bookworm
-SharedTags: 3.12.5, 3.12, 3, latest
+Tags: 3.12.6-bookworm, 3.12-bookworm, 3-bookworm, bookworm
+SharedTags: 3.12.6, 3.12, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/bookworm
 
-Tags: 3.12.5-slim-bookworm, 3.12-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.12.5-slim, 3.12-slim, 3-slim, slim
+Tags: 3.12.6-slim-bookworm, 3.12-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.12.6-slim, 3.12-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/slim-bookworm
 
-Tags: 3.12.5-bullseye, 3.12-bullseye, 3-bullseye, bullseye
+Tags: 3.12.6-bullseye, 3.12-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/bullseye
 
-Tags: 3.12.5-slim-bullseye, 3.12-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.12.6-slim-bullseye, 3.12-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/slim-bullseye
 
-Tags: 3.12.5-alpine3.20, 3.12-alpine3.20, 3-alpine3.20, alpine3.20, 3.12.5-alpine, 3.12-alpine, 3-alpine, alpine
+Tags: 3.12.6-alpine3.20, 3.12-alpine3.20, 3-alpine3.20, alpine3.20, 3.12.6-alpine, 3.12-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/alpine3.20
 
-Tags: 3.12.5-alpine3.19, 3.12-alpine3.19, 3-alpine3.19, alpine3.19
+Tags: 3.12.6-alpine3.19, 3.12-alpine3.19, 3-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/alpine3.19
 
-Tags: 3.12.5-windowsservercore-ltsc2022, 3.12-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 3.12.5-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.5, 3.12, 3, latest
+Tags: 3.12.6-windowsservercore-ltsc2022, 3.12-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 3.12.6-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.6, 3.12, 3, latest
 Architectures: windows-amd64
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 3.12.5-windowsservercore-1809, 3.12-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
-SharedTags: 3.12.5-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.5, 3.12, 3, latest
+Tags: 3.12.6-windowsservercore-1809, 3.12-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+SharedTags: 3.12.6-windowsservercore, 3.12-windowsservercore, 3-windowsservercore, windowsservercore, 3.12.6, 3.12, 3, latest
 Architectures: windows-amd64
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: ceb2ec17e8c168a574d0430d394d0e05544693df
 Directory: 3.12/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
 
-Tags: 3.11.9-bookworm, 3.11-bookworm
-SharedTags: 3.11.9, 3.11
+Tags: 3.11.10-bookworm, 3.11-bookworm
+SharedTags: 3.11.10, 3.11
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 8d51c9a3687abd70a9699444a6a0a415514058df
 Directory: 3.11/bookworm
 
-Tags: 3.11.9-slim-bookworm, 3.11-slim-bookworm, 3.11.9-slim, 3.11-slim
+Tags: 3.11.10-slim-bookworm, 3.11-slim-bookworm, 3.11.10-slim, 3.11-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 8d51c9a3687abd70a9699444a6a0a415514058df
 Directory: 3.11/slim-bookworm
 
-Tags: 3.11.9-bullseye, 3.11-bullseye
+Tags: 3.11.10-bullseye, 3.11-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 8d51c9a3687abd70a9699444a6a0a415514058df
 Directory: 3.11/bullseye
 
-Tags: 3.11.9-slim-bullseye, 3.11-slim-bullseye
+Tags: 3.11.10-slim-bullseye, 3.11-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 8d51c9a3687abd70a9699444a6a0a415514058df
 Directory: 3.11/slim-bullseye
 
-Tags: 3.11.9-alpine3.20, 3.11-alpine3.20, 3.11.9-alpine, 3.11-alpine
+Tags: 3.11.10-alpine3.20, 3.11-alpine3.20, 3.11.10-alpine, 3.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 8d51c9a3687abd70a9699444a6a0a415514058df
 Directory: 3.11/alpine3.20
 
-Tags: 3.11.9-alpine3.19, 3.11-alpine3.19
+Tags: 3.11.10-alpine3.19, 3.11-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 8d51c9a3687abd70a9699444a6a0a415514058df
 Directory: 3.11/alpine3.19
 
-Tags: 3.11.9-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022
-SharedTags: 3.11.9-windowsservercore, 3.11-windowsservercore, 3.11.9, 3.11
-Architectures: windows-amd64
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
-Directory: 3.11/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-Builder: classic
-
-Tags: 3.11.9-windowsservercore-1809, 3.11-windowsservercore-1809
-SharedTags: 3.11.9-windowsservercore, 3.11-windowsservercore, 3.11.9, 3.11
-Architectures: windows-amd64
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
-Directory: 3.11/windows/windowsservercore-1809
-Constraints: windowsservercore-1809
-Builder: classic
-
-Tags: 3.10.14-bookworm, 3.10-bookworm
-SharedTags: 3.10.14, 3.10
+Tags: 3.10.15-bookworm, 3.10-bookworm
+SharedTags: 3.10.15, 3.10
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: cecac62a2c89fe28e2aca31f4ccbf799292061e0
 Directory: 3.10/bookworm
 
-Tags: 3.10.14-slim-bookworm, 3.10-slim-bookworm, 3.10.14-slim, 3.10-slim
+Tags: 3.10.15-slim-bookworm, 3.10-slim-bookworm, 3.10.15-slim, 3.10-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: cecac62a2c89fe28e2aca31f4ccbf799292061e0
 Directory: 3.10/slim-bookworm
 
-Tags: 3.10.14-bullseye, 3.10-bullseye
+Tags: 3.10.15-bullseye, 3.10-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: cecac62a2c89fe28e2aca31f4ccbf799292061e0
 Directory: 3.10/bullseye
 
-Tags: 3.10.14-slim-bullseye, 3.10-slim-bullseye
+Tags: 3.10.15-slim-bullseye, 3.10-slim-bullseye
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: cecac62a2c89fe28e2aca31f4ccbf799292061e0
 Directory: 3.10/slim-bullseye
 
-Tags: 3.10.14-alpine3.20, 3.10-alpine3.20, 3.10.14-alpine, 3.10-alpine
+Tags: 3.10.15-alpine3.20, 3.10-alpine3.20, 3.10.15-alpine, 3.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: cecac62a2c89fe28e2aca31f4ccbf799292061e0
 Directory: 3.10/alpine3.20
 
-Tags: 3.10.14-alpine3.19, 3.10-alpine3.19
+Tags: 3.10.15-alpine3.19, 3.10-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: cecac62a2c89fe28e2aca31f4ccbf799292061e0
 Directory: 3.10/alpine3.19
 
-Tags: 3.9.19-bookworm, 3.9-bookworm
-SharedTags: 3.9.19, 3.9
+Tags: 3.9.20-bookworm, 3.9-bookworm
+SharedTags: 3.9.20, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: b4ded1bb3966d489d8f98b829beb40c4eff8202d
 Directory: 3.9/bookworm
 
-Tags: 3.9.19-slim-bookworm, 3.9-slim-bookworm, 3.9.19-slim, 3.9-slim
+Tags: 3.9.20-slim-bookworm, 3.9-slim-bookworm, 3.9.20-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: b4ded1bb3966d489d8f98b829beb40c4eff8202d
 Directory: 3.9/slim-bookworm
 
-Tags: 3.9.19-bullseye, 3.9-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+Tags: 3.9.20-bullseye, 3.9-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: b4ded1bb3966d489d8f98b829beb40c4eff8202d
 Directory: 3.9/bullseye
 
-Tags: 3.9.19-slim-bullseye, 3.9-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+Tags: 3.9.20-slim-bullseye, 3.9-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: b4ded1bb3966d489d8f98b829beb40c4eff8202d
 Directory: 3.9/slim-bullseye
 
-Tags: 3.9.19-alpine3.20, 3.9-alpine3.20, 3.9.19-alpine, 3.9-alpine
+Tags: 3.9.20-alpine3.20, 3.9-alpine3.20, 3.9.20-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: b4ded1bb3966d489d8f98b829beb40c4eff8202d
 Directory: 3.9/alpine3.20
 
-Tags: 3.9.19-alpine3.19, 3.9-alpine3.19
+Tags: 3.9.20-alpine3.19, 3.9-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: b4ded1bb3966d489d8f98b829beb40c4eff8202d
 Directory: 3.9/alpine3.19
 
-Tags: 3.8.19-bookworm, 3.8-bookworm
-SharedTags: 3.8.19, 3.8
+Tags: 3.8.20-bookworm, 3.8-bookworm
+SharedTags: 3.8.20, 3.8
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 36e52f14df57eeab9efd1d4716c06810a3b968a5
 Directory: 3.8/bookworm
 
-Tags: 3.8.19-slim-bookworm, 3.8-slim-bookworm, 3.8.19-slim, 3.8-slim
+Tags: 3.8.20-slim-bookworm, 3.8-slim-bookworm, 3.8.20-slim, 3.8-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 36e52f14df57eeab9efd1d4716c06810a3b968a5
 Directory: 3.8/slim-bookworm
 
-Tags: 3.8.19-bullseye, 3.8-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+Tags: 3.8.20-bullseye, 3.8-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 36e52f14df57eeab9efd1d4716c06810a3b968a5
 Directory: 3.8/bullseye
 
-Tags: 3.8.19-slim-bullseye, 3.8-slim-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+Tags: 3.8.20-slim-bullseye, 3.8-slim-bullseye
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 36e52f14df57eeab9efd1d4716c06810a3b968a5
 Directory: 3.8/slim-bullseye
 
-Tags: 3.8.19-alpine3.20, 3.8-alpine3.20, 3.8.19-alpine, 3.8-alpine
+Tags: 3.8.20-alpine3.20, 3.8-alpine3.20, 3.8.20-alpine, 3.8-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 36e52f14df57eeab9efd1d4716c06810a3b968a5
 Directory: 3.8/alpine3.20
 
-Tags: 3.8.19-alpine3.19, 3.8-alpine3.19
+Tags: 3.8.20-alpine3.19, 3.8-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 811625e080937a4eca2055b8a31e382563e5b1a3
+GitCommit: 36e52f14df57eeab9efd1d4716c06810a3b968a5
 Directory: 3.8/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/ceb2ec1: Update 3.12 to 3.12.6
- https://github.com/docker-library/python/commit/b4ded1b: Update 3.9 to 3.9.20
- https://github.com/docker-library/python/commit/36e52f1: Update 3.8 to 3.8.20
- https://github.com/docker-library/python/commit/551060c: Update 3.13-rc to 3.13.0rc2, pip 24.2
- https://github.com/docker-library/python/commit/8d51c9a: Update 3.11 to 3.11.10
- https://github.com/docker-library/python/commit/cecac62: Update 3.10 to 3.10.15

See https://pythoninsider.blogspot.com/2024/09/python-3130rc2-3126-31110-31015-3920.html