### PR TITLE
Update Redis Versions List & Entrypoint Implementation for 8.0

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -28,16 +28,6 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5f08363e6d64b97a0c2e651f4bdcec6e71a32ab4
 Directory: 7.2/alpine
 
-Tags: 7.0.15, 7.0, 7.0.15-bookworm, 7.0-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f08363e6d64b97a0c2e651f4bdcec6e71a32ab4
-Directory: 7.0/debian
-
-Tags: 7.0.15-alpine, 7.0-alpine, 7.0.15-alpine3.20, 7.0-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5f08363e6d64b97a0c2e651f4bdcec6e71a32ab4
-Directory: 7.0/alpine
-
 Tags: 6.2.14, 6.2, 6, 6.2.14-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 5f08363e6d64b97a0c2e651f4bdcec6e71a32ab4

--- a/library/redis
+++ b/library/redis
@@ -4,7 +4,7 @@ GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.0-M01, 8.0-M01-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af8fe134a94d9d3ac4c696a5d8fd0096e7df6794
+GitCommit: 1b88507c82861395a5c1b354baab795c73c051e3
 GitFetch: refs/heads/release/8.0
 Directory: debian
 


### PR DESCRIPTION
- Removal of Redis 7.0.
- Replace usage of `eval` with `exec` in the entrypoint script to avoid the risk of arbitrary code execution.

Relates to:
- https://github.com/docker-library/official-images/pull/17549#pullrequestreview-2310314318
- https://github.com/docker-library/official-images/pull/17549#issuecomment-2356427812