### PR TITLE
chore: Update to Rustup version 1.28.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/760aa127cc3da4d27851b67a08fed9e64df3e315/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
@@ -6,31 +6,31 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
 
 Tags: 1-bullseye, 1.85-bullseye, 1.85.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 760aa127cc3da4d27851b67a08fed9e64df3e315
+GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
 Directory: stable/bullseye
 
 Tags: 1-slim-bullseye, 1.85-slim-bullseye, 1.85.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 760aa127cc3da4d27851b67a08fed9e64df3e315
+GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
 Directory: stable/bullseye/slim
 
 Tags: 1-bookworm, 1.85-bookworm, 1.85.0-bookworm, bookworm, 1, 1.85, 1.85.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 760aa127cc3da4d27851b67a08fed9e64df3e315
+GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
 Directory: stable/bookworm
 
 Tags: 1-slim-bookworm, 1.85-slim-bookworm, 1.85.0-slim-bookworm, slim-bookworm, 1-slim, 1.85-slim, 1.85.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 760aa127cc3da4d27851b67a08fed9e64df3e315
+GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
 Directory: stable/bookworm/slim
 
 Tags: 1-alpine3.20, 1.85-alpine3.20, 1.85.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: 760aa127cc3da4d27851b67a08fed9e64df3e315
+GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
 Directory: stable/alpine3.20
 
 Tags: 1-alpine3.21, 1.85-alpine3.21, 1.85.0-alpine3.21, alpine3.21, 1-alpine, 1.85-alpine, 1.85.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 760aa127cc3da4d27851b67a08fed9e64df3e315
+GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
 Directory: stable/alpine3.21
 


### PR DESCRIPTION
https://blog.rust-lang.org/2025/03/04/Rustup-1.28.1.html
https://github.com/rust-lang/rustup/blob/master/CHANGELOG.md#1281---2025-03-05