### PR TITLE
Redis CE 8.0 Milestone 03

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,16 +1,19 @@
 Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
-             Yossi Gottlieb <yossi@redis.com> (@yossigo)
+             Yossi Gottlieb <yossi@redis.com> (@yossigo),
+             Alexander Dobrzhansky <alexander.dobrzhansky@redis.com> (@adobrzhansky),
+             Max Berkman <max.berkman@redis.com> (@maxb-io),
+             Dagan Sandler <dagan.sandler@redis.com> (@dagansandler)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.0-M02-alpine, 8.0-M02-alpine3.21
+Tags: 8.0-M03-alpine, 8.0-M03-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f1e991818a8124502b5a4e8e6c7f4ae23d0c7bb4
+GitCommit: 7109557d2a7612b292a6ff2712eba560dc5e70bc
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
-Tags: 8.0-M02, 8.0-M02-bookworm
+Tags: 8.0-M03, 8.0-M03-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f1e991818a8124502b5a4e8e6c7f4ae23d0c7bb4
+GitCommit: 7109557d2a7612b292a6ff2712eba560dc5e70bc
 GitFetch: refs/heads/release/8.0
 Directory: debian
 


### PR DESCRIPTION
Redis CE 8.0 Milestone 03.
- Update to Redis 8.0 Milestone 03.
- Add additional maintainers.