### PR TITLE
Update Clear Linux OS to 42790

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: e6fdba6b2c6768dc9c6c090010e09c17628e0948
-GitFetch: refs/heads/base-42780
+GitCommit: 66696cc399a15d4af023b6533983110081f2de00
+GitFetch: refs/heads/base-42790


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42790

@bryteise @djklimes @bryteise