### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev7, 3.2-dev, 3.2-dev7-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev8, 3.2-dev, 3.2-dev8-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b47b21a6996b0a8ca4421bbfeb7ec789a8858f26
+GitCommit: a3a9a360d63ff6f9e50e7dc3aeb7184911ef580d
 Directory: 3.2
 
-Tags: 3.2-dev7-alpine, 3.2-dev-alpine, 3.2-dev7-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev8-alpine, 3.2-dev-alpine, 3.2-dev8-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b47b21a6996b0a8ca4421bbfeb7ec789a8858f26
+GitCommit: a3a9a360d63ff6f9e50e7dc3aeb7184911ef580d
 Directory: 3.2/alpine
 
 Tags: 3.1.6, 3.1, latest, 3.1.6-bookworm, 3.1-bookworm, bookworm
@@ -33,16 +33,6 @@ Tags: 3.0.9-alpine, 3.0-alpine, lts-alpine, 3.0.9-alpine3.21, 3.0-alpine3.21, lt
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a4ad1d171a2056e3c1215ccac0005d012e2eced1
 Directory: 3.0/alpine
-
-Tags: 2.9.15, 2.9, 2.9.15-bookworm, 2.9-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c9cb10f61c58ea4e748a22e9485d31584c25fb47
-Directory: 2.9
-
-Tags: 2.9.15-alpine, 2.9-alpine, 2.9.15-alpine3.21, 2.9-alpine3.21
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c9cb10f61c58ea4e748a22e9485d31584c25fb47
-Directory: 2.9/alpine
 
 Tags: 2.8.14, 2.8, 2.8.14-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3b008a6: Merge pull request https://github.com/docker-library/haproxy/pull/242 from TimWolla/2.9-eol
- https://github.com/docker-library/haproxy/commit/a3a9a36: Update 3.2 to 3.2-dev8
- https://github.com/docker-library/haproxy/commit/f689594: Remove EOL 2.9