### PR TITLE
[SECURITY] Redis Release `6.2.17`, `7.2.7`, `7.4.2`

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -16,30 +16,30 @@ Directory: debian
 
 Tags: 7.4.2, 7.4, 7, latest, 7.4.2-bookworm, 7.4-bookworm, 7-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
+GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.4/debian
 
 Tags: 7.4.2-alpine, 7.4-alpine, 7-alpine, alpine, 7.4.2-alpine3.20, 7.4-alpine3.20, 7-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
+GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.4/alpine
 
 Tags: 7.2.7, 7.2, 7.2.7-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
+GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.2/debian
 
 Tags: 7.2.7-alpine, 7.2-alpine, 7.2.7-alpine3.20, 7.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
+GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.2/alpine
 
 Tags: 6.2.17, 6.2, 6, 6.2.17-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
+GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 6.2/debian
 
 Tags: 6.2.17-alpine, 6.2-alpine, 6-alpine, 6.2.17-alpine3.20, 6.2-alpine3.20, 6-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
+GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 6.2/alpine

--- a/library/redis
+++ b/library/redis
@@ -16,30 +16,30 @@ Directory: debian
 
 Tags: 7.4.1, 7.4, 7, latest, 7.4.1-bookworm, 7.4-bookworm, 7-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e5650da99bb377b2ed4f9f1ef993ff24729b1c16
+GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.4/debian
 
 Tags: 7.4.1-alpine, 7.4-alpine, 7-alpine, alpine, 7.4.1-alpine3.20, 7.4-alpine3.20, 7-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e5650da99bb377b2ed4f9f1ef993ff24729b1c16
+GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.4/alpine
 
 Tags: 7.2.6, 7.2, 7.2.6-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e5650da99bb377b2ed4f9f1ef993ff24729b1c16
+GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.2/debian
 
 Tags: 7.2.6-alpine, 7.2-alpine, 7.2.6-alpine3.20, 7.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e5650da99bb377b2ed4f9f1ef993ff24729b1c16
+GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.2/alpine
 
 Tags: 6.2.16, 6.2, 6, 6.2.16-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e5650da99bb377b2ed4f9f1ef993ff24729b1c16
+GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 6.2/debian
 
 Tags: 6.2.16-alpine, 6.2-alpine, 6-alpine, 6.2.16-alpine3.20, 6.2-alpine3.20, 6-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e5650da99bb377b2ed4f9f1ef993ff24729b1c16
+GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 6.2/alpine

--- a/library/redis
+++ b/library/redis
@@ -14,32 +14,32 @@ GitCommit: f1e991818a8124502b5a4e8e6c7f4ae23d0c7bb4
 GitFetch: refs/heads/release/8.0
 Directory: debian
 
-Tags: 7.4.1, 7.4, 7, latest, 7.4.1-bookworm, 7.4-bookworm, 7-bookworm, bookworm
+Tags: 7.4.2, 7.4, 7, latest, 7.4.2-bookworm, 7.4-bookworm, 7-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.4/debian
 
-Tags: 7.4.1-alpine, 7.4-alpine, 7-alpine, alpine, 7.4.1-alpine3.20, 7.4-alpine3.20, 7-alpine3.20, alpine3.20
+Tags: 7.4.2-alpine, 7.4-alpine, 7-alpine, alpine, 7.4.2-alpine3.20, 7.4-alpine3.20, 7-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.4/alpine
 
-Tags: 7.2.6, 7.2, 7.2.6-bookworm, 7.2-bookworm
+Tags: 7.2.7, 7.2, 7.2.7-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.2/debian
 
-Tags: 7.2.6-alpine, 7.2-alpine, 7.2.6-alpine3.20, 7.2-alpine3.20
+Tags: 7.2.7-alpine, 7.2-alpine, 7.2.7-alpine3.20, 7.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 7.2/alpine
 
-Tags: 6.2.16, 6.2, 6, 6.2.16-bookworm, 6.2-bookworm, 6-bookworm
+Tags: 6.2.17, 6.2, 6, 6.2.17-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 6.2/debian
 
-Tags: 6.2.16-alpine, 6.2-alpine, 6-alpine, 6.2.16-alpine3.20, 6.2-alpine3.20, 6-alpine3.20
+Tags: 6.2.17-alpine, 6.2-alpine, 6-alpine, 6.2.17-alpine3.20, 6.2-alpine3.20, 6-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c60d293cb610fc242f63c0b78450269e49bba693
 Directory: 6.2/alpine

--- a/library/redis
+++ b/library/redis
@@ -2,7 +2,7 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Yossi Gottlieb <yossi@redis.com> (@yossigo)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.0-M02-alpine, 8.0-M02-alpine3.20
+Tags: 8.0-M02-alpine, 8.0-M02-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: f1e991818a8124502b5a4e8e6c7f4ae23d0c7bb4
 GitFetch: refs/heads/release/8.0
@@ -19,7 +19,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.4/debian
 
-Tags: 7.4.2-alpine, 7.4-alpine, 7-alpine, alpine, 7.4.2-alpine3.20, 7.4-alpine3.20, 7-alpine3.20, alpine3.20
+Tags: 7.4.2-alpine, 7.4-alpine, 7-alpine, alpine, 7.4.2-alpine3.21, 7.4-alpine3.21, 7-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.4/alpine
@@ -29,7 +29,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.2/debian
 
-Tags: 7.2.7-alpine, 7.2-alpine, 7.2.7-alpine3.20, 7.2-alpine3.20
+Tags: 7.2.7-alpine, 7.2-alpine, 7.2.7-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 7.2/alpine
@@ -39,7 +39,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 6.2/debian
 
-Tags: 6.2.17-alpine, 6.2-alpine, 6-alpine, 6.2.17-alpine3.20, 6.2-alpine3.20, 6-alpine3.20
+Tags: 6.2.17-alpine, 6.2-alpine, 6-alpine, 6.2.17-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 8338d86bc3f7b195046138f8c31bf9a839cdedd3
 Directory: 6.2/alpine


### PR DESCRIPTION
Release of the latest supported redis versions:
- https://github.com/redis/redis/releases/tag/6.2.17
- https://github.com/redis/redis/releases/tag/7.2.7
- https://github.com/redis/redis/releases/tag/7.4.2

https://github.com/redis/docker-library-redis/commit/c60d293cb610fc242f63c0b78450269e49bba693 https://github.com/redis/docker-library-redis/pull/426