### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-0733"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9fe8ed8899da004b76331cea812f7caae9c3a957
+amd64-GitCommit: 0acc836395dcf9dfe31d21688bf6d5f8e883d39a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c54d39c9290fe6b005a44bf0e9167a1ddf3acb12
+arm64v8-GitCommit: 76bb9ddfd4473f14c21e9813edd565e318e2a2a7
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2019-12900, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-0733.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
