### PR TITLE
[oraclelinux] Updating 7, 7-slim and 7-slim-fips for ELBA-2024-8805.

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 26aae444213a50facdad312acc0d183085090164
+amd64-GitCommit: ed973527055cb65676f3b274410b9ed8b7dd5c15
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0e738960d8e95b132aea1ca8f34a376fff144dc0
+arm64v8-GitCommit: 7799b16ddb5834d6f52c61b745d86d7486170f72
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for tzdata-2024b.

See the following for details:
https://linux.oracle.com/errata/ELBA-2024-8805.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
