### PR TITLE
chore(rust): Remove unsupported bullseye architectures

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/a1d3d373229185bf5d1ae5d31db0581e2d351182/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/63f877a36f8ba9d9b4b35cd49df3327264510886/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
 Tags: 1-bullseye, 1.81-bullseye, 1.81.0-bullseye, bullseye
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1d3d373229185bf5d1ae5d31db0581e2d351182
-Directory: 1.81.0/bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 63f877a36f8ba9d9b4b35cd49df3327264510886
+Directory: stable/bullseye
 
 Tags: 1-slim-bullseye, 1.81-slim-bullseye, 1.81.0-slim-bullseye, slim-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1d3d373229185bf5d1ae5d31db0581e2d351182
-Directory: 1.81.0/bullseye/slim
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 63f877a36f8ba9d9b4b35cd49df3327264510886
+Directory: stable/bullseye/slim
 
 Tags: 1-bookworm, 1.81-bookworm, 1.81.0-bookworm, bookworm, 1, 1.81, 1.81.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1d3d373229185bf5d1ae5d31db0581e2d351182
-Directory: 1.81.0/bookworm
+GitCommit: 63f877a36f8ba9d9b4b35cd49df3327264510886
+Directory: stable/bookworm
 
 Tags: 1-slim-bookworm, 1.81-slim-bookworm, 1.81.0-slim-bookworm, slim-bookworm, 1-slim, 1.81-slim, 1.81.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a1d3d373229185bf5d1ae5d31db0581e2d351182
-Directory: 1.81.0/bookworm/slim
+GitCommit: 63f877a36f8ba9d9b4b35cd49df3327264510886
+Directory: stable/bookworm/slim
 
 Tags: 1-alpine3.19, 1.81-alpine3.19, 1.81.0-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: a1d3d373229185bf5d1ae5d31db0581e2d351182
-Directory: 1.81.0/alpine3.19
+GitCommit: 63f877a36f8ba9d9b4b35cd49df3327264510886
+Directory: stable/alpine3.19
 
 Tags: 1-alpine3.20, 1.81-alpine3.20, 1.81.0-alpine3.20, alpine3.20, 1-alpine, 1.81-alpine, 1.81.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: a1d3d373229185bf5d1ae5d31db0581e2d351182
-Directory: 1.81.0/alpine3.20
+GitCommit: 63f877a36f8ba9d9b4b35cd49df3327264510886
+Directory: stable/alpine3.20


### PR DESCRIPTION
This PR contains two changes from [`docker-rust`](https://github.com/rust-lang/docker-rust):
1. [fix: Remove non-LTS arches from bullseye](https://github.com/rust-lang/docker-rust/pull/214)
    - This removes `ppc64el` and `s390x` from Rust images based on Debian Bullseye as Debian Bullseye no longer supports those arches since it entered LTS
2. [refactor: Don't change folder on version bump](https://github.com/rust-lang/docker-rust/pull/213)
    - On each release of `Rust` we would move the files to a new folder, which was unnecessary, so it was changed to always be in `stable`

Note: The commit message only references `1` as `2` is mostly an internal change