### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2025-3531"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 074f5018f469892d1c0ea107d238b796bece5633
+amd64-GitCommit: 5103c10a3d63171ae41d0672130411abef9fbd1a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f11c229ec7af229367b74f4eb8c899d3fb467695
+arm64v8-GitCommit: ce27984bf7dcb5e4a8a250fe9b04d3bd5d3994e7
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-8176, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-3531.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
