### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev11, 3.1-dev, 3.1-dev11-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev12, 3.1-dev, 3.1-dev12-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ae8136b1c0383795fc02b2443dfe785a52dd08ef
+GitCommit: b28bb896cedfee705518a8232cfaadda8a35dbed
 Directory: 3.1
 
-Tags: 3.1-dev11-alpine, 3.1-dev-alpine, 3.1-dev11-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev12-alpine, 3.1-dev-alpine, 3.1-dev12-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ae8136b1c0383795fc02b2443dfe785a52dd08ef
+GitCommit: b28bb896cedfee705518a8232cfaadda8a35dbed
 Directory: 3.1/alpine
 
-Tags: 3.0.5, 3.0, lts, latest, 3.0.5-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.6, 3.0, lts, latest, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 43e0f19fb557ead37a57f8d5fe8664eb25bffdc8
+GitCommit: 7341cb2441f9663fb52866df74ccb427960cc8c9
 Directory: 3.0
 
-Tags: 3.0.5-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.5-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.6-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.6-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 43e0f19fb557ead37a57f8d5fe8664eb25bffdc8
+GitCommit: 7341cb2441f9663fb52866df74ccb427960cc8c9
 Directory: 3.0/alpine
 
-Tags: 2.9.11, 2.9, 2.9.11-bookworm, 2.9-bookworm
+Tags: 2.9.12, 2.9, 2.9.12-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 89dbd2e4a131058bb919f0c3442c57033147c242
+GitCommit: 4214bc32bf5038120b1cacbb0f5337169b817aa4
 Directory: 2.9
 
-Tags: 2.9.11-alpine, 2.9-alpine, 2.9.11-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.12-alpine, 2.9-alpine, 2.9.12-alpine3.20, 2.9-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 89dbd2e4a131058bb919f0c3442c57033147c242
+GitCommit: 4214bc32bf5038120b1cacbb0f5337169b817aa4
 Directory: 2.9/alpine
 
-Tags: 2.8.11, 2.8, 2.8.11-bookworm, 2.8-bookworm
+Tags: 2.8.12, 2.8, 2.8.12-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5b8b4056b3fb808eb70f9109eb1ca44ae4514247
+GitCommit: 5235fbf1ddb46b8f6d179958494098ac2708e384
 Directory: 2.8
 
-Tags: 2.8.11-alpine, 2.8-alpine, 2.8.11-alpine3.20, 2.8-alpine3.20
+Tags: 2.8.12-alpine, 2.8-alpine, 2.8.12-alpine3.20, 2.8-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5b8b4056b3fb808eb70f9109eb1ca44ae4514247
+GitCommit: 5235fbf1ddb46b8f6d179958494098ac2708e384
 Directory: 2.8/alpine
 
-Tags: 2.6.19, 2.6, 2.6.19-bookworm, 2.6-bookworm
+Tags: 2.6.20, 2.6, 2.6.20-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 104fd7474379429fd5ad8e23c340eede93736010
+GitCommit: a0cdd805ad2cccf3400fb99dd18d0f49579d1cf4
 Directory: 2.6
 
-Tags: 2.6.19-alpine, 2.6-alpine, 2.6.19-alpine3.20, 2.6-alpine3.20
+Tags: 2.6.20-alpine, 2.6-alpine, 2.6.20-alpine3.20, 2.6-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 104fd7474379429fd5ad8e23c340eede93736010
+GitCommit: a0cdd805ad2cccf3400fb99dd18d0f49579d1cf4
 Directory: 2.6/alpine
 
-Tags: 2.4.27, 2.4, 2.4.27-bookworm, 2.4-bookworm
+Tags: 2.4.28, 2.4, 2.4.28-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c72a79f8fe0a0db91b36645220409c08d11cc0a6
+GitCommit: a59d80d27242e98cb3fa234e5fa9c81a3968be18
 Directory: 2.4
 
-Tags: 2.4.27-alpine, 2.4-alpine, 2.4.27-alpine3.20, 2.4-alpine3.20
+Tags: 2.4.28-alpine, 2.4-alpine, 2.4.28-alpine3.20, 2.4-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c72a79f8fe0a0db91b36645220409c08d11cc0a6
+GitCommit: a59d80d27242e98cb3fa234e5fa9c81a3968be18
 Directory: 2.4/alpine
 
 Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b28bb89: Update 3.1 to 3.1-dev12
- https://github.com/docker-library/haproxy/commit/4214bc3: Update 2.9 to 2.9.12
- https://github.com/docker-library/haproxy/commit/5235fbf: Update 2.8 to 2.8.12
- https://github.com/docker-library/haproxy/commit/a0cdd80: Update 2.6 to 2.6.20
- https://github.com/docker-library/haproxy/commit/a59d80d: Update 2.4 to 2.4.28
- https://github.com/docker-library/haproxy/commit/7341cb2: Update 3.0 to 3.0.6