### PR TITLE
Bump Traefik to v3.2.0-rc1, v3.1.5, and v2.11.11

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,56 +27,56 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
 Directory: v3.2/alpine
 
-Tags: v3.1.4-windowsservercore-ltsc2022, 3.1.4-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.1.5-windowsservercore-ltsc2022, 3.1.5-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
+GitCommit: 67a97158e005ef8f2bcbb1b3effe4130b40cdb9a
 Directory: v3.1/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.1.4-windowsservercore-1809, 3.1.4-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
+Tags: v3.1.5-windowsservercore-1809, 3.1.5-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, comte-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
+GitCommit: 67a97158e005ef8f2bcbb1b3effe4130b40cdb9a
 Directory: v3.1/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.1.4-nanoserver-ltsc2022, 3.1.4-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.1.5-nanoserver-ltsc2022, 3.1.5-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
+GitCommit: 67a97158e005ef8f2bcbb1b3effe4130b40cdb9a
 Directory: v3.1/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.1.4, 3.1.4, v3.1, 3.1, v3, 3, comte, latest
+Tags: v3.1.5, 3.1.5, v3.1, 3.1, v3, 3, comte, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 5070edb25b03cca6802d75d5037576c840f73fdd
+GitCommit: 67a97158e005ef8f2bcbb1b3effe4130b40cdb9a
 Directory: v3.1/alpine
 
-Tags: v2.11.10-windowsservercore-ltsc2022, 2.11.10-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.11-windowsservercore-ltsc2022, 2.11.11-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
+GitCommit: 21f91bdf061ed2e36abf6182da7b8d264758df33
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.10-windowsservercore-1809, 2.11.10-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.11-windowsservercore-1809, 2.11.11-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
+GitCommit: 21f91bdf061ed2e36abf6182da7b8d264758df33
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.10-nanoserver-ltsc2022, 2.11.10-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.11-nanoserver-ltsc2022, 2.11.11-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
+GitCommit: 21f91bdf061ed2e36abf6182da7b8d264758df33
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.10, 2.11.10, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.11, 2.11.11, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: b5c6d99645bdb2ef48676f84b0efa6e8f3dd3226
+GitCommit: 21f91bdf061ed2e36abf6182da7b8d264758df33
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,32 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
+Tags: v3.2.0-rc1-windowsservercore-ltsc2022, 3.2.0-rc1-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+Directory: v3.2/windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: v3.2.0-rc1-windowsservercore-1809, 3.2.0-rc1-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+Directory: v3.2/windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v3.2.0-rc1-nanoserver-ltsc2022, 3.2.0-rc1-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+Directory: v3.2/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: v3.2.0-rc1, 3.2.0-rc1, v3.2, 3.2, munster
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+Directory: v3.2/alpine
+
 Tags: v3.1.4-windowsservercore-ltsc2022, 3.1.4-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.2.0-rc1](https://github.com/traefik/traefik/releases/tag/v3.2.0-rc1), [v3.1.5](https://github.com/traefik/traefik/releases/tag/v3.1.5), and [v2.11.11](https://github.com/traefik/traefik/releases/tag/v2.11.11).

/cc @mmatur @kevinpollet

Cheers
