### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,25 +1,35 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/30dfd20e1a4aadf9e5457cc1d2c52ec9c6eb41cb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/59112301dd30c2377084770b78fa9cc33fdfb759/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.1-dev14, 3.1-dev, 3.1-dev14-bookworm, 3.1-dev-bookworm
+Tags: 3.2-dev0, 3.2-dev, 3.2-dev0-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4fc823bc6faadaf9b2912b3323dac9d78367bb71
+GitCommit: 056667a3593e0e18d97518709e30b6bd8574f760
+Directory: 3.2
+
+Tags: 3.2-dev0-alpine, 3.2-dev-alpine, 3.2-dev0-alpine3.20, 3.2-dev-alpine3.20
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 056667a3593e0e18d97518709e30b6bd8574f760
+Directory: 3.2/alpine
+
+Tags: 3.1.0, 3.1, latest, 3.1.0-bookworm, 3.1-bookworm, bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 845b6f45ac1a8e0ee5706a23ef2fbf56516aebc6
 Directory: 3.1
 
-Tags: 3.1-dev14-alpine, 3.1-dev-alpine, 3.1-dev14-alpine3.20, 3.1-dev-alpine3.20
+Tags: 3.1.0-alpine, 3.1-alpine, alpine, 3.1.0-alpine3.20, 3.1-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4fc823bc6faadaf9b2912b3323dac9d78367bb71
+GitCommit: 845b6f45ac1a8e0ee5706a23ef2fbf56516aebc6
 Directory: 3.1/alpine
 
-Tags: 3.0.6, 3.0, lts, latest, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm, bookworm
+Tags: 3.0.6, 3.0, lts, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 7341cb2441f9663fb52866df74ccb427960cc8c9
 Directory: 3.0
 
-Tags: 3.0.6-alpine, 3.0-alpine, lts-alpine, alpine, 3.0.6-alpine3.20, 3.0-alpine3.20, lts-alpine3.20, alpine3.20
+Tags: 3.0.6-alpine, 3.0-alpine, lts-alpine, 3.0.6-alpine3.20, 3.0-alpine3.20, lts-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 7341cb2441f9663fb52866df74ccb427960cc8c9
 Directory: 3.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/870d8c6: Merge pull request https://github.com/docker-library/haproxy/pull/238 from infosiftr/haproxy-3.2
- https://github.com/docker-library/haproxy/commit/5911230: Update "latest" to 3.1 (3.1.0 GA)
- https://github.com/docker-library/haproxy/commit/056667a: Add 3.2-dev0
- https://github.com/docker-library/haproxy/commit/845b6f4: Update 3.1 to 3.1.0