### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.5.20241001.1
+Tags: 2023, latest, 2023.6.20241010.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 5c9fcc247702271c2322b661be0dd73275953750
+amd64-GitCommit: c83383b00b6d1382f06ca5dca262091847258322
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 60615490df0997edf1abfdb967e26de69e10fb88
+arm64v8-GitCommit: 2d9a9f52689f239a04f7cc6dc6c95570edaed093
 
-Tags: 2, 2.0.20241001.0
+Tags: 2, 2.0.20241014.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 56c21485422ff336ba13fe3d95d957477b89ee95
+amd64-GitCommit: 0c5f82c64737f55a558fe44ef6a79b9537c4d143
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 551809d77c8c21f7c5b2e16c7ad7765afbbe5f0a
+arm64v8-GitCommit: 0160c3ee0744eaf389cf31f7173db0b48b494995
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
    Updated Packages for Amazon Linux 2:
    Packages addressing CVES:

    Updated Packages for Amazon Linux 2023:
    - libgcrypt-1.10.2-1.amzn2023.0.2
    - amazon-linux-repo-cdn-2023.6.20241010-0.amzn2023
    - system-release-2023.6.20241010-0.amzn2023
    - openssl-libs-3.0.8-1.amzn2023.0.16
    - python3-pip-wheel-21.3.1-2.amzn2023.0.8 Packages addressing CVES:
    - libgcrypt-1.10.2-1.amzn2023.0.2
      - [CVE-2024-2236](https://alas.aws.amazon.com/cve/html/CVE-2024-2236.html)
    - openssl-libs-3.0.8-1.amzn2023.0.16 - [CVE-2024-41996](https://alas.aws.amazon.com/cve/html/CVE-2024-41996.html)
    - python3-pip-wheel-21.3.1-2.amzn2023.0.8
      - [CVE-2024-37891](https://alas.aws.amazon.com/cve/html/CVE-2024-37891.html)