### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/41679683d8bdf995d53318bef2e34e328239eace/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/9e96b4488a3289a74cee97dae955dfe03aece0ad/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.6.2-php8.1-apache, 6.6-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.6.2-php8.1, 6.6-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.1/apache
 
 Tags: 6.6.2-php8.1-fpm, 6.6-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.1/fpm
 
 Tags: 6.6.2-php8.1-fpm-alpine, 6.6-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.1/fpm-alpine
 
 Tags: 6.6.2-apache, 6.6-apache, 6-apache, apache, 6.6.2, 6.6, 6, latest, 6.6.2-php8.2-apache, 6.6-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.6.2-php8.2, 6.6-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.2/apache
 
 Tags: 6.6.2-fpm, 6.6-fpm, 6-fpm, fpm, 6.6.2-php8.2-fpm, 6.6-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.2/fpm
 
 Tags: 6.6.2-fpm-alpine, 6.6-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.6.2-php8.2-fpm-alpine, 6.6-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.2/fpm-alpine
 
 Tags: 6.6.2-php8.3-apache, 6.6-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.6.2-php8.3, 6.6-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.3/apache
 
 Tags: 6.6.2-php8.3-fpm, 6.6-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.3/fpm
 
 Tags: 6.6.2-php8.3-fpm-alpine, 6.6-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
+GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
 Directory: latest/php8.3/fpm-alpine
 
 Tags: cli-2.11.0-php8.1, cli-2.11-php8.1, cli-2-php8.1, cli-php8.1
@@ -63,3 +63,48 @@ Tags: cli-2.11.0-php8.3, cli-2.11-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
 Directory: cli/php8.3/alpine
+
+Tags: beta-6.7-beta1-php8.1-apache, beta-6.7-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.7-beta1-php8.1, beta-6.7-php8.1, beta-6-php8.1, beta-php8.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.1/apache
+
+Tags: beta-6.7-beta1-php8.1-fpm, beta-6.7-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.1/fpm
+
+Tags: beta-6.7-beta1-php8.1-fpm-alpine, beta-6.7-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.1/fpm-alpine
+
+Tags: beta-6.7-beta1-apache, beta-6.7-apache, beta-6-apache, beta-apache, beta-6.7-beta1, beta-6.7, beta-6, beta, beta-6.7-beta1-php8.2-apache, beta-6.7-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.7-beta1-php8.2, beta-6.7-php8.2, beta-6-php8.2, beta-php8.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.2/apache
+
+Tags: beta-6.7-beta1-fpm, beta-6.7-fpm, beta-6-fpm, beta-fpm, beta-6.7-beta1-php8.2-fpm, beta-6.7-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.2/fpm
+
+Tags: beta-6.7-beta1-fpm-alpine, beta-6.7-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.7-beta1-php8.2-fpm-alpine, beta-6.7-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.2/fpm-alpine
+
+Tags: beta-6.7-beta1-php8.3-apache, beta-6.7-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.7-beta1-php8.3, beta-6.7-php8.3, beta-6-php8.3, beta-php8.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.3/apache
+
+Tags: beta-6.7-beta1-php8.3-fpm, beta-6.7-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.3/fpm
+
+Tags: beta-6.7-beta1-php8.3-fpm-alpine, beta-6.7-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: bd76dc3a667476fb94b7e6d10cfafb0aba40cc38
+Directory: beta/php8.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/bd76dc3: Update beta to 6.7-beta1
- https://github.com/docker-library/wordpress/commit/9e96b44: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates
- https://github.com/docker-library/wordpress/commit/d6690c7: Resync wp-config comments with upstream