### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 9.0.1, 9.0, 9, innovation, latest, 9.0.1-oraclelinux9, 9.0-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.0.1-oracle, 9.0-oracle, 9-oracle, innovation-oracle, oracle
+Tags: 9.1.0, 9.1, 9, innovation, latest, 9.1.0-oraclelinux9, 9.1-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.1.0-oracle, 9.1-oracle, 9-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: a482468640c602ccd8a7c86a4c7422f18a307326
+GitCommit: b7333451d7be9f066e43f9612e6bbe3751e548f1
 Directory: innovation
 File: Dockerfile.oracle
 
-Tags: 8.4.2, 8.4, 8, lts, 8.4.2-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.2-oracle, 8.4-oracle, 8-oracle, lts-oracle
+Tags: 8.4.3, 8.4, 8, lts, 8.4.3-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.3-oracle, 8.4-oracle, 8-oracle, lts-oracle
 Architectures: amd64, arm64v8
-GitCommit: ea8ec8343c4540ac52e8bba94b5a531e298ff700
+GitCommit: 8a0100a365707fa3e59d5b23defc64b9314c4bc7
 Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.39, 8.0, 8.0.39-oraclelinux9, 8.0-oraclelinux9, 8.0.39-oracle, 8.0-oracle
+Tags: 8.0.40, 8.0, 8.0.40-oraclelinux9, 8.0-oraclelinux9, 8.0.40-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 3e6dfd03b956727c7fb5b30360512a11751a3e9d
+GitCommit: 090eb25ac69bca920fc5320484bc35aac92a8143
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.39-bookworm, 8.0-bookworm, 8.0.39-debian, 8.0-debian
+Tags: 8.0.40-bookworm, 8.0-bookworm, 8.0.40-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 3e6dfd03b956727c7fb5b30360512a11751a3e9d
+GitCommit: 090eb25ac69bca920fc5320484bc35aac92a8143
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/b733345: Update innovation to 9.1.0, oracle 9.1.0-1.el9, mysql-shell 9.1.0-1.el9
- https://github.com/docker-library/mysql/commit/8a0100a: Update 8.4 to 8.4.3, oracle 8.4.3-1.el9, mysql-shell 8.4.3-1.el9
- https://github.com/docker-library/mysql/commit/090eb25: Update 8.0 to 8.0.40, debian 8.0.40-1debian12, oracle 8.0.40-1.el9, mysql-shell 8.0.40-1.el9