### PR TITLE
Update Clear Linux OS to 42520

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 07ecdcda48354fb87bea40971e9f49b6eb9fcfcc
-GitFetch: refs/heads/base-42440
+GitCommit: 6a3ac15e2aa632078f357db3880163a225cd9b45
+GitFetch: refs/heads/base-42520


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42520

@bryteise @djklimes @bryteise