### PR TITLE
MediaWiki 1.42.5 maintenance releases

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,7 +3,7 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: 1be3b2bf0efd0f09e4cf2e706b2ecd92f3680fab
+GitCommit: aa20b593fa1190fa37dcf8a0ccedab375539ee81
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable & lts version
@@ -18,13 +18,13 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.43/fpm-alpine
 
 # current legacy versions
-Tags: 1.42.4, 1.42, legacy
+Tags: 1.42.5, 1.42, legacy
 Directory: 1.42/apache
 
-Tags: 1.42.4-fpm, 1.42-fpm, legacy-fpm
+Tags: 1.42.5-fpm, 1.42-fpm, legacy-fpm
 Directory: 1.42/fpm
 
-Tags: 1.42.4-fpm-alpine, 1.42-fpm-alpine, legacy-fpm-alpine
+Tags: 1.42.5-fpm-alpine, 1.42-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.42/fpm-alpine
 


### PR DESCRIPTION
See https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/3PLMZGEX22IKHXRMNO5XU3SCRIO4GZMN/ for the maling list announcement.

Related to https://github.com/wikimedia/mediawiki-docker/pull/154