### PR TITLE
archlinux: Release 20250112.0.297543

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250105.0.295102
-GitCommit: 1ec9445b440a3e75d347ded5ba3620ea009af85d
-GitFetch: refs/tags/v20250105.0.295102
+Tags: latest, base, base-20250112.0.297543
+GitCommit: 78c58d6f2c8da9516147d784817e91c557d24d33
+GitFetch: refs/tags/v20250112.0.297543
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250105.0.295102
-GitCommit: 1ec9445b440a3e75d347ded5ba3620ea009af85d
-GitFetch: refs/tags/v20250105.0.295102
+Tags: base-devel, base-devel-20250112.0.297543
+GitCommit: 78c58d6f2c8da9516147d784817e91c557d24d33
+GitFetch: refs/tags/v20250112.0.297543
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250105.0.295102
-GitCommit: 1ec9445b440a3e75d347ded5ba3620ea009af85d
-GitFetch: refs/tags/v20250105.0.295102
+Tags: multilib-devel, multilib-devel-20250112.0.297543
+GitCommit: 78c58d6f2c8da9516147d784817e91c557d24d33
+GitFetch: refs/tags/v20250112.0.297543
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks