### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev8, 3.1-dev, 3.1-dev8-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev9, 3.1-dev, 3.1-dev9-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 33bccb3231f8b94b0781a35bfe38542d8e2792c9
+GitCommit: e93b3588a6cc0f2eb19412e54de7e741b50f734b
 Directory: 3.1
 
-Tags: 3.1-dev8-alpine, 3.1-dev-alpine, 3.1-dev8-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev9-alpine, 3.1-dev-alpine, 3.1-dev9-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 33bccb3231f8b94b0781a35bfe38542d8e2792c9
+GitCommit: e93b3588a6cc0f2eb19412e54de7e741b50f734b
 Directory: 3.1/alpine
 
 Tags: 3.0.5, 3.0, lts, latest, 3.0.5-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e93b358: Update 3.1 to 3.1-dev9
- https://github.com/docker-library/haproxy/commit/30dfd20: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates