### PR TITLE
Registry v3.rc-1 release

### DIFF
--- a/library/registry
+++ b/library/registry
@@ -3,9 +3,9 @@ Maintainers: Milos Gajdos (@milosgajdos),
 GitRepo: https://github.com/distribution/distribution-library-image.git
 GitFetch: refs/heads/master
 
-Tags: 3.0.0-beta.1
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-GitCommit: a943e89c3efe06134cd9a4b439203c5341082cbc
+Tags: 3.0.0-rc.1
+Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x, riscv64
+GitCommit: be4eca0a5f3af34a026d1e9294d63f3464c06131
 
 Tags: 2.8.3, 2.8, 2, latest
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x


### PR DESCRIPTION
See:
* https://github.com/distribution/distribution/releases/tag/v3.0.0-rc.1
* https://github.com/distribution/distribution-library-image/pull/177

The only change wrt DOI is the addition of `riscv64` arch