### PR TITLE
Redis CE 8.0 Milestone 1 release for Debian

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,8 +1,12 @@
-# This file was generated via https://github.com/redis/docker-library-redis/blob/d3809987c491cc61fa4f3c05ef0f4044e7fb6000/generate-stackbrew-library-mac.sh
-
-Maintainers: David Maier <david.maier@redis.com> (@dmaier-redislabs),
+Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Yossi Gottlieb <yossi@redis.com> (@yossigo)
 GitRepo: https://github.com/redis/docker-library-redis.git
+
+Tags: 8.0-M01, 8.0-M01-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: af8fe134a94d9d3ac4c696a5d8fd0096e7df6794
+GitFetch: refs/heads/release/8.0
+Directory: debian
 
 Tags: 7.4.0, 7.4, 7, latest, 7.4.0-bookworm, 7.4-bookworm, 7-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Related links:

1. https://github.com/redis/docker-library-redis/commit/8f1a23f9fd78e9d227bcc59ed43f571614151a63
2. https://github.com/redis/redis/releases/tag/8.0-m01