### PR TITLE
 Update Jetty to 10.0.24, 11.0.24 & 12.0.13

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -79,175 +79,175 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.12-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.12-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.13-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.13-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jre21, 12.0-jre21, 12-jre21, 12.0.12-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.13-jre21, 12.0-jre21, 12-jre21, 12.0.13-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.12-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.13-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.13-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jre17, 12.0-jre17, 12-jre17, 12.0.12-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.13-jre17, 12.0-jre17, 12-jre17, 12.0.13-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk22-alpine, 12.0-jdk22-alpine, 12-jdk22-alpine, 12.0.12-jdk22-alpine-eclipse-temurin, 12.0-jdk22-alpine-eclipse-temurin, 12-jdk22-alpine-eclipse-temurin
+Tags: 12.0.13-jdk22-alpine, 12.0-jdk22-alpine, 12-jdk22-alpine, 12.0.13-jdk22-alpine-eclipse-temurin, 12.0-jdk22-alpine-eclipse-temurin, 12-jdk22-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk22-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk22, 12.0-jdk22, 12-jdk22, 12.0.12-jdk22-eclipse-temurin, 12.0-jdk22-eclipse-temurin, 12-jdk22-eclipse-temurin
+Tags: 12.0.13-jdk22, 12.0-jdk22, 12-jdk22, 12.0.13-jdk22-eclipse-temurin, 12.0-jdk22-eclipse-temurin, 12-jdk22-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk22
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.12-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.13-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.13-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12, 12.0, 12, 12.0.12-jdk21, 12.0-jdk21, 12-jdk21, 12.0.12-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.12-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.13, 12.0, 12, 12.0.13-jdk21, 12.0-jdk21, 12-jdk21, 12.0.13-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.13-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.12-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.13-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.13-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk17, 12.0-jdk17, 12-jdk17, 12.0.12-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.13-jdk17, 12.0-jdk17, 12-jdk17, 12.0.13-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.23-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
+Tags: 11.0.24-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.24-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jre21, 11.0-jre21, 11-jre21, 11.0.23-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
+Tags: 11.0.24-jre21, 11.0-jre21, 11-jre21, 11.0.24-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.23-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
+Tags: 11.0.24-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.24-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jre17, 11.0-jre17, 11-jre17, 11.0.23-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
+Tags: 11.0.24-jre17, 11.0-jre17, 11-jre17, 11.0.24-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.23-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
+Tags: 11.0.24-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.24-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jre11, 11.0-jre11, 11-jre11, 11.0.23-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
+Tags: 11.0.24-jre11, 11.0-jre11, 11-jre11, 11.0.24-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.23-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
+Tags: 11.0.24-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.24-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23, 11.0, 11, 11.0.23-jdk21, 11.0-jdk21, 11-jdk21, 11.0.23-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.23-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
+Tags: 11.0.24, 11.0, 11, 11.0.24-jdk21, 11.0-jdk21, 11-jdk21, 11.0.24-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.24-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.23-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.24-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.24-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk17, 11.0-jdk17, 11-jdk17, 11.0.23-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.24-jdk17, 11.0-jdk17, 11-jdk17, 11.0.24-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.23-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.24-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.24-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk11, 11.0-jdk11, 11-jdk11, 11.0.23-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.24-jdk11, 11.0-jdk11, 11-jdk11, 11.0.24-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.23-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
+Tags: 10.0.24-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.24-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jre21, 10.0-jre21, 10-jre21, 10.0.23-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
+Tags: 10.0.24-jre21, 10.0-jre21, 10-jre21, 10.0.24-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.23-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
+Tags: 10.0.24-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.24-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jre17, 10.0-jre17, 10-jre17, 10.0.23-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
+Tags: 10.0.24-jre17, 10.0-jre17, 10-jre17, 10.0.24-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.23-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
+Tags: 10.0.24-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.24-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jre11, 10.0-jre11, 10-jre11, 10.0.23-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
+Tags: 10.0.24-jre11, 10.0-jre11, 10-jre11, 10.0.24-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.23-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
+Tags: 10.0.24-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.24-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23, 10.0, 10, 10.0.23-jdk21, 10.0-jdk21, 10-jdk21, 10.0.23-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.23-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
+Tags: 10.0.24, 10.0, 10, 10.0.24-jdk21, 10.0-jdk21, 10-jdk21, 10.0.24-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.24-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.23-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.24-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.24-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk17, 10.0-jdk17, 10-jdk17, 10.0.23-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.24-jdk17, 10.0-jdk17, 10-jdk17, 10.0.24-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.23-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.24-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.24-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk11, 10.0-jdk11, 10-jdk11, 10.0.23-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.24-jdk11, 10.0-jdk11, 10-jdk11, 10.0.24-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
 Tags: 9.4.56-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -289,82 +289,82 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.12-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.13-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.12-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.13-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.13-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.13-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 12.0.12-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.13-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
+Tags: 11.0.24-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.23-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
+Tags: 11.0.24-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.24-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.24-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.24-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.24-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 11.0.23-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.24-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
+Tags: 10.0.24-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.23-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
+Tags: 10.0.24-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.24-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.24-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.24-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.24-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 
-Tags: 10.0.23-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.24-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43


### PR DESCRIPTION
 Update Jetty Versions
- `10.0.23` -> `10.0.24`
- `11.0.23` -> `11.0.24`
- `12.0.12` -> `12.0.13`