### PR TITLE
Update Clear Linux OS to 43160

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: dca75611de9532455b01e015fa8e1bae4b2d2d4b
-GitFetch: refs/heads/base-43140
+GitCommit: fa4af2d9ebce5e7f5947194c975e5598de0bcdea
+GitFetch: refs/heads/base-43160


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 43160

@bryteise @djklimes @bryteise