### PR TITLE
archlinux: Release 20241013.0.269705

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20241006.0.268140
-GitCommit: c2541ed2357f2de026af2a2e5c26742a1a579572
-GitFetch: refs/tags/v20241006.0.268140
+Tags: latest, base, base-20241013.0.269705
+GitCommit: 0c148627cbaec35859691a2a55df21874ad665ef
+GitFetch: refs/tags/v20241013.0.269705
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20241006.0.268140
-GitCommit: c2541ed2357f2de026af2a2e5c26742a1a579572
-GitFetch: refs/tags/v20241006.0.268140
+Tags: base-devel, base-devel-20241013.0.269705
+GitCommit: 0c148627cbaec35859691a2a55df21874ad665ef
+GitFetch: refs/tags/v20241013.0.269705
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20241006.0.268140
-GitCommit: c2541ed2357f2de026af2a2e5c26742a1a579572
-GitFetch: refs/tags/v20241006.0.268140
+Tags: multilib-devel, multilib-devel-20241013.0.269705
+GitCommit: 0c148627cbaec35859691a2a55df21874ad665ef
+GitFetch: refs/tags/v20241013.0.269705
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks