### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a4ad1d171a2056e3c1215ccac0005d012e2eced1
 Directory: 3.0/alpine
 
-Tags: 2.9.14, 2.9, 2.9.14-bookworm, 2.9-bookworm
+Tags: 2.9.15, 2.9, 2.9.15-bookworm, 2.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 812c8779de1250bb2e3e2c7da0a4b543ccc49edb
+GitCommit: c9cb10f61c58ea4e748a22e9485d31584c25fb47
 Directory: 2.9
 
-Tags: 2.9.14-alpine, 2.9-alpine, 2.9.14-alpine3.21, 2.9-alpine3.21
+Tags: 2.9.15-alpine, 2.9-alpine, 2.9.15-alpine3.21, 2.9-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 812c8779de1250bb2e3e2c7da0a4b543ccc49edb
+GitCommit: c9cb10f61c58ea4e748a22e9485d31584c25fb47
 Directory: 2.9/alpine
 
 Tags: 2.8.14, 2.8, 2.8.14-bookworm, 2.8-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c9cb10f: Update 2.9 to 2.9.15