### PR TITLE
Update Clear Linux OS to 42910

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 758add1a2635a92a2ea4a9fd0d1ffdf5c9dad258
-GitFetch: refs/heads/base-42870
+GitCommit: 48c457640c743fbe9222d6f7e0cb275467071c94
+GitFetch: refs/heads/base-42910


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42910

@bryteise @djklimes @bryteise