### PR TITLE
archlinux: Release 20250302.0.316047

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250223.0.312761
-GitCommit: 95b9dc8ea7fafbd4dc823c665b2f676c1e1240c9
-GitFetch: refs/tags/v20250223.0.312761
+Tags: latest, base, base-20250302.0.316047
+GitCommit: c9cc0b9ff6483a5226ebebff096f5f17d57df0fc
+GitFetch: refs/tags/v20250302.0.316047
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250223.0.312761
-GitCommit: 95b9dc8ea7fafbd4dc823c665b2f676c1e1240c9
-GitFetch: refs/tags/v20250223.0.312761
+Tags: base-devel, base-devel-20250302.0.316047
+GitCommit: c9cc0b9ff6483a5226ebebff096f5f17d57df0fc
+GitFetch: refs/tags/v20250302.0.316047
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250223.0.312761
-GitCommit: 95b9dc8ea7fafbd4dc823c665b2f676c1e1240c9
-GitFetch: refs/tags/v20250223.0.312761
+Tags: multilib-devel, multilib-devel-20250302.0.316047
+GitCommit: c9cc0b9ff6483a5226ebebff096f5f17d57df0fc
+GitFetch: refs/tags/v20250302.0.316047
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks