### PR TITLE
[oraclelinux] Updating 7, 7-slim and 7-slim-fips for ELSA-2024-5076 ELSA-2024-12730

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ff71c2bef14fafee24b8c7a8c71a3cc266b6d424
+amd64-GitCommit: b1d5a1b29292865ed0b5ba26ff6a024935b8d65b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a826858c848d3552d502db0d0093afd7ff5f4325
+arm64v8-GitCommit: d748cd4f97446020aa5b73c9eaaf11af124ebf5c
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-37370, CVE-2024-37371, CVE-2022-1304

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-5076.html
https://linux.oracle.com/errata/ELSA-2024-12730.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
