### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 17.1, 17, latest, 17.1-bookworm, 17-bookworm, bookworm
+Tags: 17.2, 17, latest, 17.2-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
+GitCommit: 0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0
 Directory: 17/bookworm
 
-Tags: 17.1-bullseye, 17-bullseye, bullseye
+Tags: 17.2-bullseye, 17-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
+GitCommit: 0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0
 Directory: 17/bullseye
 
-Tags: 17.1-alpine3.20, 17-alpine3.20, alpine3.20, 17.1-alpine, 17-alpine, alpine
+Tags: 17.2-alpine3.20, 17-alpine3.20, alpine3.20, 17.2-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
+GitCommit: 0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0
 Directory: 17/alpine3.20
 
-Tags: 17.1-alpine3.19, 17-alpine3.19, alpine3.19
+Tags: 17.2-alpine3.19, 17-alpine3.19, alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: b64a17080eaaab2ec717352379ecd20456562fb5
+GitCommit: 0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0
 Directory: 17/alpine3.19
 
-Tags: 16.5, 16, 16.5-bookworm, 16-bookworm
+Tags: 16.6, 16, 16.6-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
+GitCommit: 960ebdf14ef92d328588e77af2a879c63e577e96
 Directory: 16/bookworm
 
-Tags: 16.5-bullseye, 16-bullseye
+Tags: 16.6-bullseye, 16-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
+GitCommit: 960ebdf14ef92d328588e77af2a879c63e577e96
 Directory: 16/bullseye
 
-Tags: 16.5-alpine3.20, 16-alpine3.20, 16.5-alpine, 16-alpine
+Tags: 16.6-alpine3.20, 16-alpine3.20, 16.6-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
+GitCommit: 960ebdf14ef92d328588e77af2a879c63e577e96
 Directory: 16/alpine3.20
 
-Tags: 16.5-alpine3.19, 16-alpine3.19
+Tags: 16.6-alpine3.19, 16-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: f6c1f5b3765fdb3dce87ac5adc6270e0d5485a76
+GitCommit: 960ebdf14ef92d328588e77af2a879c63e577e96
 Directory: 16/alpine3.19
 
-Tags: 15.9, 15, 15.9-bookworm, 15-bookworm
+Tags: 15.10, 15, 15.10-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
+GitCommit: 50b4cdb50e3599013f2fce9cd8860600f53c696c
 Directory: 15/bookworm
 
-Tags: 15.9-bullseye, 15-bullseye
+Tags: 15.10-bullseye, 15-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
+GitCommit: 50b4cdb50e3599013f2fce9cd8860600f53c696c
 Directory: 15/bullseye
 
-Tags: 15.9-alpine3.20, 15-alpine3.20, 15.9-alpine, 15-alpine
+Tags: 15.10-alpine3.20, 15-alpine3.20, 15.10-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
+GitCommit: 50b4cdb50e3599013f2fce9cd8860600f53c696c
 Directory: 15/alpine3.20
 
-Tags: 15.9-alpine3.19, 15-alpine3.19
+Tags: 15.10-alpine3.19, 15-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 89e0c9265d95bc82c67d417ca04039ec2d5ccefc
+GitCommit: 50b4cdb50e3599013f2fce9cd8860600f53c696c
 Directory: 15/alpine3.19
 
-Tags: 14.14, 14, 14.14-bookworm, 14-bookworm
+Tags: 14.15, 14, 14.15-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
+GitCommit: c44484583320c81b35824ec0ce16864690d68bc3
 Directory: 14/bookworm
 
-Tags: 14.14-bullseye, 14-bullseye
+Tags: 14.15-bullseye, 14-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
+GitCommit: c44484583320c81b35824ec0ce16864690d68bc3
 Directory: 14/bullseye
 
-Tags: 14.14-alpine3.20, 14-alpine3.20, 14.14-alpine, 14-alpine
+Tags: 14.15-alpine3.20, 14-alpine3.20, 14.15-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
+GitCommit: c44484583320c81b35824ec0ce16864690d68bc3
 Directory: 14/alpine3.20
 
-Tags: 14.14-alpine3.19, 14-alpine3.19
+Tags: 14.15-alpine3.19, 14-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9c7abb997a013a96c2651ee541ddea06f424e1f3
+GitCommit: c44484583320c81b35824ec0ce16864690d68bc3
 Directory: 14/alpine3.19
 
-Tags: 13.17, 13, 13.17-bookworm, 13-bookworm
+Tags: 13.18, 13, 13.18-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
+GitCommit: 9fadd0e250ba0c150dafec9e3c8728de3c8e318f
 Directory: 13/bookworm
 
-Tags: 13.17-bullseye, 13-bullseye
+Tags: 13.18-bullseye, 13-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
+GitCommit: 9fadd0e250ba0c150dafec9e3c8728de3c8e318f
 Directory: 13/bullseye
 
-Tags: 13.17-alpine3.20, 13-alpine3.20, 13.17-alpine, 13-alpine
+Tags: 13.18-alpine3.20, 13-alpine3.20, 13.18-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
+GitCommit: 9fadd0e250ba0c150dafec9e3c8728de3c8e318f
 Directory: 13/alpine3.20
 
-Tags: 13.17-alpine3.19, 13-alpine3.19
+Tags: 13.18-alpine3.19, 13-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 9f3bef00aaeb4453ed9e7336ab1856f7e9424b25
+GitCommit: 9fadd0e250ba0c150dafec9e3c8728de3c8e318f
 Directory: 13/alpine3.19
 
-Tags: 12.21, 12, 12.21-bookworm, 12-bookworm
+Tags: 12.22, 12, 12.22-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
+GitCommit: 5f590b8df7f12270d1d5227758744ca3b0bdef74
 Directory: 12/bookworm
 
-Tags: 12.21-bullseye, 12-bullseye
+Tags: 12.22-bullseye, 12-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
+GitCommit: 5f590b8df7f12270d1d5227758744ca3b0bdef74
 Directory: 12/bullseye
 
-Tags: 12.21-alpine3.20, 12-alpine3.20, 12.21-alpine, 12-alpine
+Tags: 12.22-alpine3.20, 12-alpine3.20, 12.22-alpine, 12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
+GitCommit: 5f590b8df7f12270d1d5227758744ca3b0bdef74
 Directory: 12/alpine3.20
 
-Tags: 12.21-alpine3.19, 12-alpine3.19
+Tags: 12.22-alpine3.19, 12-alpine3.19
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: cbe3b78084800aa553239f9726942bb17929ba73
+GitCommit: 5f590b8df7f12270d1d5227758744ca3b0bdef74
 Directory: 12/alpine3.19


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/0b87a9b: Update 17 to 17.2, bookworm 17.2-1.pgdg120+1, bullseye 17.2-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/960ebdf: Update 16 to 16.6, bookworm 16.6-1.pgdg120+1, bullseye 16.6-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/50b4cdb: Update 15 to 15.10, bookworm 15.10-1.pgdg120+1, bullseye 15.10-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/c444845: Update 14 to 14.15, bookworm 14.15-1.pgdg120+1, bullseye 14.15-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/9fadd0e: Update 13 to 13.18, bookworm 13.18-1.pgdg120+1, bullseye 13.18-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/5f590b8: Update 12 to 12.22, bookworm 12.22-1.pgdg120+1, bullseye 12.22-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/7a1418a: Update README