### PR TITLE
Add Laurent as a codeowner to more library files

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,9 +3,19 @@
 # give Laurent a bit more responsibility / authority on images where he's comfortable and knowledgeable 🎉
 /library/express-gateway  @LaurentGoderre  @docker-library/maintainers
 /library/ghost            @LaurentGoderre  @docker-library/maintainers
-/library/mongo-express    @LaurentGoderre  @docker-library/maintainers
-/library/node             @LaurentGoderre  @docker-library/maintainers
 /library/httpd            @LaurentGoderre  @docker-library/maintainers
+/library/mongo            @LaurentGoderre  @docker-library/maintainers
+/library/mongo-express    @LaurentGoderre  @docker-library/maintainers
+/library/nginx            @LaurentGoderre  @docker-library/maintainers
+/library/node             @LaurentGoderre  @docker-library/maintainers
+/library/oraclelinux      @LaurentGoderre  @docker-library/maintainers
+/library/postgres         @LaurentGoderre  @docker-library/maintainers
+/library/python           @LaurentGoderre  @docker-library/maintainers
+/library/redis            @LaurentGoderre  @docker-library/maintainers
+/library/redmine          @LaurentGoderre  @docker-library/maintainers
+/library/ruby             @LaurentGoderre  @docker-library/maintainers
+/library/traefik          @LaurentGoderre  @docker-library/maintainers
+/library/ubuntu           @LaurentGoderre  @docker-library/maintainers
 
 # make sure we check with Laurent before we update our SBOM indexer (he follows and is involved in those releases more closely than the rest of us) 👀
 /.external-pins/docker/scout-sbom-indexer*  @LaurentGoderre


### PR DESCRIPTION
Let's add @LaurentGoderre to a few more images as a follow up to https://github.com/docker-library/official-images/pull/16369.

Also, sort the list.