### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -6,120 +6,120 @@ GitRepo: https://github.com/docker-library/ruby.git
 
 Tags: 3.4.1-bookworm, 3.4-bookworm, 3-bookworm, bookworm, 3.4.1, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d86ed5ea3aead8dc6c3d30bf7bc8d0344cc65466
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.4/bookworm
 
 Tags: 3.4.1-slim-bookworm, 3.4-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.4.1-slim, 3.4-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.4/slim-bookworm
 
 Tags: 3.4.1-bullseye, 3.4-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d86ed5ea3aead8dc6c3d30bf7bc8d0344cc65466
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.4/bullseye
 
 Tags: 3.4.1-slim-bullseye, 3.4-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.4/slim-bullseye
 
 Tags: 3.4.1-alpine3.21, 3.4-alpine3.21, 3-alpine3.21, alpine3.21, 3.4.1-alpine, 3.4-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.4/alpine3.21
 
 Tags: 3.4.1-alpine3.20, 3.4-alpine3.20, 3-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.4/alpine3.20
 
 Tags: 3.3.6-bookworm, 3.3-bookworm, 3.3.6, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d86ed5ea3aead8dc6c3d30bf7bc8d0344cc65466
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.3/bookworm
 
 Tags: 3.3.6-slim-bookworm, 3.3-slim-bookworm, 3.3.6-slim, 3.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.3/slim-bookworm
 
 Tags: 3.3.6-bullseye, 3.3-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d86ed5ea3aead8dc6c3d30bf7bc8d0344cc65466
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.3/bullseye
 
 Tags: 3.3.6-slim-bullseye, 3.3-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.3/slim-bullseye
 
 Tags: 3.3.6-alpine3.21, 3.3-alpine3.21, 3.3.6-alpine, 3.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.3/alpine3.21
 
 Tags: 3.3.6-alpine3.20, 3.3-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.3/alpine3.20
 
 Tags: 3.2.6-bookworm, 3.2-bookworm, 3.2.6, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d86ed5ea3aead8dc6c3d30bf7bc8d0344cc65466
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.2/bookworm
 
 Tags: 3.2.6-slim-bookworm, 3.2-slim-bookworm, 3.2.6-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.2/slim-bookworm
 
 Tags: 3.2.6-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: d86ed5ea3aead8dc6c3d30bf7bc8d0344cc65466
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.2/bullseye
 
 Tags: 3.2.6-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.2/slim-bullseye
 
 Tags: 3.2.6-alpine3.21, 3.2-alpine3.21, 3.2.6-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.2/alpine3.21
 
 Tags: 3.2.6-alpine3.20, 3.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9b6a2e2c9155e3cd23adc263e35cbb5940aad91a
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.2/alpine3.20
 
 Tags: 3.1.6-bookworm, 3.1-bookworm, 3.1.6, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.1/bookworm
 
 Tags: 3.1.6-slim-bookworm, 3.1-slim-bookworm, 3.1.6-slim, 3.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f078b1b01338e19130eb8b01cb7f35153ba6b04
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.1/slim-bookworm
 
 Tags: 3.1.6-bullseye, 3.1-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 780654067ddce418269e6710c13b75de288c3c0d
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.1/bullseye
 
 Tags: 3.1.6-slim-bullseye, 3.1-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7f078b1b01338e19130eb8b01cb7f35153ba6b04
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.1/slim-bullseye
 
 Tags: 3.1.6-alpine3.21, 3.1-alpine3.21, 3.1.6-alpine, 3.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7f078b1b01338e19130eb8b01cb7f35153ba6b04
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.1/alpine3.21
 
 Tags: 3.1.6-alpine3.20, 3.1-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7f078b1b01338e19130eb8b01cb7f35153ba6b04
+GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
 Directory: 3.1/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/2ba928a: Merge pull request https://github.com/docker-library/ruby/pull/497 from Earlopain/revert-slim-trim
- https://github.com/docker-library/ruby/commit/1ea0c59: Remove packages again at next minor release of each series
- https://github.com/docker-library/ruby/commit/6f84caa: Revert "Remove runtime dependencies from slim and alpine variants"