### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.94.2, 5.94, 5, latest
+Tags: 5.95.0, 5.95, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b86225e695d887e1b00c576df562532eba7dbb9d
+GitCommit: f574787d1c2f2ccbd3336c830c5d6d08126f7aac
 Directory: 5/debian
 
-Tags: 5.94.2-alpine, 5.94-alpine, 5-alpine, alpine
+Tags: 5.95.0-alpine, 5.95-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: b86225e695d887e1b00c576df562532eba7dbb9d
+GitCommit: f574787d1c2f2ccbd3336c830c5d6d08126f7aac
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/f574787: Update to 5.95.0, ghost-cli 1.26.1