### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,24 +14,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b47b21a6996b0a8ca4421bbfeb7ec789a8858f26
 Directory: 3.2/alpine
 
-Tags: 3.1.5, 3.1, latest, 3.1.5-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.6, 3.1, latest, 3.1.6-bookworm, 3.1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e1dd4e1ca3d371d604a530397ad090cb0b0d8bda
+GitCommit: 2568abb822486a3abd10fa1942b98cfe5e1d5af7
 Directory: 3.1
 
-Tags: 3.1.5-alpine, 3.1-alpine, alpine, 3.1.5-alpine3.21, 3.1-alpine3.21, alpine3.21
+Tags: 3.1.6-alpine, 3.1-alpine, alpine, 3.1.6-alpine3.21, 3.1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e1dd4e1ca3d371d604a530397ad090cb0b0d8bda
+GitCommit: 2568abb822486a3abd10fa1942b98cfe5e1d5af7
 Directory: 3.1/alpine
 
-Tags: 3.0.8, 3.0, lts, 3.0.8-bookworm, 3.0-bookworm, lts-bookworm
+Tags: 3.0.9, 3.0, lts, 3.0.9-bookworm, 3.0-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 262506addcf26d79cf3983d5556b835d5818ee63
+GitCommit: a4ad1d171a2056e3c1215ccac0005d012e2eced1
 Directory: 3.0
 
-Tags: 3.0.8-alpine, 3.0-alpine, lts-alpine, 3.0.8-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
+Tags: 3.0.9-alpine, 3.0-alpine, lts-alpine, 3.0.9-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 262506addcf26d79cf3983d5556b835d5818ee63
+GitCommit: a4ad1d171a2056e3c1215ccac0005d012e2eced1
 Directory: 3.0/alpine
 
 Tags: 2.9.14, 2.9, 2.9.14-bookworm, 2.9-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2568abb: Update 3.1 to 3.1.6
- https://github.com/docker-library/haproxy/commit/a4ad1d1: Update 3.0 to 3.0.9