### PR TITLE
Update Clear Linux OS to 42410

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c7cf331012789f817ed8c3f7fbf6f26c9f0b9876
-GitFetch: refs/heads/base-42390
+GitCommit: 36f7744256f01cfa1b0a90fb6999d3f7507af979
+GitFetch: refs/heads/base-42410


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42410

@bryteise @djklimes @bryteise