### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/e41a2394306665fd94abf117076c9ae93a259742/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/dc442a4e31414552f7c00c8940272b0699ce0c20/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: e41a2394306665fd94abf117076c9ae93a259742
+GitCommit: dc442a4e31414552f7c00c8940272b0699ce0c20
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 91f9975d4bb91d7c916ef74de77911d961ac9b75
+amd64-GitCommit: a2783b883c18c45a4d91a24327d42048a04068ff
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: b535ef8fcaea49f6f31931c7daebc0ff5bb62ed4
+arm32v5-GitCommit: bd26637e84bf52f0f6fff92dc98de904c76c47a4
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 849c068967c453f4f520a1ff02ddac5300572a08
+arm32v6-GitCommit: f511e3b14ac4a74df50983e58c38e7c8e5df5523
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 32ea273581d3d29929e1b4ba6132ea65f874535a
+arm32v7-GitCommit: 2c710ecda64060cb7b07b44cf014b30b85b740ec
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a9331813011300f50adf201616a1794bf81cba2a
+arm64v8-GitCommit: fa65c12dcdb105f3110a0bd04a4de9336df4d162
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: e0d585110541419c7c5909bcea0198ab12e37c49
+i386-GitCommit: 7bc2517691466a1bbc9f810ea938d8888f4847a5
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 7f1897425e18b5242f6916ebe9a050ac724b572c
+mips64le-GitCommit: 644fb1d4cd3c6fca4f1ca5c73c0f1fe01b39f458
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: ea991ac8d49f704e43b3825c4e4f8fb25d09b351
+ppc64le-GitCommit: cc51d12d77293faad06a8a4a32a56129cff4805c
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: f33975f5708b6e64fd128e748332c58d129c9a98
+riscv64-GitCommit: 05da609ad07c759f24c2ae673807b720314506b7
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ae1f683d9ec1695a32c63bac764e997b1ab20915
+s390x-GitCommit: 2292efafbbf0e4bddbbaaa3b02059bac096a1e7c
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/dc442a4: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/a9515d7: Update metadata for i386
- https://github.com/docker-library/busybox/commit/9d7406e: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/741938b: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/9148256: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/2e70e54: Merge pull request https://github.com/docker-library/busybox/pull/209 from infosiftr/buildroot-2024.08.1
- https://github.com/docker-library/busybox/commit/2dd00e4: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/0514a66: Update buildroot to 2024.08.1
- https://github.com/docker-library/busybox/commit/e41a239: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/2ad4c4f: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/e258905: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/d1f66b2: Update metadata for i386
- https://github.com/docker-library/busybox/commit/13e1415: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/943b07b: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/eb8b9a1: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/fa016ca: Update metadata for arm32v5