### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev2, 3.2-dev, 3.2-dev2-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev3, 3.2-dev, 3.2-dev3-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 10d18fdff5067448f4b88fbdac42594a005b60a9
+GitCommit: 7a65a5613e64528b0e9e11ca090419ed61f03966
 Directory: 3.2
 
-Tags: 3.2-dev2-alpine, 3.2-dev-alpine, 3.2-dev2-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev3-alpine, 3.2-dev-alpine, 3.2-dev3-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 10d18fdff5067448f4b88fbdac42594a005b60a9
+GitCommit: 7a65a5613e64528b0e9e11ca090419ed61f03966
 Directory: 3.2/alpine
 
-Tags: 3.1.1, 3.1, latest, 3.1.1-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.2, 3.1, latest, 3.1.2-bookworm, 3.1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc5f5ce22146dc39f7597ab9f857f0408622c8d8
+GitCommit: 116ca50708ff505ac73b7c8dcc6d7689151946bb
 Directory: 3.1
 
-Tags: 3.1.1-alpine, 3.1-alpine, alpine, 3.1.1-alpine3.21, 3.1-alpine3.21, alpine3.21
+Tags: 3.1.2-alpine, 3.1-alpine, alpine, 3.1.2-alpine3.21, 3.1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: 116ca50708ff505ac73b7c8dcc6d7689151946bb
 Directory: 3.1/alpine
 
 Tags: 3.0.7, 3.0, lts, 3.0.7-bookworm, 3.0-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7a65a56: Update 3.2 to 3.2-dev3
- https://github.com/docker-library/haproxy/commit/116ca50: Update 3.1 to 3.1.2