### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240903.0
+Tags: 2023, latest, 2023.5.20240916.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: e3615dc9e73e50ddb9bf7bcf1fd76807878014cf
+amd64-GitCommit: 215cb518a78daaff3c2ff87096374e3ff4965cdb
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: be8956c8f811c17bf77b6cbe33d06ab1a120ad8a
+arm64v8-GitCommit: beaf864c7d0cd231f9052c47f8681476eedcff31
 
-Tags: 2, 2.0.20240903.0
+Tags: 2, 2.0.20240916.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 2433b42c5ba17a2c73fa604deece91cd73b40d56
+amd64-GitCommit: a276974e820cdbd9d3d39b1751da73192ea91647
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 6a90510af507dfde9368f82688afa4bcbc5ae45e
+arm64v8-GitCommit: d9c716eed1aecb85deff1f17b185457db0ebb14d
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Hello

This commit updates AL2 tags and packages on AL2023 containers.

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.5.20240916-0.amzn2023
- system-release-2023.5.20240916-0.amzn2023

Thanks!
