### PR TITLE
Update Clear Linux OS to 42920

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 48c457640c743fbe9222d6f7e0cb275467071c94
-GitFetch: refs/heads/base-42910
+GitCommit: 161ae2584d299d4347d1bc46b2b3d90771b7bf5e
+GitFetch: refs/heads/base-42920


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42920

@bryteise @djklimes @bryteise