### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20250115.0
+Tags: 2023, latest, 2023.6.20250128.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 0fcfdb19e02852797bdacf8eba0017b9578fd7ad
+amd64-GitCommit: 62364e1af381cdd199a0d7ad735f8baf1fb9e09b
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 3885cfc1b1cb68ed86380df117cfa429c5f5235a
+arm64v8-GitCommit: e81136972279716c9f5eaa5af031fc7b2023e9e5
 
-Tags: 2, 2.0.20250116.0
+Tags: 2, 2.0.20250123.4
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: a45d17fb340df67793447c58b118cea0a2343267
+amd64-GitCommit: 78695135792b5f19183bad50d0c90f627ab9850a
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a962f5c619399738a656812a1872d9d8b36ab184
+arm64v8-GitCommit: 37a2200b784b8fb422a49f7ecc137b4580b31929
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- system-release-2-17.amzn2
#### Packages addressing CVES:

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20250128-0.amzn2023
- system-release-2023.6.20250128-0.amzn2023
#### Packages addressing CVES: