### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/ruby.git
 
-Tags: 3.4.1-bookworm, 3.4-bookworm, 3-bookworm, bookworm, 3.4.1, 3.4, 3, latest
+Tags: 3.4.2-bookworm, 3.4-bookworm, 3-bookworm, bookworm, 3.4.2, 3.4, 3, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: b8c490723bba11a80431effaee96030475f643bb
 Directory: 3.4/bookworm
 
-Tags: 3.4.1-slim-bookworm, 3.4-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.4.1-slim, 3.4-slim, 3-slim, slim
+Tags: 3.4.2-slim-bookworm, 3.4-slim-bookworm, 3-slim-bookworm, slim-bookworm, 3.4.2-slim, 3.4-slim, 3-slim, slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: b8c490723bba11a80431effaee96030475f643bb
 Directory: 3.4/slim-bookworm
 
-Tags: 3.4.1-bullseye, 3.4-bullseye, 3-bullseye, bullseye
+Tags: 3.4.2-bullseye, 3.4-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: b8c490723bba11a80431effaee96030475f643bb
 Directory: 3.4/bullseye
 
-Tags: 3.4.1-slim-bullseye, 3.4-slim-bullseye, 3-slim-bullseye, slim-bullseye
+Tags: 3.4.2-slim-bullseye, 3.4-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: b8c490723bba11a80431effaee96030475f643bb
 Directory: 3.4/slim-bullseye
 
-Tags: 3.4.1-alpine3.21, 3.4-alpine3.21, 3-alpine3.21, alpine3.21, 3.4.1-alpine, 3.4-alpine, 3-alpine, alpine
+Tags: 3.4.2-alpine3.21, 3.4-alpine3.21, 3-alpine3.21, alpine3.21, 3.4.2-alpine, 3.4-alpine, 3-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: b8c490723bba11a80431effaee96030475f643bb
 Directory: 3.4/alpine3.21
 
-Tags: 3.4.1-alpine3.20, 3.4-alpine3.20, 3-alpine3.20, alpine3.20
+Tags: 3.4.2-alpine3.20, 3.4-alpine3.20, 3-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: b8c490723bba11a80431effaee96030475f643bb
 Directory: 3.4/alpine3.20
 
 Tags: 3.3.7-bookworm, 3.3-bookworm, 3.3.7, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 59bb4e05d063fe3fbf2ec0fc96d226a8e7c4f41d
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/bookworm
 
 Tags: 3.3.7-slim-bookworm, 3.3-slim-bookworm, 3.3.7-slim, 3.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 59bb4e05d063fe3fbf2ec0fc96d226a8e7c4f41d
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/slim-bookworm
 
 Tags: 3.3.7-bullseye, 3.3-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 59bb4e05d063fe3fbf2ec0fc96d226a8e7c4f41d
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/bullseye
 
 Tags: 3.3.7-slim-bullseye, 3.3-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 59bb4e05d063fe3fbf2ec0fc96d226a8e7c4f41d
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/slim-bullseye
 
 Tags: 3.3.7-alpine3.21, 3.3-alpine3.21, 3.3.7-alpine, 3.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 59bb4e05d063fe3fbf2ec0fc96d226a8e7c4f41d
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/alpine3.21
 
 Tags: 3.3.7-alpine3.20, 3.3-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 59bb4e05d063fe3fbf2ec0fc96d226a8e7c4f41d
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/alpine3.20
 
 Tags: 3.2.7-bookworm, 3.2-bookworm, 3.2.7, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3a813c18eea9fa2060e02d238e39382b15618995
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.2/bookworm
 
 Tags: 3.2.7-slim-bookworm, 3.2-slim-bookworm, 3.2.7-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3a813c18eea9fa2060e02d238e39382b15618995
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.2/slim-bookworm
 
 Tags: 3.2.7-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3a813c18eea9fa2060e02d238e39382b15618995
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.2/bullseye
 
 Tags: 3.2.7-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3a813c18eea9fa2060e02d238e39382b15618995
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.2/slim-bullseye
 
 Tags: 3.2.7-alpine3.21, 3.2-alpine3.21, 3.2.7-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3a813c18eea9fa2060e02d238e39382b15618995
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.2/alpine3.21
 
 Tags: 3.2.7-alpine3.20, 3.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3a813c18eea9fa2060e02d238e39382b15618995
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.2/alpine3.20
 
 Tags: 3.1.6-bookworm, 3.1-bookworm, 3.1.6, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.1/bookworm
 
 Tags: 3.1.6-slim-bookworm, 3.1-slim-bookworm, 3.1.6-slim, 3.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.1/slim-bookworm
 
 Tags: 3.1.6-bullseye, 3.1-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.1/bullseye
 
 Tags: 3.1.6-slim-bullseye, 3.1-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.1/slim-bullseye
 
 Tags: 3.1.6-alpine3.21, 3.1-alpine3.21, 3.1.6-alpine, 3.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.1/alpine3.21
 
 Tags: 3.1.6-alpine3.20, 3.1-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1ea0c595e6a6e477a66142b8ed40c82c2af3a28a
+GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.1/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/b8c4907: Update 3.4 to 3.4.2
- https://github.com/docker-library/ruby/commit/02bc038: Merge pull request https://github.com/docker-library/ruby/pull/490 from Earlopain/remove-path-check-workaround
- https://github.com/docker-library/ruby/commit/c12fe5b: Remove `ENABLE_PATH_CHECK` workaround