### PR TITLE
[oraclelinux] Updating 8 for ELSA-2024-6989 ELSA-2024-6975

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6facd30e53cb2967bee862e8427b6bd6a4fba612
+amd64-GitCommit: 7dc52a5a72593f896ed9f7c27062a4dda8466196
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e0bbbe48efa9b15b75f3aa342bd1292a21aca147
+arm64v8-GitCommit: ae0e107e071cef8f906f0205e4dcb9609b66896a
 
 Tags: 9
 Architectures: amd64, arm64v8
@@ -16,10 +16,6 @@ Directory: 9
 Tags: 9-slim
 Architectures: amd64, arm64v8
 Directory: 9-slim
-
-Tags: 9-slim-fips
-Architectures: amd64, arm64v8
-Directory: 9-slim-fips
 
 Tags: 8.10, 8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-45490, CVE-2024-45491, CVE-2024-45492, CVE-2024-4032, CVE-2024-6232, CVE-2024-6923, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-6989.html
https://linux.oracle.com/errata/ELSA-2024-6975.html

Signed-off-by: Mark Will <mark.will@oracle.com>
