### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev7, 3.1-dev, 3.1-dev7-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev8, 3.1-dev, 3.1-dev8-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e15bc9b51aa03402fbdf832e0e041ed75f70bed5
+GitCommit: 33bccb3231f8b94b0781a35bfe38542d8e2792c9
 Directory: 3.1
 
-Tags: 3.1-dev7-alpine, 3.1-dev-alpine, 3.1-dev7-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev8-alpine, 3.1-dev-alpine, 3.1-dev8-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e15bc9b51aa03402fbdf832e0e041ed75f70bed5
+GitCommit: 33bccb3231f8b94b0781a35bfe38542d8e2792c9
 Directory: 3.1/alpine
 
-Tags: 3.0.4, 3.0, lts, latest, 3.0.4-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.5, 3.0, lts, latest, 3.0.5-bookworm, 3.0-bookworm, lts-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 217149de5f069af7a540918e71ba6a3d967598c1
+GitCommit: 43e0f19fb557ead37a57f8d5fe8664eb25bffdc8
 Directory: 3.0
 
-Tags: 3.0.4-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.4-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.5-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.5-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 217149de5f069af7a540918e71ba6a3d967598c1
+GitCommit: 43e0f19fb557ead37a57f8d5fe8664eb25bffdc8
 Directory: 3.0/alpine
 
-Tags: 2.9.10, 2.9, 2.9.10-bookworm, 2.9-bookworm
+Tags: 2.9.11, 2.9, 2.9.11-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9f4709d9c692b7b4ef2999cf689ba947e07e1394
+GitCommit: 89dbd2e4a131058bb919f0c3442c57033147c242
 Directory: 2.9
 
-Tags: 2.9.10-alpine, 2.9-alpine, 2.9.10-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.11-alpine, 2.9-alpine, 2.9.11-alpine3.20, 2.9-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9f4709d9c692b7b4ef2999cf689ba947e07e1394
+GitCommit: 89dbd2e4a131058bb919f0c3442c57033147c242
 Directory: 2.9/alpine
 
-Tags: 2.8.10, 2.8, 2.8.10-bookworm, 2.8-bookworm
+Tags: 2.8.11, 2.8, 2.8.11-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 01b3b0d48c75a815148d46ae86b409507e232e1c
+GitCommit: 5b8b4056b3fb808eb70f9109eb1ca44ae4514247
 Directory: 2.8
 
-Tags: 2.8.10-alpine, 2.8-alpine, 2.8.10-alpine3.20, 2.8-alpine3.20
+Tags: 2.8.11-alpine, 2.8-alpine, 2.8.11-alpine3.20, 2.8-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 01b3b0d48c75a815148d46ae86b409507e232e1c
+GitCommit: 5b8b4056b3fb808eb70f9109eb1ca44ae4514247
 Directory: 2.8/alpine
 
-Tags: 2.6.18, 2.6, 2.6.18-bookworm, 2.6-bookworm
+Tags: 2.6.19, 2.6, 2.6.19-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af88bbc9186ea2ea09fa59dc77ae9437cad687b4
+GitCommit: 104fd7474379429fd5ad8e23c340eede93736010
 Directory: 2.6
 
-Tags: 2.6.18-alpine, 2.6-alpine, 2.6.18-alpine3.20, 2.6-alpine3.20
+Tags: 2.6.19-alpine, 2.6-alpine, 2.6.19-alpine3.20, 2.6-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: af88bbc9186ea2ea09fa59dc77ae9437cad687b4
+GitCommit: 104fd7474379429fd5ad8e23c340eede93736010
 Directory: 2.6/alpine
 
 Tags: 2.4.27, 2.4, 2.4.27-bookworm, 2.4-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/43e0f19: Update 3.0 to 3.0.5
- https://github.com/docker-library/haproxy/commit/89dbd2e: Update 2.9 to 2.9.11
- https://github.com/docker-library/haproxy/commit/5b8b405: Update 2.8 to 2.8.11
- https://github.com/docker-library/haproxy/commit/104fd74: Update 2.6 to 2.6.19
- https://github.com/docker-library/haproxy/commit/33bccb3: Update 3.1 to 3.1-dev8