### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-7848

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7dc52a5a72593f896ed9f7c27062a4dda8466196
+amd64-GitCommit: ff71c2bef14fafee24b8c7a8c71a3cc266b6d424
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ae0e107e071cef8f906f0205e4dcb9609b66896a
+arm64v8-GitCommit: a826858c848d3552d502db0d0093afd7ff5f4325
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-5535, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-7848.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
