### PR TITLE
chore: Update to Rust version 1.86.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,36 +1,36 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/decf7685a03d1d0ee8803cff48c6bf5c440d968d/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/db908c8cad6c5c2c205be2c0f1ec1145b344feea/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.85-bullseye, 1.85.1-bullseye, bullseye
+Tags: 1-bullseye, 1.86-bullseye, 1.86.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
+GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.85-slim-bullseye, 1.85.1-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.86-slim-bullseye, 1.86.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
+GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.85-bookworm, 1.85.1-bookworm, bookworm, 1, 1.85, 1.85.1, latest
+Tags: 1-bookworm, 1.86-bookworm, 1.86.0-bookworm, bookworm, 1, 1.86, 1.86.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
+GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.85-slim-bookworm, 1.85.1-slim-bookworm, slim-bookworm, 1-slim, 1.85-slim, 1.85.1-slim, slim
+Tags: 1-slim-bookworm, 1.86-slim-bookworm, 1.86.0-slim-bookworm, slim-bookworm, 1-slim, 1.86-slim, 1.86.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
+GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.20, 1.85-alpine3.20, 1.85.1-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.86-alpine3.20, 1.86.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
+GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.85-alpine3.21, 1.85.1-alpine3.21, alpine3.21, 1-alpine, 1.85-alpine, 1.85.1-alpine, alpine
+Tags: 1-alpine3.21, 1.86-alpine3.21, 1.86.0-alpine3.21, alpine3.21, 1-alpine, 1.86-alpine, 1.86.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: decf7685a03d1d0ee8803cff48c6bf5c440d968d
+GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
 Directory: stable/alpine3.21
 


### PR DESCRIPTION
- https://github.com/rust-lang/rust/releases/tag/1.86.
- https://blog.rust-lang.org/2025/04/03/Rust-1.86.0.html

