### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.4.0-rc1-bookworm, 3.4-rc-bookworm, 3.4.0-rc1, 3.4-rc
+Tags: 3.4.1-bookworm, 3.4-bookworm, 3-bookworm, bookworm, 3.4.1, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 34da3c21b6eb8a63f2c72167f3ad46fe31260dc3
-Directory: 3.4-rc/bookworm
+GitCommit: 3caadc6cd9931b347181c517968c2ad414c49760
+Directory: 3.4/bookworm
 
-Tags: 3.4.0-rc1-slim-bookworm, 3.4-rc-slim-bookworm, 3.4.0-rc1-slim, 3.4-rc-slim
+Tags: 3.4.1-slim-bookworm, 3.4-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.4.1-slim, 3.4-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 34da3c21b6eb8a63f2c72167f3ad46fe31260dc3
-Directory: 3.4-rc/slim-bookworm
+GitCommit: 3caadc6cd9931b347181c517968c2ad414c49760
+Directory: 3.4/slim-bookworm
 
-Tags: 3.4.0-rc1-bullseye, 3.4-rc-bullseye
+Tags: 3.4.1-bullseye, 3.4-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 34da3c21b6eb8a63f2c72167f3ad46fe31260dc3
-Directory: 3.4-rc/bullseye
+GitCommit: 3caadc6cd9931b347181c517968c2ad414c49760
+Directory: 3.4/bullseye
 
-Tags: 3.4.0-rc1-slim-bullseye, 3.4-rc-slim-bullseye
+Tags: 3.4.1-slim-bullseye, 3.4-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 34da3c21b6eb8a63f2c72167f3ad46fe31260dc3
-Directory: 3.4-rc/slim-bullseye
+GitCommit: 3caadc6cd9931b347181c517968c2ad414c49760
+Directory: 3.4/slim-bullseye
 
-Tags: 3.4.0-rc1-alpine3.21, 3.4-rc-alpine3.21, 3.4.0-rc1-alpine, 3.4-rc-alpine
+Tags: 3.4.1-alpine3.21, 3.4-alpine3.21, 3-alpine3.21, alpine3.21, 3.4.1-alpine, 3.4-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34da3c21b6eb8a63f2c72167f3ad46fe31260dc3
-Directory: 3.4-rc/alpine3.21
+GitCommit: 3caadc6cd9931b347181c517968c2ad414c49760
+Directory: 3.4/alpine3.21
 
-Tags: 3.4.0-rc1-alpine3.20, 3.4-rc-alpine3.20
+Tags: 3.4.1-alpine3.20, 3.4-alpine3.20, 3-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34da3c21b6eb8a63f2c72167f3ad46fe31260dc3
-Directory: 3.4-rc/alpine3.20
+GitCommit: 3caadc6cd9931b347181c517968c2ad414c49760
+Directory: 3.4/alpine3.20
 
-Tags: 3.3.6-bookworm, 3.3-bookworm, 3-bookworm, bookworm, 3.3.6, 3.3, 3, latest
+Tags: 3.3.6-bookworm, 3.3-bookworm, 3.3.6, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
 Directory: 3.3/bookworm
 
-Tags: 3.3.6-slim-bookworm, 3.3-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.3.6-slim, 3.3-slim, 3-slim, slim
+Tags: 3.3.6-slim-bookworm, 3.3-slim-bookworm, 3.3.6-slim, 3.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
 Directory: 3.3/slim-bookworm
 
-Tags: 3.3.6-bullseye, 3.3-bullseye, 3-bullseye, bullseye
+Tags: 3.3.6-bullseye, 3.3-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
 Directory: 3.3/bullseye
 
-Tags: 3.3.6-slim-bullseye, 3.3-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.3.6-slim-bullseye, 3.3-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
 GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
 Directory: 3.3/slim-bullseye
 
-Tags: 3.3.6-alpine3.21, 3.3-alpine3.21, 3-alpine3.21, alpine3.21, 3.3.6-alpine, 3.3-alpine, 3-alpine, alpine
+Tags: 3.3.6-alpine3.21, 3.3-alpine3.21, 3.3.6-alpine, 3.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
 Directory: 3.3/alpine3.21
 
-Tags: 3.3.6-alpine3.20, 3.3-alpine3.20, 3-alpine3.20, alpine3.20
+Tags: 3.3.6-alpine3.20, 3.3-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
 Directory: 3.3/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/559bc12: Update 3.4-rc
- https://github.com/docker-library/ruby/commit/3caadc6: Update 3.4 to 3.4.1, rust 1.74.1, rustup 1.26.0
- https://github.com/docker-library/ruby/commit/15cf9d7: Simplify and update `verify-templating.yml`