### PR TITLE
Odoo: update 16.0-18.0 to release 20241118

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5d79fb3b294227a6264fab1b68917bd344f0c517
+GitCommit: 593824b6735d46a7be744006e98f8f53d50cc5db
 
-Tags: 18.0-20241108, 18.0, 18, latest
+Tags: 18.0-20241118, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20241108, 17.0, 17
+Tags: 17.0-20241118, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20241108, 16.0, 16
+Tags: 16.0-20241118, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks