### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.0.3, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: fbd52bb7e92323a056919bfe6154080f65531bb4
+GitCommit: 471ed1c648396130ba247ce62fb475f666db7d2d
 Directory: 4.0/ubuntu
 
 Tags: 4.0.3-management, 4.0-management, 4-management, management
@@ -17,7 +17,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.3-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fbd52bb7e92323a056919bfe6154080f65531bb4
+GitCommit: 471ed1c648396130ba247ce62fb475f666db7d2d
 Directory: 4.0/alpine
 
 Tags: 4.0.3-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 4.0/alpine/management
 
 Tags: 3.13.7, 3.13, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 1ac53e66c002089bc5cab47554edcaa0087d023f
+GitCommit: ff0bdcfd8c2e81bfeec9a7ad0b432b561ee9f04f
 Directory: 3.13/ubuntu
 
 Tags: 3.13.7-management, 3.13-management, 3-management
@@ -37,7 +37,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.7-alpine, 3.13-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1ac53e66c002089bc5cab47554edcaa0087d023f
+GitCommit: ff0bdcfd8c2e81bfeec9a7ad0b432b561ee9f04f
 Directory: 3.13/alpine
 
 Tags: 3.13.7-management-alpine, 3.13-management-alpine, 3-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/471ed1c: Update 4.0 to otp 26.2.5.5
- https://github.com/docker-library/rabbitmq/commit/ff0bdcf: Update 3.13 to otp 26.2.5.5