### PR TITLE
archlinux: Release 20241103.0.276161

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20241027.0.273886
-GitCommit: a31e5494d1279a4ba7fc80161ff1c4bf91f196bd
-GitFetch: refs/tags/v20241027.0.273886
+Tags: latest, base, base-20241103.0.276161
+GitCommit: eed36f58ea5e58e82422000506891281ecc918e0
+GitFetch: refs/tags/v20241103.0.276161
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20241027.0.273886
-GitCommit: a31e5494d1279a4ba7fc80161ff1c4bf91f196bd
-GitFetch: refs/tags/v20241027.0.273886
+Tags: base-devel, base-devel-20241103.0.276161
+GitCommit: eed36f58ea5e58e82422000506891281ecc918e0
+GitFetch: refs/tags/v20241103.0.276161
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20241027.0.273886
-GitCommit: a31e5494d1279a4ba7fc80161ff1c4bf91f196bd
-GitFetch: refs/tags/v20241027.0.273886
+Tags: multilib-devel, multilib-devel-20241103.0.276161
+GitCommit: eed36f58ea5e58e82422000506891281ecc918e0
+GitFetch: refs/tags/v20241103.0.276161
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks