### PR TITLE
REL-3640 SonarQube Server 2025 Release 2

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -3,22 +3,38 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
              Davi Koscianski Vidal <davi.koscianski-vidal@sonarsource.com> (@davividal)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
-GitCommit: 500fa5278eef556c2404f51191e3d4b1b93ddbce
+GitCommit: 2c5fde2923701623402dbec59369d4fa115f1adb
 Builder: buildkit
 
-Tags: 2025.1.1-developer, 2025.1-developer, 2025-lta-developer, developer
+Tags: 2025.2.0-developer, 2025.2-developer, developer
+Architectures: amd64, arm64v8
+Directory: 2025/developer
+
+Tags: 2025.2.0-enterprise, 2025.2-enterprise, enterprise
+Architectures: amd64, arm64v8
+Directory: 2025/enterprise
+
+Tags: 2025.2.0-datacenter-app, 2025.2-datacenter-app, datacenter-app
+Architectures: amd64, arm64v8
+Directory: 2025/datacenter/app
+
+Tags: 2025.2.0-datacenter-search, 2025.2-datacenter-search, datacenter-search
+Architectures: amd64, arm64v8
+Directory: 2025/datacenter/search
+
+Tags: 2025.1.1-developer, 2025.1-developer, 2025-lta-developer
 Architectures: amd64, arm64v8
 Directory: 2025.1/developer
 
-Tags: 2025.1.1-enterprise, 2025.1-enterprise, 2025-lta-enterprise, enterprise
+Tags: 2025.1.1-enterprise, 2025.1-enterprise, 2025-lta-enterprise
 Architectures: amd64, arm64v8
 Directory: 2025.1/enterprise
 
-Tags: 2025.1.1-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app, datacenter-app
+Tags: 2025.1.1-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app
 Architectures: amd64, arm64v8
 Directory: 2025.1/datacenter/app
 
-Tags: 2025.1.1-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search, datacenter-search
+Tags: 2025.1.1-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search
 Architectures: amd64, arm64v8
 Directory: 2025.1/datacenter/search
 


### PR DESCRIPTION
Follow up of #18697.

Small comment on why we added `chown`, mostly it is for being overly explicit with the different runtime use case like:

- anyuser/root
- sonarque-user/anygroup

This is not strictly required as the folders will most of the time be overridden with volume mounts, nonetheless some users are using the images in very specific setups and this will helps.

