### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -7,7 +7,7 @@ GitRepo: https://github.com/docker-library/mongo.git
 Tags: 8.0.6-rc2-noble, 8.0-rc-noble
 SharedTags: 8.0.6-rc2, 8.0-rc
 Architectures: amd64, arm64v8
-GitCommit: d3e7063d9df36fdee313e79cb0b4d214d6d35858
+GitCommit: 7bf22284b34d88f3b4d6a6b5ad6d50297111f691
 Directory: 8.0-rc
 
 Tags: 8.0.6-rc2-windowsservercore-ltsc2025, 8.0-rc-windowsservercore-ltsc2025
@@ -48,7 +48,7 @@ Constraints: nanoserver-1809, windowsservercore-1809
 Tags: 8.0.5-noble, 8.0-noble, 8-noble, noble
 SharedTags: 8.0.5, 8.0, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: ce024078e646db3615a59c1950888d82b9733cc4
+GitCommit: 7bf22284b34d88f3b4d6a6b5ad6d50297111f691
 Directory: 8.0
 
 Tags: 8.0.5-windowsservercore-ltsc2025, 8.0-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025, windowsservercore-ltsc2025
@@ -84,6 +84,47 @@ SharedTags: 8.0.5-nanoserver, 8.0-nanoserver, 8-nanoserver, nanoserver
 Architectures: windows-amd64
 GitCommit: ce024078e646db3615a59c1950888d82b9733cc4
 Directory: 8.0/windows/nanoserver-1809
+Constraints: nanoserver-1809, windowsservercore-1809
+
+Tags: 7.0.18-rc0-jammy, 7.0-rc-jammy
+SharedTags: 7.0.18-rc0, 7.0-rc
+Architectures: amd64, arm64v8
+GitCommit: 72f37f03821caf90a986ded9defd7b32f4ae6731
+Directory: 7.0-rc
+
+Tags: 7.0.18-rc0-windowsservercore-ltsc2025, 7.0-rc-windowsservercore-ltsc2025
+SharedTags: 7.0.18-rc0-windowsservercore, 7.0-rc-windowsservercore, 7.0.18-rc0, 7.0-rc
+Architectures: windows-amd64
+GitCommit: 72f37f03821caf90a986ded9defd7b32f4ae6731
+Directory: 7.0-rc/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
+Tags: 7.0.18-rc0-windowsservercore-ltsc2022, 7.0-rc-windowsservercore-ltsc2022
+SharedTags: 7.0.18-rc0-windowsservercore, 7.0-rc-windowsservercore, 7.0.18-rc0, 7.0-rc
+Architectures: windows-amd64
+GitCommit: 72f37f03821caf90a986ded9defd7b32f4ae6731
+Directory: 7.0-rc/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 7.0.18-rc0-windowsservercore-1809, 7.0-rc-windowsservercore-1809
+SharedTags: 7.0.18-rc0-windowsservercore, 7.0-rc-windowsservercore, 7.0.18-rc0, 7.0-rc
+Architectures: windows-amd64
+GitCommit: 72f37f03821caf90a986ded9defd7b32f4ae6731
+Directory: 7.0-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+
+Tags: 7.0.18-rc0-nanoserver-ltsc2022, 7.0-rc-nanoserver-ltsc2022
+SharedTags: 7.0.18-rc0-nanoserver, 7.0-rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 72f37f03821caf90a986ded9defd7b32f4ae6731
+Directory: 7.0-rc/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 7.0.18-rc0-nanoserver-1809, 7.0-rc-nanoserver-1809
+SharedTags: 7.0.18-rc0-nanoserver, 7.0-rc-nanoserver
+Architectures: windows-amd64
+GitCommit: 72f37f03821caf90a986ded9defd7b32f4ae6731
+Directory: 7.0-rc/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
 Tags: 7.0.17-jammy, 7.0-jammy, 7-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/72f37f0: Update 7.0-rc to 7.0.18-rc0
- https://github.com/docker-library/mongo/commit/51c1023: Merge pull request https://github.com/docker-library/mongo/pull/723 from infosiftr/tcmalloc-rseq
- https://github.com/docker-library/mongo/commit/7bf2228: Enable tcmalloc per-cpu caches