### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,106 +4,106 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 25-ea-1-jdk-oraclelinux9, 25-ea-1-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-1-jdk-oracle, 25-ea-1-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-1-jdk, 25-ea-1, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-2-jdk-oraclelinux9, 25-ea-2-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-2-jdk-oracle, 25-ea-2-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-2-jdk, 25-ea-2, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-1-jdk-oraclelinux8, 25-ea-1-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-2-jdk-oraclelinux8, 25-ea-2-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-1-jdk-bookworm, 25-ea-1-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-2-jdk-bookworm, 25-ea-2-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-1-jdk-slim-bookworm, 25-ea-1-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-1-jdk-slim, 25-ea-1-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-2-jdk-slim-bookworm, 25-ea-2-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-2-jdk-slim, 25-ea-2-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-1-jdk-bullseye, 25-ea-1-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-2-jdk-bullseye, 25-ea-2-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-1-jdk-slim-bullseye, 25-ea-1-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-2-jdk-slim-bullseye, 25-ea-2-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-1-jdk-windowsservercore-ltsc2022, 25-ea-1-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-1-jdk-windowsservercore, 25-ea-1-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-1-jdk, 25-ea-1, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-2-jdk-windowsservercore-ltsc2022, 25-ea-2-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-2-jdk-windowsservercore, 25-ea-2-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-2-jdk, 25-ea-2, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-1-jdk-windowsservercore-1809, 25-ea-1-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
-SharedTags: 25-ea-1-jdk-windowsservercore, 25-ea-1-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-1-jdk, 25-ea-1, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-2-jdk-windowsservercore-1809, 25-ea-2-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
+SharedTags: 25-ea-2-jdk-windowsservercore, 25-ea-2-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-2-jdk, 25-ea-2, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 25-ea-1-jdk-nanoserver-1809, 25-ea-1-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
-SharedTags: 25-ea-1-jdk-nanoserver, 25-ea-1-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-2-jdk-nanoserver-1809, 25-ea-2-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
+SharedTags: 25-ea-2-jdk-nanoserver, 25-ea-2-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 8b4eb9793be5c98bd49a8046f59e2fc3e187caec
+GitCommit: 0fbf74890b5f9256bb4b9680c3ca5bf65749e7df
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 24-ea-27-jdk-oraclelinux9, 24-ea-27-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-27-jdk-oracle, 24-ea-27-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-27-jdk, 24-ea-27, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-28-jdk-oraclelinux9, 24-ea-28-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-28-jdk-oracle, 24-ea-28-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-28-jdk, 24-ea-28, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-27-jdk-oraclelinux8, 24-ea-27-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-28-jdk-oraclelinux8, 24-ea-28-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-27-jdk-bookworm, 24-ea-27-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-28-jdk-bookworm, 24-ea-28-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-27-jdk-slim-bookworm, 24-ea-27-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-27-jdk-slim, 24-ea-27-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-28-jdk-slim-bookworm, 24-ea-28-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-28-jdk-slim, 24-ea-28-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-27-jdk-bullseye, 24-ea-27-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-28-jdk-bullseye, 24-ea-28-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-27-jdk-slim-bullseye, 24-ea-27-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-28-jdk-slim-bullseye, 24-ea-28-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-27-jdk-windowsservercore-ltsc2022, 24-ea-27-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-27-jdk-windowsservercore, 24-ea-27-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-27-jdk, 24-ea-27, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-28-jdk-windowsservercore-ltsc2022, 24-ea-28-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-28-jdk-windowsservercore, 24-ea-28-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-28-jdk, 24-ea-28, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-27-jdk-windowsservercore-1809, 24-ea-27-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-27-jdk-windowsservercore, 24-ea-27-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-27-jdk, 24-ea-27, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-28-jdk-windowsservercore-1809, 24-ea-28-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-28-jdk-windowsservercore, 24-ea-28-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-28-jdk, 24-ea-28, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-27-jdk-nanoserver-1809, 24-ea-27-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-27-jdk-nanoserver, 24-ea-27-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-28-jdk-nanoserver-1809, 24-ea-28-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-28-jdk-nanoserver, 24-ea-28-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 97526fa3a91c5d4b57f9278aa637618d12e006aa
+GitCommit: 1e0ca6e2aa72a0a1bcfd512060e9fe805bf94a24
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/0fbf748: Update 25 to 25-ea+2
- https://github.com/docker-library/openjdk/commit/1e0ca6e: Update 24 to 24-ea+28