### PR TITLE
Bump Traefik to v3.3.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,58 +1,31 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.3.1-windowsservercore-ltsc2022, 3.3.1-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.3.2-windowsservercore-ltsc2022, 3.3.2-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 79eb99e8c991e149bfa5fd468bbbf2b0e1f2b16a
+GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
 Directory: v3.3/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.3.1-windowsservercore-1809, 3.3.1-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
+Tags: v3.3.2-windowsservercore-1809, 3.3.2-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 79eb99e8c991e149bfa5fd468bbbf2b0e1f2b16a
+GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
 Directory: v3.3/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.3.1-nanoserver-ltsc2022, 3.3.1-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.3.2-nanoserver-ltsc2022, 3.3.2-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 79eb99e8c991e149bfa5fd468bbbf2b0e1f2b16a
+GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
 Directory: v3.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.3.1, 3.3.1, v3.3, 3.3, v3, 3, saintnectaire, latest
+Tags: v3.3.2, 3.3.2, v3.3, 3.3, v3, 3, saintnectaire, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 79eb99e8c991e149bfa5fd468bbbf2b0e1f2b16a
+GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
 Directory: v3.3/alpine
-
-Tags: v3.2.5-windowsservercore-ltsc2022, 3.2.5-windowsservercore-ltsc2022, v3.2-windowsservercore-ltsc2022, 3.2-windowsservercore-ltsc2022, munster-windowsservercore-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 176e60176eab4506006057b716d5499aabc082bd
-Directory: v3.2/windows/servercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: v3.2.5-windowsservercore-1809, 3.2.5-windowsservercore-1809, v3.2-windowsservercore-1809, 3.2-windowsservercore-1809, munster-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 176e60176eab4506006057b716d5499aabc082bd
-Directory: v3.2/windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v3.2.5-nanoserver-ltsc2022, 3.2.5-nanoserver-ltsc2022, v3.2-nanoserver-ltsc2022, 3.2-nanoserver-ltsc2022, munster-nanoserver-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 176e60176eab4506006057b716d5499aabc082bd
-Directory: v3.2/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: v3.2.5, 3.2.5, v3.2, 3.2, munster
-Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 176e60176eab4506006057b716d5499aabc082bd
-Directory: v3.2/alpine
 
 Tags: v2.11.18-windowsservercore-ltsc2022, 2.11.18-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.3.2](https://github.com/traefik/traefik/releases/tag/v3.3.2).

/cc @nmengin @mmatur @rtribotte

Cheers
