### PR TITLE
Update Clear Linux OS to 42780

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 08f41a5297c0b0d27fad6899032357061335bb92
-GitFetch: refs/heads/base-42760
+GitCommit: e6fdba6b2c6768dc9c6c090010e09c17628e0948
+GitFetch: refs/heads/base-42780


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42780

@bryteise @djklimes @bryteise