### PR TITLE
chore: Update to Rust version 1.84.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/a6488232546c088ca9153d7a4154a3e5964ec576/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/da786eca125b17916ae42faae8631fa4a1d992d4/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.84-bullseye, 1.84.0-bullseye, bullseye
+Tags: 1-bullseye, 1.84-bullseye, 1.84.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
+GitCommit: da786eca125b17916ae42faae8631fa4a1d992d4
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.84-slim-bullseye, 1.84.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.84-slim-bullseye, 1.84.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
+GitCommit: da786eca125b17916ae42faae8631fa4a1d992d4
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.84-bookworm, 1.84.0-bookworm, bookworm, 1, 1.84, 1.84.0, latest
+Tags: 1-bookworm, 1.84-bookworm, 1.84.1-bookworm, bookworm, 1, 1.84, 1.84.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
+GitCommit: da786eca125b17916ae42faae8631fa4a1d992d4
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.84-slim-bookworm, 1.84.0-slim-bookworm, slim-bookworm, 1-slim, 1.84-slim, 1.84.0-slim, slim
+Tags: 1-slim-bookworm, 1.84-slim-bookworm, 1.84.1-slim-bookworm, slim-bookworm, 1-slim, 1.84-slim, 1.84.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
+GitCommit: da786eca125b17916ae42faae8631fa4a1d992d4
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.20, 1.84-alpine3.20, 1.84.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.84-alpine3.20, 1.84.1-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
+GitCommit: da786eca125b17916ae42faae8631fa4a1d992d4
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.84-alpine3.21, 1.84.0-alpine3.21, alpine3.21, 1-alpine, 1.84-alpine, 1.84.0-alpine, alpine
+Tags: 1-alpine3.21, 1.84-alpine3.21, 1.84.1-alpine3.21, alpine3.21, 1-alpine, 1.84-alpine, 1.84.1-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: a6488232546c088ca9153d7a4154a3e5964ec576
+GitCommit: da786eca125b17916ae42faae8631fa4a1d992d4
 Directory: stable/alpine3.21


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.84.1
https://blog.rust-lang.org/2025/01/30/Rust-1.84.1.html
