### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 17.0, 17, latest, 17.0-bookworm, 17-bookworm, bookworm
+Tags: 17.1, 17, latest, 17.1-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 172544062d1031004b241e917f5f3f9dfebc0df5
+GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
 Directory: 17/bookworm
 
-Tags: 17.0-bullseye, 17-bullseye, bullseye
+Tags: 17.1-bullseye, 17-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 172544062d1031004b241e917f5f3f9dfebc0df5
+GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
 Directory: 17/bullseye
 
-Tags: 17.0-alpine3.20, 17-alpine3.20, alpine3.20, 17.0-alpine, 17-alpine, alpine
+Tags: 17.1-alpine3.20, 17-alpine3.20, alpine3.20, 17.1-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 172544062d1031004b241e917f5f3f9dfebc0df5
+GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
 Directory: 17/alpine3.20
 
-Tags: 17.0-alpine3.19, 17-alpine3.19, alpine3.19
+Tags: 17.1-alpine3.19, 17-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 172544062d1031004b241e917f5f3f9dfebc0df5
+GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
 Directory: 17/alpine3.19
 
-Tags: 16.4, 16, 16.4-bookworm, 16-bookworm
+Tags: 16.5, 16, 16.5-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c9906f922daaacdfc425b3b918e7644a8722290d
+GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
 Directory: 16/bookworm
 
-Tags: 16.4-bullseye, 16-bullseye
+Tags: 16.5-bullseye, 16-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c9906f922daaacdfc425b3b918e7644a8722290d
+GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
 Directory: 16/bullseye
 
-Tags: 16.4-alpine3.20, 16-alpine3.20, 16.4-alpine, 16-alpine
+Tags: 16.5-alpine3.20, 16-alpine3.20, 16.5-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3a94d965ecbe08f4b1b255d3ed9ccae671a7a984
+GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
 Directory: 16/alpine3.20
 
-Tags: 16.4-alpine3.19, 16-alpine3.19
+Tags: 16.5-alpine3.19, 16-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3a94d965ecbe08f4b1b255d3ed9ccae671a7a984
+GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
 Directory: 16/alpine3.19
 
-Tags: 15.8, 15, 15.8-bookworm, 15-bookworm
+Tags: 15.9, 15, 15.9-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
+GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
 Directory: 15/bookworm
 
-Tags: 15.8-bullseye, 15-bullseye
+Tags: 15.9-bullseye, 15-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
+GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
 Directory: 15/bullseye
 
-Tags: 15.8-alpine3.20, 15-alpine3.20, 15.8-alpine, 15-alpine
+Tags: 15.9-alpine3.20, 15-alpine3.20, 15.9-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
+GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
 Directory: 15/alpine3.20
 
-Tags: 15.8-alpine3.19, 15-alpine3.19
+Tags: 15.9-alpine3.19, 15-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 8cce578a4361ed18a29f53fed24e4554f673a3a4
+GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
 Directory: 15/alpine3.19
 
-Tags: 14.13, 14, 14.13-bookworm, 14-bookworm
+Tags: 14.14, 14, 14.14-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
+GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
 Directory: 14/bookworm
 
-Tags: 14.13-bullseye, 14-bullseye
+Tags: 14.14-bullseye, 14-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
+GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
 Directory: 14/bullseye
 
-Tags: 14.13-alpine3.20, 14-alpine3.20, 14.13-alpine, 14-alpine
+Tags: 14.14-alpine3.20, 14-alpine3.20, 14.14-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
+GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
 Directory: 14/alpine3.20
 
-Tags: 14.13-alpine3.19, 14-alpine3.19
+Tags: 14.14-alpine3.19, 14-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: e324d93eba7160270512436fd5e9464f91cfbcb9
+GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
 Directory: 14/alpine3.19
 
-Tags: 13.16, 13, 13.16-bookworm, 13-bookworm
+Tags: 13.17, 13, 13.17-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
+GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
 Directory: 13/bookworm
 
-Tags: 13.16-bullseye, 13-bullseye
+Tags: 13.17-bullseye, 13-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
+GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
 Directory: 13/bullseye
 
-Tags: 13.16-alpine3.20, 13-alpine3.20, 13.16-alpine, 13-alpine
+Tags: 13.17-alpine3.20, 13-alpine3.20, 13.17-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
+GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
 Directory: 13/alpine3.20
 
-Tags: 13.16-alpine3.19, 13-alpine3.19
+Tags: 13.17-alpine3.19, 13-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: ce54cce510ed5da4ed9e1e66ddeb6e3300786813
+GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
 Directory: 13/alpine3.19
 
-Tags: 12.20, 12, 12.20-bookworm, 12-bookworm
+Tags: 12.21, 12, 12.21-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
+GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
 Directory: 12/bookworm
 
-Tags: 12.20-bullseye, 12-bullseye
+Tags: 12.21-bullseye, 12-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
+GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
 Directory: 12/bullseye
 
-Tags: 12.20-alpine3.20, 12-alpine3.20, 12.20-alpine, 12-alpine
+Tags: 12.21-alpine3.20, 12-alpine3.20, 12.21-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
+GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
 Directory: 12/alpine3.20
 
-Tags: 12.20-alpine3.19, 12-alpine3.19
+Tags: 12.21-alpine3.19, 12-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 62f99df90060f4105ebe9a6bd88611370f52aa16
+GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
 Directory: 12/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/b64a170: Update 17 to 17.1, bookworm 17.1-1.pgdg120+1, bullseye 17.1-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/f6c1f5b: Update 16 to 16.5, bookworm 16.5-1.pgdg120+1, bullseye 16.5-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/89e0c92: Update 15 to 15.9, bookworm 15.9-1.pgdg120+1, bullseye 15.9-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/9c7abb9: Update 14 to 14.14, bookworm 14.14-1.pgdg120+1, bullseye 14.14-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/9f3bef0: Update 13 to 13.17, bookworm 13.17-1.pgdg120+1, bullseye 13.17-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/cbe3b78: Update 12 to 12.21, bookworm 12.21-1.pgdg120+1, bullseye 12.21-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/0f80628: Merge pull request https://github.com/docker-library/postgres/pull/1280 from docker-library/jq-IN
- https://github.com/docker-library/postgres/commit/5db7a17: Use jq's `IN()` instead of `index()`
- https://github.com/docker-library/postgres/commit/a37e929: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates