### PR TITLE
Update Clear Linux OS to 42950

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 161ae2584d299d4347d1bc46b2b3d90771b7bf5e
-GitFetch: refs/heads/base-42920
+GitCommit: 92cf62bded14557c002e816e07e36df2e45b216e
+GitFetch: refs/heads/base-42950


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 42950

@bryteise @djklimes @bryteise