### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/b3331332c350661ca7bbe58fa16468942c494d7b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/baf678c2aa7c72322ffe7f09df955b60a9498086/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: b3331332c350661ca7bbe58fa16468942c494d7b
+GitCommit: baf678c2aa7c72322ffe7f09df955b60a9498086
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 065fabdfa397ac19969e667cb227274b3cad25e7
+amd64-GitCommit: 5eb4e443534e093c4d8fe2b6761432430827cc95
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: cccfaa5431fc5d3b8a24f8fb18cae45c3c76e28c
+arm32v5-GitCommit: 2ebc74ddc238df4f445db98eeb18ce1752a17f75
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 23eff7229974f00b70d7620a160ef3f8ed946c5c
+arm32v6-GitCommit: f952f50fdb990288c88868e2dd4466bfee28bbfc
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: c9a54b41733f0b58984e5ac0bf23add0e337b960
+arm32v7-GitCommit: 9789898767be841976f1e28e0f89212db2de833d
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d87b6a353ab6ebdb94467bb211867d8df5674ebb
+arm64v8-GitCommit: 9df05e09b53bcc7629ec0fc93242780ad29073b8
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: f5072eea7d75771dbc7ef21b5e7a175aaa6912d9
+i386-GitCommit: cef2f29824bb353e1d13da2b52657f7645afb1ff
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 06083a4524c5b5f80edb2f093fb030bd7ec13c1a
+mips64le-GitCommit: 7daa135cc7c30a3217efdf6d42d1f3e1d603188a
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: fefd86ca74f43fd6a253ffda388351f6352fa1e1
+ppc64le-GitCommit: 083d1a17d8cc851d6d29d798ca4b1f3ee4b6b564
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 28011eb6454b9295a216951ada52f1668ab25043
+riscv64-GitCommit: 32ea9383b7ff2b818d8a206ed264d5a721b5a290
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: eddabd4d61010ca638b8d388f85d1bbc6875d404
+s390x-GitCommit: 6789229a68e5c3879f0eab31059f08466884e147
 
 Tags: 1.36.1-glibc, 1.36-glibc, 1-glibc, stable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/baf678c: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/39b9ca7: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/dd52a09: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/a2ea348: Update metadata for i386
- https://github.com/docker-library/busybox/commit/e70731d: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/a8a0a32: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/87d6fdf: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/f771196: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/bf65195: Merge pull request https://github.com/docker-library/busybox/pull/205 from infosiftr/buildroot-2024.05.3
- https://github.com/docker-library/busybox/commit/6b8f2c7: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/b9ffb18: Update buildroot to 2024.05.3