### PR TITLE
Update neurodebian to use `/etc/apt/keyrings`

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,6 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: a0af1d460705d7efc9d6de9483f1ce4aa48ad152
+GitCommit: 89ca52860d80889fd878392a29150e46d9d91a71
 
 Tags: focal, nd20.04
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This still doesn't fix trixie/sid (because we need a new upstream key for that), but at least it updates the existing builds to the `apt-key`-less configuration. 🦾

See:
- https://github.com/neurodebian/dockerfiles/pull/20
- https://github.com/neurodebian/dockerfiles/issues/18
- https://github.com/neurodebian/neurodebian/issues/97