### PR TITLE
Odoo: update 16.0-18.0 to release 20250401

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 7f951108da3d376c59a8fe25523f044060870534
+GitCommit: 564eb08e948bd8cb9cd5422e4aabdad72cdd952a
 
-Tags: 18.0-20250320, 18.0, 18, latest
+Tags: 18.0-20250401, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250320, 17.0, 17
+Tags: 17.0-20250401, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250320, 16.0, 16
+Tags: 16.0-20250401, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest Odoo updates for supported versions.

Thanks