### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2024-6783 ELSA-2024-6754

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5622119f2db6e7f825f31efccc7753c85b47cb50
+amd64-GitCommit: 6facd30e53cb2967bee862e8427b6bd6a4fba612
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b8761da23a42f824f2c9c2e61f8fccc085a438a5
+arm64v8-GitCommit: e0bbbe48efa9b15b75f3aa342bd1292a21aca147
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-6119, CVE-2024-45490, CVE-2024-45491, CVE-2024-45492, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-6783.html
https://linux.oracle.com/errata/ELSA-2024-6754.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
