### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,54 +14,54 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 7befb826ce64d07796378978a0bf12b3aabec301
 Directory: 3.2/alpine
 
-Tags: 3.1.2, 3.1, latest, 3.1.2-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.3, 3.1, latest, 3.1.3-bookworm, 3.1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 116ca50708ff505ac73b7c8dcc6d7689151946bb
+GitCommit: 9172eda0839755b609790ff159545e1f7d66d9b1
 Directory: 3.1
 
-Tags: 3.1.2-alpine, 3.1-alpine, alpine, 3.1.2-alpine3.21, 3.1-alpine3.21, alpine3.21
+Tags: 3.1.3-alpine, 3.1-alpine, alpine, 3.1.3-alpine3.21, 3.1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 116ca50708ff505ac73b7c8dcc6d7689151946bb
+GitCommit: 9172eda0839755b609790ff159545e1f7d66d9b1
 Directory: 3.1/alpine
 
-Tags: 3.0.7, 3.0, lts, 3.0.7-bookworm, 3.0-bookworm, lts-bookworm
+Tags: 3.0.8, 3.0, lts, 3.0.8-bookworm, 3.0-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f0dc84e9e09aa9aa758e6f9340ee0ab3b440930d
+GitCommit: 262506addcf26d79cf3983d5556b835d5818ee63
 Directory: 3.0
 
-Tags: 3.0.7-alpine, 3.0-alpine, lts-alpine, 3.0.7-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
+Tags: 3.0.8-alpine, 3.0-alpine, lts-alpine, 3.0.8-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: 262506addcf26d79cf3983d5556b835d5818ee63
 Directory: 3.0/alpine
 
-Tags: 2.9.13, 2.9, 2.9.13-bookworm, 2.9-bookworm
+Tags: 2.9.14, 2.9, 2.9.14-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0c1da312a638ecef78b17c6919ec9780bc1f75e9
+GitCommit: 812c8779de1250bb2e3e2c7da0a4b543ccc49edb
 Directory: 2.9
 
-Tags: 2.9.13-alpine, 2.9-alpine, 2.9.13-alpine3.21, 2.9-alpine3.21
+Tags: 2.9.14-alpine, 2.9-alpine, 2.9.14-alpine3.21, 2.9-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: 812c8779de1250bb2e3e2c7da0a4b543ccc49edb
 Directory: 2.9/alpine
 
-Tags: 2.8.13, 2.8, 2.8.13-bookworm, 2.8-bookworm
+Tags: 2.8.14, 2.8, 2.8.14-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ff4e3ce324778f1c2b65d6d61ddbf00c0b51793b
+GitCommit: c491c7f23708215e6f6d3e6cc9339acfda331821
 Directory: 2.8
 
-Tags: 2.8.13-alpine, 2.8-alpine, 2.8.13-alpine3.21, 2.8-alpine3.21
+Tags: 2.8.14-alpine, 2.8-alpine, 2.8.14-alpine3.21, 2.8-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: c491c7f23708215e6f6d3e6cc9339acfda331821
 Directory: 2.8/alpine
 
-Tags: 2.6.20, 2.6, 2.6.20-bookworm, 2.6-bookworm
+Tags: 2.6.21, 2.6, 2.6.21-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a0cdd805ad2cccf3400fb99dd18d0f49579d1cf4
+GitCommit: 1d0ad8c9e8dd1b976f8cc81b263f18bcfc1d9be2
 Directory: 2.6
 
-Tags: 2.6.20-alpine, 2.6-alpine, 2.6.20-alpine3.21, 2.6-alpine3.21
+Tags: 2.6.21-alpine, 2.6-alpine, 2.6.21-alpine3.21, 2.6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: 1d0ad8c9e8dd1b976f8cc81b263f18bcfc1d9be2
 Directory: 2.6/alpine
 
 Tags: 2.4.28, 2.4, 2.4.28-bookworm, 2.4-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9172eda: Update 3.1 to 3.1.3
- https://github.com/docker-library/haproxy/commit/262506a: Update 3.0 to 3.0.8
- https://github.com/docker-library/haproxy/commit/812c877: Update 2.9 to 2.9.14
- https://github.com/docker-library/haproxy/commit/c491c7f: Update 2.8 to 2.8.14
- https://github.com/docker-library/haproxy/commit/1d0ad8c: Update 2.6 to 2.6.21