### PR TITLE
Rollback amazonlinux releases. This reverts commit 20b02e5.

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20250114.0
+Tags: 2023, latest, 2023.6.20250107.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 77426fa0c680111c20324c283e8b8e71135b4be7
+amd64-GitCommit: 74a0e4d258d1a5efeadc82395d228357a68d38a8
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 5cad4ebd04ef9dcc0ee815a82d621d269cd25b29
+arm64v8-GitCommit: 6d37b43628844cc88916b1b8a0b239281441b546
 
-Tags: 2, 2.0.20250113.0
+Tags: 2, 2.0.20250108.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: b84556ba433d65237ffe8fb05954817fb106d75c
+amd64-GitCommit: 41d7f68f76f06dfc10f91f2fb1a66c0b409bb24a
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 4259593778d2933c570c7dca93babfb308a0defc
+arm64v8-GitCommit: 6d97eb936d51e8f9d7925da7869df7b5b65a0fc7
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
This reverts commit 20b02e5.

The new releases are configured with repositories pulling in an rsync security fix. However the patch has a regression reported upstream and hence as a precaution, we want to rollback to previous known good images.