### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,16 +1,16 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/ded836149ec5086738eaba49d4c5c31568e8a466/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/6a063825809df456d38adbf20bf8e12a2375831f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.95.0, 5.95, 5, latest
+Tags: 5.96.0, 5.96, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f574787d1c2f2ccbd3336c830c5d6d08126f7aac
+GitCommit: 5573c66d815671c4b6ff873c741e92224982a142
 Directory: 5/debian
 
-Tags: 5.95.0-alpine, 5.95-alpine, 5-alpine, alpine
+Tags: 5.96.0-alpine, 5.96-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f574787d1c2f2ccbd3336c830c5d6d08126f7aac
+GitCommit: 5573c66d815671c4b6ff873c741e92224982a142
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/5573c66: Update to 5.96.0, ghost-cli 1.26.1
- https://github.com/docker-library/ghost/commit/6a06382: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates