### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-8922 ELSA-2024-8860  ELBA-2024-8805"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 34ca4ff693d1e72e5570f6696a27575ade9e9c5b
+amd64-GitCommit: 3ff0a2b17a20bcadbe0d6f523f9cce5a1a043a1a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 246c7622d024d738532d3783fa00ccc4c9405947
+arm64v8-GitCommit: ed19e8b3e2e0d12a90044a2859aaab4eaa970f24
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for tzdata-2024b,  CVE-2019-12900, CVE-2024-3596, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-8922.html
https://linux.oracle.com/errata/ELSA-2024-8860.html
https://linux.oracle.com/errata/ELBA-2024-8805.html


Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
