### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 24-ea-19-jdk-oraclelinux9, 24-ea-19-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-19-jdk-oracle, 24-ea-19-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-19-jdk, 24-ea-19, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-20-jdk-oraclelinux9, 24-ea-20-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-20-jdk-oracle, 24-ea-20-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-20-jdk, 24-ea-20, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-19-jdk-oraclelinux8, 24-ea-19-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-20-jdk-oraclelinux8, 24-ea-20-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-19-jdk-bookworm, 24-ea-19-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-20-jdk-bookworm, 24-ea-20-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-19-jdk-slim-bookworm, 24-ea-19-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-19-jdk-slim, 24-ea-19-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-20-jdk-slim-bookworm, 24-ea-20-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-20-jdk-slim, 24-ea-20-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-19-jdk-bullseye, 24-ea-19-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-20-jdk-bullseye, 24-ea-20-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-19-jdk-slim-bullseye, 24-ea-19-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-20-jdk-slim-bullseye, 24-ea-20-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-19-jdk-windowsservercore-ltsc2022, 24-ea-19-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-19-jdk-windowsservercore, 24-ea-19-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-19-jdk, 24-ea-19, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-20-jdk-windowsservercore-ltsc2022, 24-ea-20-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-20-jdk-windowsservercore, 24-ea-20-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-20-jdk, 24-ea-20, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-19-jdk-windowsservercore-1809, 24-ea-19-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-19-jdk-windowsservercore, 24-ea-19-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-19-jdk, 24-ea-19, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-20-jdk-windowsservercore-1809, 24-ea-20-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-20-jdk-windowsservercore, 24-ea-20-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-20-jdk, 24-ea-20, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-19-jdk-nanoserver-1809, 24-ea-19-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-19-jdk-nanoserver, 24-ea-19-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-20-jdk-nanoserver-1809, 24-ea-20-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-20-jdk-nanoserver, 24-ea-20-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: f1194fa1060e93ae0eae9aa083b9dade9f89ad51
+GitCommit: b00a7bfcf54636848fa4473829e631638368346b
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/b00a7bf: Update 24 to 24-ea+20