### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20250107.0
+Tags: 2023, latest, 2023.6.20250114.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 6ac65e605ca087694ceb4b735be7f6b348974948
+amd64-GitCommit: 77426fa0c680111c20324c283e8b8e71135b4be7
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 4f346b5561bf9959b1f1da464cbfc898fc4f23b0
+arm64v8-GitCommit: 5cad4ebd04ef9dcc0ee815a82d621d269cd25b29
 
-Tags: 2, 2.0.20250108.0
+Tags: 2, 2.0.20250113.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 24a281808a55e7605aa49718d4f4769dcce08607
+amd64-GitCommit: b84556ba433d65237ffe8fb05954817fb106d75c
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 01404cf0b7cf7dabb67d0234502b47b1e8094640
+arm64v8-GitCommit: 4259593778d2933c570c7dca93babfb308a0defc
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20250114-0.amzn2023
- system-release-2023.6.20250114-0.amzn2023