### PR TITLE
archlinux: Release 20250406.0.331908

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250330.0.328921
-GitCommit: 78e569eae2d3a2fb0f72815eb596739da955ec5f
-GitFetch: refs/tags/v20250330.0.328921
+Tags: latest, base, base-20250406.0.331908
+GitCommit: cbc122e627cf8abf286b2e1a306909a57711f13d
+GitFetch: refs/tags/v20250406.0.331908
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250330.0.328921
-GitCommit: 78e569eae2d3a2fb0f72815eb596739da955ec5f
-GitFetch: refs/tags/v20250330.0.328921
+Tags: base-devel, base-devel-20250406.0.331908
+GitCommit: cbc122e627cf8abf286b2e1a306909a57711f13d
+GitFetch: refs/tags/v20250406.0.331908
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250330.0.328921
-GitCommit: 78e569eae2d3a2fb0f72815eb596739da955ec5f
-GitFetch: refs/tags/v20250330.0.328921
+Tags: multilib-devel, multilib-devel-20250406.0.331908
+GitCommit: cbc122e627cf8abf286b2e1a306909a57711f13d
+GitFetch: refs/tags/v20250406.0.331908
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks