### PR TITLE
eclipse-temurin: add JDK24 release

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -35,7 +35,7 @@ Directory: 8/jdk/ubuntu/noble
 
 Tags: 8u442-b06-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 8/jdk/ubi/ubi9-minimal
 
 Tags: 8u442-b06-jdk-windowsservercore-ltsc2025, 8-jdk-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025
@@ -114,7 +114,7 @@ Directory: 8/jre/ubuntu/noble
 
 Tags: 8u442-b06-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 8/jre/ubi/ubi9-minimal
 
 Tags: 8u442-b06-jre-windowsservercore-ltsc2025, 8-jre-windowsservercore-ltsc2025
@@ -195,7 +195,7 @@ Directory: 11/jdk/ubuntu/noble
 
 Tags: 11.0.26_4-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 11/jdk/ubi/ubi9-minimal
 
 Tags: 11.0.26_4-jdk-windowsservercore-ltsc2025, 11-jdk-windowsservercore-ltsc2025, 11-windowsservercore-ltsc2025
@@ -274,7 +274,7 @@ Directory: 11/jre/ubuntu/noble
 
 Tags: 11.0.26_4-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 11/jre/ubi/ubi9-minimal
 
 Tags: 11.0.26_4-jre-windowsservercore-ltsc2025, 11-jre-windowsservercore-ltsc2025
@@ -355,7 +355,7 @@ Directory: 17/jdk/ubuntu/noble
 
 Tags: 17.0.14_7-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 17/jdk/ubi/ubi9-minimal
 
 Tags: 17.0.14_7-jdk-windowsservercore-ltsc2025, 17-jdk-windowsservercore-ltsc2025, 17-windowsservercore-ltsc2025
@@ -434,7 +434,7 @@ Directory: 17/jre/ubuntu/noble
 
 Tags: 17.0.14_7-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 17/jre/ubi/ubi9-minimal
 
 Tags: 17.0.14_7-jre-windowsservercore-ltsc2025, 17-jre-windowsservercore-ltsc2025
@@ -510,7 +510,7 @@ Directory: 21/jdk/ubuntu/noble
 
 Tags: 21.0.6_7-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 21/jdk/ubi/ubi9-minimal
 
 Tags: 21.0.6_7-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
@@ -584,7 +584,7 @@ Directory: 21/jre/ubuntu/noble
 
 Tags: 21.0.6_7-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
 Directory: 21/jre/ubi/ubi9-minimal
 
 Tags: 21.0.6_7-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
@@ -636,142 +636,142 @@ Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
 
-#------------------------------v23 images---------------------------------
-Tags: 23.0.2_7-jdk-alpine-3.20, 23-jdk-alpine-3.20, 23-alpine-3.20
+#------------------------------v24 images---------------------------------
+Tags: 24_36-jdk-alpine-3.20, 24-jdk-alpine-3.20, 24-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/alpine/3.20
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/alpine/3.20
 
-Tags: 23.0.2_7-jdk-alpine-3.21, 23-jdk-alpine-3.21, 23-alpine-3.21, 23.0.2_7-jdk-alpine, 23-jdk-alpine, 23-alpine
+Tags: 24_36-jdk-alpine-3.21, 24-jdk-alpine-3.21, 24-alpine-3.21, 24_36-jdk-alpine, 24-jdk-alpine, 24-alpine
 Architectures: amd64, arm64v8
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/alpine/3.21
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/alpine/3.21
 
-Tags: 23.0.2_7-jdk-noble, 23-jdk-noble, 23-noble
-SharedTags: 23.0.2_7-jdk, 23-jdk, 23
+Tags: 24_36-jdk-noble, 24-jdk-noble, 24-noble
+SharedTags: 24_36-jdk, 24-jdk, 24
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/ubuntu/noble
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/ubuntu/noble
 
-Tags: 23.0.2_7-jdk-ubi9-minimal, 23-jdk-ubi9-minimal, 23-ubi9-minimal
+Tags: 24_36-jdk-ubi9-minimal, 24-jdk-ubi9-minimal, 24-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/ubi/ubi9-minimal
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/ubi/ubi9-minimal
 
-Tags: 23.0.2_7-jdk-windowsservercore-ltsc2025, 23-jdk-windowsservercore-ltsc2025, 23-windowsservercore-ltsc2025
-SharedTags: 23.0.2_7-jdk-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23.0.2_7-jdk, 23-jdk, 23
+Tags: 24_36-jdk-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
+SharedTags: 24_36-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24_36-jdk, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/windows/windowsservercore-ltsc2025
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 23.0.2_7-jdk-nanoserver-ltsc2025, 23-jdk-nanoserver-ltsc2025, 23-nanoserver-ltsc2025
-SharedTags: 23.0.2_7-jdk-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 24_36-jdk-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
+SharedTags: 24_36-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/windows/nanoserver-ltsc2025
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 23.0.2_7-jdk-windowsservercore-ltsc2022, 23-jdk-windowsservercore-ltsc2022, 23-windowsservercore-ltsc2022
-SharedTags: 23.0.2_7-jdk-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23.0.2_7-jdk, 23-jdk, 23
+Tags: 24_36-jdk-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24_36-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24_36-jdk, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/windows/windowsservercore-ltsc2022
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23.0.2_7-jdk-nanoserver-ltsc2022, 23-jdk-nanoserver-ltsc2022, 23-nanoserver-ltsc2022
-SharedTags: 23.0.2_7-jdk-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 24_36-jdk-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
+SharedTags: 24_36-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/windows/nanoserver-ltsc2022
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 23.0.2_7-jdk-windowsservercore-1809, 23-jdk-windowsservercore-1809, 23-windowsservercore-1809
-SharedTags: 23.0.2_7-jdk-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23.0.2_7-jdk, 23-jdk, 23
+Tags: 24_36-jdk-windowsservercore-1809, 24-jdk-windowsservercore-1809, 24-windowsservercore-1809
+SharedTags: 24_36-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24_36-jdk, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/windows/windowsservercore-1809
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 23.0.2_7-jdk-nanoserver-1809, 23-jdk-nanoserver-1809, 23-nanoserver-1809
-SharedTags: 23.0.2_7-jdk-nanoserver, 23-jdk-nanoserver, 23-nanoserver
+Tags: 24_36-jdk-nanoserver-1809, 24-jdk-nanoserver-1809, 24-nanoserver-1809
+SharedTags: 24_36-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jdk/windows/nanoserver-1809
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jdk/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 23.0.2_7-jre-alpine-3.20, 23-jre-alpine-3.20
+Tags: 24_36-jre-alpine-3.20, 24-jre-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/alpine/3.20
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/alpine/3.20
 
-Tags: 23.0.2_7-jre-alpine-3.21, 23-jre-alpine-3.21, 23.0.2_7-jre-alpine, 23-jre-alpine
+Tags: 24_36-jre-alpine-3.21, 24-jre-alpine-3.21, 24_36-jre-alpine, 24-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/alpine/3.21
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/alpine/3.21
 
-Tags: 23.0.2_7-jre-noble, 23-jre-noble
-SharedTags: 23.0.2_7-jre, 23-jre
+Tags: 24_36-jre-noble, 24-jre-noble
+SharedTags: 24_36-jre, 24-jre
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/ubuntu/noble
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/ubuntu/noble
 
-Tags: 23.0.2_7-jre-ubi9-minimal, 23-jre-ubi9-minimal
+Tags: 24_36-jre-ubi9-minimal, 24-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/ubi/ubi9-minimal
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/ubi/ubi9-minimal
 
-Tags: 23.0.2_7-jre-windowsservercore-ltsc2025, 23-jre-windowsservercore-ltsc2025
-SharedTags: 23.0.2_7-jre-windowsservercore, 23-jre-windowsservercore, 23.0.2_7-jre, 23-jre
+Tags: 24_36-jre-windowsservercore-ltsc2025, 24-jre-windowsservercore-ltsc2025
+SharedTags: 24_36-jre-windowsservercore, 24-jre-windowsservercore, 24_36-jre, 24-jre
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/windows/windowsservercore-ltsc2025
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 23.0.2_7-jre-nanoserver-ltsc2025, 23-jre-nanoserver-ltsc2025
-SharedTags: 23.0.2_7-jre-nanoserver, 23-jre-nanoserver
+Tags: 24_36-jre-nanoserver-ltsc2025, 24-jre-nanoserver-ltsc2025
+SharedTags: 24_36-jre-nanoserver, 24-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/windows/nanoserver-ltsc2025
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 23.0.2_7-jre-windowsservercore-ltsc2022, 23-jre-windowsservercore-ltsc2022
-SharedTags: 23.0.2_7-jre-windowsservercore, 23-jre-windowsservercore, 23.0.2_7-jre, 23-jre
+Tags: 24_36-jre-windowsservercore-ltsc2022, 24-jre-windowsservercore-ltsc2022
+SharedTags: 24_36-jre-windowsservercore, 24-jre-windowsservercore, 24_36-jre, 24-jre
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/windows/windowsservercore-ltsc2022
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 23.0.2_7-jre-nanoserver-ltsc2022, 23-jre-nanoserver-ltsc2022
-SharedTags: 23.0.2_7-jre-nanoserver, 23-jre-nanoserver
+Tags: 24_36-jre-nanoserver-ltsc2022, 24-jre-nanoserver-ltsc2022
+SharedTags: 24_36-jre-nanoserver, 24-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/windows/nanoserver-ltsc2022
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 23.0.2_7-jre-windowsservercore-1809, 23-jre-windowsservercore-1809
-SharedTags: 23.0.2_7-jre-windowsservercore, 23-jre-windowsservercore, 23.0.2_7-jre, 23-jre
+Tags: 24_36-jre-windowsservercore-1809, 24-jre-windowsservercore-1809
+SharedTags: 24_36-jre-windowsservercore, 24-jre-windowsservercore, 24_36-jre, 24-jre
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/windows/windowsservercore-1809
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/windows/windowsservercore-1809
 Builder: classic
 Constraints: windowsservercore-1809
 
-Tags: 23.0.2_7-jre-nanoserver-1809, 23-jre-nanoserver-1809
-SharedTags: 23.0.2_7-jre-nanoserver, 23-jre-nanoserver
+Tags: 24_36-jre-nanoserver-1809, 24-jre-nanoserver-1809
+SharedTags: 24_36-jre-nanoserver, 24-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 766789f16156ca5424fbd3a1b435d6bcd13d14b0
-Directory: 23/jre/windows/nanoserver-1809
+GitCommit: 043d39d27d24f217a235083e4011065086d1a464
+Directory: 24/jre/windows/nanoserver-1809
 Builder: classic
 Constraints: nanoserver-1809, windowsservercore-1809
 


### PR DESCRIPTION
also adds openssl to the UBI images as they no longer seem to ship it by default