### PR TITLE
Add idle image

### DIFF
--- a/library/idle
+++ b/library/idle
@@ -1,0 +1,6 @@
+Maintainers: James Spurin <james@spurin.com> (@spurin)
+GitRepo: https://github.com/spurin/idle.git
+
+Tags: 1.0.0, latest
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+GitCommit: 4a532d3a158e05dbd422acf38bf01a3e0ad4bedb


### PR DESCRIPTION
Hi,

This PR is to start the process of adding the [idle](https://github.com/spurin/idle) docker image under the umbrella of Docker Library.

## **idle: A Purpose-Built, Ultra-Lightweight Container for Doing Nothing Efficiently**  

**idle** is an intentionally minimalist container image designed to remain running while consuming the absolute minimum amount of system resources. It serves as an alternative to commonly used lightweight images such as busybox or alpine, but with an even smaller footprint and a singular purpose - idling.  

Designed for Docker, Kubernetes and containerised environments, **idle** is statically compiled into a scratch-based image, making it ultra-lightweight, multi-architecture compatible, and highly efficient. It provides a simple yet powerful solution for scenarios where a running container is required but does not need to perform any active tasks.  

## **Why idle?**  

While various base images exist for running minimal workloads, there are very few options that are explicitly designed for idling with the least possible overhead. Existing solutions such as **busybox**, **alpine**, and even the **Kubernetes pause container** come with additional components, dependencies, or process management features that may be unnecessary for simple use cases.  

**idle** is designed to fill this gap by:  

- **Being as lightweight as possible**: It is built on a `scratch` base, with no unnecessary libraries or runtime dependencies.  
- **Using minimal system resources**: The binary is statically compiled and stripped down to the essentials, reducing both memory and disk footprint.  
- **Supporting multiple architectures**: Prebuilt images are available for various platforms, ensuring compatibility across different containerised environments.  
- **Gracefully handling shutdowns**: It responds cleanly to SIGINT and SIGTERM, making it well-suited for Docker and Kubernetes deployments.  

## **Use Cases**  

**idle** is particularly beneficial in the following scenarios:  

### 1. **Docker and Kubernetes Documentation & Examples**  
Many tutorials and examples require a placeholder container that simply runs without doing anything. **idle** serves as a perfect fit for such cases while keeping resource usage minimal.  

### 2. **Secrets Store CSI Driver & Volume Mounting**  
In Kubernetes, the Secrets Store CSI driver can sync secrets to Kubernetes, but requires a pod to mount the secret volume. **idle** is an ideal candidate for such scenarios, as it provides an ultra-lightweight, long-running container.  

### 3. **Placeholder Containers in CI/CD Pipelines**  
When testing or debugging workloads, sometimes an inactive container is required as a placeholder. Instead of using larger images, **idle** provides a more efficient alternative.  

### 4. **Alternative to the Kubernetes Pause Container**  
The `pause` container plays an integral role in Kubernetes, handling PID 1, namespace lifecycle management, and other functions. However, for situations where those features are not required, **idle** offers a simpler, smaller, and more efficient option.  

## **Why Make idle an Official Docker Image?**  

By making **idle** an official Docker image, it would:  

- Provide the container community with a **dedicated, purpose-built solution** for scenarios requiring an idle container.  
- Offer a **reliable and verified** source for a container that does nothing efficiently.  
- Reduce reliance on alternative images that may contain unnecessary components, increasing security and efficiency.  
- Serve as a **useful supplement** in official Docker and Kubernetes documentation, where a minimal placeholder container is often required.  

With its **ultra-lightweight design, cross-architecture support, and intentional simplicity**, **idle** is a highly beneficial addition to the official Docker image registry.  

## **To help fill out a review checklist**:

I am a Docker Captain and educator in Docker and Cloud Native. I actively promote Docker and best practices wherever possible. Whilst the repo has been created in a way where it is fun and entertaining, this project was designed to serve a much needed requirement. It was created out of of the frustration of frequently waiting 5-10 seconds for pods to start, that were literally doing nothing. 

**idle** is published under [The Unlicense](https://github.com/spurin/idle/blob/main/LICENSE)

## **Checklist for Review**:

NOTE: This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us ❤️)

-	[ ] associated with or contacted upstream?
-	[ ] available under [an OSI-approved license](https://opensource.org/licenses)?
-	[ ] does it fit into one of the common categories? ("service", "language stack", "base distribution")
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[ ] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[ ] if `FROM scratch`, tarballs only exist in a single commit within the associated history?
-	[ ] passes current tests? any simple new tests that might be appropriate to add? (https://github.com/docker-library/official-images/tree/master/test)