### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -6,10 +6,10 @@ GitRepo: https://github.com/docker-library/memcached.git
 
 Tags: 1.6.38, 1.6, 1, latest, 1.6.38-bookworm, 1.6-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 836b883895e581d28aebdfb2aadc59c4233d0fd9
+GitCommit: f8aa037f70e96f77b3797a2ead8fa0e5dcdec2c1
 Directory: 1/debian
 
 Tags: 1.6.38-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.38-alpine3.21, 1.6-alpine3.21, 1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 836b883895e581d28aebdfb2aadc59c4233d0fd9
+GitCommit: f8aa037f70e96f77b3797a2ead8fa0e5dcdec2c1
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/f8aa037: Merge pull request https://github.com/docker-library/memcached/pull/104 from infosiftr/backport-extstore-test-fixes
- https://github.com/docker-library/memcached/commit/d6fbe6b: Merge pull request https://github.com/docker-library/memcached/pull/103 from infosiftr/arm32-alignment
- https://github.com/docker-library/memcached/commit/f3f961a: Backport upstream extstore test improvements
- https://github.com/docker-library/memcached/commit/1336cbc: Force alignment on arm32
- https://github.com/docker-library/memcached/commit/9152f80: Add back arm32v6+v7 so we can try them again