### PR TITLE
Update Clear Linux OS to 42760

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 518c3b0f163eb92d2360c799c985db9b8884a00e
-GitFetch: refs/heads/base-42710
+GitCommit: 08f41a5297c0b0d27fad6899032357061335bb92
+GitFetch: refs/heads/base-42760


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42760

@bryteise @djklimes @bryteise