### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev13, 3.1-dev, 3.1-dev13-bookworm, 3.1-dev-bookworm
+Tags: 3.1-dev14, 3.1-dev, 3.1-dev14-bookworm, 3.1-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 15ad9aaa9e192c0db0a733d67a0bdf24bc70ef09
+GitCommit: 4fc823bc6faadaf9b2912b3323dac9d78367bb71
 Directory: 3.1
 
-Tags: 3.1-dev13-alpine, 3.1-dev-alpine, 3.1-dev13-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1-dev14-alpine, 3.1-dev-alpine, 3.1-dev14-alpine3.20, 3.1-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 15ad9aaa9e192c0db0a733d67a0bdf24bc70ef09
+GitCommit: 4fc823bc6faadaf9b2912b3323dac9d78367bb71
 Directory: 3.1/alpine
 
 Tags: 3.0.6, 3.0, lts, latest, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/4fc823b: Update 3.1 to 3.1-dev14
- https://github.com/docker-library/haproxy/commit/fdc2f4b: Update README