### PR TITLE
[ros] Add ROSDISTRO_PKGS_SYNC_DATE env var

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
+GitCommit: cf1c3c02d0657c05b8b19ac98d58895ff79c989c
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
@@ -36,7 +36,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
+GitCommit: cf1c3c02d0657c05b8b19ac98d58895ff79c989c
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble
@@ -58,7 +58,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: iron-ros-core, iron-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 27cc0b68263bbbb10bb58dd814efc0a6b0a01ec7
+GitCommit: cf1c3c02d0657c05b8b19ac98d58895ff79c989c
 Directory: ros/iron/ubuntu/jammy/ros-core
 
 Tags: iron-ros-base, iron-ros-base-jammy, iron
@@ -80,7 +80,7 @@ Directory: ros/iron/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 74e321bc1837c29f223a6d54895aa3c8eb184119
+GitCommit: cf1c3c02d0657c05b8b19ac98d58895ff79c989c
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
@@ -102,7 +102,7 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 7f98ddd88d872299c45b60c8bcd70d4eb6665222
+GitCommit: cf1c3c02d0657c05b8b19ac98d58895ff79c989c
 Directory: ros/rolling/ubuntu/noble/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-noble, rolling


### PR DESCRIPTION
This allows user to know on what official package sync the image is based on. This allow them to install any other package of the ecosystem  at the same sync date (from http://snapshots.ros.org/noetic/).

This also permits to bust the docker cache when new version of packages are available which has been a long lasting issue https://github.com/osrf/docker_images/issues/112