### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.0-beta.5, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: e71a6615d15bb2c4f91c437398ecbcb8f7d0d371
+GitCommit: 984ba672207fd9fe228aba07a3a38a8f0a29beca
 Directory: 4.1-rc/ubuntu
 
 Tags: 4.1.0-beta.5-management, 4.1-rc-management
@@ -17,7 +17,7 @@ Directory: 4.1-rc/ubuntu/management
 
 Tags: 4.1.0-beta.5-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e71a6615d15bb2c4f91c437398ecbcb8f7d0d371
+GitCommit: 984ba672207fd9fe228aba07a3a38a8f0a29beca
 Directory: 4.1-rc/alpine
 
 Tags: 4.1.0-beta.5-management-alpine, 4.1-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 4.1-rc/alpine/management
 
 Tags: 4.0.7, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 292565a5bed3673c8c8885e275cbc13d382151f0
+GitCommit: aa9c780ec9844f7dfc622b3cfd54d642d50af8f1
 Directory: 4.0/ubuntu
 
 Tags: 4.0.7-management, 4.0-management, 4-management, management
@@ -37,7 +37,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.7-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 292565a5bed3673c8c8885e275cbc13d382151f0
+GitCommit: aa9c780ec9844f7dfc622b3cfd54d642d50af8f1
 Directory: 4.0/alpine
 
 Tags: 4.0.7-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 4.0/alpine/management
 
 Tags: 3.13.7, 3.13, 3
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 0493ba78b10522172b98215343cc50dbebc87374
+GitCommit: ccb71776b16c0d07cb502988b421ec41c3bef932
 Directory: 3.13/ubuntu
 
 Tags: 3.13.7-management, 3.13-management, 3-management
@@ -57,7 +57,7 @@ Directory: 3.13/ubuntu/management
 
 Tags: 3.13.7-alpine, 3.13-alpine, 3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0493ba78b10522172b98215343cc50dbebc87374
+GitCommit: ccb71776b16c0d07cb502988b421ec41c3bef932
 Directory: 3.13/alpine
 
 Tags: 3.13.7-management-alpine, 3.13-management-alpine, 3-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/984ba67: Update 4.1-rc to otp 27.3.1
- https://github.com/docker-library/rabbitmq/commit/aa9c780: Update 4.0 to otp 27.3.1
- https://github.com/docker-library/rabbitmq/commit/ccb7177: Update 3.13 to otp 26.2.5.10