### PR TITLE
archlinux: Release 20250223.0.312761

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250216.0.309127
-GitCommit: c5e57588679339f02c5ff1a26902301c20c62898
-GitFetch: refs/tags/v20250216.0.309127
+Tags: latest, base, base-20250223.0.312761
+GitCommit: 95b9dc8ea7fafbd4dc823c665b2f676c1e1240c9
+GitFetch: refs/tags/v20250223.0.312761
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250216.0.309127
-GitCommit: c5e57588679339f02c5ff1a26902301c20c62898
-GitFetch: refs/tags/v20250216.0.309127
+Tags: base-devel, base-devel-20250223.0.312761
+GitCommit: 95b9dc8ea7fafbd4dc823c665b2f676c1e1240c9
+GitFetch: refs/tags/v20250223.0.312761
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250216.0.309127
-GitCommit: c5e57588679339f02c5ff1a26902301c20c62898
-GitFetch: refs/tags/v20250216.0.309127
+Tags: multilib-devel, multilib-devel-20250223.0.312761
+GitCommit: 95b9dc8ea7fafbd4dc823c665b2f676c1e1240c9
+GitFetch: refs/tags/v20250223.0.312761
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks