### PR TITLE
Upgrade Zookeper to 3.9.3 and remove 3.7.2

### DIFF
--- a/library/zookeeper
+++ b/library/zookeeper
@@ -14,6 +14,6 @@ Tags: 3.8.4, 3.8, 3.8.4-jre-17, 3.8-jre-17
 GitCommit: ec1050affd761a7886c1f1f5d18165c19d3143e8
 Directory: 3.8.4
 
-Tags: 3.9.2, 3.9, 3.9.2-jre-17, 3.9-jre-17, latest
-GitCommit: ec1050affd761a7886c1f1f5d18165c19d3143e8
-Directory: 3.9.2
+Tags: 3.9.3, 3.9, 3.9.3-jre-17, 3.9-jre-17, latest
+GitCommit: 268d33caa089426f4f173ba0bac9277919f88dc7
+Directory: 3.9.3

--- a/library/zookeeper
+++ b/library/zookeeper
@@ -2,14 +2,6 @@ Maintainers: Elisey Zanko <elisey.zanko@gmail.com> (@31z4)
 GitRepo: https://github.com/31z4/zookeeper-docker.git
 Architectures: amd64, arm64v8, s390x, ppc64le
 
-Tags: 3.7.2, 3.7, 3.7.2-jre-11, 3.7-jre-11
-GitCommit: c03e4eea773bb3406fed38bdda15bf0bdfb1b35b
-Directory: 3.7.2-jre11
-
-Tags: 3.7.2-jre-17, 3.7-jre-17
-GitCommit: 5076660820c73f3b119cbdd1267c25a1e29cbbf4
-Directory: 3.7.2
-
 Tags: 3.8.4, 3.8, 3.8.4-jre-17, 3.8-jre-17
 GitCommit: ec1050affd761a7886c1f1f5d18165c19d3143e8
 Directory: 3.8.4


### PR DESCRIPTION
> 3.7 is EoL since 2nd of February, 2024

https://zookeeper.apache.org/releases.html