### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.104.2, 5.104, 5, latest
+Tags: 5.105.0, 5.105, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 980d1147ebcabf88c9279984e7453afb7f2f7f21
+GitCommit: fab52d5c943038af09062b995d8a9822483e933e
 Directory: 5/debian
 
-Tags: 5.104.2-alpine, 5.104-alpine, 5-alpine, alpine
+Tags: 5.105.0-alpine, 5.105-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 371ce7bbb480b1e1cf60287325041b4d02b1e30d
+GitCommit: fab52d5c943038af09062b995d8a9822483e933e
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/fab52d5: Update to 5.105.0, ghost-cli 1.26.1