### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -47,7 +47,7 @@ Directory: 3.13/alpine/management
 
 Tags: 3.12.14, 3.12
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 444c58b5b51433019a9422737ee98b05adcf7e06
+GitCommit: 20cfa9c4feae1c23ebcbe6817167f9430639d545
 Directory: 3.12/ubuntu
 
 Tags: 3.12.14-management, 3.12-management
@@ -57,7 +57,7 @@ Directory: 3.12/ubuntu/management
 
 Tags: 3.12.14-alpine, 3.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 444c58b5b51433019a9422737ee98b05adcf7e06
+GitCommit: 20cfa9c4feae1c23ebcbe6817167f9430639d545
 Directory: 3.12/alpine
 
 Tags: 3.12.14-management-alpine, 3.12-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/20cfa9c: Update 3.12 to otp 25.3.2.15