### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2024-8922 ELSA-2024-9502"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3ff0a2b17a20bcadbe0d6f523f9cce5a1a043a1a
+amd64-GitCommit: 79c480de394abd553f94225d0af35b58323e1792
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ed19e8b3e2e0d12a90044a2859aaab4eaa970f24
+arm64v8-GitCommit: 1cefce22076383a3c0bb02e1d8afa646d2f447c8
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2019-12900, CVE-2024-50602, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-8922.html
https://linux.oracle.com/errata/ELSA-2024-9502.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
