### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,47 +64,47 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: aa3c30f8c0a6a5ba0e1b26f73be802dfc8f18e4f
 Directory: cli/php8.3/alpine
 
-Tags: beta-6.7.2-RC1-php8.1-apache, beta-6.7.2-php8.1-apache, beta-6.7-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.7.2-RC1-php8.1, beta-6.7.2-php8.1, beta-6.7-php8.1, beta-6-php8.1, beta-php8.1
+Tags: beta-6.7.2-RC2-php8.1-apache, beta-6.7.2-php8.1-apache, beta-6.7-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.7.2-RC2-php8.1, beta-6.7.2-php8.1, beta-6.7-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.1/apache
 
-Tags: beta-6.7.2-RC1-php8.1-fpm, beta-6.7.2-php8.1-fpm, beta-6.7-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.7.2-RC2-php8.1-fpm, beta-6.7.2-php8.1-fpm, beta-6.7-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.7.2-RC1-php8.1-fpm-alpine, beta-6.7.2-php8.1-fpm-alpine, beta-6.7-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.7.2-RC2-php8.1-fpm-alpine, beta-6.7.2-php8.1-fpm-alpine, beta-6.7-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.7.2-RC1-apache, beta-6.7.2-apache, beta-6.7-apache, beta-6-apache, beta-apache, beta-6.7.2-RC1, beta-6.7.2, beta-6.7, beta-6, beta, beta-6.7.2-RC1-php8.2-apache, beta-6.7.2-php8.2-apache, beta-6.7-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.7.2-RC1-php8.2, beta-6.7.2-php8.2, beta-6.7-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.7.2-RC2-apache, beta-6.7.2-apache, beta-6.7-apache, beta-6-apache, beta-apache, beta-6.7.2-RC2, beta-6.7.2, beta-6.7, beta-6, beta, beta-6.7.2-RC2-php8.2-apache, beta-6.7.2-php8.2-apache, beta-6.7-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.7.2-RC2-php8.2, beta-6.7.2-php8.2, beta-6.7-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.2/apache
 
-Tags: beta-6.7.2-RC1-fpm, beta-6.7.2-fpm, beta-6.7-fpm, beta-6-fpm, beta-fpm, beta-6.7.2-RC1-php8.2-fpm, beta-6.7.2-php8.2-fpm, beta-6.7-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.7.2-RC2-fpm, beta-6.7.2-fpm, beta-6.7-fpm, beta-6-fpm, beta-fpm, beta-6.7.2-RC2-php8.2-fpm, beta-6.7.2-php8.2-fpm, beta-6.7-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.7.2-RC1-fpm-alpine, beta-6.7.2-fpm-alpine, beta-6.7-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.7.2-RC1-php8.2-fpm-alpine, beta-6.7.2-php8.2-fpm-alpine, beta-6.7-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.7.2-RC2-fpm-alpine, beta-6.7.2-fpm-alpine, beta-6.7-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.7.2-RC2-php8.2-fpm-alpine, beta-6.7.2-php8.2-fpm-alpine, beta-6.7-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.2/fpm-alpine
 
-Tags: beta-6.7.2-RC1-php8.3-apache, beta-6.7.2-php8.3-apache, beta-6.7-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.7.2-RC1-php8.3, beta-6.7.2-php8.3, beta-6.7-php8.3, beta-6-php8.3, beta-php8.3
+Tags: beta-6.7.2-RC2-php8.3-apache, beta-6.7.2-php8.3-apache, beta-6.7-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.7.2-RC2-php8.3, beta-6.7.2-php8.3, beta-6.7-php8.3, beta-6-php8.3, beta-php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.3/apache
 
-Tags: beta-6.7.2-RC1-php8.3-fpm, beta-6.7.2-php8.3-fpm, beta-6.7-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Tags: beta-6.7.2-RC2-php8.3-fpm, beta-6.7.2-php8.3-fpm, beta-6.7-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.3/fpm
 
-Tags: beta-6.7.2-RC1-php8.3-fpm-alpine, beta-6.7.2-php8.3-fpm-alpine, beta-6.7-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Tags: beta-6.7.2-RC2-php8.3-fpm-alpine, beta-6.7.2-php8.3-fpm-alpine, beta-6.7-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39c8a6fdd5f22c3c37437b147c36d33df3ccffa6
+GitCommit: 3b86de3fe7c99001e32ac2e7048a8adf4f85db5a
 Directory: beta/php8.3/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/3b86de3: Update beta to 6.7.2-RC2