### PR TITLE
MediaWiki 1.42.3 / 1.41.4 / 1.39.10 security releases

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,38 +3,38 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: b3b4ecdcb503a180b1f5052b04963a0fb93f6611
+GitCommit: 0b41a035fabebeda3d6b4ccc39e2c5fc3ce1cc19
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version
-Tags: 1.42.1, 1.42, stable, latest
+Tags: 1.42.3, 1.42, stable, latest
 Directory: 1.42/apache
 
-Tags: 1.42.1-fpm, 1.42-fpm, stable-fpm
+Tags: 1.42.3-fpm, 1.42-fpm, stable-fpm
 Directory: 1.42/fpm
 
-Tags: 1.42.1-fpm-alpine, 1.42-fpm-alpine, stable-fpm-alpine
+Tags: 1.42.3-fpm-alpine, 1.42-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.42/fpm-alpine
 
 # current legacy versions
-Tags: 1.41.2, 1.41, legacy
+Tags: 1.41.4, 1.41, legacy
 Directory: 1.41/apache
 
-Tags: 1.41.2-fpm, 1.41-fpm, legacy-fpm
+Tags: 1.41.4-fpm, 1.41-fpm, legacy-fpm
 Directory: 1.41/fpm
 
-Tags: 1.41.2-fpm-alpine, 1.41-fpm-alpine, legacy-fpm-alpine
+Tags: 1.41.4-fpm-alpine, 1.41-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.41/fpm-alpine
 
 # current lts version
-Tags: 1.39.8, 1.39, lts
+Tags: 1.39.10, 1.39, lts
 Directory: 1.39/apache
 
-Tags: 1.39.8-fpm, 1.39-fpm, lts-fpm
+Tags: 1.39.10-fpm, 1.39-fpm, lts-fpm
 Directory: 1.39/fpm
 
-Tags: 1.39.8-fpm-alpine, 1.39-fpm-alpine, lts-fpm-alpine
+Tags: 1.39.10-fpm-alpine, 1.39-fpm-alpine, lts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.39/fpm-alpine


### PR DESCRIPTION
See https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/BXVG7SF3DTZTPOENKXEKWC3ZEOHS4NTG/ for the maling list announcement. We're skipping one version as there has been a previous release (just a few hours before) with a wrongly backported security fix (see the announcment for details).

Related to https://github.com/wikimedia/mediawiki-docker/pull/148

Signed-off-by: Christian Heusel <christian@heusel.eu>
