### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2024-11250"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1eebd14baf7dfda1b15d1c2efe9b3776e4a4b60d
+amd64-GitCommit: 9fe8ed8899da004b76331cea812f7caae9c3a957
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 91f9368b4bc42f1914095342aa2d11274cebbec2
+arm64v8-GitCommit: c54d39c9290fe6b005a44bf0e9167a1ddf3acb12
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-10041, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2024-11250.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
