### PR TITLE
Update bash

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -30,40 +30,40 @@ Directory: 5.0
 
 Tags: 4.4.23, 4.4, 4, 4.4.23-alpine3.21, 4.4-alpine3.21, 4-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: 9d45ba25a4e765a55bac62098e4f0360dc3c79b3
 Directory: 4.4
 
 Tags: 4.3.48, 4.3, 4.3.48-alpine3.21, 4.3-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 4.3
 
 Tags: 4.2.53, 4.2, 4.2.53-alpine3.21, 4.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 4.2
 
 Tags: 4.1.17, 4.1, 4.1.17-alpine3.21, 4.1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 4.1
 
 Tags: 4.0.44, 4.0, 4.0.44-alpine3.21, 4.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3, 3.2.57-alpine3.21, 3.2-alpine3.21, 3-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 3.2
 
 Tags: 3.1.23, 3.1, 3.1.23-alpine3.21, 3.1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 3.1
 
 Tags: 3.0.22, 3.0, 3.0.22-alpine3.21, 3.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4811b83a9b81e2af6587fbe01c7932a078cb1acc
+GitCommit: ddea3cd1ca0fc97dc8ba41ddac489eec71ee8081
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/tianon/docker-bash/commit/9d45ba2: Also apply job control fix to 4.4
- https://github.com/tianon/docker-bash/commit/fc161dc: Merge pull request https://github.com/tianon/docker-bash/pull/45 from chaifeng/fix-job-control
- https://github.com/tianon/docker-bash/commit/ddea3cd: Fix missing Job Control builtins in Bash 3.0-4.3 and stabilize Bash 3.x builds