### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -123,3 +123,18 @@ Tags: oracular, 24.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: f24f02bc0fda57d7f0e30b205df4a38114712b0a
 Directory: ubuntu/oracular
+
+Tags: plucky-curl, 25.04-curl
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0
+Directory: ubuntu/plucky/curl
+
+Tags: plucky-scm, 25.04-scm
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0
+Directory: ubuntu/plucky/scm
+
+Tags: plucky, 25.04
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0
+Directory: ubuntu/plucky


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/ab3ae04: Add Ubuntu Plucky (25.04)
- https://github.com/docker-library/buildpack-deps/commit/4f4a759: Merge pull request https://github.com/docker-library/buildpack-deps/pull/164 from infosiftr/canonical-suites
- https://github.com/docker-library/buildpack-deps/commit/49631df: Simplify and update `verify-templating.yml`
- https://github.com/docker-library/buildpack-deps/commit/ad037d4: Update README
- https://github.com/docker-library/buildpack-deps/commit/92d8c61: Merge pull request https://github.com/docker-library/buildpack-deps/pull/165 from infosiftr/jq-IN
- https://github.com/docker-library/buildpack-deps/commit/c708f4c: Use jq's `IN()` instead of `index()`
- https://github.com/docker-library/buildpack-deps/commit/cc2dc88: Update `generate-stackbrew-library.sh` to support `BASHBREW_LIBRARY` for easier cascading updates