### PR TITLE
Update R to version 4.4.2 released yesterday

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.4.1, latest
+Tags: 4.4.2, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 91dd14805998d37ca5617b1853e8c60f5e032f28
-Directory: r-base/4.4.1
+GitCommit: 91be49790deb5c8a1c0f2b64ccc5fb3696645a54
+Directory: r-base/4.4.2
 


### PR DESCRIPTION
This update R to version 4.4.2 released on yesterday.

As before, we use the Debian package I prepared yesterday. Setup is unchanged from the preceding 4.4.1 release.

Thanks as always for reviewing the PR.