### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,148 +4,148 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 25-ea-7-jdk-oraclelinux9, 25-ea-7-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-7-jdk-oracle, 25-ea-7-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-7-jdk, 25-ea-7, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-8-jdk-oraclelinux9, 25-ea-8-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-8-jdk-oracle, 25-ea-8-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-7-jdk-oraclelinux8, 25-ea-7-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-8-jdk-oraclelinux8, 25-ea-8-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-7-jdk-bookworm, 25-ea-7-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-8-jdk-bookworm, 25-ea-8-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-7-jdk-slim-bookworm, 25-ea-7-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-7-jdk-slim, 25-ea-7-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-8-jdk-slim-bookworm, 25-ea-8-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-8-jdk-slim, 25-ea-8-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-7-jdk-bullseye, 25-ea-7-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-8-jdk-bullseye, 25-ea-8-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-7-jdk-slim-bullseye, 25-ea-7-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-8-jdk-slim-bullseye, 25-ea-8-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-7-jdk-windowsservercore-ltsc2025, 25-ea-7-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
-SharedTags: 25-ea-7-jdk-windowsservercore, 25-ea-7-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-7-jdk, 25-ea-7, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-8-jdk-windowsservercore-ltsc2025, 25-ea-8-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-ea-8-jdk-windowsservercore, 25-ea-8-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 25-ea-7-jdk-windowsservercore-ltsc2022, 25-ea-7-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-7-jdk-windowsservercore, 25-ea-7-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-7-jdk, 25-ea-7, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-8-jdk-windowsservercore-ltsc2022, 25-ea-8-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-8-jdk-windowsservercore, 25-ea-8-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-7-jdk-windowsservercore-1809, 25-ea-7-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
-SharedTags: 25-ea-7-jdk-windowsservercore, 25-ea-7-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-7-jdk, 25-ea-7, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-8-jdk-windowsservercore-1809, 25-ea-8-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
+SharedTags: 25-ea-8-jdk-windowsservercore, 25-ea-8-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 25-ea-7-jdk-nanoserver-ltsc2025, 25-ea-7-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
-SharedTags: 25-ea-7-jdk-nanoserver, 25-ea-7-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-8-jdk-nanoserver-ltsc2025, 25-ea-8-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-ea-8-jdk-nanoserver, 25-ea-8-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 25-ea-7-jdk-nanoserver-ltsc2022, 25-ea-7-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
-SharedTags: 25-ea-7-jdk-nanoserver, 25-ea-7-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-8-jdk-nanoserver-ltsc2022, 25-ea-8-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-ea-8-jdk-nanoserver, 25-ea-8-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 25-ea-7-jdk-nanoserver-1809, 25-ea-7-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
-SharedTags: 25-ea-7-jdk-nanoserver, 25-ea-7-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-8-jdk-nanoserver-1809, 25-ea-8-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
+SharedTags: 25-ea-8-jdk-nanoserver, 25-ea-8-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 5bcbbafa1bd19282eb84c76d5120be545705299e
+GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 24-ea-33-jdk-oraclelinux9, 24-ea-33-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-33-jdk-oracle, 24-ea-33-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-33-jdk, 24-ea-33, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-34-jdk-oraclelinux9, 24-ea-34-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-34-jdk-oracle, 24-ea-34-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-33-jdk-oraclelinux8, 24-ea-33-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-34-jdk-oraclelinux8, 24-ea-34-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-33-jdk-bookworm, 24-ea-33-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-34-jdk-bookworm, 24-ea-34-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-33-jdk-slim-bookworm, 24-ea-33-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-33-jdk-slim, 24-ea-33-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-34-jdk-slim-bookworm, 24-ea-34-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-34-jdk-slim, 24-ea-34-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-33-jdk-bullseye, 24-ea-33-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-34-jdk-bullseye, 24-ea-34-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-33-jdk-slim-bullseye, 24-ea-33-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-34-jdk-slim-bullseye, 24-ea-34-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-33-jdk-windowsservercore-ltsc2025, 24-ea-33-windowsservercore-ltsc2025, 24-ea-jdk-windowsservercore-ltsc2025, 24-ea-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
-SharedTags: 24-ea-33-jdk-windowsservercore, 24-ea-33-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-33-jdk, 24-ea-33, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-34-jdk-windowsservercore-ltsc2025, 24-ea-34-windowsservercore-ltsc2025, 24-ea-jdk-windowsservercore-ltsc2025, 24-ea-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
+SharedTags: 24-ea-34-jdk-windowsservercore, 24-ea-34-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 24-ea-33-jdk-windowsservercore-ltsc2022, 24-ea-33-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-33-jdk-windowsservercore, 24-ea-33-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-33-jdk, 24-ea-33, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-34-jdk-windowsservercore-ltsc2022, 24-ea-34-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-34-jdk-windowsservercore, 24-ea-34-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-33-jdk-windowsservercore-1809, 24-ea-33-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-33-jdk-windowsservercore, 24-ea-33-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-33-jdk, 24-ea-33, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-34-jdk-windowsservercore-1809, 24-ea-34-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-34-jdk-windowsservercore, 24-ea-34-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-33-jdk-nanoserver-ltsc2025, 24-ea-33-nanoserver-ltsc2025, 24-ea-jdk-nanoserver-ltsc2025, 24-ea-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
-SharedTags: 24-ea-33-jdk-nanoserver, 24-ea-33-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-34-jdk-nanoserver-ltsc2025, 24-ea-34-nanoserver-ltsc2025, 24-ea-jdk-nanoserver-ltsc2025, 24-ea-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
+SharedTags: 24-ea-34-jdk-nanoserver, 24-ea-34-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 24-ea-33-jdk-nanoserver-ltsc2022, 24-ea-33-nanoserver-ltsc2022, 24-ea-jdk-nanoserver-ltsc2022, 24-ea-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
-SharedTags: 24-ea-33-jdk-nanoserver, 24-ea-33-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-34-jdk-nanoserver-ltsc2022, 24-ea-34-nanoserver-ltsc2022, 24-ea-jdk-nanoserver-ltsc2022, 24-ea-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
+SharedTags: 24-ea-34-jdk-nanoserver, 24-ea-34-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 24-ea-33-jdk-nanoserver-1809, 24-ea-33-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-33-jdk-nanoserver, 24-ea-33-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-34-jdk-nanoserver-1809, 24-ea-34-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-34-jdk-nanoserver, 24-ea-34-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: b2e19027c8e633d581e48d2b3074f1330a4d8da6
+GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/a9b9f21: Update 25 to 25-ea+8
- https://github.com/docker-library/openjdk/commit/d973893: Update 24 to 24-ea+34