### PR TITLE
archlinux: Release 20241006.0.268140

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20240929.0.266368
-GitCommit: 460eea4ccb705612cfd80eadeefd16e0ab524dbc
-GitFetch: refs/tags/v20240929.0.266368
+Tags: latest, base, base-20241006.0.268140
+GitCommit: c2541ed2357f2de026af2a2e5c26742a1a579572
+GitFetch: refs/tags/v20241006.0.268140
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20240929.0.266368
-GitCommit: 460eea4ccb705612cfd80eadeefd16e0ab524dbc
-GitFetch: refs/tags/v20240929.0.266368
+Tags: base-devel, base-devel-20241006.0.268140
+GitCommit: c2541ed2357f2de026af2a2e5c26742a1a579572
+GitFetch: refs/tags/v20241006.0.268140
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20240929.0.266368
-GitCommit: 460eea4ccb705612cfd80eadeefd16e0ab524dbc
-GitFetch: refs/tags/v20240929.0.266368
+Tags: multilib-devel, multilib-devel-20241006.0.268140
+GitCommit: c2541ed2357f2de026af2a2e5c26742a1a579572
+GitFetch: refs/tags/v20241006.0.268140
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks