### PR TITLE
Update to Apache Flink 1.19.2 and 1.20.1

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,12 +3,12 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, scala_2.12-java17, 2.0-preview1-java17, 2.0-java17, java17
+Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, 2.0-preview1-java17, 2.0-java17
 Architectures: amd64,arm64v8
 GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
 Directory: ./2.0/scala_2.12-java17-ubuntu
 
-Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, scala_2.12, 2.0-preview1-java11, 2.0-java11, java11, 2.0-preview1, 2.0, latest
+Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, 2.0-preview1-java11, 2.0-java11, 2.0-preview1, 2.0
 Architectures: amd64,arm64v8
 GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
 Directory: ./2.0/scala_2.12-java11-ubuntu
@@ -18,12 +18,12 @@ Architectures: amd64,arm64v8
 GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java8-ubuntu
 
-Tags: 1.20.1-scala_2.12-java17, 1.20-scala_2.12-java17, 1.20.1-java17, 1.20-java17
+Tags: 1.20.1-scala_2.12-java17, 1.20-scala_2.12-java17, scala_2.12-java17, 1.20-java17, 1.20.1-java17, java17
 Architectures: amd64,arm64v8
 GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java17-ubuntu
 
-Tags: 1.20.1-scala_2.12-java11, 1.20-scala_2.12-java11, 1.20.1-scala_2.12, 1.20-scala_2.12, 1.20.1-java11, 1.20-java11, 1.20.1, 1.20
+Tags: 1.20.1-scala_2.12-java11, 1.20-scala_2.12-java11, scala_2.12-java11, 1.20.1-scala_2.12, 1.20-scala_2.12, scala_2.12, 1.20.1-java11, 1.20-java11, java11, 1.20.1, 1.20, latest
 Architectures: amd64,arm64v8
 GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java11-ubuntu

--- a/library/flink
+++ b/library/flink
@@ -3,57 +3,42 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, 2.0-preview1-java17, 2.0-java17
+Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, scala_2.12-java17, 2.0-preview1-java17, 2.0-java17, java17
 Architectures: amd64,arm64v8
 GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
 Directory: ./2.0/scala_2.12-java17-ubuntu
 
-Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, 2.0-preview1-java11, 2.0-java11, 2.0-preview1, 2.0
+Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, scala_2.12, 2.0-preview1-java11, 2.0-java11, java11, 2.0-preview1, 2.0, latest
 Architectures: amd64,arm64v8
 GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
 Directory: ./2.0/scala_2.12-java11-ubuntu
 
-Tags: 1.20.0-scala_2.12-java8, 1.20-scala_2.12-java8, scala_2.12-java8, 1.20.0-java8, 1.20-java8, java8
+Tags: 1.20.1-scala_2.12-java8, 1.20-scala_2.12-java8, 1.20.1-java8, 1.20-java8
 Architectures: amd64,arm64v8
-GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
+GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java8-ubuntu
 
-Tags: 1.20.0-scala_2.12-java17, 1.20-scala_2.12-java17, scala_2.12-java17, 1.20.0-java17, 1.20-java17, java17
+Tags: 1.20.1-scala_2.12-java17, 1.20-scala_2.12-java17, 1.20.1-java17, 1.20-java17
 Architectures: amd64,arm64v8
-GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
+GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java17-ubuntu
 
-Tags: 1.20.0-scala_2.12-java11, 1.20-scala_2.12-java11, scala_2.12-java11, 1.20.0-scala_2.12, 1.20-scala_2.12, scala_2.12, 1.20.0-java11, 1.20-java11, java11, 1.20.0, 1.20, latest
+Tags: 1.20.1-scala_2.12-java11, 1.20-scala_2.12-java11, 1.20.1-scala_2.12, 1.20-scala_2.12, 1.20.1-java11, 1.20-java11, 1.20.1, 1.20
 Architectures: amd64,arm64v8
-GitCommit: 9d335b16e579d3207b769118990a602b8584b63d
+GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java11-ubuntu
 
-Tags: 1.19.1-scala_2.12-java8, 1.19-scala_2.12-java8, 1.19.1-java8, 1.19-java8
+Tags: 1.19.2-scala_2.12-java8, 1.19-scala_2.12-java8, 1.19.2-java8, 1.19-java8
 Architectures: amd64,arm64v8
-GitCommit: f77b347d0a534da0482e692d80f559f47041829e
+GitCommit: e2765a6d67449ccd22bc75050449b199a3a91302
 Directory: ./1.19/scala_2.12-java8-ubuntu
 
-Tags: 1.19.1-scala_2.12-java17, 1.19-scala_2.12-java17, 1.19.1-java17, 1.19-java17
+Tags: 1.19.2-scala_2.12-java17, 1.19-scala_2.12-java17, 1.19.2-java17, 1.19-java17
 Architectures: amd64,arm64v8
-GitCommit: f77b347d0a534da0482e692d80f559f47041829e
+GitCommit: e2765a6d67449ccd22bc75050449b199a3a91302
 Directory: ./1.19/scala_2.12-java17-ubuntu
 
-Tags: 1.19.1-scala_2.12-java11, 1.19-scala_2.12-java11, 1.19.1-scala_2.12, 1.19-scala_2.12, 1.19.1-java11, 1.19-java11, 1.19.1, 1.19
+Tags: 1.19.2-scala_2.12-java11, 1.19-scala_2.12-java11, 1.19.2-scala_2.12, 1.19-scala_2.12, 1.19.2-java11, 1.19-java11, 1.19.2, 1.19
 Architectures: amd64,arm64v8
-GitCommit: f77b347d0a534da0482e692d80f559f47041829e
+GitCommit: e2765a6d67449ccd22bc75050449b199a3a91302
 Directory: ./1.19/scala_2.12-java11-ubuntu
-
-Tags: 1.18.1-scala_2.12-java8, 1.18-scala_2.12-java8, 1.18.1-java8, 1.18-java8
-Architectures: amd64,arm64v8
-GitCommit: 883600747505c128d97e9d25c9326f0c6f1d31e4
-Directory: ./1.18/scala_2.12-java8-ubuntu
-
-Tags: 1.18.1-scala_2.12-java17, 1.18-scala_2.12-java17, 1.18.1-java17, 1.18-java17
-Architectures: amd64,arm64v8
-GitCommit: 883600747505c128d97e9d25c9326f0c6f1d31e4
-Directory: ./1.18/scala_2.12-java17-ubuntu
-
-Tags: 1.18.1-scala_2.12-java11, 1.18-scala_2.12-java11, 1.18.1-scala_2.12, 1.18-scala_2.12, 1.18.1-java11, 1.18-java11, 1.18.1, 1.18
-Architectures: amd64,arm64v8
-GitCommit: 883600747505c128d97e9d25c9326f0c6f1d31e4
-Directory: ./1.18/scala_2.12-java11-ubuntu


### PR DESCRIPTION
- Add new release `1.19.2`
- Add new release `1.20.1`
- Remove EOL `1.18` release