### PR TITLE
"[oraclelinux] Updating 7, 7-slim and 7-slim-fips for ELSA-2024-8788"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 41dfa6f49ef407bf503eb64c5173eafdf821bbee
+amd64-GitCommit: 1283f86cf42e07ae0b7547f1ec8bdd71ca1467fc
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e4b4a46b6b6eaf1504e918aa6c29734ef3414bab
+arm64v8-GitCommit: c12b9577e7414f09c2119e2e611e67a7b080676e
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-3596, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-8788.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
