### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev5, 3.2-dev, 3.2-dev5-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev6, 3.2-dev, 3.2-dev6-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d604c89bc8794e2444c76f3421d5adde679651f9
+GitCommit: 52fe35d0664a4d6ea63e1be22508dfca73a481c4
 Directory: 3.2
 
-Tags: 3.2-dev5-alpine, 3.2-dev-alpine, 3.2-dev5-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev6-alpine, 3.2-dev-alpine, 3.2-dev6-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d604c89bc8794e2444c76f3421d5adde679651f9
+GitCommit: 52fe35d0664a4d6ea63e1be22508dfca73a481c4
 Directory: 3.2/alpine
 
-Tags: 3.1.3, 3.1, latest, 3.1.3-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.5, 3.1, latest, 3.1.5-bookworm, 3.1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9172eda0839755b609790ff159545e1f7d66d9b1
+GitCommit: e1dd4e1ca3d371d604a530397ad090cb0b0d8bda
 Directory: 3.1
 
-Tags: 3.1.3-alpine, 3.1-alpine, alpine, 3.1.3-alpine3.21, 3.1-alpine3.21, alpine3.21
+Tags: 3.1.5-alpine, 3.1-alpine, alpine, 3.1.5-alpine3.21, 3.1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9172eda0839755b609790ff159545e1f7d66d9b1
+GitCommit: e1dd4e1ca3d371d604a530397ad090cb0b0d8bda
 Directory: 3.1/alpine
 
 Tags: 3.0.8, 3.0, lts, 3.0.8-bookworm, 3.0-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e1dd4e1: Update 3.1 to 3.1.5
- https://github.com/docker-library/haproxy/commit/52fe35d: Update 3.2 to 3.2-dev6
- https://github.com/docker-library/haproxy/commit/2d6c0f5: Update 3.1 to 3.1.4