### PR TITLE
REL-3507 Upgrade SonarQube Server to 2025.1

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -3,7 +3,7 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Davi Koscianski Vidal <davi.koscianski-vidal@sonarsource.com> (@davividal)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: 2194a60cf0dbf5de11789389fddafb8002bd7d8a
+GitCommit: 1edbd4a3f756a8b6eba3f039be62fd9c4862e9b9
 
 Tags: 9.9.8-community, 9.9-community, 9-community, lts, lts-community
 Architectures: amd64, arm64v8
@@ -25,21 +25,21 @@ Tags: 9.9.8-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-d
 Architectures: amd64, arm64v8
 Directory: 9/datacenter/search
 
-Tags: 10.8.1-developer, 10.8-developer, 10-developer, developer
+Tags: 2025.1.0-developer, 2025.1-developer, 2025-lta-developer, developer
 Architectures: amd64, arm64v8
-Directory: 10/developer
+Directory: 2025.1/developer
 
-Tags: 10.8.1-enterprise, 10.8-enterprise, 10-enterprise, enterprise
+Tags: 2025.1.0-enterprise, 2025.1-enterprise, 2025-lta-enterprise, enterprise
 Architectures: amd64, arm64v8
-Directory: 10/enterprise
+Directory: 2025.1/enterprise
 
-Tags: 10.8.1-datacenter-app, 10.8-datacenter-app, 10-datacenter-app, datacenter-app
+Tags: 2025.1.0-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app, datacenter-app
 Architectures: amd64, arm64v8
-Directory: 10/datacenter/app
+Directory: 2025.1/datacenter/app
 
-Tags: 10.8.1-datacenter-search, 10.8-datacenter-search, 10-datacenter-search, datacenter-search
+Tags: 2025.1.0-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search, datacenter-search
 Architectures: amd64, arm64v8
-Directory: 10/datacenter/search
+Directory: 2025.1/datacenter/search
 
 Tags: 25.1.0.102122-community, community, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Dear team,

we are releasing SonarQube Server `2025.1`. Could you please review our PR?