### PR TITLE
archlinux: Release 20250119.0.299327

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250112.0.297543
-GitCommit: 78c58d6f2c8da9516147d784817e91c557d24d33
-GitFetch: refs/tags/v20250112.0.297543
+Tags: latest, base, base-20250119.0.299327
+GitCommit: d5901839bb8e07ad1325ab5f23ed5e4562a5a958
+GitFetch: refs/tags/v20250119.0.299327
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250112.0.297543
-GitCommit: 78c58d6f2c8da9516147d784817e91c557d24d33
-GitFetch: refs/tags/v20250112.0.297543
+Tags: base-devel, base-devel-20250119.0.299327
+GitCommit: d5901839bb8e07ad1325ab5f23ed5e4562a5a958
+GitFetch: refs/tags/v20250119.0.299327
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250112.0.297543
-GitCommit: 78c58d6f2c8da9516147d784817e91c557d24d33
-GitFetch: refs/tags/v20250112.0.297543
+Tags: multilib-devel, multilib-devel-20250119.0.299327
+GitCommit: d5901839bb8e07ad1325ab5f23ed5e4562a5a958
+GitFetch: refs/tags/v20250119.0.299327
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks