### PR TITLE
Bump Traefik to v3.3.3 and v2.11.20

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,55 +1,55 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.3.2-windowsservercore-ltsc2022, 3.3.2-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.3.3-windowsservercore-ltsc2022, 3.3.3-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
+GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
 Directory: v3.3/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.3.2-windowsservercore-1809, 3.3.2-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
+Tags: v3.3.3-windowsservercore-1809, 3.3.3-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
+GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
 Directory: v3.3/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.3.2-nanoserver-ltsc2022, 3.3.2-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.3.3-nanoserver-ltsc2022, 3.3.3-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
+GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
 Directory: v3.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.3.2, 3.3.2, v3.3, 3.3, v3, 3, saintnectaire, latest
+Tags: v3.3.3, 3.3.3, v3.3, 3.3, v3, 3, saintnectaire, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 4fc0980f9d74f7c3be2ef4bf2513cb39b3d2226b
+GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
 Directory: v3.3/alpine
 
-Tags: v2.11.19-windowsservercore-ltsc2022, 2.11.19-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.20-windowsservercore-ltsc2022, 2.11.20-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
+GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.19-windowsservercore-1809, 2.11.19-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.20-windowsservercore-1809, 2.11.20-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
+GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.19-nanoserver-ltsc2022, 2.11.19-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.20-nanoserver-ltsc2022, 2.11.20-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
+GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.19, 2.11.19, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.20, 2.11.20, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 718a74efcab7df2fbe6fbe7ceac1bbf21c4d3f46
+GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.3.3](https://github.com/traefik/traefik/releases/tag/v3.3.3) and [v2.11.20](https://github.com/traefik/traefik/releases/tag/v2.11.20).

/cc @mmatur @kevinpollet

Cheers

