### PR TITLE
chore: Update Rust Alpine versions

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/700c4f146427808cfb1e07a646e4afabbe99da4f/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/85c88f3a3e192ad11f392e829c54ded1178e8447/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
@@ -24,12 +24,12 @@ Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.19, 1.83-alpine3.19, 1.83.0-alpine3.19, alpine3.19
-Architectures: amd64, arm64v8
-GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
-Directory: stable/alpine3.19
-
-Tags: 1-alpine3.20, 1.83-alpine3.20, 1.83.0-alpine3.20, alpine3.20, 1-alpine, 1.83-alpine, 1.83.0-alpine, alpine
+Tags: 1-alpine3.20, 1.83-alpine3.20, 1.83.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
 GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
 Directory: stable/alpine3.20
+
+Tags: 1-alpine3.21, 1.83-alpine3.21, 1.83.0-alpine3.21, alpine3.21, 1-alpine, 1.83-alpine, 1.83.0-alpine, alpine
+Architectures: amd64, arm64v8
+GitCommit: 85c88f3a3e192ad11f392e829c54ded1178e8447
+Directory: stable/alpine3.21


### PR DESCRIPTION
This updates Rust to support Alpine 3.21 and drops support for Alpine 3.19