### PR TITLE
archlinux: Release 20250216.0.309127

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250209.0.306557
-GitCommit: ad193674d2b4d7a95655223e70e1824079af2420
-GitFetch: refs/tags/v20250209.0.306557
+Tags: latest, base, base-20250216.0.309127
+GitCommit: c5e57588679339f02c5ff1a26902301c20c62898
+GitFetch: refs/tags/v20250216.0.309127
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250209.0.306557
-GitCommit: ad193674d2b4d7a95655223e70e1824079af2420
-GitFetch: refs/tags/v20250209.0.306557
+Tags: base-devel, base-devel-20250216.0.309127
+GitCommit: c5e57588679339f02c5ff1a26902301c20c62898
+GitFetch: refs/tags/v20250216.0.309127
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250209.0.306557
-GitCommit: ad193674d2b4d7a95655223e70e1824079af2420
-GitFetch: refs/tags/v20250209.0.306557
+Tags: multilib-devel, multilib-devel-20250216.0.309127
+GitCommit: c5e57588679339f02c5ff1a26902301c20c62898
+GitFetch: refs/tags/v20250216.0.309127
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks