### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,49 +4,49 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.7.0-php8.1-apache, 6.7-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.7.0-php8.1, 6.7-php8.1, 6-php8.1, php8.1
+Tags: 6.7.1-php8.1-apache, 6.7-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.7.1-php8.1, 6.7-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.1/apache
 
-Tags: 6.7.0-php8.1-fpm, 6.7-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.7.1-php8.1-fpm, 6.7-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.1/fpm
 
-Tags: 6.7.0-php8.1-fpm-alpine, 6.7-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.7.1-php8.1-fpm-alpine, 6.7-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.7.0-apache, 6.7-apache, 6-apache, apache, 6.7.0, 6.7, 6, latest, 6.7.0-php8.2-apache, 6.7-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.7.0-php8.2, 6.7-php8.2, 6-php8.2, php8.2
+Tags: 6.7.1-apache, 6.7-apache, 6-apache, apache, 6.7.1, 6.7, 6, latest, 6.7.1-php8.2-apache, 6.7-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.7.1-php8.2, 6.7-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.2/apache
 
-Tags: 6.7.0-fpm, 6.7-fpm, 6-fpm, fpm, 6.7.0-php8.2-fpm, 6.7-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.7.1-fpm, 6.7-fpm, 6-fpm, fpm, 6.7.1-php8.2-fpm, 6.7-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.2/fpm
 
-Tags: 6.7.0-fpm-alpine, 6.7-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.7.0-php8.2-fpm-alpine, 6.7-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.7.1-fpm-alpine, 6.7-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.7.1-php8.2-fpm-alpine, 6.7-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.7.0-php8.3-apache, 6.7-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.7.0-php8.3, 6.7-php8.3, 6-php8.3, php8.3
+Tags: 6.7.1-php8.3-apache, 6.7-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.7.1-php8.3, 6.7-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.3/apache
 
-Tags: 6.7.0-php8.3-fpm, 6.7-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.7.1-php8.3-fpm, 6.7-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.3/fpm
 
-Tags: 6.7.0-php8.3-fpm-alpine, 6.7-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.7.1-php8.3-fpm-alpine, 6.7-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 805a50001c4457b69c949cbc8b2ff1f7e563e2c6
+GitCommit: 0015d465b4115ade0e0f98b3df8b5c17ec4a98e4
 Directory: latest/php8.3/fpm-alpine
 
 Tags: cli-2.11.0-php8.1, cli-2.11-php8.1, cli-2-php8.1, cli-php8.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/0015d46: Update latest to 6.7.1
- https://github.com/docker-library/wordpress/commit/df7a98f: Update beta to 6.7.1
- https://github.com/docker-library/wordpress/commit/349f9ce: Update README
- https://github.com/docker-library/wordpress/commit/956a96d: Update beta to 6.7.1-RC1