### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-0925"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0acc836395dcf9dfe31d21688bf6d5f8e883d39a
+amd64-GitCommit: 87cb4c6c3b8c13d075a1ab26fd682c2bf8603a36
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 76bb9ddfd4473f14c21e9813edd565e318e2a2a7
+arm64v8-GitCommit: f8300bc9e2d66a5565bac4d0c81a293fc770e352
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2019-12900, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-0925.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
