### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,21 +12,21 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20241121.0
+Tags: 2023, latest, 2023.6.20241212.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 167d1c4f918992a8fb72b6f20f95b55f974e638c
+amd64-GitCommit: 57f3185c634b55eafe58bfdec5f5db20c6462032
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2ef88b6824fad85f32ed8479d2dddcab97ff3b8a
+arm64v8-GitCommit: 2039f9733e6d53b647da26d92cb9d6d4d59410a9
 
 Tags: 2, 2.0.20241113.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 9345a9ec09cd77260d6000edcaa954d8cc0cd983
+amd64-GitCommit: 6e2bb5876f14f080ad1ed81b8b5fc69775f62f36
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: d1b11d99a319c569fc7a0ab2e9c9afacf621df22
+arm64v8-GitCommit: d762c772b9f4f1706842af517c4f830cef4d2643
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64
 amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: 21ffab08ccd83dc317d0607e94ad0f9a63590a60
+amd64-GitCommit: cfb41ad1c7624786ea10f60c15ce9c117c4da3b6


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- python3-libs-3.9.20-1.amzn2023.0.2
- amazon-linux-repo-cdn-2023.6.20241212-0.amzn2023
- system-release-2023.6.20241212-0.amzn2023
- python3-3.9.20-1.amzn2023.0.2

(update other releases to not rely on EOL alpine:3.17)