### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-2679"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 770aa8a4f57123f03a2ddcf0e8e0816bf57ff448
+amd64-GitCommit: 3449248c48ca5d20ce4746756a70fd598925dec9
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: dab4288a12b13ba50729108ba9a5531cf5951a93
+arm64v8-GitCommit: ea2989ec3873166b4eb7212e6c1137d3fabbb0ac
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-56171, CVE-2025-24928, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-2679.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
