### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.96.0, 5.96, 5, latest
+Tags: 5.96.1, 5.96, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5573c66d815671c4b6ff873c741e92224982a142
+GitCommit: 875b49aa4d7fde32b6708f43ddd5f1052d5be7d7
 Directory: 5/debian
 
-Tags: 5.96.0-alpine, 5.96-alpine, 5-alpine, alpine
+Tags: 5.96.1-alpine, 5.96-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 5573c66d815671c4b6ff873c741e92224982a142
+GitCommit: 875b49aa4d7fde32b6708f43ddd5f1052d5be7d7
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/875b49a: Update to 5.96.1, ghost-cli 1.26.1