### PR TITLE
Bump Traefik to v3.3.4

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.3.3-windowsservercore-ltsc2022, 3.3.3-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.3.4-windowsservercore-ltsc2022, 3.3.4-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
+GitCommit: dbb14d16f565c6b98affe491254d95cee5fc92e9
 Directory: v3.3/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.3.3-windowsservercore-1809, 3.3.3-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
+Tags: v3.3.4-windowsservercore-1809, 3.3.4-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
+GitCommit: dbb14d16f565c6b98affe491254d95cee5fc92e9
 Directory: v3.3/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.3.3-nanoserver-ltsc2022, 3.3.3-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.3.4-nanoserver-ltsc2022, 3.3.4-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
+GitCommit: dbb14d16f565c6b98affe491254d95cee5fc92e9
 Directory: v3.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.3.3, 3.3.3, v3.3, 3.3, v3, 3, saintnectaire, latest
+Tags: v3.3.4, 3.3.4, v3.3, 3.3, v3, 3, saintnectaire, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 039d2d724b144fcba54ba572f3d4aa34ce286a6f
+GitCommit: dbb14d16f565c6b98affe491254d95cee5fc92e9
 Directory: v3.3/alpine
 
 Tags: v2.11.21-windowsservercore-ltsc2022, 2.11.21-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.3.4](https://github.com/traefik/traefik/releases/tag/v3.3.4).

/cc @nmengin @mmatur @rtribotte

Cheers
