### PR TITLE
Update CrateDB 5.9.9

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -6,7 +6,7 @@ GitRepo: https://github.com/crate/docker-crate.git
 
 Tags: 5.9.9, 5.9, latest
 Architectures: amd64, arm64v8
-GitCommit: c83963c3aefaf30e0a17a3162e8692b723d48781
+GitCommit: 5972d59d5a2521ad29ae2f3edd9edad2697e36be
 
 Tags: 5.8.6, 5.8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Unfortunately, the base image almalinux:10-kitten-minimal introduced before doesn't have `hostname` tool that is required for https://github.com/crate/crate-operator to work. 

Hence, we need to update it to AlmaLinux 10 non-minimal.

Doing it makes 5.9.9 (that includes a data loss fix) available for users relying on k8s operator for their deployment.

Sorry for updating the OS in the same version.