### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/memcached/blob/da71ed9ea0800cd7e3af90cb8b0670fef8c166c7/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/memcached/blob/c75c22c45a0a79124becdc38b3c005b0b820ea20/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.31, 1.6, 1, latest, 1.6.31-bookworm, 1.6-bookworm, 1-bookworm, bookworm
+Tags: 1.6.32, 1.6, 1, latest, 1.6.32-bookworm, 1.6-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3598423e1058ace87504520c43095bf87438deaf
+GitCommit: 89c8fdb68df3a904503298751ac8862f283328e6
 Directory: 1/debian
 
-Tags: 1.6.31-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.31-alpine3.20, 1.6-alpine3.20, 1-alpine3.20, alpine3.20
+Tags: 1.6.32-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.32-alpine3.20, 1.6-alpine3.20, 1-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3598423e1058ace87504520c43095bf87438deaf
+GitCommit: 89c8fdb68df3a904503298751ac8862f283328e6
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/89c8fdb: Update 1 to 1.6.32
- https://github.com/docker-library/memcached/commit/c75c22c: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates