### PR TITLE
Update to Flink 2.0-preview1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,27 +3,27 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, scala_2.12-java17, 2.0-preview1-java17, 2.0-java17, java17
+Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, 2.0-preview1-java17, 2.0-java17
 Architectures: amd64,arm64v8
 GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
 Directory: ./2.0/scala_2.12-java17-ubuntu
 
-Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, scala_2.12, 2.0-preview1-java11, 2.0-java11, java11, 2.0-preview1, 2.0, latest
+Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, 2.0-preview1-java11, 2.0-java11, 2.0-preview1, 2.0
 Architectures: amd64,arm64v8
 GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
 Directory: ./2.0/scala_2.12-java11-ubuntu
 
-Tags: 1.20.0-scala_2.12-java8, 1.20-scala_2.12-java8, 1.20.0-java8, 1.20-java8
+Tags: 1.20.0-scala_2.12-java8, 1.20-scala_2.12-java8, scala_2.12-java8, 1.20.0-java8, 1.20-java8, java8
 Architectures: amd64,arm64v8
 GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
 Directory: ./1.20/scala_2.12-java8-ubuntu
 
-Tags: 1.20.0-scala_2.12-java17, 1.20-scala_2.12-java17, 1.20.0-java17, 1.20-java17
+Tags: 1.20.0-scala_2.12-java17, 1.20-scala_2.12-java17, scala_2.12-java17, 1.20.0-java17, 1.20-java17, java17
 Architectures: amd64,arm64v8
 GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
 Directory: ./1.20/scala_2.12-java17-ubuntu
 
-Tags: 1.20.0-scala_2.12-java11, 1.20-scala_2.12-java11, 1.20.0-scala_2.12, 1.20-scala_2.12, 1.20.0-java11, 1.20-java11, 1.20.0, 1.20
+Tags: 1.20.0-scala_2.12-java11, 1.20-scala_2.12-java11, scala_2.12-java11, 1.20.0-scala_2.12, 1.20-scala_2.12, scala_2.12, 1.20.0-java11, 1.20-java11, java11, 1.20.0, 1.20, latest
 Architectures: amd64,arm64v8
 GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
 Directory: ./1.20/scala_2.12-java11-ubuntu

--- a/library/flink
+++ b/library/flink
@@ -3,17 +3,27 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 1.20.0-scala_2.12-java8, 1.20-scala_2.12-java8, scala_2.12-java8, 1.20.0-java8, 1.20-java8, java8
+Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, scala_2.12-java17, 2.0-preview1-java17, 2.0-java17, java17
+Architectures: amd64,arm64v8
+GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
+Directory: ./2.0/scala_2.12-java17-ubuntu
+
+Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, scala_2.12, 2.0-preview1-java11, 2.0-java11, java11, 2.0-preview1, 2.0, latest
+Architectures: amd64,arm64v8
+GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
+Directory: ./2.0/scala_2.12-java11-ubuntu
+
+Tags: 1.20.0-scala_2.12-java8, 1.20-scala_2.12-java8, 1.20.0-java8, 1.20-java8
 Architectures: amd64,arm64v8
 GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
 Directory: ./1.20/scala_2.12-java8-ubuntu
 
-Tags: 1.20.0-scala_2.12-java17, 1.20-scala_2.12-java17, scala_2.12-java17, 1.20.0-java17, 1.20-java17, java17
+Tags: 1.20.0-scala_2.12-java17, 1.20-scala_2.12-java17, 1.20.0-java17, 1.20-java17
 Architectures: amd64,arm64v8
 GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
 Directory: ./1.20/scala_2.12-java17-ubuntu
 
-Tags: 1.20.0-scala_2.12-java11, 1.20-scala_2.12-java11, scala_2.12-java11, 1.20.0-scala_2.12, 1.20-scala_2.12, scala_2.12, 1.20.0-java11, 1.20-java11, java11, 1.20.0, 1.20, latest
+Tags: 1.20.0-scala_2.12-java11, 1.20-scala_2.12-java11, 1.20.0-scala_2.12, 1.20-scala_2.12, 1.20.0-java11, 1.20-java11, 1.20.0, 1.20
 Architectures: amd64,arm64v8
 GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
 Directory: ./1.20/scala_2.12-java11-ubuntu


### PR DESCRIPTION
The preview release of flink 2.0.

NB. jdk1.8 is no longer supported in flink 2.0