### PR TITLE
[oraclelinux] Updating 8 for ELSA-2024-10779

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3758adfdcd3ab4d5b3927b1a6c52a3afa19b4b75
+amd64-GitCommit: 41dfa6f49ef407bf503eb64c5173eafdf821bbee
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cb49161efb82562e03b2093f7b3c6fde51ac2d35
+arm64v8-GitCommit: e4b4a46b6b6eaf1504e918aa6c29734ef3414bab
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-11168, CVE-2024-9287

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-10779.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
