### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,13 +1,13 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/92f5c6df613e07adabe2ba6f954762f89dcd210b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/ec73c001228001b3810964369c0d24d574ad7fff/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 8.0.5-rc1-noble, 8.0-rc-noble
-SharedTags: 8.0.5-rc1, 8.0-rc
+Tags: 8.0.5-rc2-noble, 8.0-rc-noble
+SharedTags: 8.0.5-rc2, 8.0-rc
 Architectures: amd64, arm64v8
-GitCommit: fe2a707f3b58ac1a210100ef6f316fdcd9ccd98b
+GitCommit: 5958f5e55353034428ab1cae0ecdbe285c90f258
 Directory: 8.0-rc
 
 Tags: 8.0.4-noble, 8.0-noble, 8-noble, noble
@@ -49,6 +49,47 @@ SharedTags: 8.0.4-nanoserver, 8.0-nanoserver, 8-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: 3eed4008b42e739dc9ed4234d3da682462ffdc9c
 Directory: 8.0/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
+
+Tags: 7.0.17-rc0-jammy, 7.0-rc-jammy
+SharedTags: 7.0.17-rc0, 7.0-rc
+Architectures: amd64, arm64v8
+GitCommit: 8e1134460c0b94afa5595207b2b7be03d2916e69
+Directory: 7.0-rc
+
+Tags: 7.0.17-rc0-windowsservercore-ltsc2025, 7.0-rc-windowsservercore-ltsc2025
+SharedTags: 7.0.17-rc0-windowsservercore, 7.0-rc-windowsservercore, 7.0.17-rc0, 7.0-rc
+Architectures: windows-amd64
+GitCommit: 8e1134460c0b94afa5595207b2b7be03d2916e69
+Directory: 7.0-rc/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
+Tags: 7.0.17-rc0-windowsservercore-ltsc2022, 7.0-rc-windowsservercore-ltsc2022
+SharedTags: 7.0.17-rc0-windowsservercore, 7.0-rc-windowsservercore, 7.0.17-rc0, 7.0-rc
+Architectures: windows-amd64
+GitCommit: 8e1134460c0b94afa5595207b2b7be03d2916e69
+Directory: 7.0-rc/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 7.0.17-rc0-windowsservercore-1809, 7.0-rc-windowsservercore-1809
+SharedTags: 7.0.17-rc0-windowsservercore, 7.0-rc-windowsservercore, 7.0.17-rc0, 7.0-rc
+Architectures: windows-amd64
+GitCommit: 8e1134460c0b94afa5595207b2b7be03d2916e69
+Directory: 7.0-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 7.0.17-rc0-nanoserver-ltsc2022, 7.0-rc-nanoserver-ltsc2022
+SharedTags: 7.0.17-rc0-nanoserver, 7.0-rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 8e1134460c0b94afa5595207b2b7be03d2916e69
+Directory: 7.0-rc/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 7.0.17-rc0-nanoserver-1809, 7.0-rc-nanoserver-1809
+SharedTags: 7.0.17-rc0-nanoserver, 7.0-rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 8e1134460c0b94afa5595207b2b7be03d2916e69
+Directory: 7.0-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 7.0.16-jammy, 7.0-jammy, 7-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/ec73c00: Carry "temporary" hack forward again
- https://github.com/docker-library/mongo/commit/5958f5e: Update 8.0-rc to 8.0.5-rc2
- https://github.com/docker-library/mongo/commit/8e11344: Update 7.0-rc to 7.0.17-rc0