### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.6.20250203.1
+Tags: 2023, latest, 2023.6.20250218.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: dcd3593bb82fac820a4dc25d028d8e46c2424bcb
+amd64-GitCommit: 271d0bf7ec6d134694d67722f3bda9af6cbcccd4
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 90643869f70b79d2058b08cda93dad538d235170
+arm64v8-GitCommit: 9b8712ce91ffa6e7d46ec8256e7f0465e8f8267a
 
-Tags: 2, 2.0.20250201.0
+Tags: 2, 2.0.20250220.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 35791b0faed7f8ba07b37a377e9bab1bcfa496f3
+amd64-GitCommit: 2d1136398a8951e414a869392af0636d7f326822
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: bb0f2b6a2a17be2bd51bef4bc78b36fa9785e5e5
+arm64v8-GitCommit: 9789653793e7748d88747a2c9b4c714910f846ee
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- vim-minimal-9.0.2153-1.amzn2.0.3
- vim-data-9.0.2153-1.amzn2.0.3
- glib2-2.56.1-9.amzn2.0.9

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.6.20250218-0.amzn2023
- system-release-2023.6.20250218-0.amzn2023
- libxml2-2.10.4-1.amzn2023.0.8
- python3-dnf-4.14.0-1.amzn2023.0.6
- yum-4.14.0-1.amzn2023.0.6
- dnf-data-4.14.0-1.amzn2023.0.6
- dnf-4.14.0-1.amzn2023.0.6