### PR TITLE
Apache CouchDB: add 3.4.3 and 3.4.3-nouveau

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -4,15 +4,15 @@
 Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: 734c61f2a9421637ff58be225665477be52dd4b7
+GitCommit: 8a7dfc18fe8a9ba55a1c544ee3416f945dbb94ad
 
-Tags: latest, 3.4.2, 3.4, 3
+Tags: latest, 3.4.3, 3.4, 3
 Architectures: amd64, arm64v8, s390x
-Directory: 3.4.2
+Directory: 3.4.3
 
-Tags: 3.4.2-nouveau, 3.4-nouveau, 3-nouveau
+Tags: 3.4.3-nouveau, 3.4-nouveau, 3-nouveau
 Architectures: amd64, arm64v8, s390x
-Directory: 3.4.2-nouveau
+Directory: 3.4.3-nouveau
 
 Tags: 3.3.3, 3.3
 Architectures: amd64, arm64v8, ppc64le, s390x


### PR DESCRIPTION
New Apache CouchDB release 3.4.3

https://github.com/apache/couchdb/releases/tag/3.4.3

https://docs.couchdb.org/en/stable/whatsnew/3.4.html#version-3-4-3