### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev0, 3.2-dev, 3.2-dev0-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev1, 3.2-dev, 3.2-dev1-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 056667a3593e0e18d97518709e30b6bd8574f760
+GitCommit: 98981317e3520043f10841a76e8c0f691b29037d
 Directory: 3.2
 
-Tags: 3.2-dev0-alpine, 3.2-dev-alpine, 3.2-dev0-alpine3.20, 3.2-dev-alpine3.20
+Tags: 3.2-dev1-alpine, 3.2-dev-alpine, 3.2-dev1-alpine3.20, 3.2-dev-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 056667a3593e0e18d97518709e30b6bd8574f760
+GitCommit: 98981317e3520043f10841a76e8c0f691b29037d
 Directory: 3.2/alpine
 
-Tags: 3.1.0, 3.1, latest, 3.1.0-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.1, 3.1, latest, 3.1.1-bookworm, 3.1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 845b6f45ac1a8e0ee5706a23ef2fbf56516aebc6
+GitCommit: dc5f5ce22146dc39f7597ab9f857f0408622c8d8
 Directory: 3.1
 
-Tags: 3.1.0-alpine, 3.1-alpine, alpine, 3.1.0-alpine3.20, 3.1-alpine3.20, alpine3.20
+Tags: 3.1.1-alpine, 3.1-alpine, alpine, 3.1.1-alpine3.20, 3.1-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 845b6f45ac1a8e0ee5706a23ef2fbf56516aebc6
+GitCommit: dc5f5ce22146dc39f7597ab9f857f0408622c8d8
 Directory: 3.1/alpine
 
 Tags: 3.0.6, 3.0, lts, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9898131: Update 3.2 to 3.2-dev1
- https://github.com/docker-library/haproxy/commit/dc5f5ce: Update 3.1 to 3.1.1