### PR TITLE
archlinux: Release 20241124.0.282387

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20241117.0.280007
-GitCommit: 7c5e646fe913319019d629627f00cdea5bea3a05
-GitFetch: refs/tags/v20241117.0.280007
+Tags: latest, base, base-20241124.0.282387
+GitCommit: 414cda585e2add3b240815c85173ae1bb42fffe1
+GitFetch: refs/tags/v20241124.0.282387
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20241117.0.280007
-GitCommit: 7c5e646fe913319019d629627f00cdea5bea3a05
-GitFetch: refs/tags/v20241117.0.280007
+Tags: base-devel, base-devel-20241124.0.282387
+GitCommit: 414cda585e2add3b240815c85173ae1bb42fffe1
+GitFetch: refs/tags/v20241124.0.282387
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20241117.0.280007
-GitCommit: 7c5e646fe913319019d629627f00cdea5bea3a05
-GitFetch: refs/tags/v20241117.0.280007
+Tags: multilib-devel, multilib-devel-20241124.0.282387
+GitCommit: 414cda585e2add3b240815c85173ae1bb42fffe1
+GitFetch: refs/tags/v20241124.0.282387
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks