### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,49 +4,49 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 5.3.0-beta1-php8.1-apache, 5.3-php8.1-apache, 5.3.beta-php8.1-apache, 5.3.0-beta-php8.1-apache
+Tags: 5.3.0-beta2-php8.1-apache, 5.3-php8.1-apache, 5.3.beta-php8.1-apache, 5.3.0-beta-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.1/apache
 
-Tags: 5.3.0-beta1-php8.1-fpm-alpine, 5.3-php8.1-fpm-alpine, 5.3.beta-php8.1-fpm-alpine, 5.3.0-beta-php8.1-fpm-alpine
+Tags: 5.3.0-beta2-php8.1-fpm-alpine, 5.3-php8.1-fpm-alpine, 5.3.beta-php8.1-fpm-alpine, 5.3.0-beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.1/fpm-alpine
 
-Tags: 5.3.0-beta1-php8.1-fpm, 5.3-php8.1-fpm, 5.3.beta-php8.1-fpm, 5.3.0-beta-php8.1-fpm
+Tags: 5.3.0-beta2-php8.1-fpm, 5.3-php8.1-fpm, 5.3.beta-php8.1-fpm, 5.3.0-beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.1/fpm
 
-Tags: 5.3.0-beta1, 5.3, 5.3.beta, 5.3.0-beta, 5.3.0-beta1-apache, 5.3-apache, 5.3.beta-apache, 5.3.0-beta-apache, 5.3.0-beta1-php8.2, 5.3-php8.2, 5.3.beta-php8.2, 5.3.0-beta-php8.2, 5.3.0-beta1-php8.2-apache, 5.3-php8.2-apache, 5.3.beta-php8.2-apache, 5.3.0-beta-php8.2-apache
+Tags: 5.3.0-beta2-php8.2-apache, 5.3-php8.2-apache, 5.3.beta-php8.2-apache, 5.3.0-beta-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.2/apache
 
-Tags: 5.3.0-beta1-php8.2-fpm-alpine, 5.3-php8.2-fpm-alpine, 5.3.beta-php8.2-fpm-alpine, 5.3.0-beta-php8.2-fpm-alpine
+Tags: 5.3.0-beta2-php8.2-fpm-alpine, 5.3-php8.2-fpm-alpine, 5.3.beta-php8.2-fpm-alpine, 5.3.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.2/fpm-alpine
 
-Tags: 5.3.0-beta1-php8.2-fpm, 5.3-php8.2-fpm, 5.3.beta-php8.2-fpm, 5.3.0-beta-php8.2-fpm
+Tags: 5.3.0-beta2-php8.2-fpm, 5.3-php8.2-fpm, 5.3.beta-php8.2-fpm, 5.3.0-beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.2/fpm
 
-Tags: 5.3.0-beta1-php8.3-apache, 5.3-php8.3-apache, 5.3.beta-php8.3-apache, 5.3.0-beta-php8.3-apache
+Tags: 5.3.0-beta2, 5.3, 5.3.beta, 5.3.0-beta, 5.3.0-beta2-apache, 5.3-apache, 5.3.beta-apache, 5.3.0-beta-apache, 5.3.0-beta2-php8.3, 5.3-php8.3, 5.3.beta-php8.3, 5.3.0-beta-php8.3, 5.3.0-beta2-php8.3-apache, 5.3-php8.3-apache, 5.3.beta-php8.3-apache, 5.3.0-beta-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.3/apache
 
-Tags: 5.3.0-beta1-php8.3-fpm-alpine, 5.3-php8.3-fpm-alpine, 5.3.beta-php8.3-fpm-alpine, 5.3.0-beta-php8.3-fpm-alpine
+Tags: 5.3.0-beta2-php8.3-fpm-alpine, 5.3-php8.3-fpm-alpine, 5.3.beta-php8.3-fpm-alpine, 5.3.0-beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.3/fpm-alpine
 
-Tags: 5.3.0-beta1-php8.3-fpm, 5.3-php8.3-fpm, 5.3.beta-php8.3-fpm, 5.3.0-beta-php8.3-fpm
+Tags: 5.3.0-beta2-php8.3-fpm, 5.3-php8.3-fpm, 5.3.beta-php8.3-fpm, 5.3.0-beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e4ab2c679f88fa7ff6fdad6a1cc4b17ea2b3ceb2
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.3.beta/php8.3/fpm
 
 Tags: 5.2.4-php8.1-apache, 5.2-php8.1-apache, 5-php8.1-apache, php8.1-apache
@@ -64,7 +64,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
 Directory: 5.2/php8.1/fpm
 
-Tags: 5.2.4, 5.2, 5, latest, 5.2.4-apache, 5.2-apache, 5-apache, apache, 5.2.4-php8.2, 5.2-php8.2, 5-php8.2, php8.2, 5.2.4-php8.2-apache, 5.2-php8.2-apache, 5-php8.2-apache, php8.2-apache
+Tags: 5.2.4-php8.2-apache, 5.2-php8.2-apache, 5-php8.2-apache, php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
 Directory: 5.2/php8.2/apache
@@ -79,22 +79,22 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
 Directory: 5.2/php8.2/fpm
 
-Tags: 5.2.4-php8.3-apache, 5.2-php8.3-apache, 5-php8.3-apache, php8.3-apache
+Tags: 5.2.4, 5.2, 5, latest, 5.2.4-apache, 5.2-apache, 5-apache, apache, 5.2.4-php8.3, 5.2-php8.3, 5-php8.3, php8.3, 5.2.4-php8.3-apache, 5.2-php8.3-apache, 5-php8.3-apache, php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.2/php8.3/apache
 
 Tags: 5.2.4-php8.3-fpm-alpine, 5.2-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.2/php8.3/fpm-alpine
 
 Tags: 5.2.4-php8.3-fpm, 5.2-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
+GitCommit: 8ad67eeeebf64ed3e4ff726dae2086c2d9156571
 Directory: 5.2/php8.3/fpm
 
-Tags: 4.4.11, 4.4, 4, 4.4.11-apache, 4.4-apache, 4-apache, 4.4.11-php8.1, 4.4-php8.1, 4-php8.1, 4.4.11-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
+Tags: 4.4.11-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
 Directory: 4.4/php8.1/apache
@@ -109,7 +109,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
 Directory: 4.4/php8.1/fpm
 
-Tags: 4.4.11-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
+Tags: 4.4.11, 4.4, 4, 4.4.11-apache, 4.4-apache, 4-apache, 4.4.11-php8.2, 4.4-php8.2, 4-php8.2, 4.4.11-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b61f85639c6c474e41314f43d8b1217f1c1bc30b
 Directory: 4.4/php8.2/apache


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@ad3bbae Update Joomla 5.3.0-beta1 to 5.3.0-beta2. Set new default correct PHP versions on each Joomla version.