### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/rabbitmq/blob/266d9cdc38a670282b731e2a0ed0381c49ba9b96/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/rabbitmq/blob/6016bb334e72c5886c1e81cbcef19b46c8bcd6b5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.0.2, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: c632cbc38e0b7d70678ba2cf5bbaba798af27339
+GitCommit: 4d384714be0c4e4c528745136c38b7f89620410f
 Directory: 4.0/ubuntu
 
 Tags: 4.0.2-management, 4.0-management, 4-management, management
@@ -17,7 +17,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.2-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c632cbc38e0b7d70678ba2cf5bbaba798af27339
+GitCommit: 4d384714be0c4e4c528745136c38b7f89620410f
 Directory: 4.0/alpine
 
 Tags: 4.0.2-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 4.0/alpine/management
 
 Tags: 3.13.7, 3.13, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: bfcb6a804bb3a46c8601d1b65be0675c9ef82eff
+GitCommit: 1ac53e66c002089bc5cab47554edcaa0087d023f
 Directory: 3.13/ubuntu
 
 Tags: 3.13.7-management, 3.13-management, 3-management
@@ -37,7 +37,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.7-alpine, 3.13-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfcb6a804bb3a46c8601d1b65be0675c9ef82eff
+GitCommit: 1ac53e66c002089bc5cab47554edcaa0087d023f
 Directory: 3.13/alpine
 
 Tags: 3.13.7-management-alpine, 3.13-management-alpine, 3-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/4d38471: Update 4.0 to otp 26.2.5.4
- https://github.com/docker-library/rabbitmq/commit/1ac53e6: Update 3.13 to otp 26.2.5.4
- https://github.com/docker-library/rabbitmq/commit/6016bb3: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates