### PR TITLE
Odoo: update 16.0-18.0 to release 20250311

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 061cbb890fb7750146483717c32d9f533856468e
+GitCommit: 768a1e5da82712f358b0a39b693a252f5cb43ce1
 
-Tags: 18.0-20250218, 18.0, 18, latest
+Tags: 18.0-20250311, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250218, 17.0, 17
+Tags: 17.0-20250311, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250218, 16.0, 16
+Tags: 16.0-20250311, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks