### PR TITLE
Updating Backdrop CMS Docker image to latest release of Backdrop CMS …

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.29.3, 1.29, 1, 1.29.3-apache, 1.29-apache, 1-apache, apache, latest
+Tags: 1.30.0, 1.30, 1, 1.30.0-apache, 1.30-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 65dad6f2ee2a86b28b14d9dbf1578c62018cd681
+GitCommit: eec73e9b23f76ffc609be7cdaf27afeccdd91732
 Directory: 1/apache
 
-Tags: 1.29.3-fpm, 1.29-fpm, 1-fpm, fpm
+Tags: 1.30.0-fpm, 1.30-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 65dad6f2ee2a86b28b14d9dbf1578c62018cd681
+GitCommit: eec73e9b23f76ffc609be7cdaf27afeccdd91732
 Directory: 1/fpm


### PR DESCRIPTION
…1.30.0

Latest backdrop release 1.30.0
https://github.com/backdrop/backdrop/releases/tag/1.30.0

Latest commit to the backdrop-docker repo
https://github.com/backdrop-ops/backdrop-docker/commits/master

Reach out if we missed anything, and thanks!
