### PR TITLE
Bump Traefik to v2.11.14

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,56 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
 Directory: v3.2/alpine
 
-Tags: v3.1.7-windowsservercore-ltsc2022, 3.1.7-windowsservercore-ltsc2022, v3.1-windowsservercore-ltsc2022, 3.1-windowsservercore-ltsc2022, comte-windowsservercore-ltsc2022
+Tags: v2.11.14-windowsservercore-ltsc2022, 2.11.14-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
-Directory: v3.1/windows/servercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: v3.1.7-windowsservercore-1809, 3.1.7-windowsservercore-1809, v3.1-windowsservercore-1809, 3.1-windowsservercore-1809, comte-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
-Directory: v3.1/windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v3.1.7-nanoserver-ltsc2022, 3.1.7-nanoserver-ltsc2022, v3.1-nanoserver-ltsc2022, 3.1-nanoserver-ltsc2022, comte-nanoserver-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
-Directory: v3.1/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: v3.1.7, 3.1.7, v3.1, 3.1, comte
-Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 40f669e3bf6b1827863a3ab9c901025e6c25b77c
-Directory: v3.1/alpine
-
-Tags: v2.11.13-windowsservercore-ltsc2022, 2.11.13-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
+GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.13-windowsservercore-1809, 2.11.13-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, mimolette-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809
+Tags: v2.11.14-windowsservercore-1809, 2.11.14-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
+GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.13-nanoserver-ltsc2022, 2.11.13-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
+Tags: v2.11.14-nanoserver-ltsc2022, 2.11.14-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
+GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.13, 2.11.13, v2.11, 2.11, mimolette, v2, 2
+Tags: v2.11.14, 2.11.14, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c5d63851ac1dea31b5ab54e6fdbee68ffb1dfd87
+GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.14](https://github.com/traefik/traefik/releases/tag/v2.11.14).

/cc @mmatur @kevinpollet

Cheers
