### PR TITLE
archlinux: Release 20241110.0.278197

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20241103.0.276161
-GitCommit: eed36f58ea5e58e82422000506891281ecc918e0
-GitFetch: refs/tags/v20241103.0.276161
+Tags: latest, base, base-20241110.0.278197
+GitCommit: cb072c818c5bfc56914ca00cf92991e6ccc657a6
+GitFetch: refs/tags/v20241110.0.278197
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20241103.0.276161
-GitCommit: eed36f58ea5e58e82422000506891281ecc918e0
-GitFetch: refs/tags/v20241103.0.276161
+Tags: base-devel, base-devel-20241110.0.278197
+GitCommit: cb072c818c5bfc56914ca00cf92991e6ccc657a6
+GitFetch: refs/tags/v20241110.0.278197
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20241103.0.276161
-GitCommit: eed36f58ea5e58e82422000506891281ecc918e0
-GitFetch: refs/tags/v20241103.0.276161
+Tags: multilib-devel, multilib-devel-20241110.0.278197
+GitCommit: cb072c818c5bfc56914ca00cf92991e6ccc657a6
+GitFetch: refs/tags/v20241110.0.278197
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks