### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20250107.0
+Tags: 2023, latest, 2023.6.20250115.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 74a0e4d258d1a5efeadc82395d228357a68d38a8
+amd64-GitCommit: 0fcfdb19e02852797bdacf8eba0017b9578fd7ad
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 6d37b43628844cc88916b1b8a0b239281441b546
+arm64v8-GitCommit: 3885cfc1b1cb68ed86380df117cfa429c5f5235a
 
-Tags: 2, 2.0.20250108.0
+Tags: 2, 2.0.20250116.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 41d7f68f76f06dfc10f91f2fb1a66c0b409bb24a
+amd64-GitCommit: a45d17fb340df67793447c58b118cea0a2343267
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 6d97eb936d51e8f9d7925da7869df7b5b65a0fc7
+arm64v8-GitCommit: a962f5c619399738a656812a1872d9d8b36ab184
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- N/A
Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20250115-0.amzn2023
- system-release-2023.6.20250115-0.amzn2023