### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2024-8446"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b1d5a1b29292865ed0b5ba26ff6a024935b8d65b
+amd64-GitCommit: 49ff350383c3dfe8143620769b65f3b1934034db
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d748cd4f97446020aa5b73c9eaaf11af124ebf5c
+arm64v8-GitCommit: 4ac974bfcd836456a8d49e900a4dd3b23557ee0b
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-6232, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-8446.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
