### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.0-beta.4, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: d0eb7432aad185f078fac1f4ea90c31f45f7b725
+GitCommit: 0698c475d60876b794e9fcee5a5f91fb41e18b8f
 Directory: 4.1-rc/ubuntu
 
 Tags: 4.1.0-beta.4-management, 4.1-rc-management
@@ -17,7 +17,7 @@ Directory: 4.1-rc/ubuntu/management
 
 Tags: 4.1.0-beta.4-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d0eb7432aad185f078fac1f4ea90c31f45f7b725
+GitCommit: 0698c475d60876b794e9fcee5a5f91fb41e18b8f
 Directory: 4.1-rc/alpine
 
 Tags: 4.1.0-beta.4-management-alpine, 4.1-rc-management-alpine
@@ -25,29 +25,29 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c0dcc40c9bce4bb6a826a61d250a2aeb0fa35416
 Directory: 4.1-rc/alpine/management
 
-Tags: 4.0.5, 4.0, 4, latest
+Tags: 4.0.6, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 4a68131a960e8a352eac238bfd4a9d869bc0562d
+GitCommit: 5095943110df494043917098f99c17ea10591485
 Directory: 4.0/ubuntu
 
-Tags: 4.0.5-management, 4.0-management, 4-management, management
+Tags: 4.0.6-management, 4.0-management, 4-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 36e4d246e934a96b1c3a920e398f96434f3fc34c
 Directory: 4.0/ubuntu/management
 
-Tags: 4.0.5-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.6-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4a68131a960e8a352eac238bfd4a9d869bc0562d
+GitCommit: 5095943110df494043917098f99c17ea10591485
 Directory: 4.0/alpine
 
-Tags: 4.0.5-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
+Tags: 4.0.6-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 36e4d246e934a96b1c3a920e398f96434f3fc34c
 Directory: 4.0/alpine/management
 
 Tags: 3.13.7, 3.13, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a6e24f2c3c34229c7ab622c81ba93ae02f244f36
+GitCommit: 32ff17343cd6b6756094d43120babb089b55d13c
 Directory: 3.13/ubuntu
 
 Tags: 3.13.7-management, 3.13-management, 3-management
@@ -57,7 +57,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.7-alpine, 3.13-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a6e24f2c3c34229c7ab622c81ba93ae02f244f36
+GitCommit: 32ff17343cd6b6756094d43120babb089b55d13c
 Directory: 3.13/alpine
 
 Tags: 3.13.7-management-alpine, 3.13-management-alpine, 3-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/0698c47: Update 4.1-rc to openssl 3.3.3
- https://github.com/docker-library/rabbitmq/commit/5095943: Update 4.0 to 4.0.6, openssl 3.3.3
- https://github.com/docker-library/rabbitmq/commit/32ff173: Update 3.13 to openssl 3.1.8