### PR TITLE
archlinux: Release 20240915.0.262934

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240908.0.261281
-GitCommit: fdcc9fde44035155a6f71699f842f77cbe52d526
-GitFetch: refs/tags/v20240908.0.261281
+Tags: latest, base, base-20240915.0.262934
+GitCommit: 13312789ac2639c9d02e1ef3df34d3cd7753920f
+GitFetch: refs/tags/v20240915.0.262934
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240908.0.261281
-GitCommit: fdcc9fde44035155a6f71699f842f77cbe52d526
-GitFetch: refs/tags/v20240908.0.261281
+Tags: base-devel, base-devel-20240915.0.262934
+GitCommit: 13312789ac2639c9d02e1ef3df34d3cd7753920f
+GitFetch: refs/tags/v20240915.0.262934
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240908.0.261281
-GitCommit: fdcc9fde44035155a6f71699f842f77cbe52d526
-GitFetch: refs/tags/v20240908.0.261281
+Tags: multilib-devel, multilib-devel-20240915.0.262934
+GitCommit: 13312789ac2639c9d02e1ef3df34d3cd7753920f
+GitFetch: refs/tags/v20240915.0.262934
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks