### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -1,57 +1,57 @@
-# this file is generated via https://github.com/docker-library/openjdk/blob/3345e54d319e7247c3adb700ded0209f26e8171c/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/openjdk/blob/3d37b6b3441beba81c9bc799912b72ae1dc6a2f1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 24-ea-17-jdk-oraclelinux9, 24-ea-17-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-17-jdk-oracle, 24-ea-17-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-17-jdk, 24-ea-17, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-18-jdk-oraclelinux9, 24-ea-18-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-18-jdk-oracle, 24-ea-18-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-18-jdk, 24-ea-18, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-17-jdk-oraclelinux8, 24-ea-17-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-18-jdk-oraclelinux8, 24-ea-18-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-17-jdk-bookworm, 24-ea-17-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-18-jdk-bookworm, 24-ea-18-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-17-jdk-slim-bookworm, 24-ea-17-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-17-jdk-slim, 24-ea-17-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-18-jdk-slim-bookworm, 24-ea-18-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-18-jdk-slim, 24-ea-18-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-17-jdk-bullseye, 24-ea-17-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-18-jdk-bullseye, 24-ea-18-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-17-jdk-slim-bullseye, 24-ea-17-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-18-jdk-slim-bullseye, 24-ea-18-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-17-jdk-windowsservercore-ltsc2022, 24-ea-17-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-17-jdk-windowsservercore, 24-ea-17-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-17-jdk, 24-ea-17, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-18-jdk-windowsservercore-ltsc2022, 24-ea-18-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-18-jdk-windowsservercore, 24-ea-18-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-18-jdk, 24-ea-18, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-17-jdk-windowsservercore-1809, 24-ea-17-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-17-jdk-windowsservercore, 24-ea-17-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-17-jdk, 24-ea-17, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-18-jdk-windowsservercore-1809, 24-ea-18-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-18-jdk-windowsservercore, 24-ea-18-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-18-jdk, 24-ea-18, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-17-jdk-nanoserver-1809, 24-ea-17-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-17-jdk-nanoserver, 24-ea-17-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-18-jdk-nanoserver-1809, 24-ea-18-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-18-jdk-nanoserver, 24-ea-18-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: e8eda6b7eb749f71463b1360405472e9dbbf6755
+GitCommit: 6a15ad904559ef795b2b5156f355d07dac259e8a
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/6a15ad9: Update 24 to 24-ea+18
- https://github.com/docker-library/openjdk/commit/3d37b6b: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates