### PR TITLE
Odoo: update 16.0-18.0 to release 20241017

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 282f5a3761223344e610dfe889f737d75039531d
+GitCommit: decdaff7f94fd13001ac5dbdba59776b628265eb
 
-Tags: 18.0-20241007, 18.0, 18, latest
+Tags: 18.0-20241017, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20241007, 17.0, 17
+Tags: 17.0-20241017, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20241007, 16.0, 16
+Tags: 16.0-20241017, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

Here are the latest updates of Odoo supported versions.

Thanks