### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev10, 3.1-dev, 3.1-dev10-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev11, 3.1-dev, 3.1-dev11-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a2995ab1bab48159a97c44e9e301714d105ec3e9
+GitCommit: ae8136b1c0383795fc02b2443dfe785a52dd08ef
 Directory: 3.1
 
-Tags: 3.1-dev10-alpine, 3.1-dev-alpine, 3.1-dev10-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev11-alpine, 3.1-dev-alpine, 3.1-dev11-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a2995ab1bab48159a97c44e9e301714d105ec3e9
+GitCommit: ae8136b1c0383795fc02b2443dfe785a52dd08ef
 Directory: 3.1/alpine
 
 Tags: 3.0.5, 3.0, lts, latest, 3.0.5-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ae8136b: Update 3.1 to 3.1-dev11
- https://github.com/docker-library/haproxy/commit/7dce106: Merge pull request https://github.com/docker-library/haproxy/pull/235 from docker-library/jq-IN
- https://github.com/docker-library/haproxy/commit/f9b92d6: Use jq's `IN()` instead of `index()`