### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,8 +1,14 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/faa7e4c6c0e7269606b87a78cf2d159e298a84b5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/92f5c6df613e07adabe2ba6f954762f89dcd210b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
+
+Tags: 8.0.5-rc1-noble, 8.0-rc-noble
+SharedTags: 8.0.5-rc1, 8.0-rc
+Architectures: amd64, arm64v8
+GitCommit: fe2a707f3b58ac1a210100ef6f316fdcd9ccd98b
+Directory: 8.0-rc
 
 Tags: 8.0.4-noble, 8.0-noble, 8-noble, noble
 SharedTags: 8.0.4, 8.0, 8, latest


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/92f5c6d: Temporarily hack out Windows variants of 8.0.5-rc1
- https://github.com/docker-library/mongo/commit/fe2a707: Update 8.0-rc to 8.0.5-rc1