### PR TITLE
Bump Traefik to v2.11.21

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,29 +27,29 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
 Directory: v3.3/alpine
 
-Tags: v2.11.20-windowsservercore-ltsc2022, 2.11.20-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.21-windowsservercore-ltsc2022, 2.11.21-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
+GitCommit: 747eab3667642ee3da6ac90ee18883d01d52ada8
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.20-windowsservercore-1809, 2.11.20-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
+Tags: v2.11.21-windowsservercore-1809, 2.11.21-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
+GitCommit: 747eab3667642ee3da6ac90ee18883d01d52ada8
 Directory: v2.11/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v2.11.20-nanoserver-ltsc2022, 2.11.20-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.21-nanoserver-ltsc2022, 2.11.21-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
+GitCommit: 747eab3667642ee3da6ac90ee18883d01d52ada8
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.20, 2.11.20, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.21, 2.11.21, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 17858f20fe51ffa4e0e42b77137d868a82268e58
+GitCommit: 747eab3667642ee3da6ac90ee18883d01d52ada8
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.21](https://github.com/traefik/traefik/releases/tag/v2.11.21).

/cc @nmengin @mmatur @rtribotte

Cheers
