### PR TITLE
[oraclelinux] Updating 8, 8-slim, 8-slim-fips, 9, 9-slim, 9-slim-fips for tzdata-2025a

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 87cb4c6c3b8c13d075a1ab26fd682c2bf8603a36
+amd64-GitCommit: 8d25279f509bc37b1b79ec83e4dbe812bdc76831
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f8300bc9e2d66a5565bac4d0c81a293fc770e352
+arm64v8-GitCommit: 56d9ffb3eb5779a43e98d8f59844ce4c5ac76e02
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for tzdata-2025a.

See the following for details:
https://linux.oracle.com/errata/ELBA-2025-1104.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
