### PR TITLE
Update backdrop to 1.29.2, and update some image configuration

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.26.1, 1.26, 1, 1.26.1-apache, 1.26-apache, 1-apache, apache, latest
+Tags: 1.29.1, 1.29, 1, 1.29.1-apache, 1.29-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 95902d6610b2474ca88ff8faae40ed30e7d3318a
+GitCommit: cb21983b4ec3b6fb90e8c12a916684688a3e9118
 Directory: 1/apache
 
-Tags: 1.26.1-fpm, 1.26-fpm, 1-fpm, fpm
+Tags: 1.29.1-fpm, 1.29-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 95902d6610b2474ca88ff8faae40ed30e7d3318a
+GitCommit: cb21983b4ec3b6fb90e8c12a916684688a3e9118
 Directory: 1/fpm

--- a/library/backdrop
+++ b/library/backdrop
@@ -6,10 +6,10 @@ GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
 Tags: 1.29.1, 1.29, 1, 1.29.1-apache, 1.29-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: cb21983b4ec3b6fb90e8c12a916684688a3e9118
+GitCommit: 4f986f41b86617411c52eefc86b59380312f1751
 Directory: 1/apache
 
 Tags: 1.29.1-fpm, 1.29-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: cb21983b4ec3b6fb90e8c12a916684688a3e9118
+GitCommit: 4f986f41b86617411c52eefc86b59380312f1751
 Directory: 1/fpm


### PR DESCRIPTION
The latest backdrop release is now 1.29.2 - https://github.com/backdrop/backdrop/releases/, which was a security release of Backdrop CMS. 

We have also updated some of the image config to resolve issues with file locations.  

You can see all the repo updates at the backdrop-docker repo, along with the latest merge commit.  https://github.com/backdrop-ops/backdrop-docker/commits/master

Here is the latest merge hash 
`cb21983b4ec3b6fb90e8c12a916684688a3e9118`