### PR TITLE
Apache Storm 2.8.0

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -5,9 +5,9 @@ GitRepo: https://github.com/apache/storm-docker.git
 Architectures: amd64, arm64v8
 
 Tags: 2.8.0, 2.8, latest
-GitCommit: eba09e577f8a43ac96496272f035c0ce662a2bac
+GitCommit: fefacef2f400d8f437675b11e08bc6098a91c188
 Directory: 2.8.0
 
 Tags: 2.8.0-jre17, 2.8-jre17
-GitCommit: eba09e577f8a43ac96496272f035c0ce662a2bac
+GitCommit: fefacef2f400d8f437675b11e08bc6098a91c188
 Directory: 2.8.0

--- a/library/storm
+++ b/library/storm
@@ -4,10 +4,10 @@ Maintainers: The Apache Storm Project <dev@storm.apache.org> (@asfbot),
 GitRepo: https://github.com/apache/storm-docker.git
 Architectures: amd64, arm64v8
 
-Tags: 2.7.1, 2.7, latest
-GitCommit: 59ee14a11bd6d890c8ff3ed7a327b8464ab79f3a
-Directory: 2.7.1
+Tags: 2.8.0, 2.8, latest
+GitCommit: eba09e577f8a43ac96496272f035c0ce662a2bac
+Directory: 2.8.0
 
-Tags: 2.7.1-jre17, 2.7-jre17
-GitCommit: 59ee14a11bd6d890c8ff3ed7a327b8464ab79f3a
-Directory: 2.7.1-jre17
+Tags: 2.8.0-jre17, 2.8-jre17
+GitCommit: eba09e577f8a43ac96496272f035c0ce662a2bac
+Directory: 2.8.0


### PR DESCRIPTION
Updates to Apache Storm 2.8.0 with two notable changes

- (1) We removed the version based directory in the image to allow for a better UX for end users
- (2) Storm 2.8.0 only supports Java 17+ now, so the base image will also be Java 17 based now.