### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 17.3, 17, latest, 17.3-bookworm, 17-bookworm, bookworm
+Tags: 17.4, 17, latest, 17.4-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a537d6002b1a4bb92eb88e1e894332a76b1d2e6b
+GitCommit: 729d22b104ede82d7b2d8681bb85f2f44c33eb60
 Directory: 17/bookworm
 
-Tags: 17.3-bullseye, 17-bullseye, bullseye
+Tags: 17.4-bullseye, 17-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a537d6002b1a4bb92eb88e1e894332a76b1d2e6b
+GitCommit: 729d22b104ede82d7b2d8681bb85f2f44c33eb60
 Directory: 17/bullseye
 
-Tags: 17.3-alpine3.21, 17-alpine3.21, alpine3.21, 17.3-alpine, 17-alpine, alpine
+Tags: 17.4-alpine3.21, 17-alpine3.21, alpine3.21, 17.4-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 22dad776d9f858f5fb1940ac165be76aa8521e49
+GitCommit: 729d22b104ede82d7b2d8681bb85f2f44c33eb60
 Directory: 17/alpine3.21
 
-Tags: 17.3-alpine3.20, 17-alpine3.20, alpine3.20
+Tags: 17.4-alpine3.20, 17-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 22dad776d9f858f5fb1940ac165be76aa8521e49
+GitCommit: 729d22b104ede82d7b2d8681bb85f2f44c33eb60
 Directory: 17/alpine3.20
 
-Tags: 16.7, 16, 16.7-bookworm, 16-bookworm
+Tags: 16.8, 16, 16.8-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
+GitCommit: ce5da348e75d283cdd90963f97bd61c374d41ee5
 Directory: 16/bookworm
 
-Tags: 16.7-bullseye, 16-bullseye
+Tags: 16.8-bullseye, 16-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
+GitCommit: ce5da348e75d283cdd90963f97bd61c374d41ee5
 Directory: 16/bullseye
 
-Tags: 16.7-alpine3.21, 16-alpine3.21, 16.7-alpine, 16-alpine
+Tags: 16.8-alpine3.21, 16-alpine3.21, 16.8-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
+GitCommit: ce5da348e75d283cdd90963f97bd61c374d41ee5
 Directory: 16/alpine3.21
 
-Tags: 16.7-alpine3.20, 16-alpine3.20
+Tags: 16.8-alpine3.20, 16-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c17c1aad6bc4a8cc9d0a1791d8facaa84171c05b
+GitCommit: ce5da348e75d283cdd90963f97bd61c374d41ee5
 Directory: 16/alpine3.20
 
-Tags: 15.11, 15, 15.11-bookworm, 15-bookworm
+Tags: 15.12, 15, 15.12-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
+GitCommit: 807e218040cfae401cb0ed2e866a1efe9d6cc48d
 Directory: 15/bookworm
 
-Tags: 15.11-bullseye, 15-bullseye
+Tags: 15.12-bullseye, 15-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
+GitCommit: 807e218040cfae401cb0ed2e866a1efe9d6cc48d
 Directory: 15/bullseye
 
-Tags: 15.11-alpine3.21, 15-alpine3.21, 15.11-alpine, 15-alpine
+Tags: 15.12-alpine3.21, 15-alpine3.21, 15.12-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
+GitCommit: 807e218040cfae401cb0ed2e866a1efe9d6cc48d
 Directory: 15/alpine3.21
 
-Tags: 15.11-alpine3.20, 15-alpine3.20
+Tags: 15.12-alpine3.20, 15-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 607fdbdadc175f112ebcf94a42272ca57e3b8ab2
+GitCommit: 807e218040cfae401cb0ed2e866a1efe9d6cc48d
 Directory: 15/alpine3.20
 
-Tags: 14.16, 14, 14.16-bookworm, 14-bookworm
+Tags: 14.17, 14, 14.17-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
+GitCommit: dabb1fcefb4637c8b6e1655c520bc10e67a735cb
 Directory: 14/bookworm
 
-Tags: 14.16-bullseye, 14-bullseye
+Tags: 14.17-bullseye, 14-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
+GitCommit: dabb1fcefb4637c8b6e1655c520bc10e67a735cb
 Directory: 14/bullseye
 
-Tags: 14.16-alpine3.21, 14-alpine3.21, 14.16-alpine, 14-alpine
+Tags: 14.17-alpine3.21, 14-alpine3.21, 14.17-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
+GitCommit: dabb1fcefb4637c8b6e1655c520bc10e67a735cb
 Directory: 14/alpine3.21
 
-Tags: 14.16-alpine3.20, 14-alpine3.20
+Tags: 14.17-alpine3.20, 14-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4bc3d04127905a457a92d7eb42e7e677389b8135
+GitCommit: dabb1fcefb4637c8b6e1655c520bc10e67a735cb
 Directory: 14/alpine3.20
 
-Tags: 13.19, 13, 13.19-bookworm, 13-bookworm
+Tags: 13.20, 13, 13.20-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
+GitCommit: 2f7aa214309aca0d90a41e57f0807f53ebf77d55
 Directory: 13/bookworm
 
-Tags: 13.19-bullseye, 13-bullseye
+Tags: 13.20-bullseye, 13-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
+GitCommit: 2f7aa214309aca0d90a41e57f0807f53ebf77d55
 Directory: 13/bullseye
 
-Tags: 13.19-alpine3.21, 13-alpine3.21, 13.19-alpine, 13-alpine
+Tags: 13.20-alpine3.21, 13-alpine3.21, 13.20-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
+GitCommit: 2f7aa214309aca0d90a41e57f0807f53ebf77d55
 Directory: 13/alpine3.21
 
-Tags: 13.19-alpine3.20, 13-alpine3.20
+Tags: 13.20-alpine3.20, 13-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7da49aaa6a5d1496288b8a54c40ac2860e2ac85b
+GitCommit: 2f7aa214309aca0d90a41e57f0807f53ebf77d55
 Directory: 13/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/729d22b: Update 17 to 17.4, bookworm 17.4-1.pgdg120+2, bullseye 17.4-1.pgdg110+2
- https://github.com/docker-library/postgres/commit/ce5da34: Update 16 to 16.8, bookworm 16.8-1.pgdg120+1, bullseye 16.8-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/807e218: Update 15 to 15.12, bookworm 15.12-1.pgdg120+1, bullseye 15.12-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/dabb1fc: Update 14 to 14.17, bookworm 14.17-1.pgdg120+1, bullseye 14.17-1.pgdg110+1
- https://github.com/docker-library/postgres/commit/2f7aa21: Update 13 to 13.20, bookworm 13.20-1.pgdg120+1, bullseye 13.20-1.pgdg110+1