### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: ad1d8a96d90bd17a5be305628aac3dafa9a11f5c
 Directory: 4.1
 
-Tags: 4.0.14, 4.0, 4.0.14-jammy, 4.0-jammy
+Tags: 4.0.15, 4.0, 4.0.15-jammy, 4.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ef383f1d828a1d167b64d2575277f05654c5d903
+GitCommit: c9c51a794db0a9fd4f1bd54e2f1bf75f98af571d
 Directory: 4.0
 
 Tags: 3.11.17, 3.11, 3, 3.11.17-jammy, 3.11-jammy, 3-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/c9c51a7: Update 4.0 to 4.0.15