### PR TITLE
Update Clear Linux OS to 42870

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 66696cc399a15d4af023b6533983110081f2de00
-GitFetch: refs/heads/base-42790
+GitCommit: 758add1a2635a92a2ea4a9fd0d1ffdf5c9dad258
+GitFetch: refs/heads/base-42870


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42870

@bryteise @djklimes @bryteise