### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,34 +24,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: dc5f5ce22146dc39f7597ab9f857f0408622c8d8
 Directory: 3.1/alpine
 
-Tags: 3.0.6, 3.0, lts, 3.0.6-bookworm, 3.0-bookworm, lts-bookworm
+Tags: 3.0.7, 3.0, lts, 3.0.7-bookworm, 3.0-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7341cb2441f9663fb52866df74ccb427960cc8c9
+GitCommit: f0dc84e9e09aa9aa758e6f9340ee0ab3b440930d
 Directory: 3.0
 
-Tags: 3.0.6-alpine, 3.0-alpine, lts-alpine, 3.0.6-alpine3.20, 3.0-alpine3.20, lts-alpine3.20
+Tags: 3.0.7-alpine, 3.0-alpine, lts-alpine, 3.0.7-alpine3.20, 3.0-alpine3.20, lts-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7341cb2441f9663fb52866df74ccb427960cc8c9
+GitCommit: f0dc84e9e09aa9aa758e6f9340ee0ab3b440930d
 Directory: 3.0/alpine
 
-Tags: 2.9.12, 2.9, 2.9.12-bookworm, 2.9-bookworm
+Tags: 2.9.13, 2.9, 2.9.13-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4214bc32bf5038120b1cacbb0f5337169b817aa4
+GitCommit: 0c1da312a638ecef78b17c6919ec9780bc1f75e9
 Directory: 2.9
 
-Tags: 2.9.12-alpine, 2.9-alpine, 2.9.12-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.13-alpine, 2.9-alpine, 2.9.13-alpine3.20, 2.9-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4214bc32bf5038120b1cacbb0f5337169b817aa4
+GitCommit: 0c1da312a638ecef78b17c6919ec9780bc1f75e9
 Directory: 2.9/alpine
 
-Tags: 2.8.12, 2.8, 2.8.12-bookworm, 2.8-bookworm
+Tags: 2.8.13, 2.8, 2.8.13-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5235fbf1ddb46b8f6d179958494098ac2708e384
+GitCommit: ff4e3ce324778f1c2b65d6d61ddbf00c0b51793b
 Directory: 2.8
 
-Tags: 2.8.12-alpine, 2.8-alpine, 2.8.12-alpine3.20, 2.8-alpine3.20
+Tags: 2.8.13-alpine, 2.8-alpine, 2.8.13-alpine3.20, 2.8-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5235fbf1ddb46b8f6d179958494098ac2708e384
+GitCommit: ff4e3ce324778f1c2b65d6d61ddbf00c0b51793b
 Directory: 2.8/alpine
 
 Tags: 2.6.20, 2.6, 2.6.20-bookworm, 2.6-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/f0dc84e: Update 3.0 to 3.0.7
- https://github.com/docker-library/haproxy/commit/0c1da31: Update 2.9 to 2.9.13
- https://github.com/docker-library/haproxy/commit/ff4e3ce: Update 2.8 to 2.8.13