### PR TITLE
Update Jetty images to 12.0.15 & add support for al2023 based images

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -79,55 +79,55 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 
-Tags: 12.0.14-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.14-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.15-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.15-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jre21, 12.0-jre21, 12-jre21, 12.0.14-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.15-jre21, 12.0-jre21, 12-jre21, 12.0.15-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.14-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.15-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.15-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jre17, 12.0-jre17, 12-jre17, 12.0.14-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.15-jre17, 12.0-jre17, 12-jre17, 12.0.15-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk23-alpine, 12.0-jdk23-alpine, 12-jdk23-alpine, 12.0.14-jdk23-alpine-eclipse-temurin, 12.0-jdk23-alpine-eclipse-temurin, 12-jdk23-alpine-eclipse-temurin
+Tags: 12.0.15-jdk23-alpine, 12.0-jdk23-alpine, 12-jdk23-alpine, 12.0.15-jdk23-alpine-eclipse-temurin, 12.0-jdk23-alpine-eclipse-temurin, 12-jdk23-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk23-alpine
-GitCommit: 9c0344d032b14a8f13681e820fd81e9778140e7f
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk23, 12.0-jdk23, 12-jdk23, 12.0.14-jdk23-eclipse-temurin, 12.0-jdk23-eclipse-temurin, 12-jdk23-eclipse-temurin
+Tags: 12.0.15-jdk23, 12.0-jdk23, 12-jdk23, 12.0.15-jdk23-eclipse-temurin, 12.0-jdk23-eclipse-temurin, 12-jdk23-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk23
-GitCommit: 9c0344d032b14a8f13681e820fd81e9778140e7f
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.14-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.15-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.15-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14, 12.0, 12, 12.0.14-jdk21, 12.0-jdk21, 12-jdk21, 12.0.14-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.14-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.15, 12.0, 12, 12.0.15-jdk21, 12.0-jdk21, 12-jdk21, 12.0.15-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.15-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.14-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.15-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.15-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk17, 12.0-jdk17, 12-jdk17, 12.0.14-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.15-jdk17, 12.0-jdk17, 12-jdk17, 12.0.15-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 11.0.24-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.24-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
@@ -257,7 +257,7 @@ GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 Tags: 9.4.56-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 9.4.56-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -267,7 +267,7 @@ GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 Tags: 9.4.56-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.56-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 9.4.56-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -277,7 +277,7 @@ GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 Tags: 9.4.56-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 9.4.56-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -287,27 +287,42 @@ GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
 Tags: 9.4.56-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
-GitCommit: c0f30f8462d083ddc44b6af8ae967315421b6451
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.15-jdk23-al2023-amazoncorretto, 12.0-jdk23-al2023-amazoncorretto, 12-jdk23-al2023-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.0/jdk23-al2023
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
+
+Tags: 12.0.15-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.14-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.15-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.0/jdk21-al2023
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
+
+Tags: 12.0.15-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.15-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.15-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
-Tags: 12.0.14-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.15-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.0/jdk17-al2023
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
+
+Tags: 12.0.15-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: f0c6a3e167722283788502f39ee521ffdac911a0
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 11.0.24-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -317,7 +332,7 @@ GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 Tags: 11.0.24-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.24-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 11.0.24-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -327,7 +342,7 @@ GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 Tags: 11.0.24-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 11.0.24-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -337,7 +352,7 @@ GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 Tags: 11.0.24-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 10.0.24-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -347,7 +362,7 @@ GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 Tags: 10.0.24-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.24-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 10.0.24-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -357,7 +372,7 @@ GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 Tags: 10.0.24-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62
 
 Tags: 10.0.24-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -367,4 +382,4 @@ GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
 Tags: 10.0.24-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: f705916fcf8ad79097235a944b67d461d2fa3e43
+GitCommit: 09303c6a1c73276d5cd286dbd5f04a1a752ecf62


### PR DESCRIPTION
- Update Jetty images from 12.0.14 to 12.0.15
- Add support for amazoncorretto AL2023 base images