### PR TITLE
Desupport SapMachine 11 docker images on ppc64le and arm64v8

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -212,61 +212,61 @@ GitCommit: 29476b9382690e538a1326c1479700be1fc70b62
 Directory: dockerfiles/17/alpine/3_21/jre
 
 Tags: 11, 11-jdk-ubuntu, 11.0.26, 11.0.26-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11.0.26-ubuntu-noble, 11.0.26-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.26-jdk-ubuntu-noble, 11.0.26-jdk-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/24_04/jdk
 
 Tags: 11-jdk-headless-ubuntu, 11.0.26-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.26-jdk-headless-ubuntu-noble, 11.0.26-jdk-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/24_04/jdk-headless
 
 Tags: 11-jre-ubuntu, 11.0.26-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.26-jre-ubuntu-noble, 11.0.26-jre-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/24_04/jre
 
 Tags: 11-jre-headless-ubuntu, 11.0.26-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.26-jre-headless-ubuntu-noble, 11.0.26-jre-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/24_04/jre-headless
 
 Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11.0.26-ubuntu-jammy, 11.0.26-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.26-jdk-ubuntu-jammy, 11.0.26-jdk-ubuntu-22.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/22_04/jdk
 
 Tags: 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.26-jdk-headless-ubuntu-jammy, 11.0.26-jdk-headless-ubuntu-22.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/22_04/jdk-headless
 
 Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.26-jre-ubuntu-jammy, 11.0.26-jre-ubuntu-22.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/22_04/jre
 
 Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.26-jre-headless-ubuntu-jammy, 11.0.26-jre-headless-ubuntu-22.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/22_04/jre-headless
 
 Tags: 11-ubuntu-focal, 11-ubuntu-20.04, 11.0.26-ubuntu-focal, 11.0.26-ubuntu-20.04, 11-jdk-ubuntu-focal, 11-jdk-ubuntu-20.04, 11.0.26-jdk-ubuntu-focal, 11.0.26-jdk-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/20_04/jdk
 
 Tags: 11-jdk-headless-ubuntu-focal, 11-jdk-headless-ubuntu-20.04, 11.0.26-jdk-headless-ubuntu-focal, 11.0.26-jdk-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/20_04/jdk-headless
 
 Tags: 11-jre-ubuntu-focal, 11-jre-ubuntu-20.04, 11.0.26-jre-ubuntu-focal, 11.0.26-jre-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/20_04/jre
 
 Tags: 11-jre-headless-ubuntu-focal, 11-jre-headless-ubuntu-20.04, 11.0.26-jre-headless-ubuntu-focal, 11.0.26-jre-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
+Architectures: amd64
 GitCommit: 29fb3d840b5725460aeb66af135c70fc5a62a249
 Directory: dockerfiles/11/ubuntu/20_04/jre-headless


### PR DESCRIPTION
For SapMachine 11 we now only build x86_64, so other architectures have to be desupported. This was also reported in https://github.com/SAP/SapMachine/issues/1946