### PR TITLE
Update nats to 2.10.22

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: fec36788a2e4e4244df6cfd69b699f51b4b4b62f
+GitCommit: 23198a15d5b1df0812e7f61037e1aa8da0fe620f
 GitFetch: refs/heads/main
 
-Tags: 2.10.21-alpine3.20, 2.10-alpine3.20, 2-alpine3.20, alpine3.20, 2.10.21-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.10.22-alpine3.20, 2.10-alpine3.20, 2-alpine3.20, alpine3.20, 2.10.22-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/alpine3.20
 
-Tags: 2.10.21-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.21-linux, 2.10-linux, 2-linux, linux
-SharedTags: 2.10.21, 2.10, 2, latest
+Tags: 2.10.22-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.22-linux, 2.10-linux, 2-linux, linux
+SharedTags: 2.10.22, 2.10, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/scratch
 
-Tags: 2.10.21-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.10.21-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.10.22-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.10.22-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.21-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.10.21-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.21, 2.10, 2, latest
+Tags: 2.10.22-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.10.22-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.22, 2.10, 2, latest
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Release details at https://github.com/nats-io/nats-server/releases/tag/v2.10.22.