### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,40 +5,40 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 Builder: buildkit
 
-Tags: 27.5.0-rc.1-cli, 27-rc-cli, rc-cli, 27.5.0-rc.1-cli-alpine3.21
+Tags: 27.5.0-rc.2-cli, 27-rc-cli, rc-cli, 27.5.0-rc.2-cli-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 982bc8b4002d8c38372ef646d034ce7ca592f82a
+GitCommit: eb3c938f4f09b2b1173d99b4d9f6a1b34167e6a7
 Directory: 27-rc/cli
 
-Tags: 27.5.0-rc.1-dind, 27-rc-dind, rc-dind, 27.5.0-rc.1-dind-alpine3.21, 27.5.0-rc.1, 27-rc, rc, 27.5.0-rc.1-alpine3.21
+Tags: 27.5.0-rc.2-dind, 27-rc-dind, rc-dind, 27.5.0-rc.2-dind-alpine3.21, 27.5.0-rc.2, 27-rc, rc, 27.5.0-rc.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 982bc8b4002d8c38372ef646d034ce7ca592f82a
+GitCommit: eb3c938f4f09b2b1173d99b4d9f6a1b34167e6a7
 Directory: 27-rc/dind
 
-Tags: 27.5.0-rc.1-dind-rootless, 27-rc-dind-rootless, rc-dind-rootless
+Tags: 27.5.0-rc.2-dind-rootless, 27-rc-dind-rootless, rc-dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 982bc8b4002d8c38372ef646d034ce7ca592f82a
+GitCommit: eb3c938f4f09b2b1173d99b4d9f6a1b34167e6a7
 Directory: 27-rc/dind-rootless
 
-Tags: 27.5.0-rc.1-windowsservercore-ltsc2022, 27-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
-SharedTags: 27.5.0-rc.1-windowsservercore, 27-rc-windowsservercore, rc-windowsservercore
+Tags: 27.5.0-rc.2-windowsservercore-ltsc2022, 27-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 27.5.0-rc.2-windowsservercore, 27-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 982bc8b4002d8c38372ef646d034ce7ca592f82a
+GitCommit: eb3c938f4f09b2b1173d99b4d9f6a1b34167e6a7
 Directory: 27-rc/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 27.5.0-rc.1-windowsservercore-1809, 27-rc-windowsservercore-1809, rc-windowsservercore-1809
-SharedTags: 27.5.0-rc.1-windowsservercore, 27-rc-windowsservercore, rc-windowsservercore
+Tags: 27.5.0-rc.2-windowsservercore-1809, 27-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 27.5.0-rc.2-windowsservercore, 27-rc-windowsservercore, rc-windowsservercore
 Architectures: windows-amd64
-GitCommit: 982bc8b4002d8c38372ef646d034ce7ca592f82a
+GitCommit: eb3c938f4f09b2b1173d99b4d9f6a1b34167e6a7
 Directory: 27-rc/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic
 
 Tags: 27.4.1-cli, 27.4-cli, 27-cli, cli, 27.4.1-cli-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 1188b8d14e45467307857b8fa3196f07b3826f50
+GitCommit: dc4d40d7c5c6c823da63644efa433ee358d0e6f5
 Directory: 27/cli
 
 Tags: 27.4.1-dind, 27.4-dind, 27-dind, dind, 27.4.1-dind-alpine3.21, 27.4.1, 27.4, 27, latest, 27.4.1-alpine3.21
@@ -54,7 +54,7 @@ Directory: 27/dind-rootless
 Tags: 27.4.1-windowsservercore-ltsc2022, 27.4-windowsservercore-ltsc2022, 27-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 27.4.1-windowsservercore, 27.4-windowsservercore, 27-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 1188b8d14e45467307857b8fa3196f07b3826f50
+GitCommit: dc4d40d7c5c6c823da63644efa433ee358d0e6f5
 Directory: 27/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -62,7 +62,7 @@ Builder: classic
 Tags: 27.4.1-windowsservercore-1809, 27.4-windowsservercore-1809, 27-windowsservercore-1809, windowsservercore-1809
 SharedTags: 27.4.1-windowsservercore, 27.4-windowsservercore, 27-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 1188b8d14e45467307857b8fa3196f07b3826f50
+GitCommit: dc4d40d7c5c6c823da63644efa433ee358d0e6f5
 Directory: 27/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/eb3c938: Update 27-rc to 27.5.0-rc.2, compose 2.32.2
- https://github.com/docker-library/docker/commit/dc4d40d: Update 27 to compose 2.32.2
- https://github.com/docker-library/docker/commit/13c485a: Update compose-scraping logic to match buildx (especially to ignore provenance.json)