### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-2722"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 12e7ee4251101399fadfa03eaa6a68583d8397ec
+amd64-GitCommit: 247cdabb356b1fef9106fa2b3ff33ed5501f5a3d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 32ae9db449b88d45f373ccbda024e79d9d82b3aa
+arm64v8-GitCommit: fe38122598805c03251a35dcca1ce2f0cd7bc299
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-24528, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-2722.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
