### PR TITLE
Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -93,33 +93,3 @@ Tags: 3.2.8-alpine3.20, 3.2-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 00121708b79e89ee4c477dbae3035467ebe2484e
 Directory: 3.2/alpine3.20
-
-Tags: 3.1.7-bookworm, 3.1-bookworm, 3.1.7, 3.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
-Directory: 3.1/bookworm
-
-Tags: 3.1.7-slim-bookworm, 3.1-slim-bookworm, 3.1.7-slim, 3.1-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
-Directory: 3.1/slim-bookworm
-
-Tags: 3.1.7-bullseye, 3.1-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
-Directory: 3.1/bullseye
-
-Tags: 3.1.7-slim-bullseye, 3.1-slim-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
-Directory: 3.1/slim-bullseye
-
-Tags: 3.1.7-alpine3.21, 3.1-alpine3.21, 3.1.7-alpine, 3.1-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
-Directory: 3.1/alpine3.21
-
-Tags: 3.1.7-alpine3.20, 3.1-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5331b92f3bb60480a551b28b325e5c312d5ee794
-Directory: 3.1/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/7d40e5d: Merge pull request https://github.com/docker-library/ruby/pull/505 from Earlopain/remove-3.1
- https://github.com/docker-library/ruby/commit/f2b14fa: Merge pull request https://github.com/docker-library/ruby/pull/504 from Earlopain/remove-slim-workaround
- https://github.com/docker-library/ruby/commit/85d6f77: Drop Ruby 3.1
- https://github.com/docker-library/ruby/commit/193c69e: Remove slim/alpine temporary code