### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/984ae62e47c2383400e78f0f45f85997a51c1f70/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/d9b25526cb3482f30cb4d41539f105283b7b7533/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 984ae62e47c2383400e78f0f45f85997a51c1f70
+GitCommit: d9b25526cb3482f30cb4d41539f105283b7b7533
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 07389fddb83df4179472e65a462e69a4941ddb2c
+amd64-GitCommit: b769899394ab55428f74fb5a44a6d1ee1824d43d
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d7f57c5b77bf55a6a45fae8ae233a517c8363723
+arm32v5-GitCommit: e799b36c671f1d5aab8e06df14a3445ca7e857b3
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: cb468d3b984acc78e535ac790228e9b38e978e72
+arm32v6-GitCommit: 19af00ddab22fcf782ba55c33b9b73a1555a8b96
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: aa8eb6cedd8db85c1d39c262ce7a948a57148b97
+arm32v7-GitCommit: e355f50ead5739d8db0a6a8a966985abc8890442
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8e2f8cc2af967eab1374d1911d32d4ece9b4c88e
+arm64v8-GitCommit: dfb9586b713aa8425d55d7fa5a19033a679c3905
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: e76a8a15436a97e1b9da168e31afb69015a1d8f9
+i386-GitCommit: 512eef64a848f7da24a4288ad4899f759a3ff955
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: e7213797efd6a7f791f486d4cfd50255dd8b4ba9
+mips64le-GitCommit: b9f156878d3373473ec770e171da9518ab18c5ca
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 731a77dbe76d145e73da48c87420cee6ffb5497c
+ppc64le-GitCommit: 98ac3f1dba94bf3b616ad38ea6818f07b4c8fcd9
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: cf916c8a1a242156f40e6430c3a1e99a7b66fba4
+riscv64-GitCommit: e8113937d43db0f9c160c3cecb0680522a77d307
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 135a0514d25edfe99270e3b8bf3802ed96936130
+s390x-GitCommit: 2b15d62d2c5e599de54a42c212bdeccda37502a9
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/d9b2552: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/42208cf: Update metadata for i386
- https://github.com/docker-library/busybox/commit/867937e: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/23b755e: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/6ac6b6e: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/6774f9e: Merge pull request https://github.com/docker-library/busybox/pull/218 from infosiftr/buildroot-2024.11.2
- https://github.com/docker-library/busybox/commit/7276333: Update amd64 metadata
- https://github.com/docker-library/busybox/commit/a9a303a: Update buildroot to 2024.11.2