### PR TITLE
chore: Update to Rust version 1.84.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/85c88f3a3e192ad11f392e829c54ded1178e8447/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/a6488232546c088ca9153d7a4154a3e5964ec576/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.83-bullseye, 1.83.0-bullseye, bullseye
+Tags: 1-bullseye, 1.84-bullseye, 1.84.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
+GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.83-slim-bullseye, 1.83.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.84-slim-bullseye, 1.84.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
+GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.83-bookworm, 1.83.0-bookworm, bookworm, 1, 1.83, 1.83.0, latest
+Tags: 1-bookworm, 1.84-bookworm, 1.84.0-bookworm, bookworm, 1, 1.84, 1.84.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
+GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.83-slim-bookworm, 1.83.0-slim-bookworm, slim-bookworm, 1-slim, 1.83-slim, 1.83.0-slim, slim
+Tags: 1-slim-bookworm, 1.84-slim-bookworm, 1.84.0-slim-bookworm, slim-bookworm, 1-slim, 1.84-slim, 1.84.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
+GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.20, 1.83-alpine3.20, 1.83.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.84-alpine3.20, 1.84.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: 700c4f146427808cfb1e07a646e4afabbe99da4f
+GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.83-alpine3.21, 1.83.0-alpine3.21, alpine3.21, 1-alpine, 1.83-alpine, 1.83.0-alpine, alpine
+Tags: 1-alpine3.21, 1.84-alpine3.21, 1.84.0-alpine3.21, alpine3.21, 1-alpine, 1.84-alpine, 1.84.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 85c88f3a3e192ad11f392e829c54ded1178e8447
+GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
 Directory: stable/alpine3.21


### PR DESCRIPTION
[1.84.0 Release](https://github.com/rust-lang/rust/releases/tag/1.84.0)
[Announcement Blog](https://blog.rust-lang.org/2025/01/09/Rust-1.84.0.html)