### PR TITLE
Updating Backdrop to 1.29.3 security release.

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.29.1, 1.29, 1, 1.29.1-apache, 1.29-apache, 1-apache, apache, latest
+Tags: 1.29.3, 1.29, 1, 1.29.3-apache, 1.29-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 4f986f41b86617411c52eefc86b59380312f1751
+GitCommit: 65dad6f2ee2a86b28b14d9dbf1578c62018cd681
 Directory: 1/apache
 
-Tags: 1.29.1-fpm, 1.29-fpm, 1-fpm, fpm
+Tags: 1.29.3-fpm, 1.29-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 4f986f41b86617411c52eefc86b59380312f1751
+GitCommit: 65dad6f2ee2a86b28b14d9dbf1578c62018cd681
 Directory: 1/fpm


### PR DESCRIPTION
Here's the latest official release of Backdrop CMS: https://github.com/backdrop/backdrop/releases/tag/1.29.3

Here's the latest update of the backdrop-docker repo, with the lastest updates:
https://github.com/backdrop-ops/backdrop-docker/commits/master