### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,148 +4,148 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 25-ea-8-jdk-oraclelinux9, 25-ea-8-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-8-jdk-oracle, 25-ea-8-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-9-jdk-oraclelinux9, 25-ea-9-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-9-jdk-oracle, 25-ea-9-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-9-jdk, 25-ea-9, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-8-jdk-oraclelinux8, 25-ea-8-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-9-jdk-oraclelinux8, 25-ea-9-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-8-jdk-bookworm, 25-ea-8-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-9-jdk-bookworm, 25-ea-9-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-8-jdk-slim-bookworm, 25-ea-8-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-8-jdk-slim, 25-ea-8-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-9-jdk-slim-bookworm, 25-ea-9-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-9-jdk-slim, 25-ea-9-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-8-jdk-bullseye, 25-ea-8-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-9-jdk-bullseye, 25-ea-9-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-8-jdk-slim-bullseye, 25-ea-8-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-9-jdk-slim-bullseye, 25-ea-9-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-8-jdk-windowsservercore-ltsc2025, 25-ea-8-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
-SharedTags: 25-ea-8-jdk-windowsservercore, 25-ea-8-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-9-jdk-windowsservercore-ltsc2025, 25-ea-9-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-ea-9-jdk-windowsservercore, 25-ea-9-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-9-jdk, 25-ea-9, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 25-ea-8-jdk-windowsservercore-ltsc2022, 25-ea-8-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-8-jdk-windowsservercore, 25-ea-8-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-9-jdk-windowsservercore-ltsc2022, 25-ea-9-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-9-jdk-windowsservercore, 25-ea-9-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-9-jdk, 25-ea-9, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-8-jdk-windowsservercore-1809, 25-ea-8-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
-SharedTags: 25-ea-8-jdk-windowsservercore, 25-ea-8-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-8-jdk, 25-ea-8, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-9-jdk-windowsservercore-1809, 25-ea-9-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
+SharedTags: 25-ea-9-jdk-windowsservercore, 25-ea-9-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-9-jdk, 25-ea-9, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 25-ea-8-jdk-nanoserver-ltsc2025, 25-ea-8-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
-SharedTags: 25-ea-8-jdk-nanoserver, 25-ea-8-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-9-jdk-nanoserver-ltsc2025, 25-ea-9-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-ea-9-jdk-nanoserver, 25-ea-9-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 25-ea-8-jdk-nanoserver-ltsc2022, 25-ea-8-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
-SharedTags: 25-ea-8-jdk-nanoserver, 25-ea-8-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-9-jdk-nanoserver-ltsc2022, 25-ea-9-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-ea-9-jdk-nanoserver, 25-ea-9-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 25-ea-8-jdk-nanoserver-1809, 25-ea-8-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
-SharedTags: 25-ea-8-jdk-nanoserver, 25-ea-8-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-9-jdk-nanoserver-1809, 25-ea-9-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
+SharedTags: 25-ea-9-jdk-nanoserver, 25-ea-9-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: a9b9f214251aa186d7eebe52903d1dc842a41680
+GitCommit: e79fff4246e36766d3f90ad8466cdeb81f57e065
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 24-ea-35-jdk-oraclelinux9, 24-ea-35-oraclelinux9, 24-ea-jdk-oraclelinux9, 24-ea-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-ea-35-jdk-oracle, 24-ea-35-oracle, 24-ea-jdk-oracle, 24-ea-oracle, 24-jdk-oracle, 24-oracle
-SharedTags: 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-rc-jdk-oraclelinux9, 24-rc-oraclelinux9, 24-jdk-oraclelinux9, 24-oraclelinux9, 24-rc-jdk-oracle, 24-rc-oracle, 24-jdk-oracle, 24-oracle
+SharedTags: 24-rc-jdk, 24-rc, 24-jdk, 24
 Architectures: amd64, arm64v8
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/oraclelinux9
 
-Tags: 24-ea-35-jdk-oraclelinux8, 24-ea-35-oraclelinux8, 24-ea-jdk-oraclelinux8, 24-ea-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
+Tags: 24-rc-jdk-oraclelinux8, 24-rc-oraclelinux8, 24-jdk-oraclelinux8, 24-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/oraclelinux8
 
-Tags: 24-ea-35-jdk-bookworm, 24-ea-35-bookworm, 24-ea-jdk-bookworm, 24-ea-bookworm, 24-jdk-bookworm, 24-bookworm
+Tags: 24-rc-jdk-bookworm, 24-rc-bookworm, 24-jdk-bookworm, 24-bookworm
 Architectures: amd64, arm64v8
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/bookworm
 
-Tags: 24-ea-35-jdk-slim-bookworm, 24-ea-35-slim-bookworm, 24-ea-jdk-slim-bookworm, 24-ea-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-ea-35-jdk-slim, 24-ea-35-slim, 24-ea-jdk-slim, 24-ea-slim, 24-jdk-slim, 24-slim
+Tags: 24-rc-jdk-slim-bookworm, 24-rc-slim-bookworm, 24-jdk-slim-bookworm, 24-slim-bookworm, 24-rc-jdk-slim, 24-rc-slim, 24-jdk-slim, 24-slim
 Architectures: amd64, arm64v8
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/slim-bookworm
 
-Tags: 24-ea-35-jdk-bullseye, 24-ea-35-bullseye, 24-ea-jdk-bullseye, 24-ea-bullseye, 24-jdk-bullseye, 24-bullseye
+Tags: 24-rc-jdk-bullseye, 24-rc-bullseye, 24-jdk-bullseye, 24-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/bullseye
 
-Tags: 24-ea-35-jdk-slim-bullseye, 24-ea-35-slim-bullseye, 24-ea-jdk-slim-bullseye, 24-ea-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
+Tags: 24-rc-jdk-slim-bullseye, 24-rc-slim-bullseye, 24-jdk-slim-bullseye, 24-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/slim-bullseye
 
-Tags: 24-ea-35-jdk-windowsservercore-ltsc2025, 24-ea-35-windowsservercore-ltsc2025, 24-ea-jdk-windowsservercore-ltsc2025, 24-ea-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
-SharedTags: 24-ea-35-jdk-windowsservercore, 24-ea-35-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-rc-jdk-windowsservercore-ltsc2025, 24-rc-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
+SharedTags: 24-rc-jdk-windowsservercore, 24-rc-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-rc-jdk, 24-rc, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 24-ea-35-jdk-windowsservercore-ltsc2022, 24-ea-35-windowsservercore-ltsc2022, 24-ea-jdk-windowsservercore-ltsc2022, 24-ea-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24-ea-35-jdk-windowsservercore, 24-ea-35-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-rc-jdk-windowsservercore-ltsc2022, 24-rc-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24-rc-jdk-windowsservercore, 24-rc-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-rc-jdk, 24-rc, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24-ea-35-jdk-windowsservercore-1809, 24-ea-35-windowsservercore-1809, 24-ea-jdk-windowsservercore-1809, 24-ea-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
-SharedTags: 24-ea-35-jdk-windowsservercore, 24-ea-35-windowsservercore, 24-ea-jdk-windowsservercore, 24-ea-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-ea-35-jdk, 24-ea-35, 24-ea-jdk, 24-ea, 24-jdk, 24
+Tags: 24-rc-jdk-windowsservercore-1809, 24-rc-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24-rc-jdk-windowsservercore, 24-rc-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24-rc-jdk, 24-rc, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 24-ea-35-jdk-nanoserver-ltsc2025, 24-ea-35-nanoserver-ltsc2025, 24-ea-jdk-nanoserver-ltsc2025, 24-ea-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
-SharedTags: 24-ea-35-jdk-nanoserver, 24-ea-35-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-rc-jdk-nanoserver-ltsc2025, 24-rc-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
+SharedTags: 24-rc-jdk-nanoserver, 24-rc-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 24-ea-35-jdk-nanoserver-ltsc2022, 24-ea-35-nanoserver-ltsc2022, 24-ea-jdk-nanoserver-ltsc2022, 24-ea-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
-SharedTags: 24-ea-35-jdk-nanoserver, 24-ea-35-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-rc-jdk-nanoserver-ltsc2022, 24-rc-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
+SharedTags: 24-rc-jdk-nanoserver, 24-rc-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 24-ea-35-jdk-nanoserver-1809, 24-ea-35-nanoserver-1809, 24-ea-jdk-nanoserver-1809, 24-ea-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
-SharedTags: 24-ea-35-jdk-nanoserver, 24-ea-35-nanoserver, 24-ea-jdk-nanoserver, 24-ea-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24-rc-jdk-nanoserver-1809, 24-rc-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24-rc-jdk-nanoserver, 24-rc-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: ecf054b190c1d04e2ee4607b150b79cc0a0dd458
+GitCommit: 4b990c22c8b369a103bce738d6838fe3e289a140
 Directory: 24/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/e79fff4: Update 25 to 25-ea+9
- https://github.com/docker-library/openjdk/commit/4b990c2: Update 24 to 24