### PR TITLE
chore: Update to Rust version 1.85.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,36 +1,36 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/decf7685a03d1d0ee8803cff48c6bf5c440d968d/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.85-bullseye, 1.85.0-bullseye, bullseye
+Tags: 1-bullseye, 1.85-bullseye, 1.85.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
+GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.85-slim-bullseye, 1.85.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.85-slim-bullseye, 1.85.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
+GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.85-bookworm, 1.85.0-bookworm, bookworm, 1, 1.85, 1.85.0, latest
+Tags: 1-bookworm, 1.85-bookworm, 1.85.1-bookworm, bookworm, 1, 1.85, 1.85.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
+GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.85-slim-bookworm, 1.85.0-slim-bookworm, slim-bookworm, 1-slim, 1.85-slim, 1.85.0-slim, slim
+Tags: 1-slim-bookworm, 1.85-slim-bookworm, 1.85.1-slim-bookworm, slim-bookworm, 1-slim, 1.85-slim, 1.85.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
+GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.20, 1.85-alpine3.20, 1.85.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.85-alpine3.20, 1.85.1-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
+GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.85-alpine3.21, 1.85.0-alpine3.21, alpine3.21, 1-alpine, 1.85-alpine, 1.85.0-alpine, alpine
+Tags: 1-alpine3.21, 1.85-alpine3.21, 1.85.1-alpine3.21, alpine3.21, 1-alpine, 1.85-alpine, 1.85.1-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: bb6d64ec66907afbcd2c4a6c4efabcfbc947ac91
+GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
 Directory: stable/alpine3.21
 


### PR DESCRIPTION
https://blog.rust-lang.org/2025/03/18/Rust-1.85.1.html
https://github.com/rust-lang/rust/releases/tag/1.85.1
