### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -10,6 +10,13 @@ Architectures: amd64, arm64v8
 GitCommit: 3eed4008b42e739dc9ed4234d3da682462ffdc9c
 Directory: 8.0
 
+Tags: 8.0.4-windowsservercore-ltsc2025, 8.0-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 8.0.4-windowsservercore, 8.0-windowsservercore, 8-windowsservercore, windowsservercore, 8.0.4, 8.0, 8, latest
+Architectures: windows-amd64
+GitCommit: 55d140f1274a7d2dbe499797b0c6a4f4fb718cea
+Directory: 8.0/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
 Tags: 8.0.4-windowsservercore-ltsc2022, 8.0-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 8.0.4-windowsservercore, 8.0-windowsservercore, 8-windowsservercore, windowsservercore, 8.0.4, 8.0, 8, latest
 Architectures: windows-amd64
@@ -43,6 +50,13 @@ SharedTags: 7.0.16, 7.0, 7
 Architectures: amd64, arm64v8
 GitCommit: 72916ee710ba8eef042048bdabda8302a0912a81
 Directory: 7.0
+
+Tags: 7.0.16-windowsservercore-ltsc2025, 7.0-windowsservercore-ltsc2025, 7-windowsservercore-ltsc2025
+SharedTags: 7.0.16-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.16, 7.0, 7
+Architectures: windows-amd64
+GitCommit: 55d140f1274a7d2dbe499797b0c6a4f4fb718cea
+Directory: 7.0/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
 
 Tags: 7.0.16-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022, 7-windowsservercore-ltsc2022
 SharedTags: 7.0.16-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.16, 7.0, 7
@@ -78,6 +92,13 @@ Architectures: amd64, arm64v8
 GitCommit: 396a030cd1168154d8e71863bfb6c9aef803dc17
 Directory: 6.0
 
+Tags: 6.0.20-windowsservercore-ltsc2025, 6.0-windowsservercore-ltsc2025, 6-windowsservercore-ltsc2025
+SharedTags: 6.0.20-windowsservercore, 6.0-windowsservercore, 6-windowsservercore, 6.0.20, 6.0, 6
+Architectures: windows-amd64
+GitCommit: 55d140f1274a7d2dbe499797b0c6a4f4fb718cea
+Directory: 6.0/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
 Tags: 6.0.20-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022, 6-windowsservercore-ltsc2022
 SharedTags: 6.0.20-windowsservercore, 6.0-windowsservercore, 6-windowsservercore, 6.0.20, 6.0, 6
 Architectures: windows-amd64
@@ -112,6 +133,13 @@ Architectures: amd64, arm64v8
 GitCommit: dbe4b11fc98c9d88bfa6cd7b7d669c6c9a09c89d
 Directory: 5.0-rc
 
+Tags: 5.0.31-rc1-windowsservercore-ltsc2025, 5.0-rc-windowsservercore-ltsc2025
+SharedTags: 5.0.31-rc1-windowsservercore, 5.0-rc-windowsservercore, 5.0.31-rc1, 5.0-rc
+Architectures: windows-amd64
+GitCommit: 55d140f1274a7d2dbe499797b0c6a4f4fb718cea
+Directory: 5.0-rc/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
 Tags: 5.0.31-rc1-windowsservercore-ltsc2022, 5.0-rc-windowsservercore-ltsc2022
 SharedTags: 5.0.31-rc1-windowsservercore, 5.0-rc-windowsservercore, 5.0.31-rc1, 5.0-rc
 Architectures: windows-amd64
@@ -145,6 +173,13 @@ SharedTags: 5.0.30, 5.0, 5
 Architectures: amd64, arm64v8
 GitCommit: 65909c24a2d4c3380b7a6512fd83dbc9ce00244f
 Directory: 5.0
+
+Tags: 5.0.30-windowsservercore-ltsc2025, 5.0-windowsservercore-ltsc2025, 5-windowsservercore-ltsc2025
+SharedTags: 5.0.30-windowsservercore, 5.0-windowsservercore, 5-windowsservercore, 5.0.30, 5.0, 5
+Architectures: windows-amd64
+GitCommit: 55d140f1274a7d2dbe499797b0c6a4f4fb718cea
+Directory: 5.0/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
 
 Tags: 5.0.30-windowsservercore-ltsc2022, 5.0-windowsservercore-ltsc2022, 5-windowsservercore-ltsc2022
 SharedTags: 5.0.30-windowsservercore, 5.0-windowsservercore, 5-windowsservercore, 5.0.30, 5.0, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/71be3c5: Merge pull request https://github.com/docker-library/mongo/pull/720 from infosiftr/ltsc2025
- https://github.com/docker-library/mongo/commit/12f1d18: Remove Nano Server 2025 variants
- https://github.com/docker-library/mongo/commit/55d140f: Add Windows Server 2025 variant