### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -77,75 +77,75 @@ GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 24-ea-34-jdk-oraclelinux9, 24-ea-34-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-34-jdk-oracle, 24-ea-34-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-35-jdk-oraclelinux9, 24-ea-35-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-35-jdk-oracle, 24-ea-35-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-34-jdk-oraclelinux8, 24-ea-34-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-ea-35-jdk-oraclelinux8, 24-ea-35-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-34-jdk-bookworm, 24-ea-34-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-ea-35-jdk-bookworm, 24-ea-35-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-34-jdk-slim-bookworm, 24-ea-34-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-34-jdk-slim, 24-ea-34-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-ea-35-jdk-slim-bookworm, 24-ea-35-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-35-jdk-slim, 24-ea-35-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-34-jdk-bullseye, 24-ea-34-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-ea-35-jdk-bullseye, 24-ea-35-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-34-jdk-slim-bullseye, 24-ea-34-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-ea-35-jdk-slim-bullseye, 24-ea-35-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-34-jdk-windowsservercore-ltsc2025, 24-ea-34-windowsservercore-ltsc2025, 24-ea-jdk-windowsservercore-ltsc2025, 24-ea-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
-SharedTags: 24-ea-34-jdk-windowsservercore, 24-ea-34-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-35-jdk-windowsservercore-ltsc2025, 24-ea-35-windowsservercore-ltsc2025, 24-ea-jdk-windowsservercore-ltsc2025, 24-ea-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
+SharedTags: 24-ea-35-jdk-windowsservercore, 24-ea-35-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 24-ea-34-jdk-windowsservercore-ltsc2022, 24-ea-34-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-34-jdk-windowsservercore, 24-ea-34-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-35-jdk-windowsservercore-ltsc2022, 24-ea-35-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-ea-35-jdk-windowsservercore, 24-ea-35-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-34-jdk-windowsservercore-1809, 24-ea-34-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-34-jdk-windowsservercore, 24-ea-34-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-34-jdk, 24-ea-34, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-ea-35-jdk-windowsservercore-1809, 24-ea-35-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-ea-35-jdk-windowsservercore, 24-ea-35-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-34-jdk-nanoserver-ltsc2025, 24-ea-34-nanoserver-ltsc2025, 24-ea-jdk-nanoserver-ltsc2025, 24-ea-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
-SharedTags: 24-ea-34-jdk-nanoserver, 24-ea-34-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-35-jdk-nanoserver-ltsc2025, 24-ea-35-nanoserver-ltsc2025, 24-ea-jdk-nanoserver-ltsc2025, 24-ea-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
+SharedTags: 24-ea-35-jdk-nanoserver, 24-ea-35-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 24-ea-34-jdk-nanoserver-ltsc2022, 24-ea-34-nanoserver-ltsc2022, 24-ea-jdk-nanoserver-ltsc2022, 24-ea-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
-SharedTags: 24-ea-34-jdk-nanoserver, 24-ea-34-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-35-jdk-nanoserver-ltsc2022, 24-ea-35-nanoserver-ltsc2022, 24-ea-jdk-nanoserver-ltsc2022, 24-ea-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
+SharedTags: 24-ea-35-jdk-nanoserver, 24-ea-35-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 24-ea-34-jdk-nanoserver-1809, 24-ea-34-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-34-jdk-nanoserver, 24-ea-34-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-ea-35-jdk-nanoserver-1809, 24-ea-35-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-ea-35-jdk-nanoserver, 24-ea-35-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: d9738934e9021107b3bd4e4977767d7829bc3147
+GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/ecf054b: Update 24 to 24-ea+35