### PR TITLE
Redis CE 8.0 RC1

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -5,15 +5,15 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Dagan Sandler <dagan.sandler@redis.com> (@dagansandler)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.0-M04-alpine, 8.0-M04-alpine3.21
+Tags: 8.0-rc1-alpine, 8.0-rc1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1d61ffb74b806f51c3691e296d827c3baacc5056
+GitCommit: f3cfc256e913880e5d5eefc794e220c6b0733f22
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
-Tags: 8.0-M04, 8.0-M04-bookworm
+Tags: 8.0-rc1, 8.0-rc1-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d61ffb74b806f51c3691e296d827c3baacc5056
+GitCommit: f3cfc256e913880e5d5eefc794e220c6b0733f22
 GitFetch: refs/heads/release/8.0
 Directory: debian
 


### PR DESCRIPTION
Contains:
- Update to Redis 8.0 RC1
- Use setpriv instead of gosu for dropping privileges in the entrypoint
