### PR TITLE
Raise Alpine base version to 3.18 for existing releases

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -4,10 +4,10 @@ GitFetch: refs/heads/official
 
 Tags: 3.11, 3.11.12
 Architectures: amd64, arm64v8
-GitCommit: e10eb7c8bbdfa928b912e182571bfaf29bd55fb4
-Directory: alpine/3.11.12
+GitCommit: de481d822b675af548d17ec1a448fe7dbee97641
+Directory: alpine/3.11.12_alpine-3.18
 
 Tags: 3.12, 3.12.3, latest
 Architectures: amd64, arm64v8
-GitCommit: 76adfc275579f9e096d965a4afc429c2a1c25274
-Directory: alpine/3.12.3
+GitCommit: de481d822b675af548d17ec1a448fe7dbee97641
+Directory: alpine/3.12.3_alpine-3.18


### PR DESCRIPTION
Raise Alpine base version to 3.18 for 3.11.12 and 3.12.3.