### PR TITLE
Update Clear Linux OS to 42710

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 35901b761ba780aed3bf9a3396c414408715f75d
-GitFetch: refs/heads/base-42680
+GitCommit: 518c3b0f163eb92d2360c799c985db9b8884a00e
+GitFetch: refs/heads/base-42710


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42710

@bryteise @djklimes @bryteise