### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev12, 3.1-dev, 3.1-dev12-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev13, 3.1-dev, 3.1-dev13-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b28bb896cedfee705518a8232cfaadda8a35dbed
+GitCommit: 15ad9aaa9e192c0db0a733d67a0bdf24bc70ef09
 Directory: 3.1
 
-Tags: 3.1-dev12-alpine, 3.1-dev-alpine, 3.1-dev12-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev13-alpine, 3.1-dev-alpine, 3.1-dev13-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b28bb896cedfee705518a8232cfaadda8a35dbed
+GitCommit: 15ad9aaa9e192c0db0a733d67a0bdf24bc70ef09
 Directory: 3.1/alpine
 
 Tags: 3.0.6, 3.0, lts, latest, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/15ad9aa: Update 3.1 to 3.1-dev13