### PR TITLE
Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,71 +6,71 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.24rc2-bookworm, 1.24-rc-bookworm
-SharedTags: 1.24rc2, 1.24-rc
+Tags: 1.24rc3-bookworm, 1.24-rc-bookworm
+SharedTags: 1.24rc3, 1.24-rc
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/bookworm
 
-Tags: 1.24rc2-bullseye, 1.24-rc-bullseye
+Tags: 1.24rc3-bullseye, 1.24-rc-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/bullseye
 
-Tags: 1.24rc2-alpine3.21, 1.24-rc-alpine3.21, 1.24rc2-alpine, 1.24-rc-alpine
+Tags: 1.24rc3-alpine3.21, 1.24-rc-alpine3.21, 1.24rc3-alpine, 1.24-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/alpine3.21
 
-Tags: 1.24rc2-alpine3.20, 1.24-rc-alpine3.20
+Tags: 1.24rc3-alpine3.20, 1.24-rc-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/alpine3.20
 
-Tags: 1.24rc2-windowsservercore-ltsc2025, 1.24-rc-windowsservercore-ltsc2025
-SharedTags: 1.24rc2-windowsservercore, 1.24-rc-windowsservercore, 1.24rc2, 1.24-rc
+Tags: 1.24rc3-windowsservercore-ltsc2025, 1.24-rc-windowsservercore-ltsc2025
+SharedTags: 1.24rc3-windowsservercore, 1.24-rc-windowsservercore, 1.24rc3, 1.24-rc
 Architectures: windows-amd64
-GitCommit: 2bbd50d64246d302d782d13599d9a8b3bf616116
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.24rc2-windowsservercore-ltsc2022, 1.24-rc-windowsservercore-ltsc2022
-SharedTags: 1.24rc2-windowsservercore, 1.24-rc-windowsservercore, 1.24rc2, 1.24-rc
+Tags: 1.24rc3-windowsservercore-ltsc2022, 1.24-rc-windowsservercore-ltsc2022
+SharedTags: 1.24rc3-windowsservercore, 1.24-rc-windowsservercore, 1.24rc3, 1.24-rc
 Architectures: windows-amd64
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.24rc2-windowsservercore-1809, 1.24-rc-windowsservercore-1809
-SharedTags: 1.24rc2-windowsservercore, 1.24-rc-windowsservercore, 1.24rc2, 1.24-rc
+Tags: 1.24rc3-windowsservercore-1809, 1.24-rc-windowsservercore-1809
+SharedTags: 1.24rc3-windowsservercore, 1.24-rc-windowsservercore, 1.24rc3, 1.24-rc
 Architectures: windows-amd64
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 1.24rc2-nanoserver-ltsc2025, 1.24-rc-nanoserver-ltsc2025
-SharedTags: 1.24rc2-nanoserver, 1.24-rc-nanoserver
+Tags: 1.24rc3-nanoserver-ltsc2025, 1.24-rc-nanoserver-ltsc2025
+SharedTags: 1.24rc3-nanoserver, 1.24-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 2bbd50d64246d302d782d13599d9a8b3bf616116
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.24rc2-nanoserver-ltsc2022, 1.24-rc-nanoserver-ltsc2022
-SharedTags: 1.24rc2-nanoserver, 1.24-rc-nanoserver
+Tags: 1.24rc3-nanoserver-ltsc2022, 1.24-rc-nanoserver-ltsc2022
+SharedTags: 1.24rc3-nanoserver, 1.24-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.24rc2-nanoserver-1809, 1.24-rc-nanoserver-1809
-SharedTags: 1.24rc2-nanoserver, 1.24-rc-nanoserver
+Tags: 1.24rc3-nanoserver-1809, 1.24-rc-nanoserver-1809
+SharedTags: 1.24rc3-nanoserver, 1.24-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 6923cf49962c9bee69b0e3b363bcc314db012e90
+GitCommit: 92805c5efacbd31643efec2585e53c1eea3a7fdf
 Directory: 1.24-rc/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Technically this is a `security` update, but the CVEs only apply to the pre-release go version and `CVE-2025-22867` is irrelevant on the platforms of our container images since we can only create Linux and Windows containers:

>On Darwin, building a Go module which contains CGO

See the announcement for more details: https://groups.google.com/g/golang-announce/c/w2gBC3sJibs

Changes:

- https://github.com/docker-library/golang/commit/92805c5: Update 1.24-rc to 1.24rc3