### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,92 +6,92 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 3.4.0-preview2-bookworm, 3.4-rc-bookworm, 3.4.0-preview2, 3.4-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4e09dcf80f32040cde8ff4bb226367d45beadcd8
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.4-rc/bookworm
 
 Tags: 3.4.0-preview2-slim-bookworm, 3.4-rc-slim-bookworm, 3.4.0-preview2-slim, 3.4-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4e09dcf80f32040cde8ff4bb226367d45beadcd8
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.4-rc/slim-bookworm
 
 Tags: 3.4.0-preview2-bullseye, 3.4-rc-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4e09dcf80f32040cde8ff4bb226367d45beadcd8
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.4-rc/bullseye
 
 Tags: 3.4.0-preview2-slim-bullseye, 3.4-rc-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4e09dcf80f32040cde8ff4bb226367d45beadcd8
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.4-rc/slim-bullseye
 
 Tags: 3.4.0-preview2-alpine3.20, 3.4-rc-alpine3.20, 3.4.0-preview2-alpine, 3.4-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4e09dcf80f32040cde8ff4bb226367d45beadcd8
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.4-rc/alpine3.20
 
 Tags: 3.4.0-preview2-alpine3.19, 3.4-rc-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4e09dcf80f32040cde8ff4bb226367d45beadcd8
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.4-rc/alpine3.19
 
 Tags: 3.3.5-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.5, 3.3, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04175a1c782da7183d8cd1ebed8c91b3ce0fe50b
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.3/bookworm
 
 Tags: 3.3.5-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.5-slim, 3.3-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 04175a1c782da7183d8cd1ebed8c91b3ce0fe50b
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.3/slim-bookworm
 
 Tags: 3.3.5-bullseye, 3.3-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 04175a1c782da7183d8cd1ebed8c91b3ce0fe50b
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.3/bullseye
 
 Tags: 3.3.5-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 04175a1c782da7183d8cd1ebed8c91b3ce0fe50b
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.3/slim-bullseye
 
 Tags: 3.3.5-alpine3.20, 3.3-alpine3.20, 3-alpine3.20, alpine3.20, 3.3.5-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 04175a1c782da7183d8cd1ebed8c91b3ce0fe50b
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.3/alpine3.20
 
 Tags: 3.3.5-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 04175a1c782da7183d8cd1ebed8c91b3ce0fe50b
+GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
 Directory: 3.3/alpine3.19
 
-Tags: 3.2.5-bookworm, 3.2-bookworm, 3.2.5, 3.2
+Tags: 3.2.6-bookworm, 3.2-bookworm, 3.2.6, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6438466b4fd948a31f66b2f2a934c799b598233e
+GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
 Directory: 3.2/bookworm
 
-Tags: 3.2.5-slim-bookworm, 3.2-slim-bookworm, 3.2.5-slim, 3.2-slim
+Tags: 3.2.6-slim-bookworm, 3.2-slim-bookworm, 3.2.6-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6438466b4fd948a31f66b2f2a934c799b598233e
+GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
 Directory: 3.2/slim-bookworm
 
-Tags: 3.2.5-bullseye, 3.2-bullseye
+Tags: 3.2.6-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6438466b4fd948a31f66b2f2a934c799b598233e
+GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
 Directory: 3.2/bullseye
 
-Tags: 3.2.5-slim-bullseye, 3.2-slim-bullseye
+Tags: 3.2.6-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6438466b4fd948a31f66b2f2a934c799b598233e
+GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
 Directory: 3.2/slim-bullseye
 
-Tags: 3.2.5-alpine3.20, 3.2-alpine3.20, 3.2.5-alpine, 3.2-alpine
+Tags: 3.2.6-alpine3.20, 3.2-alpine3.20, 3.2.6-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6438466b4fd948a31f66b2f2a934c799b598233e
+GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
 Directory: 3.2/alpine3.20
 
-Tags: 3.2.5-alpine3.19, 3.2-alpine3.19
+Tags: 3.2.6-alpine3.19, 3.2-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6438466b4fd948a31f66b2f2a934c799b598233e
+GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
 Directory: 3.2/alpine3.19
 
 Tags: 3.1.6-bookworm, 3.1-bookworm, 3.1.6, 3.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/3df1b04: Update 3.2 to 3.2.6
- https://github.com/docker-library/ruby/commit/89946d9: Merge pull request https://github.com/docker-library/ruby/pull/478 from Earlopain/bump-rust
- https://github.com/docker-library/ruby/commit/e76791f: Bump rust version
- https://github.com/docker-library/ruby/commit/7cb059d: Merge pull request https://github.com/docker-library/ruby/pull/475 from docker-library/jq-IN
- https://github.com/docker-library/ruby/commit/d49362d: Use jq's `IN()` instead of `index()`