### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.97.3, 5.97, 5, latest
+Tags: 5.98.0, 5.98, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f443a37a89bee7e958afbedf0dc65a770eaf9e76
+GitCommit: 46aa6720bcac6fdcd2af55594b8db897d097baeb
 Directory: 5/debian
 
-Tags: 5.97.3-alpine, 5.97-alpine, 5-alpine, alpine
+Tags: 5.98.0-alpine, 5.98-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f443a37a89bee7e958afbedf0dc65a770eaf9e76
+GitCommit: 46aa6720bcac6fdcd2af55594b8db897d097baeb
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/46aa672: Update to 5.98.0, ghost-cli 1.26.1