### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,47 +6,47 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.6.2-php8.1-apache, 6.6-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.6.2-php8.1, 6.6-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.1/apache
 
 Tags: 6.6.2-php8.1-fpm, 6.6-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.1/fpm
 
 Tags: 6.6.2-php8.1-fpm-alpine, 6.6-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.1/fpm-alpine
 
 Tags: 6.6.2-apache, 6.6-apache, 6-apache, apache, 6.6.2, 6.6, 6, latest, 6.6.2-php8.2-apache, 6.6-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.6.2-php8.2, 6.6-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.2/apache
 
 Tags: 6.6.2-fpm, 6.6-fpm, 6-fpm, fpm, 6.6.2-php8.2-fpm, 6.6-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.2/fpm
 
 Tags: 6.6.2-fpm-alpine, 6.6-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.6.2-php8.2-fpm-alpine, 6.6-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.2/fpm-alpine
 
 Tags: 6.6.2-php8.3-apache, 6.6-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.6.2-php8.3, 6.6-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.3/apache
 
 Tags: 6.6.2-php8.3-fpm, 6.6-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.3/fpm
 
 Tags: 6.6.2-php8.3-fpm-alpine, 6.6-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d6690c71a24ad7a434d1de15f382c41279932fc3
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: latest/php8.3/fpm-alpine
 
 Tags: cli-2.11.0-php8.1, cli-2.11-php8.1, cli-2-php8.1, cli-php8.1
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
 Directory: cli/php8.3/alpine
 
-Tags: beta-6.7-beta2-php8.1-apache, beta-6.7-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.7-beta2-php8.1, beta-6.7-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.7-beta3-php8.1-apache, beta-6.7-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.7-beta3-php8.1, beta-6.7-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.1/apache
 
-Tags: beta-6.7-beta2-php8.1-fpm, beta-6.7-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.7-beta3-php8.1-fpm, beta-6.7-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.7-beta2-php8.1-fpm-alpine, beta-6.7-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.7-beta3-php8.1-fpm-alpine, beta-6.7-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.7-beta2-apache, beta-6.7-apache, beta-6-apache, beta-apache, beta-6.7-beta2, beta-6.7, beta-6, beta, beta-6.7-beta2-php8.2-apache, beta-6.7-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.7-beta2-php8.2, beta-6.7-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.7-beta3-apache, beta-6.7-apache, beta-6-apache, beta-apache, beta-6.7-beta3, beta-6.7, beta-6, beta, beta-6.7-beta3-php8.2-apache, beta-6.7-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.7-beta3-php8.2, beta-6.7-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.2/apache
 
-Tags: beta-6.7-beta2-fpm, beta-6.7-fpm, beta-6-fpm, beta-fpm, beta-6.7-beta2-php8.2-fpm, beta-6.7-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.7-beta3-fpm, beta-6.7-fpm, beta-6-fpm, beta-fpm, beta-6.7-beta3-php8.2-fpm, beta-6.7-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.7-beta2-fpm-alpine, beta-6.7-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.7-beta2-php8.2-fpm-alpine, beta-6.7-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.7-beta3-fpm-alpine, beta-6.7-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.7-beta3-php8.2-fpm-alpine, beta-6.7-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.2/fpm-alpine
 
-Tags: beta-6.7-beta2-php8.3-apache, beta-6.7-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.7-beta2-php8.3, beta-6.7-php8.3, beta-6-php8.3, beta-php8.3
+Tags: beta-6.7-beta3-php8.3-apache, beta-6.7-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.7-beta3-php8.3, beta-6.7-php8.3, beta-6-php8.3, beta-php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.3/apache
 
-Tags: beta-6.7-beta2-php8.3-fpm, beta-6.7-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Tags: beta-6.7-beta3-php8.3-fpm, beta-6.7-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.3/fpm
 
-Tags: beta-6.7-beta2-php8.3-fpm-alpine, beta-6.7-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Tags: beta-6.7-beta3-php8.3-fpm-alpine, beta-6.7-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c00b7275ea045343417e28b94bfd9d21ddf73a14
+GitCommit: c85650e7c796145b439acbe966d56f4187588b40
 Directory: beta/php8.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/c85650e: Apply upstream documentation change
- https://github.com/docker-library/wordpress/commit/0a42bbd: Update beta to 6.7-beta3