### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2024-10983"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1283f86cf42e07ae0b7547f1ec8bdd71ca1467fc
+amd64-GitCommit: 1eebd14baf7dfda1b15d1c2efe9b3776e4a4b60d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c12b9577e7414f09c2119e2e611e67a7b080676e
+arm64v8-GitCommit: 91f9368b4bc42f1914095342aa2d11274cebbec2
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-11168, CVE-2024-9287, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-10983.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
