### PR TITLE
[nats] Release v2.11.1

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,47 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 4fc384d4f5edacd12651234162799eeba62b541c
+GitCommit: 89f948f8e95c2a5b735ee8a129c33e77e641dd56
 GitFetch: refs/heads/main
 
-Tags: 2.11.1-binary-alpine3.21, 2.11-alpine3.21, 2-alpine3.21, alpine3.21, 2.11.1-binary-alpine, 2.11-alpine, 2-alpine, alpine
+Tags: 2.11.1-alpine3.21, 2.11-alpine3.21, 2-alpine3.21, alpine3.21, 2.11.1-alpine, 2.11-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/alpine3.21
 
-Tags: 2.11.1-binary-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.1-binary-linux, 2.11-linux, 2-linux, linux
-SharedTags: 2.11.1-binary, 2.11, 2, latest
+Tags: 2.11.1-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.1-linux, 2.11-linux, 2-linux, linux
+SharedTags: 2.11.1, 2.11, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.1-binary-windowsservercore-1809, 2.11-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.11.1-binary-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.11.1-windowsservercore-1809, 2.11-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.11.1-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.11.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.11.1-binary-nanoserver-1809, 2.11-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.11.1-binary-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.1-binary, 2.11, 2, latest
+Tags: 2.11.1-nanoserver-1809, 2.11-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.11.1-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.1, 2.11, 2, latest
 Architectures: windows-amd64
 Directory: 2.11.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.10.27-binary-alpine3.21, 2.10-alpine3.21, 2.10.27-binary-alpine, 2.10-alpine
+Tags: 2.10.27-alpine3.21, 2.10-alpine3.21, 2.10.27-alpine, 2.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/alpine3.21
 
-Tags: 2.10.27-binary-scratch, 2.10-scratch, 2.10.27-binary-linux, 2.10-linux
-SharedTags: 2.10.27-binary, 2.10
+Tags: 2.10.27-scratch, 2.10-scratch, 2.10.27-linux, 2.10-linux
+SharedTags: 2.10.27, 2.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/scratch
 
-Tags: 2.10.27-binary-windowsservercore-1809, 2.10-windowsservercore-1809
-SharedTags: 2.10.27-binary-windowsservercore, 2.10-windowsservercore
+Tags: 2.10.27-windowsservercore-1809, 2.10-windowsservercore-1809
+SharedTags: 2.10.27-windowsservercore, 2.10-windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.27-binary-nanoserver-1809, 2.10-nanoserver-1809
-SharedTags: 2.10.27-binary-nanoserver, 2.10-nanoserver, 2.10.27-binary, 2.10
+Tags: 2.10.27-nanoserver-1809, 2.10-nanoserver-1809
+SharedTags: 2.10.27-nanoserver, 2.10-nanoserver, 2.10.27, 2.10
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Source release available now, so no longer need `-binary`.

Release details at https://github.com/nats-io/nats-server/releases/tag/v2.11.1.