### PR TITLE
MariaDB 2025 Q1 Maintaince release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -26,42 +26,37 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 292b81d08eaab23d8bd501171e570ea0636b0b82
 Directory: 11.6
 
-Tags: 11.4.4-ubi9, 11.4-ubi9, lts-ubi9, 11.4.4-ubi, 11.4-ubi, lts-ubi
+Tags: 11.4.5-ubi9, 11.4-ubi9, lts-ubi9, 11.4.5-ubi, 11.4-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 11.4-ubi
 
-Tags: 11.4.4-noble, 11.4-noble, lts-noble, 11.4.4, 11.4, lts
+Tags: 11.4.5-noble, 11.4-noble, lts-noble, 11.4.5, 11.4, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 11.4
 
-Tags: 11.2.6-jammy, 11.2-jammy, 11.2.6, 11.2
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
-Directory: 11.2
-
-Tags: 10.11.10-ubi9, 10.11-ubi9, 10-ubi9, 10.11.10-ubi, 10.11-ubi, 10-ubi
+Tags: 10.11.11-ubi9, 10.11-ubi9, 10-ubi9, 10.11.11-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 10.11-ubi
 
-Tags: 10.11.10-jammy, 10.11-jammy, 10-jammy, 10.11.10, 10.11, 10
+Tags: 10.11.11-jammy, 10.11-jammy, 10-jammy, 10.11.11, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 10.11
 
-Tags: 10.6.20-ubi9, 10.6-ubi9, 10.6.20-ubi, 10.6-ubi
+Tags: 10.6.21-ubi9, 10.6-ubi9, 10.6.21-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 10.6-ubi
 
-Tags: 10.6.20-focal, 10.6-focal, 10.6.20, 10.6
+Tags: 10.6.21-focal, 10.6-focal, 10.6.21, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 10.6
 
-Tags: 10.5.27-focal, 10.5-focal, 10.5.27, 10.5
+Tags: 10.5.28-focal, 10.5-focal, 10.5.28, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 64252135052f269ed2bb57134ad73537e93b7ab6
+GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
 Directory: 10.5


### PR DESCRIPTION
Version bumps for maintained version.

Remove 11.2 from maintained versions.