### PR TITLE
Add supported versions of clickhouse. Fix 24.10 base

### DIFF
--- a/library/clickhouse
+++ b/library/clickhouse
@@ -5,9 +5,24 @@ Maintainers: Misha f. Shiryaev <felixoid@clickhouse.com> (@Felixoid),
              Alexander Sapin <alesapin@clickhouse.com> (@alesapin)
 GitRepo: https://github.com/ClickHouse/docker-library.git
 GitFetch: refs/heads/main
-GitCommit: 8f3278549dd6ac2832287c18c6a35a5f90eb3394
+GitCommit: e991ffaf2d96bab935a248d5701c58f637d3040e
 
-Tags: latest, jammy, 24, 24-jammy, 24.10, 24.10-jammy, 24.10.1, 24.10.1-jammy, 24.10.1.2812, 24.10.1.2812-jammy
+Tags: latest, focal, 24, 24-focal, 24.10, 24.10-focal, 24.10.1, 24.10.1-focal, 24.10.1.2812, 24.10.1.2812-focal
 Architectures: amd64, arm64v8
 Directory: server/24.10.1.2812
+File: Dockerfile.ubuntu
+
+Tags: 24.9, 24.9-focal, 24.9.2, 24.9.2-focal, 24.9.2.42, 24.9.2.42-focal
+Architectures: amd64, arm64v8
+Directory: server/24.9.2.42
+File: Dockerfile.ubuntu
+
+Tags: lts, focal-lts, 24.8, 24.8-focal, 24.8.6, 24.8.6-focal, 24.8.6.70, 24.8.6.70-focal
+Architectures: amd64, arm64v8
+Directory: server/24.8.6.70
+File: Dockerfile.ubuntu
+
+Tags: 24.3, 24.3-focal, 24.3.13, 24.3.13-focal, 24.3.13.40, 24.3.13.40-focal
+Architectures: amd64, arm64v8
+Directory: server/24.3.13.40
 File: Dockerfile.ubuntu


### PR DESCRIPTION
Regenerate 24.10 image to use ubuntu 20.04 base.
Add `chmod` to the installation step to not change files later.
Add all supported versions.