### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.109.5, 5.109, 5, latest
+Tags: 5.109.6, 5.109, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 997c9f4e3ff2fa46c08f60bc6b16f544bd42cd7a
+GitCommit: 6232bd91c2cbb7721466a8f1e8f0c797a0c29df0
 Directory: 5/debian
 
-Tags: 5.109.5-alpine, 5.109-alpine, 5-alpine, alpine
+Tags: 5.109.6-alpine, 5.109-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 997c9f4e3ff2fa46c08f60bc6b16f544bd42cd7a
+GitCommit: 6232bd91c2cbb7721466a8f1e8f0c797a0c29df0
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/6232bd9: Update to 5.109.6, ghost-cli 1.27.0
- https://github.com/docker-library/ghost/commit/579eac6: Update to 5.109.5, ghost-cli 1.27.0

#18449 just missed this `ghost-cli` update 😞 