### PR TITLE
Disable neurodebian:sid+trixie builds for now

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -42,18 +42,22 @@ Tags: bookworm-non-free, nd120-non-free, non-free
 Architectures: amd64, arm64v8, i386
 Directory: dockerfiles/bookworm-non-free
 
-Tags: trixie, nd130
-Architectures: amd64, arm64v8, i386
-Directory: dockerfiles/trixie
-
-Tags: trixie-non-free, nd130-non-free
-Architectures: amd64, arm64v8, i386
-Directory: dockerfiles/trixie-non-free
-
-Tags: sid, nd
-Architectures: amd64, arm64v8, i386
-Directory: dockerfiles/sid
-
-Tags: sid-non-free, nd-non-free
-Architectures: amd64, arm64v8, i386
-Directory: dockerfiles/sid-non-free
+#
+# https://github.com/neurodebian/dockerfiles/issues/18
+# https://github.com/neurodebian/neurodebian/issues/97
+#
+#Tags: trixie, nd130
+#Architectures: amd64, arm64v8, i386
+#Directory: dockerfiles/trixie
+#
+#Tags: trixie-non-free, nd130-non-free
+#Architectures: amd64, arm64v8, i386
+#Directory: dockerfiles/trixie-non-free
+#
+#Tags: sid, nd
+#Architectures: amd64, arm64v8, i386
+#Directory: dockerfiles/sid
+#
+#Tags: sid-non-free, nd-non-free
+#Architectures: amd64, arm64v8, i386
+#Directory: dockerfiles/sid-non-free


### PR DESCRIPTION
They need to be updated to not use `apt-key` (which is relatively straightforward), but they then run into DSA1024. 😭

See:
- https://github.com/neurodebian/dockerfiles/issues/18
- https://github.com/neurodebian/neurodebian/issues/97
- https://github.com/neurodebian/dockerfiles/pull/20