### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.0-beta.4, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 535e10c8b28e4dd55fe40849a4be65dbc92822e7
+GitCommit: 2fe4d518b2d892b6a39f10603e576cfdf815228c
 Directory: 4.1-rc/ubuntu
 
 Tags: 4.1.0-beta.4-management, 4.1-rc-management
@@ -17,7 +17,7 @@ Directory: 4.1-rc/ubuntu/management
 
 Tags: 4.1.0-beta.4-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 535e10c8b28e4dd55fe40849a4be65dbc92822e7
+GitCommit: 2fe4d518b2d892b6a39f10603e576cfdf815228c
 Directory: 4.1-rc/alpine
 
 Tags: 4.1.0-beta.4-management-alpine, 4.1-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 4.1-rc/alpine/management
 
 Tags: 4.0.7, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 96a3b27b6e0be0a66dbcd189168ff2369c7a47f3
+GitCommit: 292565a5bed3673c8c8885e275cbc13d382151f0
 Directory: 4.0/ubuntu
 
 Tags: 4.0.7-management, 4.0-management, 4-management, management
@@ -37,7 +37,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.7-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 96a3b27b6e0be0a66dbcd189168ff2369c7a47f3
+GitCommit: 292565a5bed3673c8c8885e275cbc13d382151f0
 Directory: 4.0/alpine
 
 Tags: 4.0.7-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/2fe4d51: Update 4.1-rc to otp 27.3
- https://github.com/docker-library/rabbitmq/commit/292565a: Update 4.0 to otp 27.3