### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,45 +6,45 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 6.0.2, 6.0, 6, latest, 6.0.2-bookworm, 6.0-bookworm, 6-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 6.0/bookworm
 
 Tags: 6.0.2-alpine3.21, 6.0-alpine3.21, 6-alpine3.21, alpine3.21, 6.0.2-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 6.0/alpine3.21
 
 Tags: 6.0.2-alpine3.20, 6.0-alpine3.20, 6-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 6.0/alpine3.20
 
 Tags: 5.1.5, 5.1, 5, 5.1.5-bookworm, 5.1-bookworm, 5-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 5.1/bookworm
 
 Tags: 5.1.5-alpine3.21, 5.1-alpine3.21, 5-alpine3.21, 5.1.5-alpine, 5.1-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 5.1/alpine3.21
 
 Tags: 5.1.5-alpine3.20, 5.1-alpine3.20, 5-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 5.1/alpine3.20
 
 Tags: 5.0.10, 5.0, 5.0.10-bookworm, 5.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 5.0/bookworm
 
 Tags: 5.0.10-alpine3.21, 5.0-alpine3.21, 5.0.10-alpine, 5.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 5.0/alpine3.21
 
 Tags: 5.0.10-alpine3.20, 5.0-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ac79199f72a9628d9cb9ee1dafac2dd2856487c
+GitCommit: b160f7adabeb4216193103061c576210c8ca6674
 Directory: 5.0/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/8d36a1a: Merge pull request https://github.com/docker-library/redmine/pull/366 from infosiftr/single-template
- https://github.com/docker-library/redmine/commit/b160f7a: Move to a single template for Debian and Alpine
- https://github.com/docker-library/redmine/commit/087f78a: Merge pull request https://github.com/docker-library/redmine/pull/365 from infosiftr/better-keybase
- https://github.com/docker-library/redmine/commit/922b31e: Backport https://www.redmine.org/issues/42113 patch for 5.x
- https://github.com/docker-library/redmine/commit/a57cd24: Drop secrets.yml and just use `SECRET_KEY_BASE`