### PR TITLE
archlinux: Release 20240929.0.266368

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240922.0.264758
-GitCommit: 9a0955646d23fb74b5dd3e60a2340fa9a1c80024
-GitFetch: refs/tags/v20240922.0.264758
+Tags: latest, base, base-20240929.0.266368
+GitCommit: 460eea4ccb705612cfd80eadeefd16e0ab524dbc
+GitFetch: refs/tags/v20240929.0.266368
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240922.0.264758
-GitCommit: 9a0955646d23fb74b5dd3e60a2340fa9a1c80024
-GitFetch: refs/tags/v20240922.0.264758
+Tags: base-devel, base-devel-20240929.0.266368
+GitCommit: 460eea4ccb705612cfd80eadeefd16e0ab524dbc
+GitFetch: refs/tags/v20240929.0.266368
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240922.0.264758
-GitCommit: 9a0955646d23fb74b5dd3e60a2340fa9a1c80024
-GitFetch: refs/tags/v20240922.0.264758
+Tags: multilib-devel, multilib-devel-20240929.0.266368
+GitCommit: 460eea4ccb705612cfd80eadeefd16e0ab524dbc
+GitFetch: refs/tags/v20240929.0.266368
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks