### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -64,62 +64,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
 Directory: 3.3/alpine3.20
 
-Tags: 3.2.7-bookworm, 3.2-bookworm, 3.2.7, 3.2
+Tags: 3.2.8-bookworm, 3.2-bookworm, 3.2.8, 3.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/bookworm
 
-Tags: 3.2.7-slim-bookworm, 3.2-slim-bookworm, 3.2.7-slim, 3.2-slim
+Tags: 3.2.8-slim-bookworm, 3.2-slim-bookworm, 3.2.8-slim, 3.2-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/slim-bookworm
 
-Tags: 3.2.7-bullseye, 3.2-bullseye
+Tags: 3.2.8-bullseye, 3.2-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/bullseye
 
-Tags: 3.2.7-slim-bullseye, 3.2-slim-bullseye
+Tags: 3.2.8-slim-bullseye, 3.2-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/slim-bullseye
 
-Tags: 3.2.7-alpine3.21, 3.2-alpine3.21, 3.2.7-alpine, 3.2-alpine
+Tags: 3.2.8-alpine3.21, 3.2-alpine3.21, 3.2.8-alpine, 3.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/alpine3.21
 
-Tags: 3.2.7-alpine3.20, 3.2-alpine3.20
+Tags: 3.2.8-alpine3.20, 3.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/alpine3.20
 
-Tags: 3.1.6-bookworm, 3.1-bookworm, 3.1.6, 3.1
+Tags: 3.1.7-bookworm, 3.1-bookworm, 3.1.7, 3.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
 Directory: 3.1/bookworm
 
-Tags: 3.1.6-slim-bookworm, 3.1-slim-bookworm, 3.1.6-slim, 3.1-slim
+Tags: 3.1.7-slim-bookworm, 3.1-slim-bookworm, 3.1.7-slim, 3.1-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
 Directory: 3.1/slim-bookworm
 
-Tags: 3.1.6-bullseye, 3.1-bullseye
+Tags: 3.1.7-bullseye, 3.1-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
 Directory: 3.1/bullseye
 
-Tags: 3.1.6-slim-bullseye, 3.1-slim-bullseye
+Tags: 3.1.7-slim-bullseye, 3.1-slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
 Directory: 3.1/slim-bullseye
 
-Tags: 3.1.6-alpine3.21, 3.1-alpine3.21, 3.1.6-alpine, 3.1-alpine
+Tags: 3.1.7-alpine3.21, 3.1-alpine3.21, 3.1.7-alpine, 3.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
 Directory: 3.1/alpine3.21
 
-Tags: 3.1.6-alpine3.20, 3.1-alpine3.20
+Tags: 3.1.7-alpine3.20, 3.1-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 02bc03848413b433c8256ee11b16e1d527412389
+GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
 Directory: 3.1/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/0012170: Update 3.2 to 3.2.8
- https://github.com/docker-library/ruby/commit/5331b92: Update 3.1 to 3.1.7