### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,12 +12,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20241121.0
+Tags: 2023, latest, 2023.6.20241212.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 167d1c4f918992a8fb72b6f20f95b55f974e638c
+amd64-GitCommit: 57f3185c634b55eafe58bfdec5f5db20c6462032
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2ef88b6824fad85f32ed8479d2dddcab97ff3b8a
+arm64v8-GitCommit: 2039f9733e6d53b647da26d92cb9d6d4d59410a9
 
 Tags: 2, 2.0.20241113.1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- python3-libs-3.9.20-1.amzn2023.0.2
- amazon-linux-repo-cdn-2023.6.20241212-0.amzn2023
- system-release-2023.6.20241212-0.amzn2023
- python3-3.9.20-1.amzn2023.0.2