### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -1,6 +1,6 @@
 Maintainers: Paul Tagliamonte <paultag@hylang.org> (@paultag), Hy Docker Team (@hylang/docker)
 GitRepo: https://github.com/hylang/docker-hylang.git
-GitCommit: 812de70d97ec447d05474cdf2ad053163b791bdd
+GitCommit: acccd69f30d10a810b607d67426a35477db24adb
 Directory: dockerfiles-generated
 
 Tags: 1.0.0-python3.12-bookworm, 1.0-python3.12-bookworm, 1-python3.12-bookworm, python3.12-bookworm, 1.0.0-bookworm, 1.0-bookworm, 1-bookworm, bookworm
@@ -9,7 +9,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.12-bookworm
 
 Tags: 1.0.0-python3.12-bullseye, 1.0-python3.12-bullseye, 1-python3.12-bullseye, python3.12-bullseye, 1.0.0-bullseye, 1.0-bullseye, 1-bullseye, bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.12-bullseye
 
 Tags: 1.0.0-python3.12-alpine3.20, 1.0-python3.12-alpine3.20, 1-python3.12-alpine3.20, python3.12-alpine3.20, 1.0.0-alpine3.20, 1.0-alpine3.20, 1-alpine3.20, alpine3.20, 1.0.0-python3.12-alpine, 1.0-python3.12-alpine, 1-python3.12-alpine, python3.12-alpine, 1.0.0-alpine, 1.0-alpine, 1-alpine, alpine
@@ -38,7 +38,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.11-bookworm
 
 Tags: 1.0.0-python3.11-bullseye, 1.0-python3.11-bullseye, 1-python3.11-bullseye, python3.11-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.11-bullseye
 
 Tags: 1.0.0-python3.11-alpine3.20, 1.0-python3.11-alpine3.20, 1-python3.11-alpine3.20, python3.11-alpine3.20, 1.0.0-python3.11-alpine, 1.0-python3.11-alpine, 1-python3.11-alpine, python3.11-alpine
@@ -55,7 +55,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.10-bookworm
 
 Tags: 1.0.0-python3.10-bullseye, 1.0-python3.10-bullseye, 1-python3.10-bullseye, python3.10-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.10-bullseye
 
 Tags: 1.0.0-python3.10-alpine3.20, 1.0-python3.10-alpine3.20, 1-python3.10-alpine3.20, python3.10-alpine3.20, 1.0.0-python3.10-alpine, 1.0-python3.10-alpine, 1-python3.10-alpine, python3.10-alpine
@@ -72,7 +72,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.9-bookworm
 
 Tags: 1.0.0-python3.9-bullseye, 1.0-python3.9-bullseye, 1-python3.9-bullseye, python3.9-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.9-bullseye
 
 Tags: 1.0.0-python3.9-alpine3.20, 1.0-python3.9-alpine3.20, 1-python3.9-alpine3.20, python3.9-alpine3.20, 1.0.0-python3.9-alpine, 1.0-python3.9-alpine, 1-python3.9-alpine, python3.9-alpine
@@ -89,7 +89,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 File: Dockerfile.python3.8-bookworm
 
 Tags: 1.0.0-python3.8-bullseye, 1.0-python3.8-bullseye, 1-python3.8-bullseye, python3.8-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.8-bullseye
 
 Tags: 1.0.0-python3.8-alpine3.20, 1.0-python3.8-alpine3.20, 1-python3.8-alpine3.20, python3.8-alpine3.20, 1.0.0-python3.8-alpine, 1.0-python3.8-alpine, 1-python3.8-alpine, python3.8-alpine
@@ -106,7 +106,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 File: Dockerfile.python3.13-rc-bookworm
 
 Tags: 1.0.0-python3.13-rc-bullseye, 1.0-python3.13-rc-bullseye, 1-python3.13-rc-bullseye, python3.13-rc-bullseye
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.13-rc-bullseye
 
 Tags: 1.0.0-python3.13-rc-alpine3.20, 1.0-python3.13-rc-alpine3.20, 1-python3.13-rc-alpine3.20, python3.13-rc-alpine3.20, 1.0.0-python3.13-rc-alpine, 1.0-python3.13-rc-alpine, 1-python3.13-rc-alpine, python3.13-rc-alpine


### PR DESCRIPTION
Changes:

- https://github.com/hylang/docker-hylang/commit/acccd69: Remove unsupported bullseye architectures (see Debian LTS)