### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,72 +1,72 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/ddb351a224b4858a4af49ab6b9afa5b5f8b7296c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/c4e12e7d6bf2ea970b1474cf85bae9b7d5e84e40/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 8.0.0-rc20-noble, 8.0-rc-noble
-SharedTags: 8.0.0-rc20, 8.0-rc
+Tags: 8.0.0-noble, 8.0-noble, 8-noble, noble
+SharedTags: 8.0.0, 8.0, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: 3915e9edebe40ba57a58faca2a4a55a3cfd37d23
-Directory: 8.0-rc
+GitCommit: 0223203c85f9e026c05e4f34794f2f5dc719f9b3
+Directory: 8.0
 
-Tags: 8.0.0-rc20-windowsservercore-ltsc2022, 8.0-rc-windowsservercore-ltsc2022
-SharedTags: 8.0.0-rc20-windowsservercore, 8.0-rc-windowsservercore, 8.0.0-rc20, 8.0-rc
+Tags: 8.0.0-windowsservercore-ltsc2022, 8.0-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 8.0.0-windowsservercore, 8.0-windowsservercore, 8-windowsservercore, windowsservercore, 8.0.0, 8.0, 8, latest
 Architectures: windows-amd64
-GitCommit: 3915e9edebe40ba57a58faca2a4a55a3cfd37d23
-Directory: 8.0-rc/windows/windowsservercore-ltsc2022
+GitCommit: 0223203c85f9e026c05e4f34794f2f5dc719f9b3
+Directory: 8.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8.0.0-rc20-windowsservercore-1809, 8.0-rc-windowsservercore-1809
-SharedTags: 8.0.0-rc20-windowsservercore, 8.0-rc-windowsservercore, 8.0.0-rc20, 8.0-rc
+Tags: 8.0.0-windowsservercore-1809, 8.0-windowsservercore-1809, 8-windowsservercore-1809, windowsservercore-1809
+SharedTags: 8.0.0-windowsservercore, 8.0-windowsservercore, 8-windowsservercore, windowsservercore, 8.0.0, 8.0, 8, latest
 Architectures: windows-amd64
-GitCommit: 3915e9edebe40ba57a58faca2a4a55a3cfd37d23
-Directory: 8.0-rc/windows/windowsservercore-1809
+GitCommit: 0223203c85f9e026c05e4f34794f2f5dc719f9b3
+Directory: 8.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 8.0.0-rc20-nanoserver-ltsc2022, 8.0-rc-nanoserver-ltsc2022
-SharedTags: 8.0.0-rc20-nanoserver, 8.0-rc-nanoserver
+Tags: 8.0.0-nanoserver-ltsc2022, 8.0-nanoserver-ltsc2022, 8-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 8.0.0-nanoserver, 8.0-nanoserver, 8-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 3915e9edebe40ba57a58faca2a4a55a3cfd37d23
-Directory: 8.0-rc/windows/nanoserver-ltsc2022
+GitCommit: 0223203c85f9e026c05e4f34794f2f5dc719f9b3
+Directory: 8.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8.0.0-rc20-nanoserver-1809, 8.0-rc-nanoserver-1809
-SharedTags: 8.0.0-rc20-nanoserver, 8.0-rc-nanoserver
+Tags: 8.0.0-nanoserver-1809, 8.0-nanoserver-1809, 8-nanoserver-1809, nanoserver-1809
+SharedTags: 8.0.0-nanoserver, 8.0-nanoserver, 8-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 3915e9edebe40ba57a58faca2a4a55a3cfd37d23
-Directory: 8.0-rc/windows/nanoserver-1809
+GitCommit: 0223203c85f9e026c05e4f34794f2f5dc719f9b3
+Directory: 8.0/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 7.0.14-jammy, 7.0-jammy, 7-jammy, jammy
-SharedTags: 7.0.14, 7.0, 7, latest
+Tags: 7.0.14-jammy, 7.0-jammy, 7-jammy
+SharedTags: 7.0.14, 7.0, 7
 Architectures: amd64, arm64v8
 GitCommit: c738ec82e4036ccc7269415b221e6bf6313cc77a
 Directory: 7.0
 
-Tags: 7.0.14-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022, 7-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 7.0.14-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, windowsservercore, 7.0.14, 7.0, 7, latest
+Tags: 7.0.14-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022, 7-windowsservercore-ltsc2022
+SharedTags: 7.0.14-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.14, 7.0, 7
 Architectures: windows-amd64
 GitCommit: f026329ba338f77401005d637716572837102972
 Directory: 7.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 7.0.14-windowsservercore-1809, 7.0-windowsservercore-1809, 7-windowsservercore-1809, windowsservercore-1809
-SharedTags: 7.0.14-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, windowsservercore, 7.0.14, 7.0, 7, latest
+Tags: 7.0.14-windowsservercore-1809, 7.0-windowsservercore-1809, 7-windowsservercore-1809
+SharedTags: 7.0.14-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.14, 7.0, 7
 Architectures: windows-amd64
 GitCommit: f026329ba338f77401005d637716572837102972
 Directory: 7.0/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 7.0.14-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 7.0.14-nanoserver, 7.0-nanoserver, 7-nanoserver, nanoserver
+Tags: 7.0.14-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7-nanoserver-ltsc2022
+SharedTags: 7.0.14-nanoserver, 7.0-nanoserver, 7-nanoserver
 Architectures: windows-amd64
 GitCommit: c738ec82e4036ccc7269415b221e6bf6313cc77a
 Directory: 7.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 7.0.14-nanoserver-1809, 7.0-nanoserver-1809, 7-nanoserver-1809, nanoserver-1809
-SharedTags: 7.0.14-nanoserver, 7.0-nanoserver, 7-nanoserver, nanoserver
+Tags: 7.0.14-nanoserver-1809, 7.0-nanoserver-1809, 7-nanoserver-1809
+SharedTags: 7.0.14-nanoserver, 7.0-nanoserver, 7-nanoserver
 Architectures: windows-amd64
 GitCommit: c738ec82e4036ccc7269415b221e6bf6313cc77a
 Directory: 7.0/windows/nanoserver-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/c4e12e7: Update "latest" to point to 8.0 (now GA)
- https://github.com/docker-library/mongo/commit/bd5b8f9: Update 8.0-rc
- https://github.com/docker-library/mongo/commit/0223203: Update 8.0 to 8.0.0
- https://github.com/docker-library/mongo/commit/7fd580d: Map both ways ("8.0" -> "8.0-rc" and "8.0-rc" -> "8.0") so that we don't lose versions