### PR TITLE
Odoo: update 16.0-18.0 to release 20241125

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 593824b6735d46a7be744006e98f8f53d50cc5db
+GitCommit: 5c9e504bfbf35c2e086bfb6057d7003d8a2dca1c
 
-Tags: 18.0-20241118, 18.0, 18, latest
+Tags: 18.0-20241125, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20241118, 17.0, 17
+Tags: 17.0-20241125, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20241118, 16.0, 16
+Tags: 16.0-20241125, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks