### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev1, 3.2-dev, 3.2-dev1-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev2, 3.2-dev, 3.2-dev2-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 98981317e3520043f10841a76e8c0f691b29037d
+GitCommit: 10d18fdff5067448f4b88fbdac42594a005b60a9
 Directory: 3.2
 
-Tags: 3.2-dev1-alpine, 3.2-dev-alpine, 3.2-dev1-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev2-alpine, 3.2-dev-alpine, 3.2-dev2-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: 10d18fdff5067448f4b88fbdac42594a005b60a9
 Directory: 3.2/alpine
 
 Tags: 3.1.1, 3.1, latest, 3.1.1-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/10d18fd: Update 3.2 to 3.2-dev2
- https://github.com/docker-library/haproxy/commit/db0d271: Simplify and update `verify-templating.yml`