### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/d9b25526cb3482f30cb4d41539f105283b7b7533/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/3652ad1f432bb79031af9082e84c752a2c8f3959/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: d9b25526cb3482f30cb4d41539f105283b7b7533
+GitCommit: 3652ad1f432bb79031af9082e84c752a2c8f3959
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b769899394ab55428f74fb5a44a6d1ee1824d43d
+amd64-GitCommit: 18ac409c9b1874d7b7e63634c909d29f0cd0207c
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: e799b36c671f1d5aab8e06df14a3445ca7e857b3
+arm32v5-GitCommit: 7e9cece36904f8f80c44c7ca6e0d826c091a1ee7
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 19af00ddab22fcf782ba55c33b9b73a1555a8b96
+arm32v6-GitCommit: 2934602fcbf4ad198a5ffbef5a678b852d3b1666
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: e355f50ead5739d8db0a6a8a966985abc8890442
+arm32v7-GitCommit: b78fb9141fda729c41061c0ce51a8d9e14f78e9c
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: dfb9586b713aa8425d55d7fa5a19033a679c3905
+arm64v8-GitCommit: 498afd94774b792e7048ee644f310b2df83e9777
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 512eef64a848f7da24a4288ad4899f759a3ff955
+i386-GitCommit: ea49e56359533cc265482ec3d18821f60e3fccc1
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: b9f156878d3373473ec770e171da9518ab18c5ca
+mips64le-GitCommit: ee390b2a5a927ba569609b96ab94f4af662ab027
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 98ac3f1dba94bf3b616ad38ea6818f07b4c8fcd9
+ppc64le-GitCommit: d0c7070ff8c6221fa9f7f12cd6d41ec21199db35
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: e8113937d43db0f9c160c3cecb0680522a77d307
+riscv64-GitCommit: f06a3c65b6b1ef1f26fcd8b4508a67b091a4d8e6
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 2b15d62d2c5e599de54a42c212bdeccda37502a9
+s390x-GitCommit: 643ad3d3a55b82ec4b0b1173f69c47aa576042af
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/3652ad1: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/f12b6f6: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/1929b8e: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/891544d: Update metadata for i386
- https://github.com/docker-library/busybox/commit/ffe425a: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/42f06e9: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/38d467e: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/daf5470: Merge pull request https://github.com/docker-library/busybox/pull/220 from infosiftr/buildroot-2025.02
- https://github.com/docker-library/busybox/commit/9a2d579: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/7dc1389: Update buildroot to 2025.02
- https://github.com/docker-library/busybox/commit/d9b2552: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/42208cf: Update metadata for i386
- https://github.com/docker-library/busybox/commit/867937e: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/23b755e: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/6ac6b6e: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/6774f9e: Merge pull request https://github.com/docker-library/busybox/pull/218 from infosiftr/buildroot-2024.11.2
- https://github.com/docker-library/busybox/commit/7276333: Update amd64 metadata