### PR TITLE
archlinux: Release 20241222.0.291122

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20241215.0.289170
-GitCommit: 729f0d450ee8469d038e2fb5dd8e7d4593e9b616
-GitFetch: refs/tags/v20241215.0.289170
+Tags: latest, base, base-20241222.0.291122
+GitCommit: 4cacbe0820837f0754e7fedbdf516992008dc3e5
+GitFetch: refs/tags/v20241222.0.291122
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20241215.0.289170
-GitCommit: 729f0d450ee8469d038e2fb5dd8e7d4593e9b616
-GitFetch: refs/tags/v20241215.0.289170
+Tags: base-devel, base-devel-20241222.0.291122
+GitCommit: 4cacbe0820837f0754e7fedbdf516992008dc3e5
+GitFetch: refs/tags/v20241222.0.291122
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20241215.0.289170
-GitCommit: 729f0d450ee8469d038e2fb5dd8e7d4593e9b616
-GitFetch: refs/tags/v20241215.0.289170
+Tags: multilib-devel, multilib-devel-20241222.0.291122
+GitCommit: 4cacbe0820837f0754e7fedbdf516992008dc3e5
+GitFetch: refs/tags/v20241222.0.291122
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks