### PR TITLE
Bump Traefik to v2.11.15 and v3.2.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,55 +1,55 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.2.1-windowsservercore-ltsc2022, 3.2.1-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.2.2-windowsservercore-ltsc2022, 3.2.2-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
+GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
 Directory: v3.2/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.2.1-windowsservercore-1809, 3.2.1-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, munster-windowsservercore-1809, windowsservercore-1809
+Tags: v3.2.2-windowsservercore-1809, 3.2.2-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, munster-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
+GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
 Directory: v3.2/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.2.1-nanoserver-ltsc2022, 3.2.1-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.2.2-nanoserver-ltsc2022, 3.2.2-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
+GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
 Directory: v3.2/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.2.1, 3.2.1, v3.2, 3.2, v3, 3, munster, latest
+Tags: v3.2.2, 3.2.2, v3.2, 3.2, v3, 3, munster, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 35c03d017ebb01f69cad7ba6566462886104cc73
+GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
 Directory: v3.2/alpine
 
-Tags: v2.11.14-windowsservercore-ltsc2022, 2.11.14-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.15-windowsservercore-ltsc2022, 2.11.15-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
+GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.14-windowsservercore-1809, 2.11.14-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.15-windowsservercore-1809, 2.11.15-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
+GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.14-nanoserver-ltsc2022, 2.11.14-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.15-nanoserver-ltsc2022, 2.11.15-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
+GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.14, 2.11.14, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.15, 2.11.15, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cd86caf9d71a79f0176edfa03c13b485b8fd9a3f
+GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.15](https://github.com/traefik/traefik/releases/tag/v2.11.15) and to [v3.2.2](https://github.com/traefik/traefik/releases/tag/v3.2.2).

/cc @mmatur @kevinpollet

Cheers
