### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20250128.0
+Tags: 2023, latest, 2023.6.20250203.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 62364e1af381cdd199a0d7ad735f8baf1fb9e09b
+amd64-GitCommit: dcd3593bb82fac820a4dc25d028d8e46c2424bcb
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: e81136972279716c9f5eaa5af031fc7b2023e9e5
+arm64v8-GitCommit: 90643869f70b79d2058b08cda93dad538d235170
 
-Tags: 2, 2.0.20250123.4
+Tags: 2, 2.0.20250201.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 78695135792b5f19183bad50d0c90f627ab9850a
+amd64-GitCommit: 35791b0faed7f8ba07b37a377e9bab1bcfa496f3
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 37a2200b784b8fb422a49f7ecc137b4580b31929
+arm64v8-GitCommit: bb0f2b6a2a17be2bd51bef4bc78b36fa9785e5e5
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- python-2.7.18-1.amzn2.0.10
- python-libs-2.7.18-1.amzn2.0.10
#### Packages addressing CVES:
- python-2.7.18-1.amzn2.0.10, python-libs-2.7.18-1.amzn2.0.10
  - [CVE-2024-5642](https://alas.aws.amazon.com/cve/html/CVE-2024-5642.html)

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20250203-0.amzn2023
- system-release-2023.6.20250203-0.amzn2023
- python3-libs-3.9.20-1.amzn2023.0.3
- python3-3.9.20-1.amzn2023.0.3
#### Packages addressing CVES:
