### PR TITLE
Odoo: update 16.0-18.0 to release 20241108

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: acacd14c9ce469c234b6fc2f10ab8dd254b2f706
+GitCommit: 5d79fb3b294227a6264fab1b68917bd344f0c517
 
-Tags: 18.0-20241029, 18.0, 18, latest
+Tags: 18.0-20241108, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20241029, 17.0, 17
+Tags: 17.0-20241108, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20241029, 16.0, 16
+Tags: 16.0-20241108, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

as usual, the latest Odoo updates for supported versions.

Thanks