### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2024-10244"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ed973527055cb65676f3b274410b9ed8b7dd5c15
+amd64-GitCommit: 40f82ce130f453011ef250f56f625dd9e78b276f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7799b16ddb5834d6f52c61b745d86d7486170f72
+arm64v8-GitCommit: 1f6530356917eed1d2e173708e94890f041c6650
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-10963, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-10244.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
