### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev4, 3.2-dev, 3.2-dev4-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev5, 3.2-dev, 3.2-dev5-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7befb826ce64d07796378978a0bf12b3aabec301
+GitCommit: d604c89bc8794e2444c76f3421d5adde679651f9
 Directory: 3.2
 
-Tags: 3.2-dev4-alpine, 3.2-dev-alpine, 3.2-dev4-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev5-alpine, 3.2-dev-alpine, 3.2-dev5-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7befb826ce64d07796378978a0bf12b3aabec301
+GitCommit: d604c89bc8794e2444c76f3421d5adde679651f9
 Directory: 3.2/alpine
 
 Tags: 3.1.3, 3.1, latest, 3.1.3-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/d604c89: Update 3.2 to 3.2-dev5