### PR TITLE
Add latest amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20241010.0
+Tags: 2023, latest, 2023.6.20241031.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: c83383b00b6d1382f06ca5dca262091847258322
+amd64-GitCommit: 99e97aa8d28f80ab32b979ad83ff586749ee0ec0
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2d9a9f52689f239a04f7cc6dc6c95570edaed093
+arm64v8-GitCommit: b7fad15d9dc4a11f95932cb689792c82b6b1f0ba
 
-Tags: 2, 2.0.20241014.0
+Tags: 2, 2.0.20241031.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0c5f82c64737f55a558fe44ef6a79b9537c4d143
+amd64-GitCommit: 260f46597cc645e0edf4672380737f3b5fc58be2
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 0160c3ee0744eaf389cf31f7173db0b48b494995
+arm64v8-GitCommit: 7027504485ee0661d07c515ddecd9c93f074998f
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- openssl-libs-1.0.2k-24.amzn2.0.14
- python-2.7.18-1.amzn2.0.9
- python-libs-2.7.18-1.amzn2.0.9

Updated Packages for Amazon Linux 2023:
- libarchive-3.7.4-2.amzn2023.0.2
- amazon-linux-repo-cdn-2023.6.20241031-0.amzn2023
- system-release-2023.6.20241031-0.amzn2023