### PR TITLE
TomEE: build temurin jre21-alpine based images for arm64v8 as well

### DIFF
--- a/library/tomee
+++ b/library/tomee
@@ -16,19 +16,15 @@ Tags: 10.0.0-jre21-Temurin-ubuntu-webprofile, 10.0.0-Temurin-ubuntu-webprofile, 
 Directory: TomEE-10.0/jre21/Temurin/ubuntu/webprofile
 
 Tags: 10.0.0-jre21-Temurin-alpine-microprofile, 10.0.0-Temurin-alpine-microprofile, 10.0.0-jre21-alpine-microprofile, 10.0.0-alpine-microprofile, 10.0.0-jre21-Temurin-alpine, 10.0.0-Temurin-alpine, 10.0.0-jre21-alpine, 10.0.0-alpine, 10.0-jre21-Temurin-alpine-microprofile, 10.0-Temurin-alpine-microprofile, 10.0-jre21-alpine-microprofile, 10.0-alpine-microprofile, 10.0-jre21-Temurin-alpine, 10.0-Temurin-alpine, 10.0-jre21-alpine, 10.0-alpine, 10-jre21-Temurin-alpine-microprofile, 10-Temurin-alpine-microprofile, 10-jre21-alpine-microprofile, 10-alpine-microprofile, 10-jre21-Temurin-alpine, 10-Temurin-alpine, 10-jre21-alpine, 10-alpine, jre21-Temurin-alpine-microprofile, Temurin-alpine-microprofile, jre21-alpine-microprofile, alpine-microprofile, jre21-Temurin-alpine, Temurin-alpine, jre21-alpine, alpine
-Architectures: amd64
 Directory: TomEE-10.0/jre21/Temurin/alpine/microprofile
 
 Tags: 10.0.0-jre21-Temurin-alpine-plume, 10.0.0-Temurin-alpine-plume, 10.0.0-jre21-alpine-plume, 10.0.0-alpine-plume, 10.0-jre21-Temurin-alpine-plume, 10.0-Temurin-alpine-plume, 10.0-jre21-alpine-plume, 10.0-alpine-plume, 10-jre21-Temurin-alpine-plume, 10-Temurin-alpine-plume, 10-jre21-alpine-plume, 10-alpine-plume, jre21-Temurin-alpine-plume, Temurin-alpine-plume, jre21-alpine-plume, alpine-plume
-Architectures: amd64
 Directory: TomEE-10.0/jre21/Temurin/alpine/plume
 
 Tags: 10.0.0-jre21-Temurin-alpine-plus, 10.0.0-Temurin-alpine-plus, 10.0.0-jre21-alpine-plus, 10.0.0-alpine-plus, 10.0-jre21-Temurin-alpine-plus, 10.0-Temurin-alpine-plus, 10.0-jre21-alpine-plus, 10.0-alpine-plus, 10-jre21-Temurin-alpine-plus, 10-Temurin-alpine-plus, 10-jre21-alpine-plus, 10-alpine-plus, jre21-Temurin-alpine-plus, Temurin-alpine-plus, jre21-alpine-plus, alpine-plus
-Architectures: amd64
 Directory: TomEE-10.0/jre21/Temurin/alpine/plus
 
 Tags: 10.0.0-jre21-Temurin-alpine-webprofile, 10.0.0-Temurin-alpine-webprofile, 10.0.0-jre21-alpine-webprofile, 10.0.0-alpine-webprofile, 10.0-jre21-Temurin-alpine-webprofile, 10.0-Temurin-alpine-webprofile, 10.0-jre21-alpine-webprofile, 10.0-alpine-webprofile, 10-jre21-Temurin-alpine-webprofile, 10-Temurin-alpine-webprofile, 10-jre21-alpine-webprofile, 10-alpine-webprofile, jre21-Temurin-alpine-webprofile, Temurin-alpine-webprofile, jre21-alpine-webprofile, alpine-webprofile
-Architectures: amd64
 Directory: TomEE-10.0/jre21/Temurin/alpine/webprofile
 
 Tags: 10.0.0-jre21-Semeru-ubuntu-microprofile, 10.0.0-Semeru-ubuntu-microprofile, 10.0.0-jre21-Semeru-microprofile, 10.0.0-Semeru-microprofile, 10.0.0-jre21-Semeru-ubuntu, 10.0.0-Semeru-ubuntu, 10.0.0-jre21-Semeru, 10.0.0-Semeru, 10.0-jre21-Semeru-ubuntu-microprofile, 10.0-Semeru-ubuntu-microprofile, 10.0-jre21-Semeru-microprofile, 10.0-Semeru-microprofile, 10.0-jre21-Semeru-ubuntu, 10.0-Semeru-ubuntu, 10.0-jre21-Semeru, 10.0-Semeru, 10-jre21-Semeru-ubuntu-microprofile, 10-Semeru-ubuntu-microprofile, 10-jre21-Semeru-microprofile, 10-Semeru-microprofile, 10-jre21-Semeru-ubuntu, 10-Semeru-ubuntu, 10-jre21-Semeru, 10-Semeru, jre21-Semeru-ubuntu-microprofile, Semeru-ubuntu-microprofile, jre21-Semeru-microprofile, Semeru-microprofile, jre21-Semeru-ubuntu, Semeru-ubuntu, jre21-Semeru, Semeru


### PR DESCRIPTION
On older JRE versions Temurin did not support arm64v8 on alpine, however this changed with JRE 21. See: https://adoptium.net/supported-platforms/

IMO there is no reason to build these images for amd64 only
