### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2024-6464

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5b4a86a64f379424f2c8de33264e63ca97649e2a
+amd64-GitCommit: 5622119f2db6e7f825f31efccc7753c85b47cb50
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 2c82af21e379d05f7d106e9a23322510b08ba3d4
+arm64v8-GitCommit: b8761da23a42f824f2c9c2e61f8fccc085a438a5
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-34397, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-6464.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
