### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/dc442a4e31414552f7c00c8940272b0699ce0c20/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/df9cf2ae639c5c264c6e2a7a4aaad1ecd6bcf5fb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: dc442a4e31414552f7c00c8940272b0699ce0c20
+GitCommit: df9cf2ae639c5c264c6e2a7a4aaad1ecd6bcf5fb
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a2783b883c18c45a4d91a24327d42048a04068ff
+amd64-GitCommit: 561587125f2933cf8a9226e46df3ee00b3f9c2cf
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: bd26637e84bf52f0f6fff92dc98de904c76c47a4
+arm32v5-GitCommit: 14ceb2f9212ba33fc1bdbce6cd9d03b4472b0acb
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: f511e3b14ac4a74df50983e58c38e7c8e5df5523
+arm32v6-GitCommit: 492b3a46bf8489fceaa8e9556b6e8bfa112a0879
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 2c710ecda64060cb7b07b44cf014b30b85b740ec
+arm32v7-GitCommit: 72e26107d1a6c164226e42079cfc1c9c4b102721
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fa65c12dcdb105f3110a0bd04a4de9336df4d162
+arm64v8-GitCommit: 837cfe61ee2596c008a1804f2aa82c1ca7db7285
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 7bc2517691466a1bbc9f810ea938d8888f4847a5
+i386-GitCommit: 702e9a3b31a20120db10ea848874d64359f4d73f
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 644fb1d4cd3c6fca4f1ca5c73c0f1fe01b39f458
+mips64le-GitCommit: 3adf3eebf402156bfdcdc4c1f265e3d668d5a0e4
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: cc51d12d77293faad06a8a4a32a56129cff4805c
+ppc64le-GitCommit: ae6e0fea11147312a5737372b941c1965cd0b4f9
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 05da609ad07c759f24c2ae673807b720314506b7
+riscv64-GitCommit: a5cac52fb44f96bc10370cd75fca8b2ecd2794cd
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 2292efafbbf0e4bddbbaaa3b02059bac096a1e7c
+s390x-GitCommit: 92e547354a476100b5f500e9e1a9dd4de4a80700
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/df9cf2a: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/37c8bd0: Update metadata for i386
- https://github.com/docker-library/busybox/commit/463a6ba: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/c2ca664: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/be7f505: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/43a9d01: Merge pull request https://github.com/docker-library/busybox/pull/210 from infosiftr/buildroot-2024.08.2
- https://github.com/docker-library/busybox/commit/28e6dcf: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/b67bf25: Update buildroot to 2024.08.2
- https://github.com/docker-library/busybox/commit/085d7ee: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/3c78442: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/6c85745: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/e498cfc: Update metadata for i386
- https://github.com/docker-library/busybox/commit/1af6a91: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/275f4e5: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/5bc7e1a: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/1c54440: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/dc442a4: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/a9515d7: Update metadata for i386
- https://github.com/docker-library/busybox/commit/9d7406e: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/741938b: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/9148256: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/2e70e54: Merge pull request https://github.com/docker-library/busybox/pull/209 from infosiftr/buildroot-2024.08.1
- https://github.com/docker-library/busybox/commit/2dd00e4: Update metadata for amd64