### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.0-beta.4, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 0698c475d60876b794e9fcee5a5f91fb41e18b8f
+GitCommit: 535e10c8b28e4dd55fe40849a4be65dbc92822e7
 Directory: 4.1-rc/ubuntu
 
 Tags: 4.1.0-beta.4-management, 4.1-rc-management
@@ -17,7 +17,7 @@ Directory: 4.1-rc/ubuntu/management
 
 Tags: 4.1.0-beta.4-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0698c475d60876b794e9fcee5a5f91fb41e18b8f
+GitCommit: 535e10c8b28e4dd55fe40849a4be65dbc92822e7
 Directory: 4.1-rc/alpine
 
 Tags: 4.1.0-beta.4-management-alpine, 4.1-rc-management-alpine
@@ -25,29 +25,29 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c0dcc40c9bce4bb6a826a61d250a2aeb0fa35416
 Directory: 4.1-rc/alpine/management
 
-Tags: 4.0.6, 4.0, 4, latest
+Tags: 4.0.7, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 5095943110df494043917098f99c17ea10591485
+GitCommit: 96a3b27b6e0be0a66dbcd189168ff2369c7a47f3
 Directory: 4.0/ubuntu
 
-Tags: 4.0.6-management, 4.0-management, 4-management, management
+Tags: 4.0.7-management, 4.0-management, 4-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 36e4d246e934a96b1c3a920e398f96434f3fc34c
 Directory: 4.0/ubuntu/management
 
-Tags: 4.0.6-alpine, 4.0-alpine, 4-alpine, alpine
+Tags: 4.0.7-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5095943110df494043917098f99c17ea10591485
+GitCommit: 96a3b27b6e0be0a66dbcd189168ff2369c7a47f3
 Directory: 4.0/alpine
 
-Tags: 4.0.6-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
+Tags: 4.0.7-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 36e4d246e934a96b1c3a920e398f96434f3fc34c
 Directory: 4.0/alpine/management
 
 Tags: 3.13.7, 3.13, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 7c0cf4faec0434cebe92606f05241a104c79b4b6
+GitCommit: 0493ba78b10522172b98215343cc50dbebc87374
 Directory: 3.13/ubuntu
 
 Tags: 3.13.7-management, 3.13-management, 3-management
@@ -57,7 +57,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.7-alpine, 3.13-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7c0cf4faec0434cebe92606f05241a104c79b4b6
+GitCommit: 0493ba78b10522172b98215343cc50dbebc87374
 Directory: 3.13/alpine
 
 Tags: 3.13.7-management-alpine, 3.13-management-alpine, 3-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/535e10c: Update 4.1-rc to otp 27.2.4
- https://github.com/docker-library/rabbitmq/commit/96a3b27: Update 4.0 to 4.0.7, otp 27.2.4
- https://github.com/docker-library/rabbitmq/commit/0493ba7: Update 3.13 to otp 26.2.5.9
- https://github.com/docker-library/rabbitmq/commit/1912a07: Deal with OpenSSL checksum files now including filename