### PR TITLE
Add 9.10.1 and 9.10 tags to haskell images

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -2,7 +2,7 @@ Maintainers: Albert Krewinkel <albert+docker@tarleb.com> (@tarleb),
              Andrei Dziahel <develop7@develop7.info> (@develop7)
 GitRepo: https://github.com/haskell/docker-haskell
 
-Tags: 9.10.1-bullseye, 9.10-bullseye, 9-bullseye, bullseye, 9, latest
+Tags: 9.10.1-bullseye, 9.10-bullseye, 9-bullseye, bullseye, 9.10.1, 9.10, 9, latest
 Architectures: amd64, arm64v8
 GitCommit: 68ddf626a38f6e76a81df168d1e24bd778b17bef
 Directory: 9.10/bullseye


### PR DESCRIPTION
People are requesting the more "general" version of the tags which exist for older images, but not for 9.10
https://github.com/haskell/docker-haskell/issues/149