### PR TITLE
Add Fluentd v1.18.0

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -17,13 +17,13 @@ GitCommit: ddb5019b433339f9eef991ca373445deb6e4d2b1
 Directory: v1.16/debian
 
 # Alpine images
-Tags: v1.17.1-1.0, v1.17-1, latest
+Tags: v1.18.0-1.0, v1.18-1, latest
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 1055e528ef1acbb073028e0281b60bdaf9a23595
-Directory: v1.17/alpine
+GitCommit: 0c3c82df3ec08a46ba346e53c4644cfc667dc703
+Directory: v1.18/alpine
 
 # Debian images
-Tags: v1.17.1-debian-1.0, v1.17-debian-1
+Tags: v1.18.0-debian-1.0, v1.18-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 1055e528ef1acbb073028e0281b60bdaf9a23595
-Directory: v1.17/debian
+GitCommit: 0c3c82df3ec08a46ba346e53c4644cfc667dc703
+Directory: v1.18/debian


### PR DESCRIPTION
Replace Fluentd v1.17.x with new stable v1.18.0 release.

ref. https://github.com/fluent/fluentd/security/policy
