### PR TITLE
Updated Unit to 1.34.0

### DIFF
--- a/library/unit
+++ b/library/unit
@@ -1,123 +1,123 @@
-# this file is generated via https://github.com/nginx/unit/blob/624debcf17ea7faab01fa841bd4dcd9f308cf306/pkg/docker/Makefile
+# this file is generated via https://github.com/nginx/unit/blob/d8acad350a52a20918c46c09cb0a0f5479400923/pkg/docker/Makefile
 
 Maintainers: Unit Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/unit.git
 
-Tags: 1.33.0-go1.23, go1.23, go1, go
+Tags: 1.34.0-go1.23, go1.23, go1, go
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.go1.23
 
-Tags: 1.33.0-go1.22, go1.22
+Tags: 1.34.0-go1.22, go1.22
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.go1.22
 
-Tags: 1.33.0-jsc11, jsc11, jsc
+Tags: 1.34.0-jsc11, jsc11, jsc
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.jsc11
 
-Tags: 1.33.0-node22, node22, node
+Tags: 1.34.0-node22, node22, node
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.node22
 
-Tags: 1.33.0-node20, node20
+Tags: 1.34.0-node20, node20
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.node20
 
-Tags: 1.33.0-perl5.40, perl5.40, perl5, perl
+Tags: 1.34.0-perl5.40, perl5.40, perl5, perl
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.perl5.40
 
-Tags: 1.33.0-perl5.38, perl5.38
+Tags: 1.34.0-perl5.38, perl5.38
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.perl5.38
 
-Tags: 1.33.0-php8.3, php8.3, php8, php
+Tags: 1.34.0-php8.4, php8.4, php8, php
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
+Directory: pkg/docker
+File: Dockerfile.php8.4
+
+Tags: 1.34.0-php8.3, php8.3
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/packaging
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.php8.3
 
-Tags: 1.33.0-php8.2, php8.2
+Tags: 1.34.0-python3.13, python3.13, python3, python
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
-File: Dockerfile.php8.2
+File: Dockerfile.python3.13
 
-Tags: 1.33.0-python3.12, python3.12, python3, python
+Tags: 1.34.0-python3.12, python3.12
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.python3.12
 
-Tags: 1.33.0-python3.11, python3.11
+Tags: 1.34.0-ruby3.3, ruby3.3, ruby3, ruby
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
-Directory: pkg/docker
-File: Dockerfile.python3.11
-
-Tags: 1.33.0-ruby3.3, ruby3.3, ruby3, ruby
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.ruby3.3
 
-Tags: 1.33.0-ruby3.2, ruby3.2
+Tags: 1.34.0-ruby3.2, ruby3.2
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.ruby3.2
 
-Tags: 1.33.0-python3.12-slim, python3.12-slim, python3-slim, python-slim
+Tags: 1.34.0-python3.13-slim, python3.13-slim, python3-slim, python-slim
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
+Directory: pkg/docker
+File: Dockerfile.python3.13-slim
+
+Tags: 1.34.0-python3.12-slim, python3.12-slim
+Architectures: amd64, arm64v8
+GitFetch: refs/heads/packaging
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.python3.12-slim
 
-Tags: 1.33.0-python3.11-slim, python3.11-slim
+Tags: 1.34.0-wasm, wasm
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
-Directory: pkg/docker
-File: Dockerfile.python3.11-slim
-
-Tags: 1.33.0-wasm, wasm
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.wasm
 
-Tags: 1.33.0-minimal, minimal, latest
+Tags: 1.34.0-minimal, minimal, latest
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/packaging
-GitCommit: 624debcf17ea7faab01fa841bd4dcd9f308cf306
+GitCommit: d8acad350a52a20918c46c09cb0a0f5479400923
 Directory: pkg/docker
 File: Dockerfile.minimal


### PR DESCRIPTION
This also bumps language variants to:
 - php 8.4
 - python 3.13

Note that this new release also incorporates Rust-based code into the main binary, which means build times are now longer and the resulting images have a bigger size.