### PR TITLE
Update phpMyAdmin to the latest commit

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -5,15 +5,15 @@ GitRepo: https://github.com/phpmyadmin/docker.git
 
 Tags: 5.2.1-apache, 5.2-apache, 5-apache, apache, 5.2.1, 5.2, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec0d6a5c3ae5d8df6e5f7d08570c91518cfc302e
+GitCommit: 04de4ca2ba06220049eac53b15793fb9b481994a
 Directory: apache
 
 Tags: 5.2.1-fpm, 5.2-fpm, 5-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ec0d6a5c3ae5d8df6e5f7d08570c91518cfc302e
+GitCommit: 04de4ca2ba06220049eac53b15793fb9b481994a
 Directory: fpm
 
 Tags: 5.2.1-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ec0d6a5c3ae5d8df6e5f7d08570c91518cfc302e
+GitCommit: 04de4ca2ba06220049eac53b15793fb9b481994a
 Directory: fpm-alpine


### PR DESCRIPTION
Follow up of https://github.com/docker-library/official-images/pull/17398

- Make all the files read-only
- Only allow to write to tmp and sessions
- removed PMA_SSL and PMA_SSLS from _FILE support as it makes no sense