### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -35,6 +35,13 @@ Architectures: amd64, arm64v8
 GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/slim-bullseye
 
+Tags: 25-ea-6-jdk-windowsservercore-ltsc2025, 25-ea-6-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-ea-6-jdk-windowsservercore, 25-ea-6-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-6-jdk, 25-ea-6, 25-ea-jdk, 25-ea, 25-jdk, 25
+Architectures: windows-amd64
+GitCommit: 865aad9bc52991b6e92179eb06e6e49a50004f16
+Directory: 25/jdk/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
 Tags: 25-ea-6-jdk-windowsservercore-ltsc2022, 25-ea-6-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
 SharedTags: 25-ea-6-jdk-windowsservercore, 25-ea-6-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-6-jdk, 25-ea-6, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
@@ -48,6 +55,20 @@ Architectures: windows-amd64
 GitCommit: 6795b600616b3c7f6ef9ea2934605d05f1bba516
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
+
+Tags: 25-ea-6-jdk-nanoserver-ltsc2025, 25-ea-6-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-ea-6-jdk-nanoserver, 25-ea-6-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Architectures: windows-amd64
+GitCommit: 534646f0941d909897d91eddc7f8c7c7cc53a652
+Directory: 25/jdk/windows/nanoserver-ltsc2025
+Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
+
+Tags: 25-ea-6-jdk-nanoserver-ltsc2022, 25-ea-6-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-ea-6-jdk-nanoserver, 25-ea-6-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Architectures: windows-amd64
+GitCommit: 534646f0941d909897d91eddc7f8c7c7cc53a652
+Directory: 25/jdk/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 25-ea-6-jdk-nanoserver-1809, 25-ea-6-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
 SharedTags: 25-ea-6-jdk-nanoserver, 25-ea-6-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
@@ -87,6 +108,13 @@ Architectures: amd64, arm64v8
 GitCommit: 9c0cbed17ab6b22457c51976e3c13b0dadec7dc2
 Directory: 24/jdk/slim-bullseye
 
+Tags: 24-ea-31-jdk-windowsservercore-ltsc2025, 24-ea-31-windowsservercore-ltsc2025, 24-ea-jdk-windowsservercore-ltsc2025, 24-ea-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
+SharedTags: 24-ea-31-jdk-windowsservercore, 24-ea-31-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-31-jdk, 24-ea-31, 24-ea-jdk, 24-ea, 24-jdk, 24
+Architectures: windows-amd64
+GitCommit: 865aad9bc52991b6e92179eb06e6e49a50004f16
+Directory: 24/jdk/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
 Tags: 24-ea-31-jdk-windowsservercore-ltsc2022, 24-ea-31-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
 SharedTags: 24-ea-31-jdk-windowsservercore, 24-ea-31-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-31-jdk, 24-ea-31, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
@@ -100,6 +128,20 @@ Architectures: windows-amd64
 GitCommit: 9c0cbed17ab6b22457c51976e3c13b0dadec7dc2
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
+
+Tags: 24-ea-31-jdk-nanoserver-ltsc2025, 24-ea-31-nanoserver-ltsc2025, 24-ea-jdk-nanoserver-ltsc2025, 24-ea-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
+SharedTags: 24-ea-31-jdk-nanoserver, 24-ea-31-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Architectures: windows-amd64
+GitCommit: 534646f0941d909897d91eddc7f8c7c7cc53a652
+Directory: 24/jdk/windows/nanoserver-ltsc2025
+Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
+
+Tags: 24-ea-31-jdk-nanoserver-ltsc2022, 24-ea-31-nanoserver-ltsc2022, 24-ea-jdk-nanoserver-ltsc2022, 24-ea-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
+SharedTags: 24-ea-31-jdk-nanoserver, 24-ea-31-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Architectures: windows-amd64
+GitCommit: 534646f0941d909897d91eddc7f8c7c7cc53a652
+Directory: 24/jdk/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 24-ea-31-jdk-nanoserver-1809, 24-ea-31-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
 SharedTags: 24-ea-31-jdk-nanoserver, 24-ea-31-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/cd21f0d: Merge pull request https://github.com/docker-library/openjdk/pull/545 from infosiftr/moar-nanoserver
- https://github.com/docker-library/openjdk/commit/534646f: Add more Nano Server variants
- https://github.com/docker-library/openjdk/commit/bf64d21: Merge pull request https://github.com/docker-library/openjdk/pull/544 from infosiftr/ltsc2025
- https://github.com/docker-library/openjdk/commit/865aad9: Add Windows Server 2025 variant