### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20240916.0
+Tags: 2023, latest, 2023.5.20241001.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 215cb518a78daaff3c2ff87096374e3ff4965cdb
+amd64-GitCommit: 5c9fcc247702271c2322b661be0dd73275953750
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: beaf864c7d0cd231f9052c47f8681476eedcff31
+arm64v8-GitCommit: 60615490df0997edf1abfdb967e26de69e10fb88
 
-Tags: 2, 2.0.20240916.0
+Tags: 2, 2.0.20241001.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: a276974e820cdbd9d3d39b1751da73192ea91647
+amd64-GitCommit: 56c21485422ff336ba13fe3d95d957477b89ee95
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: d9c716eed1aecb85deff1f17b185457db0ebb14d
+arm64v8-GitCommit: 551809d77c8c21f7c5b2e16c7ad7765afbbe5f0a
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Hello

We are from Amazon Linux and are adding new updates to our AL2023 container images in DockerHub in this PR.

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.5.20241001-0.amzn2023
- system-release-2023.5.20241001-0.amzn2023

Thanks!