### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/df9cf2ae639c5c264c6e2a7a4aaad1ecd6bcf5fb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/7b9cd879e42bb7e945fb9c80df0090e0bb7f900b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: df9cf2ae639c5c264c6e2a7a4aaad1ecd6bcf5fb
+GitCommit: 7b9cd879e42bb7e945fb9c80df0090e0bb7f900b
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 561587125f2933cf8a9226e46df3ee00b3f9c2cf
+amd64-GitCommit: 907e0f82e65afd01dae07774db9c70fb73c78eb2
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 14ceb2f9212ba33fc1bdbce6cd9d03b4472b0acb
+arm32v5-GitCommit: 7cd8b28b27607a88bb46c9d11c0c994e093d16db
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 492b3a46bf8489fceaa8e9556b6e8bfa112a0879
+arm32v6-GitCommit: ca9576e25bee1da832a820f0bf285fa810e810ac
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 72e26107d1a6c164226e42079cfc1c9c4b102721
+arm32v7-GitCommit: c91377c43ff214273a35d880583cfeea79cfc5fc
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 837cfe61ee2596c008a1804f2aa82c1ca7db7285
+arm64v8-GitCommit: aab472dc3aa5f0ae327c4aeb54e670cae68792e1
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 702e9a3b31a20120db10ea848874d64359f4d73f
+i386-GitCommit: 8bd172ea99b98ca54e99434ae45352136b6c6dcd
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 3adf3eebf402156bfdcdc4c1f265e3d668d5a0e4
+mips64le-GitCommit: c2a396794c01b62fa6a8ea820c5785bdd5e473bf
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: ae6e0fea11147312a5737372b941c1965cd0b4f9
+ppc64le-GitCommit: a422c12740a10a1ba595bb8c75cc2b037112e18d
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: a5cac52fb44f96bc10370cd75fca8b2ecd2794cd
+riscv64-GitCommit: bf7d8f21ae88c7c57cd3b57156f8f670ca864858
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 92e547354a476100b5f500e9e1a9dd4de4a80700
+s390x-GitCommit: ac190c00907b23ff0ba98196be867289a82e96a4
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/7b9cd87: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/bf7bac1: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/167d41c: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/619cc06: Update metadata for i386
- https://github.com/docker-library/busybox/commit/6c0196c: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/b199bd9: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/f10d137: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/a2551c8: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/79c2f30: Merge pull request https://github.com/docker-library/busybox/pull/212 from infosiftr/update
- https://github.com/docker-library/busybox/commit/9fa5eb2: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/e1aaa6e: Update to Buildroot 2024.11, Alpine 3.21
- https://github.com/docker-library/busybox/commit/e0175e4: Merge pull request https://github.com/docker-library/busybox/pull/211 from infosiftr/buildroot-gitlab
- https://github.com/docker-library/busybox/commit/273ed1c: Use GitLab for all buildroot references
- https://github.com/docker-library/busybox/commit/b1345e3: Remove nolibc bits I accidentally committed (2 months ago 😂)
- https://github.com/docker-library/busybox/commit/2a5451c: Update README
- https://github.com/docker-library/busybox/commit/df9cf2a: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/37c8bd0: Update metadata for i386
- https://github.com/docker-library/busybox/commit/463a6ba: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/c2ca664: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/be7f505: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/43a9d01: Merge pull request https://github.com/docker-library/busybox/pull/210 from infosiftr/buildroot-2024.08.2
- https://github.com/docker-library/busybox/commit/28e6dcf: Update metadata for amd64