### PR TITLE
Odoo: update 16.0-18.0 to release 20241029

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: decdaff7f94fd13001ac5dbdba59776b628265eb
+GitCommit: acacd14c9ce469c234b6fc2f10ab8dd254b2f706
 
-Tags: 18.0-20241017, 18.0, 18, latest
+Tags: 18.0-20241029, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20241017, 17.0, 17
+Tags: 17.0-20241029, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20241017, 16.0, 16
+Tags: 16.0-20241029, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks.