### PR TITLE
Update SapMachine January 2025

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,242 +1,272 @@
-Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Christian Halstrick <sapmachine@sap.com> (@chalstrick)
+Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Arno Zeller <sapmachine@sap.com> (@ArnoZeller)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: latest, jdk-ubuntu, 23, 23-jdk-ubuntu, 23.0.1, 23.0.1-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, 23-ubuntu-noble, 23-ubuntu-24.04, 23.0.1-ubuntu-noble, 23.0.1-ubuntu-24.04, 23-jdk-ubuntu-noble, 23-jdk-ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 23.0.1-jdk-ubuntu-noble, 23.0.1-jdk-ubuntu-24.04
+Tags: latest, jdk-ubuntu, 23, 23-jdk-ubuntu, 23.0.2, 23.0.2-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, 23-ubuntu-noble, 23-ubuntu-24.04, 23.0.2-ubuntu-noble, 23.0.2-ubuntu-24.04, 23-jdk-ubuntu-noble, 23-jdk-ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 23.0.2-jdk-ubuntu-noble, 23.0.2-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/24_04/jdk
 
-Tags: jdk-headless-ubuntu, 23-jdk-headless-ubuntu, 23.0.1-jdk-headless-ubuntu, 23-jdk-headless-ubuntu-noble, 23-jdk-headless-ubuntu-24.04, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 23.0.1-jdk-headless-ubuntu-noble, 23.0.1-jdk-headless-ubuntu-24.04
+Tags: jdk-headless-ubuntu, 23-jdk-headless-ubuntu, 23.0.2-jdk-headless-ubuntu, 23-jdk-headless-ubuntu-noble, 23-jdk-headless-ubuntu-24.04, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 23.0.2-jdk-headless-ubuntu-noble, 23.0.2-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/24_04/jdk-headless
 
-Tags: jre-ubuntu, 23-jre-ubuntu, 23.0.1-jre-ubuntu, 23-jre-ubuntu-noble, 23-jre-ubuntu-24.04, jre-ubuntu-noble, jre-ubuntu-24.04, 23.0.1-jre-ubuntu-noble, 23.0.1-jre-ubuntu-24.04
+Tags: jre-ubuntu, 23-jre-ubuntu, 23.0.2-jre-ubuntu, 23-jre-ubuntu-noble, 23-jre-ubuntu-24.04, jre-ubuntu-noble, jre-ubuntu-24.04, 23.0.2-jre-ubuntu-noble, 23.0.2-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/24_04/jre
 
-Tags: jre-headless-ubuntu, 23-jre-headless-ubuntu, 23.0.1-jre-headless-ubuntu, 23-jre-headless-ubuntu-noble, 23-jre-headless-ubuntu-24.04, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 23.0.1-jre-headless-ubuntu-noble, 23.0.1-jre-headless-ubuntu-24.04
+Tags: jre-headless-ubuntu, 23-jre-headless-ubuntu, 23.0.2-jre-headless-ubuntu, 23-jre-headless-ubuntu-noble, 23-jre-headless-ubuntu-24.04, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 23.0.2-jre-headless-ubuntu-noble, 23.0.2-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/24_04/jre-headless
 
-Tags: ubuntu-jammy, ubuntu-22.04, 23-ubuntu-jammy, 23-ubuntu-22.04, 23.0.1-ubuntu-jammy, 23.0.1-ubuntu-22.04, 23-jdk-ubuntu-jammy, 23-jdk-ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 23.0.1-jdk-ubuntu-jammy, 23.0.1-jdk-ubuntu-22.04
+Tags: ubuntu-jammy, ubuntu-22.04, 23-ubuntu-jammy, 23-ubuntu-22.04, 23.0.2-ubuntu-jammy, 23.0.2-ubuntu-22.04, 23-jdk-ubuntu-jammy, 23-jdk-ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 23.0.2-jdk-ubuntu-jammy, 23.0.2-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/22_04/jdk
 
-Tags: 23-jdk-headless-ubuntu-jammy, 23-jdk-headless-ubuntu-22.04, jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 23.0.1-jdk-headless-ubuntu-jammy, 23.0.1-jdk-headless-ubuntu-22.04
+Tags: 23-jdk-headless-ubuntu-jammy, 23-jdk-headless-ubuntu-22.04, jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 23.0.2-jdk-headless-ubuntu-jammy, 23.0.2-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/22_04/jdk-headless
 
-Tags: 23-jre-ubuntu-jammy, 23-jre-ubuntu-22.04, jre-ubuntu-jammy, jre-ubuntu-22.04, 23.0.1-jre-ubuntu-jammy, 23.0.1-jre-ubuntu-22.04
+Tags: 23-jre-ubuntu-jammy, 23-jre-ubuntu-22.04, jre-ubuntu-jammy, jre-ubuntu-22.04, 23.0.2-jre-ubuntu-jammy, 23.0.2-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/22_04/jre
 
-Tags: 23-jre-headless-ubuntu-jammy, 23-jre-headless-ubuntu-22.04, jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 23.0.1-jre-headless-ubuntu-jammy, 23.0.1-jre-headless-ubuntu-22.04
+Tags: 23-jre-headless-ubuntu-jammy, 23-jre-headless-ubuntu-22.04, jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 23.0.2-jre-headless-ubuntu-jammy, 23.0.2-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/22_04/jre-headless
 
-Tags: ubuntu-focal, ubuntu-20.04, 23-ubuntu-focal, 23-ubuntu-20.04, 23.0.1-ubuntu-focal, 23.0.1-ubuntu-20.04, 23-jdk-ubuntu-focal, 23-jdk-ubuntu-20.04, jdk-ubuntu-focal, jdk-ubuntu-20.04, 23.0.1-jdk-ubuntu-focal, 23.0.1-jdk-ubuntu-20.04
+Tags: ubuntu-focal, ubuntu-20.04, 23-ubuntu-focal, 23-ubuntu-20.04, 23.0.2-ubuntu-focal, 23.0.2-ubuntu-20.04, 23-jdk-ubuntu-focal, 23-jdk-ubuntu-20.04, jdk-ubuntu-focal, jdk-ubuntu-20.04, 23.0.2-jdk-ubuntu-focal, 23.0.2-jdk-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/20_04/jdk
 
-Tags: 23-jdk-headless-ubuntu-focal, 23-jdk-headless-ubuntu-20.04, jdk-headless-ubuntu-focal, jdk-headless-ubuntu-20.04, 23.0.1-jdk-headless-ubuntu-focal, 23.0.1-jdk-headless-ubuntu-20.04
+Tags: 23-jdk-headless-ubuntu-focal, 23-jdk-headless-ubuntu-20.04, jdk-headless-ubuntu-focal, jdk-headless-ubuntu-20.04, 23.0.2-jdk-headless-ubuntu-focal, 23.0.2-jdk-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/20_04/jdk-headless
 
-Tags: 23-jre-ubuntu-focal, 23-jre-ubuntu-20.04, jre-ubuntu-focal, jre-ubuntu-20.04, 23.0.1-jre-ubuntu-focal, 23.0.1-jre-ubuntu-20.04
+Tags: 23-jre-ubuntu-focal, 23-jre-ubuntu-20.04, jre-ubuntu-focal, jre-ubuntu-20.04, 23.0.2-jre-ubuntu-focal, 23.0.2-jre-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/20_04/jre
 
-Tags: 23-jre-headless-ubuntu-focal, 23-jre-headless-ubuntu-20.04, jre-headless-ubuntu-focal, jre-headless-ubuntu-20.04, 23.0.1-jre-headless-ubuntu-focal, 23.0.1-jre-headless-ubuntu-20.04
+Tags: 23-jre-headless-ubuntu-focal, 23-jre-headless-ubuntu-20.04, jre-headless-ubuntu-focal, jre-headless-ubuntu-20.04, 23.0.2-jre-headless-ubuntu-focal, 23.0.2-jre-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fb314957163ab9a7061648b0de748eab60bdb29e
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
 Directory: dockerfiles/23/ubuntu/20_04/jre-headless
 
-Tags: 21, lts, 21-jdk-ubuntu, lts-jdk-ubuntu, 21.0.5, 21.0.5-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, lts-ubuntu-noble, lts-ubuntu-24.04, 21.0.5-ubuntu-noble, 21.0.5-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 21.0.5-jdk-ubuntu-noble, 21.0.5-jdk-ubuntu-24.04
+Tags: jdk-alpine, 23-jdk-alpine, 23.0.2-jdk-alpine, alpine-3.21, 23-alpine-3.21, 23.0.2-alpine-3.21, 23-jdk-alpine-3.21, jdk-alpine-3.21, 23.0.2-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
+Directory: dockerfiles/23/alpine/3_21/jdk
+
+Tags: jre-alpine, 23-jre-alpine, 23.0.2-jre-alpine, 23-jre-alpine-3.21, jre-alpine-3.21, 23.0.2-jre-alpine-3.21
+Architectures: amd64
+GitCommit: 089b6f998cfc547b3f91283aabdd11630aa2e9d7
+Directory: dockerfiles/23/alpine/3_21/jre
+
+Tags: 21, lts, 21-jdk-ubuntu, lts-jdk-ubuntu, 21.0.6, 21.0.6-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, lts-ubuntu-noble, lts-ubuntu-24.04, 21.0.6-ubuntu-noble, 21.0.6-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 21.0.6-jdk-ubuntu-noble, 21.0.6-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/24_04/jdk
 
-Tags: 21-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, 21.0.5-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 21.0.5-jdk-headless-ubuntu-noble, 21.0.5-jdk-headless-ubuntu-24.04
+Tags: 21-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, 21.0.6-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 21.0.6-jdk-headless-ubuntu-noble, 21.0.6-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
-Tags: 21-jre-ubuntu, lts-jre-ubuntu, 21.0.5-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 21.0.5-jre-ubuntu-noble, 21.0.5-jre-ubuntu-24.04
+Tags: 21-jre-ubuntu, lts-jre-ubuntu, 21.0.6-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 21.0.6-jre-ubuntu-noble, 21.0.6-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/24_04/jre
 
-Tags: 21-jre-headless-ubuntu, lts-jre-headless-ubuntu, 21.0.5-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 21.0.5-jre-headless-ubuntu-noble, 21.0.5-jre-headless-ubuntu-24.04
+Tags: 21-jre-headless-ubuntu, lts-jre-headless-ubuntu, 21.0.6-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 21.0.6-jre-headless-ubuntu-noble, 21.0.6-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
-Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, lts-ubuntu-jammy, lts-ubuntu-22.04, 21.0.5-ubuntu-jammy, 21.0.5-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 21.0.5-jdk-ubuntu-jammy, 21.0.5-jdk-ubuntu-22.04
+Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, lts-ubuntu-jammy, lts-ubuntu-22.04, 21.0.6-ubuntu-jammy, 21.0.6-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 21.0.6-jdk-ubuntu-jammy, 21.0.6-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/22_04/jdk
 
-Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 21.0.5-jdk-headless-ubuntu-jammy, 21.0.5-jdk-headless-ubuntu-22.04
+Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 21.0.6-jdk-headless-ubuntu-jammy, 21.0.6-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
 
-Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 21.0.5-jre-ubuntu-jammy, 21.0.5-jre-ubuntu-22.04
+Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 21.0.6-jre-ubuntu-jammy, 21.0.6-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/22_04/jre
 
-Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 21.0.5-jre-headless-ubuntu-jammy, 21.0.5-jre-headless-ubuntu-22.04
+Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 21.0.6-jre-headless-ubuntu-jammy, 21.0.6-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
-Tags: 21-ubuntu-focal, 21-ubuntu-20.04, lts-ubuntu-focal, lts-ubuntu-20.04, 21.0.5-ubuntu-focal, 21.0.5-ubuntu-20.04, 21-jdk-ubuntu-focal, 21-jdk-ubuntu-20.04, lts-jdk-ubuntu-focal, lts-jdk-ubuntu-20.04, 21.0.5-jdk-ubuntu-focal, 21.0.5-jdk-ubuntu-20.04
+Tags: 21-ubuntu-focal, 21-ubuntu-20.04, lts-ubuntu-focal, lts-ubuntu-20.04, 21.0.6-ubuntu-focal, 21.0.6-ubuntu-20.04, 21-jdk-ubuntu-focal, 21-jdk-ubuntu-20.04, lts-jdk-ubuntu-focal, lts-jdk-ubuntu-20.04, 21.0.6-jdk-ubuntu-focal, 21.0.6-jdk-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/20_04/jdk
 
-Tags: 21-jdk-headless-ubuntu-focal, 21-jdk-headless-ubuntu-20.04, lts-jdk-headless-ubuntu-focal, lts-jdk-headless-ubuntu-20.04, 21.0.5-jdk-headless-ubuntu-focal, 21.0.5-jdk-headless-ubuntu-20.04
+Tags: 21-jdk-headless-ubuntu-focal, 21-jdk-headless-ubuntu-20.04, lts-jdk-headless-ubuntu-focal, lts-jdk-headless-ubuntu-20.04, 21.0.6-jdk-headless-ubuntu-focal, 21.0.6-jdk-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/20_04/jdk-headless
 
-Tags: 21-jre-ubuntu-focal, 21-jre-ubuntu-20.04, lts-jre-ubuntu-focal, lts-jre-ubuntu-20.04, 21.0.5-jre-ubuntu-focal, 21.0.5-jre-ubuntu-20.04
+Tags: 21-jre-ubuntu-focal, 21-jre-ubuntu-20.04, lts-jre-ubuntu-focal, lts-jre-ubuntu-20.04, 21.0.6-jre-ubuntu-focal, 21.0.6-jre-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/20_04/jre
 
-Tags: 21-jre-headless-ubuntu-focal, 21-jre-headless-ubuntu-20.04, lts-jre-headless-ubuntu-focal, lts-jre-headless-ubuntu-20.04, 21.0.5-jre-headless-ubuntu-focal, 21.0.5-jre-headless-ubuntu-20.04
+Tags: 21-jre-headless-ubuntu-focal, 21-jre-headless-ubuntu-20.04, lts-jre-headless-ubuntu-focal, lts-jre-headless-ubuntu-20.04, 21.0.6-jre-headless-ubuntu-focal, 21.0.6-jre-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: f6332a68a6d854ff953f36794b0103497b644e11
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
 Directory: dockerfiles/21/ubuntu/20_04/jre-headless
 
-Tags: 17, 17-jdk-ubuntu, 17.0.13, 17.0.13-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17.0.13-ubuntu-noble, 17.0.13-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.13-jdk-ubuntu-noble, 17.0.13-jdk-ubuntu-24.04
+Tags: 21-jdk-alpine, lts-jdk-alpine, 21.0.6-jdk-alpine, 21-alpine-3.21, lts-alpine-3.21, 21.0.6-alpine-3.21, 21-jdk-alpine-3.21, lts-jdk-alpine-3.21, 21.0.6-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
+Directory: dockerfiles/21/alpine/3_21/jdk
+
+Tags: 21-jre-alpine, lts-jre-alpine, 21.0.6-jre-alpine, 21-jre-alpine-3.21, lts-jre-alpine-3.21, 21.0.6-jre-alpine-3.21
+Architectures: amd64
+GitCommit: 9baa28bbb3e00497113bb1f955c5a533c003c06b
+Directory: dockerfiles/21/alpine/3_21/jre
+
+Tags: 17, 17-jdk-ubuntu, 17.0.14, 17.0.14-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17.0.14-ubuntu-noble, 17.0.14-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.14-jdk-ubuntu-noble, 17.0.14-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/24_04/jdk
 
-Tags: 17-jdk-headless-ubuntu, 17.0.13-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.13-jdk-headless-ubuntu-noble, 17.0.13-jdk-headless-ubuntu-24.04
+Tags: 17-jdk-headless-ubuntu, 17.0.14-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.14-jdk-headless-ubuntu-noble, 17.0.14-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
-Tags: 17-jre-ubuntu, 17.0.13-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.13-jre-ubuntu-noble, 17.0.13-jre-ubuntu-24.04
+Tags: 17-jre-ubuntu, 17.0.14-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.14-jre-ubuntu-noble, 17.0.14-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/24_04/jre
 
-Tags: 17-jre-headless-ubuntu, 17.0.13-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.13-jre-headless-ubuntu-noble, 17.0.13-jre-headless-ubuntu-24.04
+Tags: 17-jre-headless-ubuntu, 17.0.14-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.14-jre-headless-ubuntu-noble, 17.0.14-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
-Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17.0.13-ubuntu-jammy, 17.0.13-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.13-jdk-ubuntu-jammy, 17.0.13-jdk-ubuntu-22.04
+Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17.0.14-ubuntu-jammy, 17.0.14-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.14-jdk-ubuntu-jammy, 17.0.14-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/22_04/jdk
 
-Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.13-jdk-headless-ubuntu-jammy, 17.0.13-jdk-headless-ubuntu-22.04
+Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.14-jdk-headless-ubuntu-jammy, 17.0.14-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
 
-Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.13-jre-ubuntu-jammy, 17.0.13-jre-ubuntu-22.04
+Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.14-jre-ubuntu-jammy, 17.0.14-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/22_04/jre
 
-Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.13-jre-headless-ubuntu-jammy, 17.0.13-jre-headless-ubuntu-22.04
+Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.14-jre-headless-ubuntu-jammy, 17.0.14-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
-Tags: 17-ubuntu-focal, 17-ubuntu-20.04, 17.0.13-ubuntu-focal, 17.0.13-ubuntu-20.04, 17-jdk-ubuntu-focal, 17-jdk-ubuntu-20.04, 17.0.13-jdk-ubuntu-focal, 17.0.13-jdk-ubuntu-20.04
+Tags: 17-ubuntu-focal, 17-ubuntu-20.04, 17.0.14-ubuntu-focal, 17.0.14-ubuntu-20.04, 17-jdk-ubuntu-focal, 17-jdk-ubuntu-20.04, 17.0.14-jdk-ubuntu-focal, 17.0.14-jdk-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/20_04/jdk
 
-Tags: 17-jdk-headless-ubuntu-focal, 17-jdk-headless-ubuntu-20.04, 17.0.13-jdk-headless-ubuntu-focal, 17.0.13-jdk-headless-ubuntu-20.04
+Tags: 17-jdk-headless-ubuntu-focal, 17-jdk-headless-ubuntu-20.04, 17.0.14-jdk-headless-ubuntu-focal, 17.0.14-jdk-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/20_04/jdk-headless
 
-Tags: 17-jre-ubuntu-focal, 17-jre-ubuntu-20.04, 17.0.13-jre-ubuntu-focal, 17.0.13-jre-ubuntu-20.04
+Tags: 17-jre-ubuntu-focal, 17-jre-ubuntu-20.04, 17.0.14-jre-ubuntu-focal, 17.0.14-jre-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/20_04/jre
 
-Tags: 17-jre-headless-ubuntu-focal, 17-jre-headless-ubuntu-20.04, 17.0.13-jre-headless-ubuntu-focal, 17.0.13-jre-headless-ubuntu-20.04
+Tags: 17-jre-headless-ubuntu-focal, 17-jre-headless-ubuntu-20.04, 17.0.14-jre-headless-ubuntu-focal, 17.0.14-jre-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fd88009fc782ba7b919680ba995d749db2f5e364
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
 Directory: dockerfiles/17/ubuntu/20_04/jre-headless
 
-Tags: 11, 11-jdk-ubuntu, 11.0.25, 11.0.25-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11.0.25-ubuntu-noble, 11.0.25-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.25-jdk-ubuntu-noble, 11.0.25-jdk-ubuntu-24.04
+Tags: 17-jdk-alpine, 17.0.14-jdk-alpine, 17-alpine-3.21, 17.0.14-alpine-3.21, 17-jdk-alpine-3.21, 17.0.14-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
+Directory: dockerfiles/17/alpine/3_21/jdk
+
+Tags: 17-jre-alpine, 17.0.14-jre-alpine, 17-jre-alpine-3.21, 17.0.14-jre-alpine-3.21
+Architectures: amd64
+GitCommit: 8c95b1c817dc4c78de3f5b3824b86a0a38bea07b
+Directory: dockerfiles/17/alpine/3_21/jre
+
+Tags: 11, 11-jdk-ubuntu, 11.0.26, 11.0.26-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11.0.26-ubuntu-noble, 11.0.26-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.26-jdk-ubuntu-noble, 11.0.26-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/24_04/jdk
 
-Tags: 11-jdk-headless-ubuntu, 11.0.25-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.25-jdk-headless-ubuntu-noble, 11.0.25-jdk-headless-ubuntu-24.04
+Tags: 11-jdk-headless-ubuntu, 11.0.26-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.26-jdk-headless-ubuntu-noble, 11.0.26-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/24_04/jdk-headless
 
-Tags: 11-jre-ubuntu, 11.0.25-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.25-jre-ubuntu-noble, 11.0.25-jre-ubuntu-24.04
+Tags: 11-jre-ubuntu, 11.0.26-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.26-jre-ubuntu-noble, 11.0.26-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/24_04/jre
 
-Tags: 11-jre-headless-ubuntu, 11.0.25-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.25-jre-headless-ubuntu-noble, 11.0.25-jre-headless-ubuntu-24.04
+Tags: 11-jre-headless-ubuntu, 11.0.26-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.26-jre-headless-ubuntu-noble, 11.0.26-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/24_04/jre-headless
 
-Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11.0.25-ubuntu-jammy, 11.0.25-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.25-jdk-ubuntu-jammy, 11.0.25-jdk-ubuntu-22.04
+Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11.0.26-ubuntu-jammy, 11.0.26-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.26-jdk-ubuntu-jammy, 11.0.26-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/22_04/jdk
 
-Tags: 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.25-jdk-headless-ubuntu-jammy, 11.0.25-jdk-headless-ubuntu-22.04
+Tags: 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.26-jdk-headless-ubuntu-jammy, 11.0.26-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/22_04/jdk-headless
 
-Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.25-jre-ubuntu-jammy, 11.0.25-jre-ubuntu-22.04
+Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.26-jre-ubuntu-jammy, 11.0.26-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/22_04/jre
 
-Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.25-jre-headless-ubuntu-jammy, 11.0.25-jre-headless-ubuntu-22.04
+Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.26-jre-headless-ubuntu-jammy, 11.0.26-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/22_04/jre-headless
 
-Tags: 11-ubuntu-focal, 11-ubuntu-20.04, 11.0.25-ubuntu-focal, 11.0.25-ubuntu-20.04, 11-jdk-ubuntu-focal, 11-jdk-ubuntu-20.04, 11.0.25-jdk-ubuntu-focal, 11.0.25-jdk-ubuntu-20.04
+Tags: 11-ubuntu-focal, 11-ubuntu-20.04, 11.0.26-ubuntu-focal, 11.0.26-ubuntu-20.04, 11-jdk-ubuntu-focal, 11-jdk-ubuntu-20.04, 11.0.26-jdk-ubuntu-focal, 11.0.26-jdk-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/20_04/jdk
 
-Tags: 11-jdk-headless-ubuntu-focal, 11-jdk-headless-ubuntu-20.04, 11.0.25-jdk-headless-ubuntu-focal, 11.0.25-jdk-headless-ubuntu-20.04
+Tags: 11-jdk-headless-ubuntu-focal, 11-jdk-headless-ubuntu-20.04, 11.0.26-jdk-headless-ubuntu-focal, 11.0.26-jdk-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/20_04/jdk-headless
 
-Tags: 11-jre-ubuntu-focal, 11-jre-ubuntu-20.04, 11.0.25-jre-ubuntu-focal, 11.0.25-jre-ubuntu-20.04
+Tags: 11-jre-ubuntu-focal, 11-jre-ubuntu-20.04, 11.0.26-jre-ubuntu-focal, 11.0.26-jre-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/20_04/jre
 
-Tags: 11-jre-headless-ubuntu-focal, 11-jre-headless-ubuntu-20.04, 11.0.25-jre-headless-ubuntu-focal, 11.0.25-jre-headless-ubuntu-20.04
+Tags: 11-jre-headless-ubuntu-focal, 11-jre-headless-ubuntu-20.04, 11.0.26-jre-headless-ubuntu-focal, 11.0.26-jre-headless-ubuntu-20.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74f392cfc725505f1c49bff08a4e37c9bdb9b8c0
+GitCommit: 5f0ddc9f4c4b92766848767595b6f50955970b21
 Directory: dockerfiles/11/ubuntu/20_04/jre-headless


### PR DESCRIPTION
This updates SapMachine containers to the January 2025 update cycles.
It also adds container flavors for Alpine base images.
There's also a change in the responsible maintainers.