### PR TITLE
Bump Traefik to v2.11.13, v3.1.7, and v3.2.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -54,28 +54,28 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
 Directory: v3.1/alpine
 
-Tags: v2.11.13-windowsservercore-ltsc2022, 2.11.13-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.13-windowsservercore-ltsc2022, 2.11.13-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.13-windowsservercore-1809, 2.11.13-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.13-windowsservercore-1809, 2.11.13-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.13-nanoserver-ltsc2022, 2.11.13-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.13-nanoserver-ltsc2022, 2.11.13-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.13, 2.11.13, v2.11, 2.11, mimolette
+Tags: v2.11.13, 2.11.13, v2.11, 2.11, mimolette, v2, 2
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87

--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.2.0-rc2-windowsservercore-ltsc2022, 3.2.0-rc2-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022
+Tags: v3.2.0-windowsservercore-ltsc2022, 3.2.0-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
+GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
 Directory: v3.2/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.2.0-rc2-windowsservercore-1809, 3.2.0-rc2-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809
+Tags: v3.2.0-windowsservercore-1809, 3.2.0-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
+GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
 Directory: v3.2/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.2.0-rc2-nanoserver-ltsc2022, 3.2.0-rc2-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022
+Tags: v3.2.0-nanoserver-ltsc2022, 3.2.0-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
+GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
 Directory: v3.2/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.2.0-rc2, 3.2.0-rc2, v3.2, 3.2, munster
+Tags: v3.2.0, 3.2.0, v3.2, 3.2, munster, v3, 3, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
+GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
 Directory: v3.2/alpine
 
 Tags: v3.1.7-windowsservercore-ltsc2022, 3.1.7-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022

--- a/library/traefik
+++ b/library/traefik
@@ -54,29 +54,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 370363b6c9cb11184c944ad5dcfa98efdd78a86d
 Directory: v3.1/alpine
 
-Tags: v2.11.12-windowsservercore-ltsc2022, 2.11.12-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
+Tags: v2.11.13-windowsservercore-ltsc2022, 2.11.13-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e9f3c89d32965770fc7c1ae6f6f6fa967ddeb3e9
+GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.12-windowsservercore-1809, 2.11.12-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809
+Tags: v2.11.13-windowsservercore-1809, 2.11.13-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e9f3c89d32965770fc7c1ae6f6f6fa967ddeb3e9
+GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.12-nanoserver-ltsc2022, 2.11.12-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
+Tags: v2.11.13-nanoserver-ltsc2022, 2.11.13-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e9f3c89d32965770fc7c1ae6f6f6fa967ddeb3e9
+GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.12, 2.11.12, v2.11, 2.11, mimolette, v2, 2
+Tags: v2.11.13, 2.11.13, v2.11, 2.11, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e9f3c89d32965770fc7c1ae6f6f6fa967ddeb3e9
+GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -27,31 +27,31 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 9e567763da1d52f1916f4698a57a9f42591cd49a
 Directory: v3.2/alpine
 
-Tags: v3.1.6-windowsservercore-ltsc2022, 3.1.6-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.1.7-windowsservercore-ltsc2022, 3.1.7-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 370363b6c9cb11184c944ad5dcfa98efdd78a86d
+GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
 Directory: v3.1/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.1.6-windowsservercore-1809, 3.1.6-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+Tags: v3.1.7-windowsservercore-1809, 3.1.7-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 370363b6c9cb11184c944ad5dcfa98efdd78a86d
+GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
 Directory: v3.1/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.1.6-nanoserver-ltsc2022, 3.1.6-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.1.7-nanoserver-ltsc2022, 3.1.7-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 370363b6c9cb11184c944ad5dcfa98efdd78a86d
+GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
 Directory: v3.1/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.1.6, 3.1.6, v3.1, 3.1, comte, v3, 3, latest
+Tags: v3.1.7, 3.1.7, v3.1, 3.1, comte
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 370363b6c9cb11184c944ad5dcfa98efdd78a86d
+GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
 Directory: v3.1/alpine
 
 Tags: v2.11.13-windowsservercore-ltsc2022, 2.11.13-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.13](https://github.com/traefik/traefik/releases/tag/v2.11.13), [v3.1.7](https://github.com/traefik/traefik/releases/tag/v3.1.7), and [v3.2.0](https://github.com/traefik/traefik/releases/tag/v3.2.0).

/cc @mmatur @juliens @rtribotte

Cheers
