### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.1, 5.0, 5, latest, 5.0.1-jammy, 5.0-jammy, 5-jammy, jammy
+Tags: 5.0.2, 5.0, 5, latest, 5.0.2-jammy, 5.0-jammy, 5-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 9c4cfca225a711f4523ef5134cc54c1a62e69eba
+GitCommit: 1e3d5732f34ceb9e77870d0be9501515f917cc60
 Directory: 5.0
 
 Tags: 4.1.7, 4.1, 4, 4.1.7-jammy, 4.1-jammy, 4-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/1e3d573: Update 5.0 to 5.0.2