### PR TITLE
Bump Traefik to v3.2.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.2.0-windowsservercore-ltsc2022, 3.2.0-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.2.1-windowsservercore-ltsc2022, 3.2.1-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
+GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
 Directory: v3.2/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.2.0-windowsservercore-1809, 3.2.0-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
+Tags: v3.2.1-windowsservercore-1809, 3.2.1-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, munster-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
+GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
 Directory: v3.2/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.2.0-nanoserver-ltsc2022, 3.2.0-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.2.1-nanoserver-ltsc2022, 3.2.1-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
+GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
 Directory: v3.2/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.2.0, 3.2.0, v3.2, 3.2, munster, v3, 3, latest
+Tags: v3.2.1, 3.2.1, v3.2, 3.2, v3, 3, munster, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 05f8054703253e2b20c802fc69d24a31ca769a43
+GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
 Directory: v3.2/alpine
 
 Tags: v2.11.14-windowsservercore-ltsc2022, 2.11.14-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.2.1](https://github.com/traefik/traefik/releases/tag/v3.2.1).

/cc @mmatur @kevinpollet

Cheers
