### PR TITLE
Odoo: update 16.0-18.0 to release 20250115

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: cb992de79edab3b98702fb33fa6ccfc04aa00861
+GitCommit: a1b72bf09764b88ae69f1ffd51f5ebc283741aa0
 
-Tags: 18.0-20250106, 18.0, 18, latest
+Tags: 18.0-20250115, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250106, 17.0, 17
+Tags: 17.0-20250115, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250106, 16.0, 16
+Tags: 16.0-20250115, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates for the Odoo supported versions.

Thanks