### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/662d742aa3f57449bbbf2bb866752457363a586f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/984ae62e47c2383400e78f0f45f85997a51c1f70/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 662d742aa3f57449bbbf2bb866752457363a586f
+GitCommit: 984ae62e47c2383400e78f0f45f85997a51c1f70
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 93dbd152445b31a50a24ab810f766006da22a6e1
+amd64-GitCommit: 07389fddb83df4179472e65a462e69a4941ddb2c
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: cf4b6ba9f41002658574cf1a66ce50c42e48ae73
+arm32v5-GitCommit: d7f57c5b77bf55a6a45fae8ae233a517c8363723
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: edfa8bae7a434974ba0791402f3483b49e6df555
+arm32v6-GitCommit: cb468d3b984acc78e535ac790228e9b38e978e72
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 5247c04649f5d5bc0b957304b61f05d7a4d1ac16
+arm32v7-GitCommit: aa8eb6cedd8db85c1d39c262ce7a948a57148b97
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f479e6ef3548f74f60d9ce421574429370348eca
+arm64v8-GitCommit: 8e2f8cc2af967eab1374d1911d32d4ece9b4c88e
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 448af63f0c1d0977f7a77ff97ee113f447c0de13
+i386-GitCommit: e76a8a15436a97e1b9da168e31afb69015a1d8f9
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 9f559d9013831be0d66cd4941d67983ed62b0682
+mips64le-GitCommit: e7213797efd6a7f791f486d4cfd50255dd8b4ba9
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 90d92e8d6a6b71b8b384921095c91a693c6b3240
+ppc64le-GitCommit: 731a77dbe76d145e73da48c87420cee6ffb5497c
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: bedbbde6bffeeb3bd99bbb3bb77d4097776608e2
+riscv64-GitCommit: cf916c8a1a242156f40e6430c3a1e99a7b66fba4
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e63005de23a340abd75565aa686938492f10e9b6
+s390x-GitCommit: 135a0514d25edfe99270e3b8bf3802ed96936130
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/984ae62: Merge pull request https://github.com/docker-library/busybox/pull/217 from infosiftr/fix-i386-redux
- https://github.com/docker-library/busybox/commit/ffdd85e: Fix i386 again, but correctly
- https://github.com/docker-library/busybox/commit/0900032: Merge pull request https://github.com/docker-library/busybox/pull/216 from infosiftr/reproducible-i386
- https://github.com/docker-library/busybox/commit/90794c2: Fix reproducibility of non-uclibc i386 builds
- https://github.com/docker-library/busybox/commit/6b090fa: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/d72c8bb: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/f55435b: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/54a68ee: Update metadata for i386
- https://github.com/docker-library/busybox/commit/18a2d4f: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/23558c5: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/e85ee64: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/57d3a4c: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/82c5cb8: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/69136da: Merge pull request https://github.com/docker-library/busybox/pull/215 from infosiftr/PATH
- https://github.com/docker-library/busybox/commit/8ca4d2f: Add PATH to generated images so they're self-contained
- https://github.com/docker-library/busybox/commit/662d742: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/faed467: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/e73f302: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/ca15bb5: Update metadata for i386
- https://github.com/docker-library/busybox/commit/4dfef57: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/104fbab: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/f097df2: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/884f273: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/4aa9c18: Restore accidentally-removed "master-only" restriction for verify-templating
- https://github.com/docker-library/busybox/commit/de9a132: Merge pull request https://github.com/docker-library/busybox/pull/213 from infosiftr/buildroot-2024.11.1