### PR TITLE
[nats] Update to 2.10.24

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 72e115b56ee1840779e1c7fb83ba4f6fe3586e05
+GitCommit: c5135d645d12ee07bceea9c27d2dde79d784feb9
 GitFetch: refs/heads/main
 
-Tags: 2.10.23-alpine3.21, 2.10-alpine3.21, 2-alpine3.21, alpine3.21, 2.10.23-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.10.24-alpine3.21, 2.10-alpine3.21, 2-alpine3.21, alpine3.21, 2.10.24-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/alpine3.21
 
-Tags: 2.10.23-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.23-linux, 2.10-linux, 2-linux, linux
-SharedTags: 2.10.23, 2.10, 2, latest
+Tags: 2.10.24-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.24-linux, 2.10-linux, 2-linux, linux
+SharedTags: 2.10.24, 2.10, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/scratch
 
-Tags: 2.10.23-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.10.23-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.10.24-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.10.24-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.23-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.10.23-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.23, 2.10, 2, latest
+Tags: 2.10.24-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.10.24-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.24, 2.10, 2, latest
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Release details at https://github.com/nats-io/nats-server/releases/tag/v2.10.24.