### PR TITLE
alpline: fix CVE-2024-12797, CVE-2024-13176 and CVE-2025-26519

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -40,10 +40,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.19.6, 3.19
+Tags: 3.19.7, 3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.19
-GitCommit: da0e46144e764925f67d80a2315c17208236a2ae
+GitCommit: 7cfdb838c6f47bb3845c25f1674a9c3a44d8bafb
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.21.2, 3.21, 3, latest
+Tags: 3.21.3, 3.21, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.21
-GitCommit: 28413e472a7192492de374a257c33d2802ba163d
+GitCommit: 17fe3d1e2d2cbf54d745139eab749c252e35b883
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -52,10 +52,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.18.11, 3.18
+Tags: 3.18.12, 3.18
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.18
-GitCommit: 4283069ff594a823a2923e4d1aa3980d829f0891
+GitCommit: f92f1c2b3b7025f08b05dc11b70534568a973903
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/

--- a/library/alpine
+++ b/library/alpine
@@ -27,10 +27,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.20.5, 3.20
+Tags: 3.20.6, 3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.20
-GitCommit: e5b6428f2a04eaf7f6f6c51232c0bfb6062c9bfe
+GitCommit: a0db1d60e576114995a27356e6dda8145293d6f8
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Fixes for:

- OpenSSL: [CVE-2024-13176](https://security.alpinelinux.org/vuln/CVE-2024-13176) and [CVE-2024-12797](https://security.alpinelinux.org/vuln/CVE-2024-12797)
- musl: [CVE-2025-26519](https://security.alpinelinux.org/vuln/CVE-2025-26519)