### PR TITLE
mediawiki: fix ldd parsing logic

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,7 +3,7 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: 0b41a035fabebeda3d6b4ccc39e2c5fc3ce1cc19
+GitCommit: 4708aabf22334d933a45f714e28a78722b36427a
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version


### PR DESCRIPTION
As it turns out the liblua5 shared object is needed for runtime aswell
and having it missing produces a warning i.e. when running "php -v". Fix
this by installing it before the build time dependencies that are to be
removed later on.

Fixes https://phabricator.wikimedia.org/T376447

Signed-off-by: Christian Heusel <christian@heusel.eu>
