### PR TITLE
Adjust Munge PR action to prevent comment hide/post race

### DIFF
--- a/.github/workflows/munge-pr.yml
+++ b/.github/workflows/munge-pr.yml
@@ -15,6 +15,12 @@ env:
   # https://github.com/docker-library/bashbrew/issues/10
   GIT_LFS_SKIP_SMUDGE: 1
 
+# limit to one run at a time per pull request
+# no cancel-in-progress so that the running diff comment can finish before the next since the old diff could be helpful for review
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
 jobs:
 
   gather:

--- a/.github/workflows/test-pr.yml
+++ b/.github/workflows/test-pr.yml
@@ -13,7 +13,7 @@ env:
   
 # cancel existing runs if user makes another push
 concurrency:
-  group: ${{ github.ref }}
+  group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 permissions:


### PR DESCRIPTION
Also change group for the test-pr so that they won't conflict or cancel each other (https://docs.github.com/en/actions/writing-workflows/workflow-syntax-for-github-actions#concurrency).