### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -6,120 +6,100 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 17.2, 17, latest, 17.2-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 17/bookworm
 
 Tags: 17.2-bullseye, 17-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0b87a9bbd23f56b1e9e863ecda5cc9e66416c4e0
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 17/bullseye
 
 Tags: 17.2-alpine3.21, 17-alpine3.21, alpine3.21, 17.2-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 17/alpine3.21
 
 Tags: 17.2-alpine3.20, 17-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 17/alpine3.20
 
 Tags: 16.6, 16, 16.6-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 960ebdf14ef92d328588e77af2a879c63e577e96
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 16/bookworm
 
 Tags: 16.6-bullseye, 16-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 960ebdf14ef92d328588e77af2a879c63e577e96
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 16/bullseye
 
 Tags: 16.6-alpine3.21, 16-alpine3.21, 16.6-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 16/alpine3.21
 
 Tags: 16.6-alpine3.20, 16-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 16/alpine3.20
 
 Tags: 15.10, 15, 15.10-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 50b4cdb50e3599013f2fce9cd8860600f53c696c
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 15/bookworm
 
 Tags: 15.10-bullseye, 15-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 50b4cdb50e3599013f2fce9cd8860600f53c696c
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 15/bullseye
 
 Tags: 15.10-alpine3.21, 15-alpine3.21, 15.10-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 15/alpine3.21
 
 Tags: 15.10-alpine3.20, 15-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 15/alpine3.20
 
 Tags: 14.15, 14, 14.15-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c44484583320c81b35824ec0ce16864690d68bc3
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 14/bookworm
 
 Tags: 14.15-bullseye, 14-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c44484583320c81b35824ec0ce16864690d68bc3
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 14/bullseye
 
 Tags: 14.15-alpine3.21, 14-alpine3.21, 14.15-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 14/alpine3.21
 
 Tags: 14.15-alpine3.20, 14-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 14/alpine3.20
 
 Tags: 13.18, 13, 13.18-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9fadd0e250ba0c150dafec9e3c8728de3c8e318f
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 13/bookworm
 
 Tags: 13.18-bullseye, 13-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 9fadd0e250ba0c150dafec9e3c8728de3c8e318f
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 13/bullseye
 
 Tags: 13.18-alpine3.21, 13-alpine3.21, 13.18-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 13/alpine3.21
 
 Tags: 13.18-alpine3.20, 13-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
+GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
 Directory: 13/alpine3.20
-
-Tags: 12.22, 12, 12.22-bookworm, 12-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5f590b8df7f12270d1d5227758744ca3b0bdef74
-Directory: 12/bookworm
-
-Tags: 12.22-bullseye, 12-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 5f590b8df7f12270d1d5227758744ca3b0bdef74
-Directory: 12/bullseye
-
-Tags: 12.22-alpine3.21, 12-alpine3.21, 12.22-alpine, 12-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
-Directory: 12/alpine3.21
-
-Tags: 12.22-alpine3.20, 12-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 17818f21dca10ccf02711476e138c219bd31b456
-Directory: 12/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/3521b2f: Merge pull request https://github.com/docker-library/postgres/pull/1312 from infosiftr/eol-12
- https://github.com/docker-library/postgres/commit/042d8d0: Remove PostgreSQL 12 since it is end of life
- https://github.com/docker-library/postgres/commit/e2a4302: Update 12 to bookworm 12.22-2.pgdg120+1, bullseye 12.22-2.pgdg110+1
- https://github.com/docker-library/postgres/commit/32b6fcd: Remove inaccurate references to corruption, remove SEGTERM suggestion… (https://github.com/docker-library/postgres/pull/1303)
- https://github.com/docker-library/postgres/commit/cb04936: Simplify and update `verify-templating.yml`