### PR TITLE
Update ALT Linux - 20240920

### DIFF
--- a/library/alt
+++ b/library/alt
@@ -7,7 +7,7 @@ GitRepo: https://github.com/alt-cloud/docker-brew-alt.git
 Tags: p10, latest
 Architectures: amd64, i386, arm64v8
 GitFetch: refs/heads/p10
-GitCommit: 924b51de1708a3c8b0dd76193a414460ff721c35
+GitCommit: 2b0521341f04c191ddc8ae2c61f87c13ce4c4c83
 amd64-Directory: x86_64/
 i386-Directory: i586/
 arm64v8-Directory: aarch64/
@@ -15,7 +15,7 @@ arm64v8-Directory: aarch64/
 Tags: sisyphus
 Architectures: amd64, i386, arm64v8
 GitFetch: refs/heads/sisyphus
-GitCommit: fc69e420b7b8c5b62cd3d8b13562f122ecdcc2d7
+GitCommit: 0094deef5ac8e3d66a7f57dcf4377165adf033cb
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 i386-Directory: i586/
@@ -23,7 +23,7 @@ i386-Directory: i586/
 Tags: p11
 Architectures: amd64, i386, arm64v8
 GitFetch: refs/heads/p11
-GitCommit: 342757f6f3ca8c82bb6a4169ceef071ff3a8a879
+GitCommit: be88d3c5797a8e00da1665691317d17b352502bf
 amd64-Directory: x86_64/
 arm64v8-Directory: aarch64/
 i386-Directory: i586/


### PR DESCRIPTION
besides, added our own llicense label on stable branches and gpl label - on devel branch.