### PR TITLE
Fix the phpMyAdmin Debian image

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -5,12 +5,12 @@ GitRepo: https://github.com/phpmyadmin/docker.git
 
 Tags: 5.2.2-apache, 5.2-apache, 5-apache, apache, 5.2.2, 5.2, 5, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 216be795f7a1a60c2c27ff5d00b5c8476771e1d1
+GitCommit: 188a0e35423fb615db47e6a0a8209fe7288eb2ed
 Directory: apache
 
 Tags: 5.2.2-fpm, 5.2-fpm, 5-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 216be795f7a1a60c2c27ff5d00b5c8476771e1d1
+GitCommit: 188a0e35423fb615db47e6a0a8209fe7288eb2ed
 Directory: fpm
 
 Tags: 5.2.2-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine


### PR DESCRIPTION
PHP extensions are missing due to the wrong extensions package removals