### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-1675"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 72b2851d567ba4901b626810a3178cc4f646072a
+amd64-GitCommit: 770aa8a4f57123f03a2ddcf0e8e0816bf57ff448
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f99c6e7c29bf2a6f05e80b9f045d5c76df3d3bb5
+arm64v8-GitCommit: dab4288a12b13ba50729108ba9a5531cf5951a93
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-11187, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-1675.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
