### PR TITLE
MariaDB 11.6.2 release (2024 Q4 p2)

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,25 +6,15 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 Builder: buildkit
 
-Tags: 11.6.1-ubi9-rc, 11.6-ubi9-rc, 11.6.1-ubi-rc, 11.6-ubi-rc
+Tags: 11.6.2-ubi9, 11.6-ubi9, 11-ubi9, 11.6.2-ubi, 11.6-ubi, 11-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 12c877197f55de561614a82cd275c1219b9d60ce
+GitCommit: 292b81d08eaab23d8bd501171e570ea0636b0b82
 Directory: 11.6-ubi
 
-Tags: 11.6.1-noble-rc, 11.6-noble-rc, 11.6.1-rc, 11.6-rc
+Tags: 11.6.2-noble, 11.6-noble, 11-noble, noble, 11.6.2, 11.6, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 12c877197f55de561614a82cd275c1219b9d60ce
+GitCommit: 292b81d08eaab23d8bd501171e570ea0636b0b82
 Directory: 11.6
-
-Tags: 11.5.2-ubi9, 11.5-ubi9, 11-ubi9, 11.5.2-ubi, 11.5-ubi, 11-ubi
-Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 85df6a9f3d781bb94a88d506eca5c3fcc55d8125
-Directory: 11.5-ubi
-
-Tags: 11.5.2-noble, 11.5-noble, 11-noble, noble, 11.5.2, 11.5, 11, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 85df6a9f3d781bb94a88d506eca5c3fcc55d8125
-Directory: 11.5
 
 Tags: 11.4.4-ubi9, 11.4-ubi9, lts-ubi9, 11.4.4-ubi, 11.4-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le

--- a/library/mariadb
+++ b/library/mariadb
@@ -1,10 +1,20 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/58570c6f1988c033d052ea1442675f637d881706/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/967a7459f834bf7119d596b9192c65f3f50ec98c/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
              Faustin Lammler <faustin@mariadb.org> (@fauust)
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 Builder: buildkit
+
+Tags: 11.7.1-ubi9-rc, main-ubi9-rc, 11.7.1-ubi-rc, main-ubi-rc
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: 179af10557a5c3025e6d9346a024c2a1ba190a3b
+Directory: main-ubi
+
+Tags: 11.7.1-noble-rc, main-noble-rc, 11.7.1-rc, main-rc
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 179af10557a5c3025e6d9346a024c2a1ba190a3b
+Directory: main
 
 Tags: 11.6.2-ubi9, 11.6-ubi9, 11-ubi9, 11.6.2-ubi, 11.6-ubi, 11-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le


### PR DESCRIPTION
Release notes: https://mariadb.com/kb/en/mariadb-11-6-2-release-notes/

There's still a 11.7.1-rc coming, but another day.

11.5 eol