### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,12 +12,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20241111.0
+Tags: 2023, latest, 2023.6.20241121.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: f6ec70327ec96260cd657fab433370245a8d0a4d
+amd64-GitCommit: 167d1c4f918992a8fb72b6f20f95b55f974e638c
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: d2631172bf06f962b08a53cd0e39a7bc1509ed25
+arm64v8-GitCommit: 2ef88b6824fad85f32ed8479d2dddcab97ff3b8a
 
 Tags: 2, 2.0.20241113.1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20241121-0.amzn2023
- system-release-2023.6.20241121-0.amzn2023