### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,33 +5,41 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 Builder: buildkit
 
-Tags: 27.5.0-cli, 27.5-cli, 27-cli, cli, 27.5.0-cli-alpine3.21
+Tags: 27.5.1-cli, 27.5-cli, 27-cli, cli, 27.5.1-cli-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 4c7a6d18d9aea3620ee177b855e762f6407fd551
+GitCommit: 03ecb33955c16b34b7d52c7563f05c736f159875
 Directory: 27/cli
 
-Tags: 27.5.0-dind, 27.5-dind, 27-dind, dind, 27.5.0-dind-alpine3.21, 27.5.0, 27.5, 27, latest, 27.5.0-alpine3.21
+Tags: 27.5.1-dind, 27.5-dind, 27-dind, dind, 27.5.1-dind-alpine3.21, 27.5.1, 27.5, 27, latest, 27.5.1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 49e7a0aa907a6033c2482efbf8e25bb97588b184
+GitCommit: 03ecb33955c16b34b7d52c7563f05c736f159875
 Directory: 27/dind
 
-Tags: 27.5.0-dind-rootless, 27.5-dind-rootless, 27-dind-rootless, dind-rootless
+Tags: 27.5.1-dind-rootless, 27.5-dind-rootless, 27-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: 49e7a0aa907a6033c2482efbf8e25bb97588b184
+GitCommit: 03ecb33955c16b34b7d52c7563f05c736f159875
 Directory: 27/dind-rootless
 
-Tags: 27.5.0-windowsservercore-ltsc2022, 27.5-windowsservercore-ltsc2022, 27-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 27.5.0-windowsservercore, 27.5-windowsservercore, 27-windowsservercore, windowsservercore
+Tags: 27.5.1-windowsservercore-ltsc2025, 27.5-windowsservercore-ltsc2025, 27-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 27.5.1-windowsservercore, 27.5-windowsservercore, 27-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 4c7a6d18d9aea3620ee177b855e762f6407fd551
+GitCommit: 03ecb33955c16b34b7d52c7563f05c736f159875
+Directory: 27/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+Builder: classic
+
+Tags: 27.5.1-windowsservercore-ltsc2022, 27.5-windowsservercore-ltsc2022, 27-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 27.5.1-windowsservercore, 27.5-windowsservercore, 27-windowsservercore, windowsservercore
+Architectures: windows-amd64
+GitCommit: 03ecb33955c16b34b7d52c7563f05c736f159875
 Directory: 27/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
 
-Tags: 27.5.0-windowsservercore-1809, 27.5-windowsservercore-1809, 27-windowsservercore-1809, windowsservercore-1809
-SharedTags: 27.5.0-windowsservercore, 27.5-windowsservercore, 27-windowsservercore, windowsservercore
+Tags: 27.5.1-windowsservercore-1809, 27.5-windowsservercore-1809, 27-windowsservercore-1809, windowsservercore-1809
+SharedTags: 27.5.1-windowsservercore, 27.5-windowsservercore, 27-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 4c7a6d18d9aea3620ee177b855e762f6407fd551
+GitCommit: 03ecb33955c16b34b7d52c7563f05c736f159875
 Directory: 27/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/03ecb33: Update 27 to 27.5.1
- https://github.com/docker-library/docker/commit/cfd500f: Merge pull request https://github.com/docker-library/docker/pull/523 from infosiftr/ltsc2025
- https://github.com/docker-library/docker/commit/913a998: Add Windows Server 2025 variant