### PR TITLE
Update nats to 2.10.25

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: c5135d645d12ee07bceea9c27d2dde79d784feb9
+GitCommit: cbb9ecd4be891b33b32cc62f1dd3881be0dc8e05
 GitFetch: refs/heads/main
 
-Tags: 2.10.24-alpine3.21, 2.10-alpine3.21, 2-alpine3.21, alpine3.21, 2.10.24-alpine, 2.10-alpine, 2-alpine, alpine
+Tags: 2.10.25-alpine3.21, 2.10-alpine3.21, 2-alpine3.21, alpine3.21, 2.10.25-alpine, 2.10-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/alpine3.21
 
-Tags: 2.10.24-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.24-linux, 2.10-linux, 2-linux, linux
-SharedTags: 2.10.24, 2.10, 2, latest
+Tags: 2.10.25-scratch, 2.10-scratch, 2-scratch, scratch, 2.10.25-linux, 2.10-linux, 2-linux, linux
+SharedTags: 2.10.25, 2.10, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/scratch
 
-Tags: 2.10.24-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.10.24-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.10.25-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.10.25-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.24-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.10.24-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.24, 2.10, 2, latest
+Tags: 2.10.25-nanoserver-1809, 2.10-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.10.25-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver, 2.10.25, 2.10, 2, latest
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Release details at https://github.com/nats-io/nats-server/releases/tag/v2.10.25.