### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.0-beta.3, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a6e24f2c3c34229c7ab622c81ba93ae02f244f36
+GitCommit: 50712c727b66a322dc7f399c7d7e6a2e71f1a991
 Directory: 4.1-rc/ubuntu
 
 Tags: 4.1.0-beta.3-management, 4.1-rc-management
@@ -17,7 +17,7 @@ Directory: 4.1-rc/ubuntu/management
 
 Tags: 4.1.0-beta.3-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a6e24f2c3c34229c7ab622c81ba93ae02f244f36
+GitCommit: 50712c727b66a322dc7f399c7d7e6a2e71f1a991
 Directory: 4.1-rc/alpine
 
 Tags: 4.1.0-beta.3-management-alpine, 4.1-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 4.1-rc/alpine/management
 
 Tags: 4.0.5, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a6e24f2c3c34229c7ab622c81ba93ae02f244f36
+GitCommit: 4a68131a960e8a352eac238bfd4a9d869bc0562d
 Directory: 4.0/ubuntu
 
 Tags: 4.0.5-management, 4.0-management, 4-management, management
@@ -37,7 +37,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.5-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a6e24f2c3c34229c7ab622c81ba93ae02f244f36
+GitCommit: 4a68131a960e8a352eac238bfd4a9d869bc0562d
 Directory: 4.0/alpine
 
 Tags: 4.0.5-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/50712c7: Update 4.1-rc to otp 27.2.2
- https://github.com/docker-library/rabbitmq/commit/4a68131: Update 4.0 to otp 27.2.2