### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -47,7 +47,7 @@ Directory: 4.0/alpine/management
 
 Tags: 3.13.7, 3.13, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 32ff17343cd6b6756094d43120babb089b55d13c
+GitCommit: 7c0cf4faec0434cebe92606f05241a104c79b4b6
 Directory: 3.13/ubuntu
 
 Tags: 3.13.7-management, 3.13-management, 3-management
@@ -57,7 +57,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.7-alpine, 3.13-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 32ff17343cd6b6756094d43120babb089b55d13c
+GitCommit: 7c0cf4faec0434cebe92606f05241a104c79b4b6
 Directory: 3.13/alpine
 
 Tags: 3.13.7-management-alpine, 3.13-management-alpine, 3-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/7c0cf4f: Update 3.13 to otp 26.2.5.8