### PR TITLE
Odoo: Add Odoo 18.0 and update 16.0-17.0 to release 20241007

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -11,6 +11,6 @@ Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
 Tags: 16.0-20241007, 16.0, 16
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64, arm64v8
 Directory: 16.0
 

--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5fb6a842747c296099d9384587cd89640eb7a615
+GitCommit: 282f5a3761223344e610dfe889f737d75039531d
 
-Tags: 17.0-20240924, 17.0, 17, latest
+Tags: 18.0-20241007, 18.0, 18, latest
+Architectures: amd64, arm64v8, ppc64le
+Directory: 18.0
+
+Tags: 17.0-20241007, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20240924, 16.0, 16
+Tags: 16.0-20241007, 16.0, 16
 Architectures: amd64, arm64v8, ppc64le
 Directory: 16.0
-
-Tags: 15.0-20240924, 15.0, 15
-Architectures: amd64
-Directory: 15.0
 


### PR DESCRIPTION
Hello,

Here is the new Odoo 18.0 and the updates of supported releases.

Thanks