### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev8, 3.2-dev, 3.2-dev8-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev9, 3.2-dev, 3.2-dev9-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a3a9a360d63ff6f9e50e7dc3aeb7184911ef580d
+GitCommit: da8223cae7f24a16e7897b87f7571579e942a572
 Directory: 3.2
 
-Tags: 3.2-dev8-alpine, 3.2-dev-alpine, 3.2-dev8-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev9-alpine, 3.2-dev-alpine, 3.2-dev9-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a3a9a360d63ff6f9e50e7dc3aeb7184911ef580d
+GitCommit: da8223cae7f24a16e7897b87f7571579e942a572
 Directory: 3.2/alpine
 
 Tags: 3.1.6, 3.1, latest, 3.1.6-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/da8223c: Update 3.2 to 3.2-dev9
- https://github.com/docker-library/haproxy/commit/a17b9b0: Update shebang from /bin/bash to /usr/bin/env bash