### PR TITLE
Update Clear Linux OS to 42540

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 6a3ac15e2aa632078f357db3880163a225cd9b45
-GitFetch: refs/heads/base-42520
+GitCommit: 8ec99859f07474a8394c377f2ba9f54bc057210a
+GitFetch: refs/heads/base-42540


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42540

@bryteise @djklimes @bryteise