### PR TITLE
Update Clear Linux OS to 42630

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 80b400d42b54a19ce81b47e91bf97d0b38080d7d
-GitFetch: refs/heads/base-42590
+GitCommit: c3e797de98e03e415b5958a4e2080aa60ddbc253
+GitFetch: refs/heads/base-42630


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42630

@bryteise @djklimes @bryteise