### PR TITLE
alpine: bump releases to fix ca-certificates regression

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.21.1, 3.21, 3, latest
+Tags: 3.21.2, 3.21, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.21
-GitCommit: f44f38b28c582b725bb99ade263130e058be2f6c
+GitCommit: 28413e472a7192492de374a257c33d2802ba163d
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -27,10 +27,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.20.4, 3.20
+Tags: 3.20.5, 3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.20
-GitCommit: 570fbc0dbd327c078102c96f6556fa49ed496e98
+GitCommit: e5b6428f2a04eaf7f6f6c51232c0bfb6062c9bfe
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -40,10 +40,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.19.5, 3.19
+Tags: 3.19.6, 3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.19
-GitCommit: c7e11c73613b8d15300e65f36deaedb5add5bdca
+GitCommit: da0e46144e764925f67d80a2315c17208236a2ae
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -52,10 +52,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.18.10, 3.18
+Tags: 3.18.11, 3.18
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.18
-GitCommit: a92c90ad5a7bb2d180ff4e5603b5d8932665a949
+GitCommit: 4283069ff594a823a2923e4d1aa3980d829f0891
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,10 @@
 Maintainers: Natanael Copa <ncopa@alpinelinux.org> (@ncopa)
 GitRepo: https://github.com/alpinelinux/docker-alpine.git
 
-Tags: 20240923, edge
+Tags: 20250108, edge
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/edge
-GitCommit: 446ba06f99cf635657b51b1a5a0e81a9b8073929
+GitCommit: c1f1de232c970df2285c03050ab3747b8563164f
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
ref: https://gitlab.alpinelinux.org/alpine/ca-certificates/-/issues/6