### PR TITLE
update rocket.chat

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,25 +1,33 @@
-# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/9f02df5b6a52c60a039de4b706e653b424471962/generate-stackbrew-library.sh
+# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5/generate-stackbrew-library.sh
 
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 
-Tags: 6.9.5, 6.9
-GitCommit: 9f02df5b6a52c60a039de4b706e653b424471962
+Tags: 7.0.0, 7.0, 7, latest
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
+Directory: 7.0
+
+Tags: 6.9.7, 6.9
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
 Directory: 6.9
 
-Tags: 6.8.5, 6.8
-GitCommit: 9f02df5b6a52c60a039de4b706e653b424471962
+Tags: 6.8.7, 6.8
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
 Directory: 6.8
 
-Tags: 6.7.7, 6.7
-GitCommit: 9f02df5b6a52c60a039de4b706e653b424471962
-Directory: 6.7
+Tags: 6.13.0, 6.13, 6
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
+Directory: 6.13
 
-Tags: 6.11.1, 6.11, 6, latest
-GitCommit: 9f02df5b6a52c60a039de4b706e653b424471962
+Tags: 6.12.2, 6.12
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
+Directory: 6.12
+
+Tags: 6.11.3, 6.11
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
 Directory: 6.11
 
-Tags: 6.10.4, 6.10
-GitCommit: 9f02df5b6a52c60a039de4b706e653b424471962
+Tags: 6.10.7, 6.10
+GitCommit: 3a4113f1de4aa921dfe26c53f88b4d1f59fac3f5
 Directory: 6.10
 


### PR DESCRIPTION
Updated supported versions based on https://docs.rocket.chat/docs/version-durability