### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,16 +1,16 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/6a063825809df456d38adbf20bf8e12a2375831f/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/9287844b7657349ba8f4542b0554c2b4f83dbe52/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.114.1, 5.114, 5, latest
+Tags: 5.115.0, 5.115, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: da50c4852923aff7d62a8e32dd92c41170d45971
+GitCommit: 928a4242f54a6b6ee2bd8c9a9f1c1eccbc107564
 Directory: 5/debian
 
-Tags: 5.114.1-alpine, 5.114-alpine, 5-alpine, alpine
+Tags: 5.115.0-alpine, 5.115-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: da50c4852923aff7d62a8e32dd92c41170d45971
+GitCommit: 928a4242f54a6b6ee2bd8c9a9f1c1eccbc107564
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/928a424: Update to 5.115.0, ghost-cli 1.27.0
- https://github.com/docker-library/ghost/commit/9287844: Update shebang from /bin/bash to /usr/bin/env bash