### PR TITLE
Add Python 3.14-rc

### DIFF
--- a/library/python
+++ b/library/python
@@ -5,6 +5,53 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/python.git
 Builder: buildkit
 
+Tags: 3.14.0a1-bookworm, 3.14-rc-bookworm
+SharedTags: 3.14.0a1, 3.14-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/bookworm
+
+Tags: 3.14.0a1-slim-bookworm, 3.14-rc-slim-bookworm, 3.14.0a1-slim, 3.14-rc-slim
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/slim-bookworm
+
+Tags: 3.14.0a1-bullseye, 3.14-rc-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/bullseye
+
+Tags: 3.14.0a1-slim-bullseye, 3.14-rc-slim-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/slim-bullseye
+
+Tags: 3.14.0a1-alpine3.20, 3.14-rc-alpine3.20, 3.14.0a1-alpine, 3.14-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/alpine3.20
+
+Tags: 3.14.0a1-alpine3.19, 3.14-rc-alpine3.19
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/alpine3.19
+
+Tags: 3.14.0a1-windowsservercore-ltsc2022, 3.14-rc-windowsservercore-ltsc2022
+SharedTags: 3.14.0a1-windowsservercore, 3.14-rc-windowsservercore, 3.14.0a1, 3.14-rc
+Architectures: windows-amd64
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+Builder: classic
+
+Tags: 3.14.0a1-windowsservercore-1809, 3.14-rc-windowsservercore-1809
+SharedTags: 3.14.0a1-windowsservercore, 3.14-rc-windowsservercore, 3.14.0a1, 3.14-rc
+Architectures: windows-amd64
+GitCommit: f599a555df4b1065bfe02163f5ebff04481553e2
+Directory: 3.14-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+Builder: classic
+
 Tags: 3.13.0-bookworm, 3.13-bookworm, 3-bookworm, bookworm
 SharedTags: 3.13.0, 3.13, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
Not sure if/how this slipped under the radar, but the 3.14-rc variants were not yet added here (last PR was #17687).

*Note:* I've deliberately only included addition of the new 3.14-rc images and skipped over the changes to other variants, as they seem not to be substantial enough to warrant a rebuild. Feel free to replace this with a full update however if that's to be preferred.