### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.0-rc.1, 4.1-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 62229bb2a73f949745a1934a1e10004f5439ec3c
+GitCommit: ecda659712dd6ac68b4e99c0f8b0f1e1c70893fd
 Directory: 4.1-rc/ubuntu
 
 Tags: 4.1.0-rc.1-management, 4.1-rc-management
@@ -17,7 +17,7 @@ Directory: 4.1-rc/ubuntu/management
 
 Tags: 4.1.0-rc.1-alpine, 4.1-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 62229bb2a73f949745a1934a1e10004f5439ec3c
+GitCommit: ecda659712dd6ac68b4e99c0f8b0f1e1c70893fd
 Directory: 4.1-rc/alpine
 
 Tags: 4.1.0-rc.1-management-alpine, 4.1-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 4.1-rc/alpine/management
 
 Tags: 4.0.8, 4.0, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 6793126f0f255eb3b092533730d8ae8f3c54d111
+GitCommit: 6ec3910359898e81e66f45531ca783e60e348b9f
 Directory: 4.0/ubuntu
 
 Tags: 4.0.8-management, 4.0-management, 4-management, management
@@ -37,7 +37,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.8-alpine, 4.0-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6793126f0f255eb3b092533730d8ae8f3c54d111
+GitCommit: 6ec3910359898e81e66f45531ca783e60e348b9f
 Directory: 4.0/alpine
 
 Tags: 4.0.8-management-alpine, 4.0-management-alpine, 4-management-alpine, management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/ecda659: Update 4.1-rc to otp 27.3.2
- https://github.com/docker-library/rabbitmq/commit/6ec3910: Update 4.0 to otp 27.3.2