### PR TITLE
Bump Traefik to v3.3.0-rc1, v3.2.3 and v2.11.16

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,55 +1,82 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.2.2-windowsservercore-ltsc2022, 3.2.2-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.3.0-rc1-windowsservercore-ltsc2022, 3.3.0-rc1-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
+GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+Directory: v3.3/windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: v3.3.0-rc1-windowsservercore-1809, 3.3.0-rc1-windowsservercore-1809, saintnectaire-windowsservercore-1809
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+Directory: v3.3/windows/1809
+Constraints: windowsservercore-1809
+
+Tags: v3.3.0-rc1-nanoserver-ltsc2022, 3.3.0-rc1-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+Directory: v3.3/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: v3.3.0-rc1, 3.3.0-rc1, saintnectaire
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+Directory: v3.3/alpine
+
+Tags: v3.2.3-windowsservercore-ltsc2022, 3.2.3-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: eafc354da1aa2204b9c8b74b4e29efc12002b063
 Directory: v3.2/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.2.2-windowsservercore-1809, 3.2.2-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, munster-windowsservercore-1809, windowsservercore-1809
+Tags: v3.2.3-windowsservercore-1809, 3.2.3-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, munster-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
+GitCommit: eafc354da1aa2204b9c8b74b4e29efc12002b063
 Directory: v3.2/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.2.2-nanoserver-ltsc2022, 3.2.2-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.2.3-nanoserver-ltsc2022, 3.2.3-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, munster-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
+GitCommit: eafc354da1aa2204b9c8b74b4e29efc12002b063
 Directory: v3.2/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.2.2, 3.2.2, v3.2, 3.2, v3, 3, munster, latest
+Tags: v3.2.3, 3.2.3, v3.2, 3.2, v3, 3, munster, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fbf1dbdec0fa8e260320e0ac604b539eb3b56ec5
+GitCommit: eafc354da1aa2204b9c8b74b4e29efc12002b063
 Directory: v3.2/alpine
 
-Tags: v2.11.15-windowsservercore-ltsc2022, 2.11.15-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.16-windowsservercore-ltsc2022, 2.11.16-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
+GitCommit: 82de16d0c92acf02ede81d841a58ce86dc7bbd53
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.15-windowsservercore-1809, 2.11.15-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.16-windowsservercore-1809, 2.11.16-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
+GitCommit: 82de16d0c92acf02ede81d841a58ce86dc7bbd53
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.15-nanoserver-ltsc2022, 2.11.15-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.16-nanoserver-ltsc2022, 2.11.16-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
+GitCommit: 82de16d0c92acf02ede81d841a58ce86dc7bbd53
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.15, 2.11.15, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.16, 2.11.16, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 64d06fb359586a9e138488d8ce2ee880f9ff3074
+GitCommit: 82de16d0c92acf02ede81d841a58ce86dc7bbd53
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.3.0-rc1](https://github.com/traefik/traefik/releases/tag/v3.3.0-rc1), [v3.2.3](https://github.com/traefik/traefik/releases/tag/v3.2.3) and [v2.11.16](https://github.com/traefik/traefik/releases/tag/v2.11.16).

/cc @mmatur @kevinpollet

Cheers