### PR TITLE
Update Clear Linux OS to 42440

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 36f7744256f01cfa1b0a90fb6999d3f7507af979
-GitFetch: refs/heads/base-42410
+GitCommit: 07ecdcda48354fb87bea40971e9f49b6eb9fcfcc
+GitFetch: refs/heads/base-42440


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42440

@bryteise @djklimes @bryteise