### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -33,18 +33,3 @@ Tags: 5.1.7-alpine3.20, 5.1-alpine3.20, 5-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: eee88520aa10c29d0aa0ae70b665a7d337387be5
 Directory: 5.1/alpine3.20
-
-Tags: 5.0.12, 5.0, 5.0.12-bookworm, 5.0-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 16b54a8b32b60af14af5917888e8abff62fffe2a
-Directory: 5.0/bookworm
-
-Tags: 5.0.12-alpine3.21, 5.0-alpine3.21, 5.0.12-alpine, 5.0-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 16b54a8b32b60af14af5917888e8abff62fffe2a
-Directory: 5.0/alpine3.21
-
-Tags: 5.0.12-alpine3.20, 5.0-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 16b54a8b32b60af14af5917888e8abff62fffe2a
-Directory: 5.0/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/62bf84f: Merge pull request https://github.com/docker-library/redmine/pull/379 from infosiftr/eol-ruby-3.1
- https://github.com/docker-library/redmine/commit/f4b66f1: Remove 5.0 (Ruby 3.1 EOL)