### PR TITLE
chore: Update to Rust version 1.83.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/1700955b94ae8a589562d872da74353028fffcf3/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/700c4f146427808cfb1e07a646e4afabbe99da4f/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.82-bullseye, 1.82.0-bullseye, bullseye
+Tags: 1-bullseye, 1.83-bullseye, 1.83.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1700955b94ae8a589562d872da74353028fffcf3
+GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.82-slim-bullseye, 1.82.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.83-slim-bullseye, 1.83.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1700955b94ae8a589562d872da74353028fffcf3
+GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.82-bookworm, 1.82.0-bookworm, bookworm, 1, 1.82, 1.82.0, latest
+Tags: 1-bookworm, 1.83-bookworm, 1.83.0-bookworm, bookworm, 1, 1.83, 1.83.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1700955b94ae8a589562d872da74353028fffcf3
+GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.82-slim-bookworm, 1.82.0-slim-bookworm, slim-bookworm, 1-slim, 1.82-slim, 1.82.0-slim, slim
+Tags: 1-slim-bookworm, 1.83-slim-bookworm, 1.83.0-slim-bookworm, slim-bookworm, 1-slim, 1.83-slim, 1.83.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1700955b94ae8a589562d872da74353028fffcf3
+GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.19, 1.82-alpine3.19, 1.82.0-alpine3.19, alpine3.19
+Tags: 1-alpine3.19, 1.83-alpine3.19, 1.83.0-alpine3.19, alpine3.19
 Architectures: amd64, arm64v8
-GitCommit: 1700955b94ae8a589562d872da74353028fffcf3
+GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/alpine3.19
 
-Tags: 1-alpine3.20, 1.82-alpine3.20, 1.82.0-alpine3.20, alpine3.20, 1-alpine, 1.82-alpine, 1.82.0-alpine, alpine
+Tags: 1-alpine3.20, 1.83-alpine3.20, 1.83.0-alpine3.20, alpine3.20, 1-alpine, 1.83-alpine, 1.83.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 1700955b94ae8a589562d872da74353028fffcf3
+GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/alpine3.20


### PR DESCRIPTION
[1.83.0 Release](https://github.com/rust-lang/rust/releases/tag/1.83.0)
[Announcement Blog](https://blog.rust-lang.org/2024/11/28/Rust-1.83.0.html)