### PR TITLE
Bump Traefik to v3.2.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.2.0-rc1-windowsservercore-ltsc2022, 3.2.0-rc1-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022
+Tags: v3.2.0-rc2-windowsservercore-ltsc2022, 3.2.0-rc2-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
 Directory: v3.2/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.2.0-rc1-windowsservercore-1809, 3.2.0-rc1-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809
+Tags: v3.2.0-rc2-windowsservercore-1809, 3.2.0-rc2-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
 Directory: v3.2/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.2.0-rc1-nanoserver-ltsc2022, 3.2.0-rc1-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022
+Tags: v3.2.0-rc2-nanoserver-ltsc2022, 3.2.0-rc2-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
 Directory: v3.2/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.2.0-rc1, 3.2.0-rc1, v3.2, 3.2, munster
+Tags: v3.2.0-rc2, 3.2.0-rc2, v3.2, 3.2, munster
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c28257b2b3a1e19d1565521e77cd55db2691f831
+GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
 Directory: v3.2/alpine
 
 Tags: v3.1.5-windowsservercore-ltsc2022, 3.1.5-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.2.0-rc2](https://github.com/traefik/traefik/releases/tag/v3.2.0-rc2).

/cc @kevinpollet @mmatur @rtribotte

Cheers
