### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,92 +6,92 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 3.4.0-preview2-bookworm, 3.4-rc-bookworm, 3.4.0-preview2, 3.4-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.4-rc/bookworm
 
 Tags: 3.4.0-preview2-slim-bookworm, 3.4-rc-slim-bookworm, 3.4.0-preview2-slim, 3.4-rc-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.4-rc/slim-bookworm
 
 Tags: 3.4.0-preview2-bullseye, 3.4-rc-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.4-rc/bullseye
 
 Tags: 3.4.0-preview2-slim-bullseye, 3.4-rc-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.4-rc/slim-bullseye
 
 Tags: 3.4.0-preview2-alpine3.20, 3.4-rc-alpine3.20, 3.4.0-preview2-alpine, 3.4-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.4-rc/alpine3.20
 
 Tags: 3.4.0-preview2-alpine3.19, 3.4-rc-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.4-rc/alpine3.19
 
-Tags: 3.3.5-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.5, 3.3, 3, latest
+Tags: 3.3.6-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.6, 3.3, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: b511945b11599126f923b73533e7b906bb6e95cc
 Directory: 3.3/bookworm
 
-Tags: 3.3.5-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.5-slim, 3.3-slim, 3-slim, slim
+Tags: 3.3.6-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.6-slim, 3.3-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: b511945b11599126f923b73533e7b906bb6e95cc
 Directory: 3.3/slim-bookworm
 
-Tags: 3.3.5-bullseye, 3.3-bullseye, 3-bullseye, bullseye
+Tags: 3.3.6-bullseye, 3.3-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: b511945b11599126f923b73533e7b906bb6e95cc
 Directory: 3.3/bullseye
 
-Tags: 3.3.5-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.3.6-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: b511945b11599126f923b73533e7b906bb6e95cc
 Directory: 3.3/slim-bullseye
 
-Tags: 3.3.5-alpine3.20, 3.3-alpine3.20, 3-alpine3.20, alpine3.20, 3.3.5-alpine, 3.3-alpine, 3-alpine, alpine
+Tags: 3.3.6-alpine3.20, 3.3-alpine3.20, 3-alpine3.20, alpine3.20, 3.3.6-alpine, 3.3-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: b511945b11599126f923b73533e7b906bb6e95cc
 Directory: 3.3/alpine3.20
 
-Tags: 3.3.5-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19
+Tags: 3.3.6-alpine3.19, 3.3-alpine3.19, 3-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e76791f7c9c3a7de9c6c40561561dc718dc77fbb
+GitCommit: b511945b11599126f923b73533e7b906bb6e95cc
 Directory: 3.3/alpine3.19
 
 Tags: 3.2.6-bookworm, 3.2-bookworm, 3.2.6, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.2/bookworm
 
 Tags: 3.2.6-slim-bookworm, 3.2-slim-bookworm, 3.2.6-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.2/slim-bookworm
 
 Tags: 3.2.6-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.2/bullseye
 
 Tags: 3.2.6-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.2/slim-bullseye
 
 Tags: 3.2.6-alpine3.20, 3.2-alpine3.20, 3.2.6-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.2/alpine3.20
 
 Tags: 3.2.6-alpine3.19, 3.2-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3df1b04951937f41a01ae24a6867d833e78345c1
+GitCommit: f268d3972ab3d0f8c8f6b546be8f0bb613a9dfd9
 Directory: 3.2/alpine3.19
 
 Tags: 3.1.6-bookworm, 3.1-bookworm, 3.1.6, 3.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/b511945: Update 3.3 to 3.3.6
- https://github.com/docker-library/ruby/commit/6bb29d9: Merge pull request https://github.com/docker-library/ruby/pull/479 from Earlopain/revert-rust-bump
- https://github.com/docker-library/ruby/commit/f268d39: Revert "Bump rust version"