### PR TITLE
Bump Traefik to v2.11.19

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
 Directory: v3.3/alpine
 
-Tags: v2.11.18-windowsservercore-ltsc2022, 2.11.18-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.19-windowsservercore-ltsc2022, 2.11.19-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1ac92d6e82c89ec76c6fd3a4e2230e75c5246ec4
+GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.18-windowsservercore-1809, 2.11.18-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.19-windowsservercore-1809, 2.11.19-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1ac92d6e82c89ec76c6fd3a4e2230e75c5246ec4
+GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.18-nanoserver-ltsc2022, 2.11.18-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.19-nanoserver-ltsc2022, 2.11.19-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1ac92d6e82c89ec76c6fd3a4e2230e75c5246ec4
+GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.18, 2.11.18, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.19, 2.11.19, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 1ac92d6e82c89ec76c6fd3a4e2230e75c5246ec4
+GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.19](https://github.com/traefik/traefik/releases/tag/v2.11.19).

/cc @mmatur @kevinpollet

Cheers
