### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/7b9cd879e42bb7e945fb9c80df0090e0bb7f900b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/662d742aa3f57449bbbf2bb866752457363a586f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 7b9cd879e42bb7e945fb9c80df0090e0bb7f900b
+GitCommit: 662d742aa3f57449bbbf2bb866752457363a586f
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 907e0f82e65afd01dae07774db9c70fb73c78eb2
+amd64-GitCommit: 93dbd152445b31a50a24ab810f766006da22a6e1
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 7cd8b28b27607a88bb46c9d11c0c994e093d16db
+arm32v5-GitCommit: cf4b6ba9f41002658574cf1a66ce50c42e48ae73
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: ca9576e25bee1da832a820f0bf285fa810e810ac
+arm32v6-GitCommit: edfa8bae7a434974ba0791402f3483b49e6df555
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: c91377c43ff214273a35d880583cfeea79cfc5fc
+arm32v7-GitCommit: 5247c04649f5d5bc0b957304b61f05d7a4d1ac16
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: aab472dc3aa5f0ae327c4aeb54e670cae68792e1
+arm64v8-GitCommit: f479e6ef3548f74f60d9ce421574429370348eca
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 8bd172ea99b98ca54e99434ae45352136b6c6dcd
+i386-GitCommit: 448af63f0c1d0977f7a77ff97ee113f447c0de13
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: c2a396794c01b62fa6a8ea820c5785bdd5e473bf
+mips64le-GitCommit: 9f559d9013831be0d66cd4941d67983ed62b0682
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: a422c12740a10a1ba595bb8c75cc2b037112e18d
+ppc64le-GitCommit: 90d92e8d6a6b71b8b384921095c91a693c6b3240
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: bf7d8f21ae88c7c57cd3b57156f8f670ca864858
+riscv64-GitCommit: bedbbde6bffeeb3bd99bbb3bb77d4097776608e2
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: ac190c00907b23ff0ba98196be867289a82e96a4
+s390x-GitCommit: e63005de23a340abd75565aa686938492f10e9b6
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/662d742: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/faed467: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/e73f302: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/ca15bb5: Update metadata for i386
- https://github.com/docker-library/busybox/commit/4dfef57: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/104fbab: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/f097df2: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/884f273: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/4aa9c18: Restore accidentally-removed "master-only" restriction for verify-templating
- https://github.com/docker-library/busybox/commit/de9a132: Merge pull request https://github.com/docker-library/busybox/pull/213 from infosiftr/buildroot-2024.11.1
- https://github.com/docker-library/busybox/commit/57271c3: Update buildroot to 2024.11.1
- https://github.com/docker-library/busybox/commit/79ed6fe: Simplify and update `verify-templating.yml`
- https://github.com/docker-library/busybox/commit/7b9cd87: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/bf7bac1: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/167d41c: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/619cc06: Update metadata for i386
- https://github.com/docker-library/busybox/commit/6c0196c: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/b199bd9: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/f10d137: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/a2551c8: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/79c2f30: Merge pull request https://github.com/docker-library/busybox/pull/212 from infosiftr/update
- https://github.com/docker-library/busybox/commit/9fa5eb2: Update metadata for amd64