### PR TITLE
Redis CE 8.0 Milestone 2 release for Debian and Alpine

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -2,9 +2,15 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Yossi Gottlieb <yossi@redis.com> (@yossigo)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.0-M01, 8.0-M01-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1b88507c82861395a5c1b354baab795c73c051e3
+Tags: 8.0-M02-alpine, 8.0-M02-alpine3.20
+Architectures: amd64, arm64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
+GitFetch: refs/heads/release/8.0
+Directory: alpine
+
+Tags: 8.0-M02, 8.0-M02-bookworm
+Architectures: amd64, arm64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
 GitFetch: refs/heads/release/8.0
 Directory: debian
 

--- a/library/redis
+++ b/library/redis
@@ -4,13 +4,13 @@ GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.0-M02-alpine, 8.0-M02-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
+GitCommit: f1e991818a8124502b5a4e8e6c7f4ae23d0c7bb4
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
 Tags: 8.0-M02, 8.0-M02-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
+GitCommit: f1e991818a8124502b5a4e8e6c7f4ae23d0c7bb4
 GitFetch: refs/heads/release/8.0
 Directory: debian
 

--- a/library/redis
+++ b/library/redis
@@ -3,13 +3,13 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
 GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.0-M02-alpine, 8.0-M02-alpine3.20
-Architectures: amd64, arm64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
 Tags: 8.0-M02, 8.0-M02-bookworm
-Architectures: amd64, arm64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
 GitFetch: refs/heads/release/8.0
 Directory: debian

--- a/library/redis
+++ b/library/redis
@@ -3,7 +3,7 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
 GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.0-M02-alpine, 8.0-M02-alpine3.20
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 6203acb65e690d21efee279615c876593b1eb1cf
 GitFetch: refs/heads/release/8.0
 Directory: alpine


### PR DESCRIPTION
Added support for Alpine 