### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,122 +4,77 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.2.0-rc1-php8.1-apache, 5.2-php8.1-apache, 5.2.rc-php8.1-apache, 5.2.0-rc-php8.1-apache
+Tags: 5.2.0-php8.1-apache, 5.2-php8.1-apache, 5-php8.1-apache, php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.1/apache
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.1/apache
 
-Tags: 5.2.0-rc1-php8.1-fpm-alpine, 5.2-php8.1-fpm-alpine, 5.2.rc-php8.1-fpm-alpine, 5.2.0-rc-php8.1-fpm-alpine
+Tags: 5.2.0-php8.1-fpm-alpine, 5.2-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.1/fpm-alpine
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.1/fpm-alpine
 
-Tags: 5.2.0-rc1-php8.1-fpm, 5.2-php8.1-fpm, 5.2.rc-php8.1-fpm, 5.2.0-rc-php8.1-fpm
+Tags: 5.2.0-php8.1-fpm, 5.2-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.1/fpm
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.1/fpm
 
-Tags: 5.2.0-rc1, 5.2, 5.2.rc, 5.2.0-rc, 5.2.0-rc1-apache, 5.2-apache, 5.2.rc-apache, 5.2.0-rc-apache, 5.2.0-rc1-php8.2, 5.2-php8.2, 5.2.rc-php8.2, 5.2.0-rc-php8.2, 5.2.0-rc1-php8.2-apache, 5.2-php8.2-apache, 5.2.rc-php8.2-apache, 5.2.0-rc-php8.2-apache
+Tags: 5.2.0, 5.2, 5, latest, 5.2.0-apache, 5.2-apache, 5-apache, apache, 5.2.0-php8.2, 5.2-php8.2, 5-php8.2, php8.2, 5.2.0-php8.2-apache, 5.2-php8.2-apache, 5-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.2/apache
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.2/apache
 
-Tags: 5.2.0-rc1-php8.2-fpm-alpine, 5.2-php8.2-fpm-alpine, 5.2.rc-php8.2-fpm-alpine, 5.2.0-rc-php8.2-fpm-alpine
+Tags: 5.2.0-php8.2-fpm-alpine, 5.2-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.2/fpm-alpine
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.2/fpm-alpine
 
-Tags: 5.2.0-rc1-php8.2-fpm, 5.2-php8.2-fpm, 5.2.rc-php8.2-fpm, 5.2.0-rc-php8.2-fpm
+Tags: 5.2.0-php8.2-fpm, 5.2-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.2/fpm
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.2/fpm
 
-Tags: 5.2.0-rc1-php8.3-apache, 5.2-php8.3-apache, 5.2.rc-php8.3-apache, 5.2.0-rc-php8.3-apache
+Tags: 5.2.0-php8.3-apache, 5.2-php8.3-apache, 5-php8.3-apache, php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.3/apache
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.3/apache
 
-Tags: 5.2.0-rc1-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5.2.rc-php8.3-fpm-alpine, 5.2.0-rc-php8.3-fpm-alpine
+Tags: 5.2.0-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.3/fpm-alpine
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.3/fpm-alpine
 
-Tags: 5.2.0-rc1-php8.3-fpm, 5.2-php8.3-fpm, 5.2.rc-php8.3-fpm, 5.2.0-rc-php8.3-fpm
+Tags: 5.2.0-php8.3-fpm, 5.2-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b393e596eb27e7bf6f144d124bff9a92339726f
-Directory: 5.2.rc/php8.3/fpm
+GitCommit: 27f1228cf9b3707e5b1d3308bbc5cdcaccc3fb98
+Directory: 5.2/php8.3/fpm
 
-Tags: 5.1.4-php8.1-apache, 5.1-php8.1-apache, 5-php8.1-apache, php8.1-apache
+Tags: 4.4.9, 4.4, 4, 4.4.9-apache, 4.4-apache, 4-apache, 4.4.9-php8.1, 4.4-php8.1, 4-php8.1, 4.4.9-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.1/apache
-
-Tags: 5.1.4-php8.1-fpm-alpine, 5.1-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.1/fpm-alpine
-
-Tags: 5.1.4-php8.1-fpm, 5.1-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.1/fpm
-
-Tags: 5.1.4, 5.1, 5, latest, 5.1.4-apache, 5.1-apache, 5-apache, apache, 5.1.4-php8.2, 5.1-php8.2, 5-php8.2, php8.2, 5.1.4-php8.2-apache, 5.1-php8.2-apache, 5-php8.2-apache, php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.2/apache
-
-Tags: 5.1.4-php8.2-fpm-alpine, 5.1-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.2/fpm-alpine
-
-Tags: 5.1.4-php8.2-fpm, 5.1-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.2/fpm
-
-Tags: 5.1.4-php8.3-apache, 5.1-php8.3-apache, 5-php8.3-apache, php8.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.3/apache
-
-Tags: 5.1.4-php8.3-fpm-alpine, 5.1-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.3/fpm-alpine
-
-Tags: 5.1.4-php8.3-fpm, 5.1-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
-Directory: 5.1/php8.3/fpm
-
-Tags: 4.4.8, 4.4, 4, 4.4.8-apache, 4.4-apache, 4-apache, 4.4.8-php8.1, 4.4-php8.1, 4-php8.1, 4.4.8-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
+GitCommit: b08c5e9d08ecebc9284790208bfb74b886257f75
 Directory: 4.4/php8.1/apache
 
-Tags: 4.4.8-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
+Tags: 4.4.9-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
+GitCommit: b08c5e9d08ecebc9284790208bfb74b886257f75
 Directory: 4.4/php8.1/fpm-alpine
 
-Tags: 4.4.8-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
+Tags: 4.4.9-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
+GitCommit: b08c5e9d08ecebc9284790208bfb74b886257f75
 Directory: 4.4/php8.1/fpm
 
-Tags: 4.4.8-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
+Tags: 4.4.9-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
+GitCommit: b08c5e9d08ecebc9284790208bfb74b886257f75
 Directory: 4.4/php8.2/apache
 
-Tags: 4.4.8-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
+Tags: 4.4.9-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
+GitCommit: b08c5e9d08ecebc9284790208bfb74b886257f75
 Directory: 4.4/php8.2/fpm-alpine
 
-Tags: 4.4.8-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
+Tags: 4.4.9-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a857bb7d9864dbe7b2092e68ee93e9f2bdc463
+GitCommit: b08c5e9d08ecebc9284790208bfb74b886257f75
 Directory: 4.4/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@b08c5e9: Update Joomla 4.4.8 to 4.4.9
- joomla-docker/docker-joomla@27f1228: Add Joomla 5.2.0 build
- joomla-docker/docker-joomla@fbe53d9: Remove Joomla 5.1.4 build
- joomla-docker/docker-joomla@66af50c: Remove Joomla 5.2.0-rc build