### PR TITLE
Bump Traefik to v3.3.0-rc2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.3.0-rc1-windowsservercore-ltsc2022, 3.3.0-rc1-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022
+Tags: v3.3.0-rc2-windowsservercore-ltsc2022, 3.3.0-rc2-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+GitCommit: 441cc872203d05451071db9ae052eb8aef4610f8
 Directory: v3.3/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.3.0-rc1-windowsservercore-1809, 3.3.0-rc1-windowsservercore-1809, saintnectaire-windowsservercore-1809
+Tags: v3.3.0-rc2-windowsservercore-1809, 3.3.0-rc2-windowsservercore-1809, saintnectaire-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+GitCommit: 441cc872203d05451071db9ae052eb8aef4610f8
 Directory: v3.3/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.3.0-rc1-nanoserver-ltsc2022, 3.3.0-rc1-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022
+Tags: v3.3.0-rc2-nanoserver-ltsc2022, 3.3.0-rc2-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+GitCommit: 441cc872203d05451071db9ae052eb8aef4610f8
 Directory: v3.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.3.0-rc1, 3.3.0-rc1, saintnectaire
+Tags: v3.3.0-rc2, 3.3.0-rc2, saintnectaire
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 137c5985e4ac8087166fbb08bdd3324addb462de
+GitCommit: 441cc872203d05451071db9ae052eb8aef4610f8
 Directory: v3.3/alpine
 
 Tags: v3.2.3-windowsservercore-ltsc2022, 3.2.3-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.3.0-rc2](https://github.com/traefik/traefik/releases/tag/v3.3.0-rc2).

/cc @mmatur @kevinpollet

Cheers
