### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-1301

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8d25279f509bc37b1b79ec83e4dbe812bdc76831
+amd64-GitCommit: d06ec01e156897788f9daafc217112cff5ff140f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 56d9ffb3eb5779a43e98d8f59844ce4c5ac76e02
+arm64v8-GitCommit: 6a10fb575ae0d332762064c7844fae05c16a5d45
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2020-11023, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-1301.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
