### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 17.2, 17, latest, 17.2-bookworm, 17-bookworm, bookworm
+Tags: 17.3, 17, latest, 17.3-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 22dad776d9f858f5fb1940ac165be76aa8521e49
 Directory: 17/bookworm
 
-Tags: 17.2-bullseye, 17-bullseye, bullseye
+Tags: 17.3-bullseye, 17-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 22dad776d9f858f5fb1940ac165be76aa8521e49
 Directory: 17/bullseye
 
-Tags: 17.2-alpine3.21, 17-alpine3.21, alpine3.21, 17.2-alpine, 17-alpine, alpine
+Tags: 17.3-alpine3.21, 17-alpine3.21, alpine3.21, 17.3-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 22dad776d9f858f5fb1940ac165be76aa8521e49
 Directory: 17/alpine3.21
 
-Tags: 17.2-alpine3.20, 17-alpine3.20, alpine3.20
+Tags: 17.3-alpine3.20, 17-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 22dad776d9f858f5fb1940ac165be76aa8521e49
 Directory: 17/alpine3.20
 
-Tags: 16.6, 16, 16.6-bookworm, 16-bookworm
+Tags: 16.7, 16, 16.7-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
 Directory: 16/bookworm
 
-Tags: 16.6-bullseye, 16-bullseye
+Tags: 16.7-bullseye, 16-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
 Directory: 16/bullseye
 
-Tags: 16.6-alpine3.21, 16-alpine3.21, 16.6-alpine, 16-alpine
+Tags: 16.7-alpine3.21, 16-alpine3.21, 16.7-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
 Directory: 16/alpine3.21
 
-Tags: 16.6-alpine3.20, 16-alpine3.20
+Tags: 16.7-alpine3.20, 16-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
 Directory: 16/alpine3.20
 
-Tags: 15.10, 15, 15.10-bookworm, 15-bookworm
+Tags: 15.11, 15, 15.11-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
 Directory: 15/bookworm
 
-Tags: 15.10-bullseye, 15-bullseye
+Tags: 15.11-bullseye, 15-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
 Directory: 15/bullseye
 
-Tags: 15.10-alpine3.21, 15-alpine3.21, 15.10-alpine, 15-alpine
+Tags: 15.11-alpine3.21, 15-alpine3.21, 15.11-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
 Directory: 15/alpine3.21
 
-Tags: 15.10-alpine3.20, 15-alpine3.20
+Tags: 15.11-alpine3.20, 15-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
 Directory: 15/alpine3.20
 
-Tags: 14.15, 14, 14.15-bookworm, 14-bookworm
+Tags: 14.16, 14, 14.16-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
 Directory: 14/bookworm
 
-Tags: 14.15-bullseye, 14-bullseye
+Tags: 14.16-bullseye, 14-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
 Directory: 14/bullseye
 
-Tags: 14.15-alpine3.21, 14-alpine3.21, 14.15-alpine, 14-alpine
+Tags: 14.16-alpine3.21, 14-alpine3.21, 14.16-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
 Directory: 14/alpine3.21
 
-Tags: 14.15-alpine3.20, 14-alpine3.20
+Tags: 14.16-alpine3.20, 14-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
 Directory: 14/alpine3.20
 
-Tags: 13.18, 13, 13.18-bookworm, 13-bookworm
+Tags: 13.19, 13, 13.19-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
 Directory: 13/bookworm
 
-Tags: 13.18-bullseye, 13-bullseye
+Tags: 13.19-bullseye, 13-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
 Directory: 13/bullseye
 
-Tags: 13.18-alpine3.21, 13-alpine3.21, 13.18-alpine, 13-alpine
+Tags: 13.19-alpine3.21, 13-alpine3.21, 13.19-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
 Directory: 13/alpine3.21
 
-Tags: 13.18-alpine3.20, 13-alpine3.20
+Tags: 13.19-alpine3.20, 13-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 042d8d043fed77e0e09b6fcda0991bca9e8664e3
+GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
 Directory: 13/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/22dad77: Update 17 to 17.3, bookworm 17.3-1.pgdg120+1, bullseye 17.3-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/c17c1aa: Update 16 to 16.7, bookworm 16.7-1.pgdg120+1, bullseye 16.7-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/607fdbd: Update 15 to 15.11, bookworm 15.11-1.pgdg120+1, bullseye 15.11-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/4bc3d04: Update 14 to 14.16, bookworm 14.16-1.pgdg120+1, bullseye 14.16-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/7da49aa: Update 13 to 13.19, bookworm 13.19-1.pgdg120+1, bullseye 13.19-1.pgdg110+1

https://www.postgresql.org/about/news/postgresql-173-167-1511-1416-and-1319-released-3015/