### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 98981317e3520043f10841a76e8c0f691b29037d
 Directory: 3.2
 
-Tags: 3.2-dev1-alpine, 3.2-dev-alpine, 3.2-dev1-alpine3.20, 3.2-dev-alpine3.20
+Tags: 3.2-dev1-alpine, 3.2-dev-alpine, 3.2-dev1-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 98981317e3520043f10841a76e8c0f691b29037d
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 3.2/alpine
 
 Tags: 3.1.1, 3.1, latest, 3.1.1-bookworm, 3.1-bookworm, bookworm
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: dc5f5ce22146dc39f7597ab9f857f0408622c8d8
 Directory: 3.1
 
-Tags: 3.1.1-alpine, 3.1-alpine, alpine, 3.1.1-alpine3.20, 3.1-alpine3.20, alpine3.20
+Tags: 3.1.1-alpine, 3.1-alpine, alpine, 3.1.1-alpine3.21, 3.1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dc5f5ce22146dc39f7597ab9f857f0408622c8d8
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 3.1/alpine
 
 Tags: 3.0.7, 3.0, lts, 3.0.7-bookworm, 3.0-bookworm, lts-bookworm
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: f0dc84e9e09aa9aa758e6f9340ee0ab3b440930d
 Directory: 3.0
 
-Tags: 3.0.7-alpine, 3.0-alpine, lts-alpine, 3.0.7-alpine3.20, 3.0-alpine3.20, lts-alpine3.20
+Tags: 3.0.7-alpine, 3.0-alpine, lts-alpine, 3.0.7-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f0dc84e9e09aa9aa758e6f9340ee0ab3b440930d
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 3.0/alpine
 
 Tags: 2.9.13, 2.9, 2.9.13-bookworm, 2.9-bookworm
@@ -39,9 +39,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 0c1da312a638ecef78b17c6919ec9780bc1f75e9
 Directory: 2.9
 
-Tags: 2.9.13-alpine, 2.9-alpine, 2.9.13-alpine3.20, 2.9-alpine3.20
+Tags: 2.9.13-alpine, 2.9-alpine, 2.9.13-alpine3.21, 2.9-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0c1da312a638ecef78b17c6919ec9780bc1f75e9
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 2.9/alpine
 
 Tags: 2.8.13, 2.8, 2.8.13-bookworm, 2.8-bookworm
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: ff4e3ce324778f1c2b65d6d61ddbf00c0b51793b
 Directory: 2.8
 
-Tags: 2.8.13-alpine, 2.8-alpine, 2.8.13-alpine3.20, 2.8-alpine3.20
+Tags: 2.8.13-alpine, 2.8-alpine, 2.8.13-alpine3.21, 2.8-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ff4e3ce324778f1c2b65d6d61ddbf00c0b51793b
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 2.8/alpine
 
 Tags: 2.6.20, 2.6, 2.6.20-bookworm, 2.6-bookworm
@@ -59,9 +59,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a0cdd805ad2cccf3400fb99dd18d0f49579d1cf4
 Directory: 2.6
 
-Tags: 2.6.20-alpine, 2.6-alpine, 2.6.20-alpine3.20, 2.6-alpine3.20
+Tags: 2.6.20-alpine, 2.6-alpine, 2.6.20-alpine3.21, 2.6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a0cdd805ad2cccf3400fb99dd18d0f49579d1cf4
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 2.6/alpine
 
 Tags: 2.4.28, 2.4, 2.4.28-bookworm, 2.4-bookworm
@@ -69,9 +69,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: a59d80d27242e98cb3fa234e5fa9c81a3968be18
 Directory: 2.4
 
-Tags: 2.4.28-alpine, 2.4-alpine, 2.4.28-alpine3.20, 2.4-alpine3.20
+Tags: 2.4.28-alpine, 2.4-alpine, 2.4.28-alpine3.21, 2.4-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a59d80d27242e98cb3fa234e5fa9c81a3968be18
+GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
 Directory: 2.4/alpine
 
 Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5e7227a: Merge pull request https://github.com/docker-library/haproxy/pull/239 from infosiftr/alpine3.21
- https://github.com/docker-library/haproxy/commit/34494c3: Update to Alpine 3.21