### PR TITLE
Fix CrateDB 5.9.12 and 5.9.11

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -8,9 +8,13 @@ Tags: 5.10.3, 5.10, latest
 Architectures: amd64, arm64v8
 GitCommit: 1dbe963d8752d183fe3773c5caf22a5718f17560
 
-Tags: 5.9.11, 5.9
+Tags: 5.9.12, 5.9
 Architectures: amd64, arm64v8
 GitCommit: 42c7218d834e5c8d2a5db3406aef0d1e7efa2092
+
+Tags: 5.9.11
+Architectures: amd64, arm64v8
+GitCommit: f4ad4959f78765d2d7f0929acd49c2bdf449e8a1
 
 Tags: 5.8.7, 5.8
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Due to a mistake in https://github.com/docker-library/official-images/commit/6d4f8a1919dbc86a58f4210bfbef363d0f96b4ef

5.9.11 was overwritten and 5.9.12 didn't have an entry

Fixes https://github.com/crate/docker-crate/issues/244