### PR TITLE
Odoo: update 16.0-18.0 to release 20250106

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 6b739618081fc0ff46032b38f5c126bafcdfe3a4
+GitCommit: cb992de79edab3b98702fb33fa6ccfc04aa00861
 
-Tags: 18.0-20241220, 18.0, 18, latest
+Tags: 18.0-20250106, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20241220, 17.0, 17
+Tags: 17.0-20250106, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20241220, 16.0, 16
+Tags: 16.0-20250106, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates for Odoo supported versions.

Thanks and Happy New Year