### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,55 +4,55 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 25-ea-5-jdk-oraclelinux9, 25-ea-5-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-5-jdk-oracle, 25-ea-5-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-5-jdk, 25-ea-5, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-6-jdk-oraclelinux9, 25-ea-6-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-6-jdk-oracle, 25-ea-6-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-6-jdk, 25-ea-6, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-5-jdk-oraclelinux8, 25-ea-5-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-6-jdk-oraclelinux8, 25-ea-6-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-5-jdk-bookworm, 25-ea-5-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-6-jdk-bookworm, 25-ea-6-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-5-jdk-slim-bookworm, 25-ea-5-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-5-jdk-slim, 25-ea-5-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-6-jdk-slim-bookworm, 25-ea-6-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-6-jdk-slim, 25-ea-6-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-5-jdk-bullseye, 25-ea-5-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-6-jdk-bullseye, 25-ea-6-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-5-jdk-slim-bullseye, 25-ea-5-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-6-jdk-slim-bullseye, 25-ea-6-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-5-jdk-windowsservercore-ltsc2022, 25-ea-5-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-5-jdk-windowsservercore, 25-ea-5-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-5-jdk, 25-ea-5, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-6-jdk-windowsservercore-ltsc2022, 25-ea-6-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-6-jdk-windowsservercore, 25-ea-6-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-6-jdk, 25-ea-6, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-5-jdk-windowsservercore-1809, 25-ea-5-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
-SharedTags: 25-ea-5-jdk-windowsservercore, 25-ea-5-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-5-jdk, 25-ea-5, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-6-jdk-windowsservercore-1809, 25-ea-6-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
+SharedTags: 25-ea-6-jdk-windowsservercore, 25-ea-6-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-6-jdk, 25-ea-6, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 25-ea-5-jdk-nanoserver-1809, 25-ea-5-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
-SharedTags: 25-ea-5-jdk-nanoserver, 25-ea-5-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-6-jdk-nanoserver-1809, 25-ea-6-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
+SharedTags: 25-ea-6-jdk-nanoserver, 25-ea-6-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 7090d5afa0016605bfbd86e88bb30b96c3ac0f44
+GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/6795b60: Update 25 to 25-ea+6