### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2024-10379"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 40f82ce130f453011ef250f56f625dd9e78b276f
+amd64-GitCommit: 3758adfdcd3ab4d5b3927b1a6c52a3afa19b4b75
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1f6530356917eed1d2e173708e94890f041c6650
+arm64v8-GitCommit: cb49161efb82562e03b2093f7b3c6fde51ac2d35
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-10041, CVE-2024-10963, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-10379.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
