### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20241212.0
+Tags: 2023, latest, 2023.6.20250107.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 57f3185c634b55eafe58bfdec5f5db20c6462032
+amd64-GitCommit: 6ac65e605ca087694ceb4b735be7f6b348974948
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2039f9733e6d53b647da26d92cb9d6d4d59410a9
+arm64v8-GitCommit: 4f346b5561bf9959b1f1da464cbfc898fc4f23b0
 
-Tags: 2, 2.0.20241113.1
+Tags: 2, 2.0.20250108.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 6e2bb5876f14f080ad1ed81b8b5fc69775f62f36
+amd64-GitCommit: 24a281808a55e7605aa49718d4f4769dcce08607
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: d762c772b9f4f1706842af517c4f830cef4d2643
+arm64v8-GitCommit: 01404cf0b7cf7dabb67d0234502b47b1e8094640
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- libcurl-8.3.0-1.amzn2.0.8
- curl-8.3.0-1.amzn2.0.8

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20250107-0.amzn2023
- system-release-2023.6.20250107-0.amzn2023
- expat-2.6.3-1.amzn2023.0.2
- openssl-libs-3.0.8-1.amzn2023.0.18