### PR TITLE
Update to Flink 2.0.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,14 +3,19 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 2.0-preview1-scala_2.12-java17, 2.0-scala_2.12-java17, 2.0-preview1-java17, 2.0-java17
+Tags: 2.0.0-scala_2.12-java21, 2.0-scala_2.12-java21, scala_2.12-java21, 2.0.0-java21, 2.0-java21, java21
 Architectures: amd64,arm64v8
-GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
+GitCommit: d32c85bcf93b430d56685b54ab5732a20e472e2e
+Directory: ./2.0/scala_2.12-java21-ubuntu
+
+Tags: 2.0.0-scala_2.12-java17, 2.0-scala_2.12-java17, scala_2.12-java17, 2.0.0-scala_2.12, 2.0-scala_2.12, scala_2.12, 2.0.0-java17, 2.0-java17, java17, 2.0.0, 2.0, latest
+Architectures: amd64,arm64v8
+GitCommit: d32c85bcf93b430d56685b54ab5732a20e472e2e
 Directory: ./2.0/scala_2.12-java17-ubuntu
 
-Tags: 2.0-preview1-scala_2.12-java11, 2.0-scala_2.12-java11, 2.0-preview1-scala_2.12, 2.0-scala_2.12, 2.0-preview1-java11, 2.0-java11, 2.0-preview1, 2.0
+Tags: 2.0.0-scala_2.12-java11, 2.0-scala_2.12-java11, scala_2.12-java11, 2.0.0-java11, 2.0-java11, java11
 Architectures: amd64,arm64v8
-GitCommit: 3a8ba480ff327674b0a090c6ce417f0437576e92
+GitCommit: d32c85bcf93b430d56685b54ab5732a20e472e2e
 Directory: ./2.0/scala_2.12-java11-ubuntu
 
 Tags: 1.20.1-scala_2.12-java8, 1.20-scala_2.12-java8, 1.20.1-java8, 1.20-java8
@@ -18,12 +23,12 @@ Architectures: amd64,arm64v8
 GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java8-ubuntu
 
-Tags: 1.20.1-scala_2.12-java17, 1.20-scala_2.12-java17, scala_2.12-java17, 1.20-java17, 1.20.1-java17, java17
+Tags: 1.20.1-scala_2.12-java17, 1.20-scala_2.12-java17, 1.20.1-java17, 1.20-java17
 Architectures: amd64,arm64v8
 GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java17-ubuntu
 
-Tags: 1.20.1-scala_2.12-java11, 1.20-scala_2.12-java11, scala_2.12-java11, 1.20.1-scala_2.12, 1.20-scala_2.12, scala_2.12, 1.20.1-java11, 1.20-java11, java11, 1.20.1, 1.20, latest
+Tags: 1.20.1-scala_2.12-java11, 1.20-scala_2.12-java11, 1.20.1-scala_2.12, 1.20-scala_2.12, 1.20.1-java11, 1.20-java11, 1.20.1, 1.20
 Architectures: amd64,arm64v8
 GitCommit: 5d24800c76946c9271d285efe16a299b6c0b0607
 Directory: ./1.20/scala_2.12-java11-ubuntu


### PR DESCRIPTION
This is the official release of Apache Flink 2.0.0 (previously in preview1), with the following major changes:

1. We support jdk21 in Flink `2.0.0`, this after the preview release, so `preview1` doesn't include it.
2. After discussion, we switch the default tag to `JDK17` instead of `11` as it's the default jdk version for Flink now.