### PR TITLE
MariaDB 2025 Q1 Part 2 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,25 +6,25 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 Builder: buildkit
 
-Tags: 11.7.1-ubi9-rc, 11.7-ubi9-rc, 11.7.1-ubi-rc, 11.7-ubi-rc
+Tags: 11.8.1-ubi9-rc, 11.8-ubi9-rc, 11.8.1-ubi-rc, 11.8-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: a6b360fc45b1a8fcd63b87ab69d4ce43566a7c06
+GitCommit: 2d5103917774c4c53ec6bf3c6fdfc7b210e85690
+Directory: 11.8-ubi
+
+Tags: 11.8.1-noble-rc, 11.8-noble-rc, 11.8.1-rc, 11.8-rc
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 2d5103917774c4c53ec6bf3c6fdfc7b210e85690
+Directory: 11.8
+
+Tags: 11.7.2-ubi9, 11.7-ubi9, 11-ubi9, 11.7.2-ubi, 11.7-ubi, 11-ubi
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: 853447019725b35685d5ec3c007096a266399bea
 Directory: 11.7-ubi
 
-Tags: 11.7.1-noble-rc, 11.7-noble-rc, 11.7.1-rc, 11.7-rc
+Tags: 11.7.2-noble, 11.7-noble, 11-noble, noble, 11.7.2, 11.7, 11, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a6b360fc45b1a8fcd63b87ab69d4ce43566a7c06
+GitCommit: 853447019725b35685d5ec3c007096a266399bea
 Directory: 11.7
-
-Tags: 11.6.2-ubi9, 11.6-ubi9, 11-ubi9, 11.6.2-ubi, 11.6-ubi, 11-ubi
-Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 292b81d08eaab23d8bd501171e570ea0636b0b82
-Directory: 11.6-ubi
-
-Tags: 11.6.2-noble, 11.6-noble, 11-noble, noble, 11.6.2, 11.6, 11, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 292b81d08eaab23d8bd501171e570ea0636b0b82
-Directory: 11.6
 
 Tags: 11.4.5-ubi9, 11.4-ubi9, lts-ubi9, 11.4.5-ubi, 11.4-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le


### PR DESCRIPTION
11.8 as new RC in a LTS  version
11.7 now stable

11.6 now eol.