### PR TITLE
archlinux: Release 20241215.0.289170

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20241208.0.286830
-GitCommit: 21f7ba1577bff0624cd2295ccbf6068dd23bd6c6
-GitFetch: refs/tags/v20241208.0.286830
+Tags: latest, base, base-20241215.0.289170
+GitCommit: 729f0d450ee8469d038e2fb5dd8e7d4593e9b616
+GitFetch: refs/tags/v20241215.0.289170
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20241208.0.286830
-GitCommit: 21f7ba1577bff0624cd2295ccbf6068dd23bd6c6
-GitFetch: refs/tags/v20241208.0.286830
+Tags: base-devel, base-devel-20241215.0.289170
+GitCommit: 729f0d450ee8469d038e2fb5dd8e7d4593e9b616
+GitFetch: refs/tags/v20241215.0.289170
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20241208.0.286830
-GitCommit: 21f7ba1577bff0624cd2295ccbf6068dd23bd6c6
-GitFetch: refs/tags/v20241208.0.286830
+Tags: multilib-devel, multilib-devel-20241215.0.289170
+GitCommit: 729f0d450ee8469d038e2fb5dd8e7d4593e9b616
+GitFetch: refs/tags/v20241215.0.289170
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks