### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev9, 3.1-dev, 3.1-dev9-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev10, 3.1-dev, 3.1-dev10-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e93b3588a6cc0f2eb19412e54de7e741b50f734b
+GitCommit: a2995ab1bab48159a97c44e9e301714d105ec3e9
 Directory: 3.1
 
-Tags: 3.1-dev9-alpine, 3.1-dev-alpine, 3.1-dev9-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev10-alpine, 3.1-dev-alpine, 3.1-dev10-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e93b3588a6cc0f2eb19412e54de7e741b50f734b
+GitCommit: a2995ab1bab48159a97c44e9e301714d105ec3e9
 Directory: 3.1/alpine
 
 Tags: 3.0.5, 3.0, lts, latest, 3.0.5-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a2995ab: Update 3.1 to 3.1-dev10