### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,29 +5,29 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 4.1.0-beta.2, 4.1-rc
+Tags: 4.1.0-beta.3, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 5fb7f52a1f2f438c5994210ee06bc92f2437c8e2
+GitCommit: 99ed8dff13e2b79fc189b76bbbfec8d07947e6b9
 Directory: 4.1-rc/ubuntu
 
-Tags: 4.1.0-beta.2-management, 4.1-rc-management
+Tags: 4.1.0-beta.3-management, 4.1-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: c0dcc40c9bce4bb6a826a61d250a2aeb0fa35416
 Directory: 4.1-rc/ubuntu/management
 
-Tags: 4.1.0-beta.2-alpine, 4.1-rc-alpine
+Tags: 4.1.0-beta.3-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5fb7f52a1f2f438c5994210ee06bc92f2437c8e2
+GitCommit: 99ed8dff13e2b79fc189b76bbbfec8d07947e6b9
 Directory: 4.1-rc/alpine
 
-Tags: 4.1.0-beta.2-management-alpine, 4.1-rc-management-alpine
+Tags: 4.1.0-beta.3-management-alpine, 4.1-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c0dcc40c9bce4bb6a826a61d250a2aeb0fa35416
 Directory: 4.1-rc/alpine/management
 
 Tags: 4.0.4, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 8a0389fb2c2007af3db29b1f12fe82d239c027ac
+GitCommit: efb58cd44392eb62a59b4408dffdf09ff5505015
 Directory: 4.0/ubuntu
 
 Tags: 4.0.4-management, 4.0-management, 4-management, management
@@ -37,7 +37,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.4-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8a0389fb2c2007af3db29b1f12fe82d239c027ac
+GitCommit: efb58cd44392eb62a59b4408dffdf09ff5505015
 Directory: 4.0/alpine
 
 Tags: 4.0.4-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/99ed8df: Update 4.1-rc to otp 27.2
- https://github.com/docker-library/rabbitmq/commit/efb58cd: Update 4.0 to otp 27.2
- https://github.com/docker-library/rabbitmq/commit/966d6d1: Update 4.1-rc to 4.1.0-beta.3