### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev6, 3.2-dev, 3.2-dev6-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev7, 3.2-dev, 3.2-dev7-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 52fe35d0664a4d6ea63e1be22508dfca73a481c4
+GitCommit: b47b21a6996b0a8ca4421bbfeb7ec789a8858f26
 Directory: 3.2
 
-Tags: 3.2-dev6-alpine, 3.2-dev-alpine, 3.2-dev6-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev7-alpine, 3.2-dev-alpine, 3.2-dev7-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 52fe35d0664a4d6ea63e1be22508dfca73a481c4
+GitCommit: b47b21a6996b0a8ca4421bbfeb7ec789a8858f26
 Directory: 3.2/alpine
 
 Tags: 3.1.5, 3.1, latest, 3.1.5-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b47b21a: Update 3.2 to 3.2-dev7