### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-1517"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ee8499092893bbb6a7b939d42b10b135744e0a8c
+amd64-GitCommit: 72b2851d567ba4901b626810a3178cc4f646072a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6041b16782a2d46ff80367789b3c39c5902398e1
+arm64v8-GitCommit: f99c6e7c29bf2a6f05e80b9f045d5c76df3d3bb5
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2022-49043, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-1517.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
