### PR TITLE
Bump Traefik to v2.11.10 and v3.1.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 0924e39ed52da16232acdaeb3df49a7298b70f3d
 Directory: v3.1/alpine
 
-Tags: v2.11.9-windowsservercore-ltsc2022, 2.11.9-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.10-windowsservercore-ltsc2022, 2.11.10-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ef3b4ae57d284fbfc4253e735cc6206b490a5fa6
+GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.9-windowsservercore-1809, 2.11.9-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.10-windowsservercore-1809, 2.11.10-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ef3b4ae57d284fbfc4253e735cc6206b490a5fa6
+GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.9-nanoserver-ltsc2022, 2.11.9-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.10-nanoserver-ltsc2022, 2.11.10-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ef3b4ae57d284fbfc4253e735cc6206b490a5fa6
+GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.9, 2.11.9, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.10, 2.11.10, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: ef3b4ae57d284fbfc4253e735cc6206b490a5fa6
+GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.1.3-windowsservercore-ltsc2022, 3.1.3-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.1.4-windowsservercore-ltsc2022, 3.1.4-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0924e39ed52da16232acdaeb3df49a7298b70f3d
+GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
 Directory: v3.1/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.1.3-windowsservercore-1809, 3.1.3-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
+Tags: v3.1.4-windowsservercore-1809, 3.1.4-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0924e39ed52da16232acdaeb3df49a7298b70f3d
+GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
 Directory: v3.1/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.1.3-nanoserver-ltsc2022, 3.1.3-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.1.4-nanoserver-ltsc2022, 3.1.4-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0924e39ed52da16232acdaeb3df49a7298b70f3d
+GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
 Directory: v3.1/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.1.3, 3.1.3, v3.1, 3.1, v3, 3, comte, latest
+Tags: v3.1.4, 3.1.4, v3.1, 3.1, v3, 3, comte, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0924e39ed52da16232acdaeb3df49a7298b70f3d
+GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
 Directory: v3.1/alpine
 
 Tags: v2.11.10-windowsservercore-ltsc2022, 2.11.10-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.10](https://github.com/traefik/traefik/releases/tag/v2.11.10) and [v3.1.4](https://github.com/traefik/traefik/releases/tag/v3.1.4).

/cc @kevinpollet @mmatur @rtribotte

Cheers
