### PR TITLE
Update Clear Linux OS to 42680

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: c3e797de98e03e415b5958a4e2080aa60ddbc253
-GitFetch: refs/heads/base-42630
+GitCommit: 35901b761ba780aed3bf9a3396c414408715f75d
+GitFetch: refs/heads/base-42680


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42680

@bryteise @djklimes @bryteise