### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.96.2, 5.96, 5, latest
+Tags: 5.97.0, 5.97, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6e57615195e07b27a0bc9d09a5b41721e528b3cc
+GitCommit: 3c1f01a23077093a77eb0df9933e90c364610c8b
 Directory: 5/debian
 
-Tags: 5.96.2-alpine, 5.96-alpine, 5-alpine, alpine
+Tags: 5.97.0-alpine, 5.97-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 6e57615195e07b27a0bc9d09a5b41721e528b3cc
+GitCommit: 3c1f01a23077093a77eb0df9933e90c364610c8b
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/3c1f01a: Update to 5.97.0, ghost-cli 1.26.1