### PR TITLE
Updates for the WebSphere and Open Liberty 24.0.0.12 release

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -4,7 +4,7 @@ Maintainers: Gkerta Seferi <Gkerta.Seferi@ibm.com> (@gkertasef),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 978a4b0e8171a2c8349648e23d97a63ddba57577
+GitCommit: d9cd18803d0ac0e4a4ead2b6b750f6550e1eda14
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta

--- a/library/open-liberty
+++ b/library/open-liberty
@@ -4,7 +4,7 @@ Maintainers: Gkerta Seferi <Gkerta.Seferi@ibm.com> (@gkertasef),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/OpenLiberty/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: daccbcdfb5ec04b04fd7e5474689db143853446a
+GitCommit: 978a4b0e8171a2c8349648e23d97a63ddba57577
 Architectures: amd64, i386, ppc64le, s390x
 
 Tags: beta
@@ -52,36 +52,6 @@ Directory: releases/latest/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 24.0.0.6-kernel-slim-java8-openj9
-Directory: releases/24.0.0.6/kernel-slim
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 24.0.0.6-kernel-slim-java11-openj9
-Directory: releases/24.0.0.6/kernel-slim
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 24.0.0.6-kernel-slim-java17-openj9
-Directory: releases/24.0.0.6/kernel-slim
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 24.0.0.6-full-java8-openj9
-Directory: releases/24.0.0.6/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk8
-
-Tags: 24.0.0.6-full-java11-openj9
-Directory: releases/24.0.0.6/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 24.0.0.6-full-java17-openj9
-Directory: releases/24.0.0.6/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
 Tags: 24.0.0.9-kernel-slim-java8-openj9
 Directory: releases/24.0.0.9/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
@@ -112,32 +82,32 @@ Directory: releases/24.0.0.9/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 24.0.0.11-kernel-slim-java8-openj9
-Directory: releases/24.0.0.11/kernel-slim
+Tags: 24.0.0.12-kernel-slim-java8-openj9
+Directory: releases/24.0.0.12/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 24.0.0.11-kernel-slim-java11-openj9
-Directory: releases/24.0.0.11/kernel-slim
+Tags: 24.0.0.12-kernel-slim-java11-openj9
+Directory: releases/24.0.0.12/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 24.0.0.11-kernel-slim-java17-openj9
-Directory: releases/24.0.0.11/kernel-slim
+Tags: 24.0.0.12-kernel-slim-java17-openj9
+Directory: releases/24.0.0.12/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 24.0.0.11-full-java8-openj9
-Directory: releases/24.0.0.11/full
+Tags: 24.0.0.12-full-java8-openj9
+Directory: releases/24.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk8
 
-Tags: 24.0.0.11-full-java11-openj9
-Directory: releases/24.0.0.11/full
+Tags: 24.0.0.12-full-java11-openj9
+Directory: releases/24.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 24.0.0.11-full-java17-openj9
-Directory: releases/24.0.0.11/full
+Tags: 24.0.0.12-full-java17-openj9
+Directory: releases/24.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -4,7 +4,7 @@ Maintainers: Gkerta Seferi <Gkerta.Seferi@ibm.com> (@gkertasef),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: addfe534b880c6f4e44cda04def685af5e4f0c30
+GitCommit: 1dae060ae329d0c5dce1f144faa6789c106cc9e8
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibmjava
@@ -32,34 +32,6 @@ File: Dockerfile.ubuntu.openjdk11
 
 Tags: full-java17-openj9
 Directory: ga/latest/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 24.0.0.6-kernel-java8-ibmjava
-Directory: ga/24.0.0.6/kernel
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 24.0.0.6-kernel-java11-openj9
-Directory: ga/24.0.0.6/kernel
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 24.0.0.6-kernel-java17-openj9
-Directory: ga/24.0.0.6/kernel
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk17
-
-Tags: 24.0.0.6-full-java8-ibmjava
-Directory: ga/24.0.0.6/full
-File: Dockerfile.ubuntu.ibmjava8
-
-Tags: 24.0.0.6-full-java11-openj9
-Directory: ga/24.0.0.6/full
-Architectures: amd64, arm64v8, ppc64le, s390x
-File: Dockerfile.ubuntu.openjdk11
-
-Tags: 24.0.0.6-full-java17-openj9
-Directory: ga/24.0.0.6/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
@@ -91,30 +63,30 @@ Directory: ga/24.0.0.9/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 24.0.0.11-kernel-java8-ibmjava
-Directory: ga/24.0.0.11/kernel
+Tags: 24.0.0.12-kernel-java8-ibmjava
+Directory: ga/24.0.0.12/kernel
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 24.0.0.11-kernel-java11-openj9
-Directory: ga/24.0.0.11/kernel
+Tags: 24.0.0.12-kernel-java11-openj9
+Directory: ga/24.0.0.12/kernel
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 24.0.0.11-kernel-java17-openj9
-Directory: ga/24.0.0.11/kernel
+Tags: 24.0.0.12-kernel-java17-openj9
+Directory: ga/24.0.0.12/kernel
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
-Tags: 24.0.0.11-full-java8-ibmjava
-Directory: ga/24.0.0.11/full
+Tags: 24.0.0.12-full-java8-ibmjava
+Directory: ga/24.0.0.12/full
 File: Dockerfile.ubuntu.ibmjava8
 
-Tags: 24.0.0.11-full-java11-openj9
-Directory: ga/24.0.0.11/full
+Tags: 24.0.0.12-full-java11-openj9
+Directory: ga/24.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk11
 
-Tags: 24.0.0.11-full-java17-openj9
-Directory: ga/24.0.0.11/full
+Tags: 24.0.0.12-full-java17-openj9
+Directory: ga/24.0.0.12/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -4,7 +4,7 @@ Maintainers: Gkerta Seferi <Gkerta.Seferi@ibm.com> (@gkertasef),
              Wendy Raschke <wraschke@us.ibm.com> (@wraschke)
 GitRepo: https://github.com/WASdev/ci.docker.git
 GitFetch: refs/heads/main
-GitCommit: 1dae060ae329d0c5dce1f144faa6789c106cc9e8
+GitCommit: 5a4666b9370e5977b5b93a613e2ed893d4996f19
 Architectures: amd64, ppc64le, s390x
 
 Tags: kernel, kernel-java8-ibmjava


### PR DESCRIPTION
With corrections for the lack of executable permissions on shell scripts.