### PR TITLE
Update Clear Linux OS to 42590

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 8ec99859f07474a8394c377f2ba9f54bc057210a
-GitFetch: refs/heads/base-42540
+GitCommit: 80b400d42b54a19ce81b47e91bf97d0b38080d7d
+GitFetch: refs/heads/base-42590


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42590

@bryteise @djklimes @bryteise