### PR TITLE
Update pypy

### DIFF
--- a/library/pypy
+++ b/library/pypy
@@ -7,115 +7,115 @@ GitRepo: https://github.com/docker-library/pypy.git
 Tags: 3.11-7.3.19-bookworm, 3.11-7.3-bookworm, 3.11-7-bookworm, 3.11-bookworm
 SharedTags: 3.11-7.3.19, 3.11-7.3, 3.11-7, 3.11
 Architectures: amd64, arm64v8, i386
-GitCommit: 248e8c458c2df01f40e3c2c37564150c47380cfe
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.11/bookworm
 
 Tags: 3.11-7.3.19-slim, 3.11-7.3-slim, 3.11-7-slim, 3.11-slim, 3.11-7.3.19-slim-bookworm, 3.11-7.3-slim-bookworm, 3.11-7-slim-bookworm, 3.11-slim-bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: 248e8c458c2df01f40e3c2c37564150c47380cfe
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.11/slim-bookworm
 
 Tags: 3.11-7.3.19-windowsservercore-ltsc2025, 3.11-7.3-windowsservercore-ltsc2025, 3.11-7-windowsservercore-ltsc2025, 3.11-windowsservercore-ltsc2025
 SharedTags: 3.11-7.3.19, 3.11-7.3, 3.11-7, 3.11, 3.11-7.3.19-windowsservercore, 3.11-7.3-windowsservercore, 3.11-7-windowsservercore, 3.11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 248e8c458c2df01f40e3c2c37564150c47380cfe
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.11/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
 Tags: 3.11-7.3.19-windowsservercore-ltsc2022, 3.11-7.3-windowsservercore-ltsc2022, 3.11-7-windowsservercore-ltsc2022, 3.11-windowsservercore-ltsc2022
 SharedTags: 3.11-7.3.19, 3.11-7.3, 3.11-7, 3.11, 3.11-7.3.19-windowsservercore, 3.11-7.3-windowsservercore, 3.11-7-windowsservercore, 3.11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 248e8c458c2df01f40e3c2c37564150c47380cfe
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.11/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.11-7.3.19-windowsservercore-1809, 3.11-7.3-windowsservercore-1809, 3.11-7-windowsservercore-1809, 3.11-windowsservercore-1809
 SharedTags: 3.11-7.3.19, 3.11-7.3, 3.11-7, 3.11, 3.11-7.3.19-windowsservercore, 3.11-7.3-windowsservercore, 3.11-7-windowsservercore, 3.11-windowsservercore
 Architectures: windows-amd64
-GitCommit: 248e8c458c2df01f40e3c2c37564150c47380cfe
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.11/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 3.10-7.3.19-bookworm, 3.10-7.3-bookworm, 3.10-7-bookworm, 3.10-bookworm, 3-7.3.19-bookworm, 3-7.3-bookworm, 3-7-bookworm, 3-bookworm, bookworm
 SharedTags: 3.10-7.3.19, 3.10-7.3, 3.10-7, 3.10, 3-7.3.19, 3-7.3, 3-7, 3, latest
 Architectures: amd64, arm64v8, i386
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/bookworm
 
 Tags: 3.10-7.3.19-slim, 3.10-7.3-slim, 3.10-7-slim, 3.10-slim, 3-7.3.19-slim, 3-7.3-slim, 3-7-slim, 3-slim, slim, 3.10-7.3.19-slim-bookworm, 3.10-7.3-slim-bookworm, 3.10-7-slim-bookworm, 3.10-slim-bookworm, 3-7.3.19-slim-bookworm, 3-7.3-slim-bookworm, 3-7-slim-bookworm, 3-slim-bookworm, slim-bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/slim-bookworm
 
 Tags: 3.10-7.3.19-bullseye, 3.10-7.3-bullseye, 3.10-7-bullseye, 3.10-bullseye, 3-7.3.19-bullseye, 3-7.3-bullseye, 3-7-bullseye, 3-bullseye, bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/bullseye
 
 Tags: 3.10-7.3.19-slim-bullseye, 3.10-7.3-slim-bullseye, 3.10-7-slim-bullseye, 3.10-slim-bullseye, 3-7.3.19-slim-bullseye, 3-7.3-slim-bullseye, 3-7-slim-bullseye, 3-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/slim-bullseye
 
 Tags: 3.10-7.3.19-windowsservercore-ltsc2025, 3.10-7.3-windowsservercore-ltsc2025, 3.10-7-windowsservercore-ltsc2025, 3.10-windowsservercore-ltsc2025, 3-7.3.19-windowsservercore-ltsc2025, 3-7.3-windowsservercore-ltsc2025, 3-7-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 SharedTags: 3.10-7.3.19, 3.10-7.3, 3.10-7, 3.10, 3-7.3.19, 3-7.3, 3-7, 3, latest, 3.10-7.3.19-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.19-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
 Tags: 3.10-7.3.19-windowsservercore-ltsc2022, 3.10-7.3-windowsservercore-ltsc2022, 3.10-7-windowsservercore-ltsc2022, 3.10-windowsservercore-ltsc2022, 3-7.3.19-windowsservercore-ltsc2022, 3-7.3-windowsservercore-ltsc2022, 3-7-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 3.10-7.3.19, 3.10-7.3, 3.10-7, 3.10, 3-7.3.19, 3-7.3, 3-7, 3, latest, 3.10-7.3.19-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.19-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 3.10-7.3.19-windowsservercore-1809, 3.10-7.3-windowsservercore-1809, 3.10-7-windowsservercore-1809, 3.10-windowsservercore-1809, 3-7.3.19-windowsservercore-1809, 3-7.3-windowsservercore-1809, 3-7-windowsservercore-1809, 3-windowsservercore-1809, windowsservercore-1809
 SharedTags: 3.10-7.3.19, 3.10-7.3, 3.10-7, 3.10, 3-7.3.19, 3-7.3, 3-7, 3, latest, 3.10-7.3.19-windowsservercore, 3.10-7.3-windowsservercore, 3.10-7-windowsservercore, 3.10-windowsservercore, 3-7.3.19-windowsservercore, 3-7.3-windowsservercore, 3-7-windowsservercore, 3-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 27616dd0faf972ff12817240aa7b4399115006f5
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 3.10/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
 Tags: 2.7-7.3.19-bookworm, 2.7-7.3-bookworm, 2.7-7-bookworm, 2.7-bookworm, 2-7.3.19-bookworm, 2-7.3-bookworm, 2-7-bookworm, 2-bookworm
 SharedTags: 2.7-7.3.19, 2.7-7.3, 2.7-7, 2.7, 2-7.3.19, 2-7.3, 2-7, 2
 Architectures: amd64, arm64v8, i386
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/bookworm
 
 Tags: 2.7-7.3.19-slim, 2.7-7.3-slim, 2.7-7-slim, 2.7-slim, 2-7.3.19-slim, 2-7.3-slim, 2-7-slim, 2-slim, 2.7-7.3.19-slim-bookworm, 2.7-7.3-slim-bookworm, 2.7-7-slim-bookworm, 2.7-slim-bookworm, 2-7.3.19-slim-bookworm, 2-7.3-slim-bookworm, 2-7-slim-bookworm, 2-slim-bookworm
 Architectures: amd64, arm64v8, i386
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/slim-bookworm
 
 Tags: 2.7-7.3.19-bullseye, 2.7-7.3-bullseye, 2.7-7-bullseye, 2.7-bullseye, 2-7.3.19-bullseye, 2-7.3-bullseye, 2-7-bullseye, 2-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/bullseye
 
 Tags: 2.7-7.3.19-slim-bullseye, 2.7-7.3-slim-bullseye, 2.7-7-slim-bullseye, 2.7-slim-bullseye, 2-7.3.19-slim-bullseye, 2-7.3-slim-bullseye, 2-7-slim-bullseye, 2-slim-bullseye
 Architectures: amd64, arm64v8, i386
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/slim-bullseye
 
 Tags: 2.7-7.3.19-windowsservercore-ltsc2025, 2.7-7.3-windowsservercore-ltsc2025, 2.7-7-windowsservercore-ltsc2025, 2.7-windowsservercore-ltsc2025, 2-7.3.19-windowsservercore-ltsc2025, 2-7.3-windowsservercore-ltsc2025, 2-7-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025
 SharedTags: 2.7-7.3.19, 2.7-7.3, 2.7-7, 2.7, 2-7.3.19, 2-7.3, 2-7, 2, 2.7-7.3.19-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.19-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
 Tags: 2.7-7.3.19-windowsservercore-ltsc2022, 2.7-7.3-windowsservercore-ltsc2022, 2.7-7-windowsservercore-ltsc2022, 2.7-windowsservercore-ltsc2022, 2-7.3.19-windowsservercore-ltsc2022, 2-7.3-windowsservercore-ltsc2022, 2-7-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
 SharedTags: 2.7-7.3.19, 2.7-7.3, 2.7-7, 2.7, 2-7.3.19, 2-7.3, 2-7, 2, 2.7-7.3.19-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.19-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
 Tags: 2.7-7.3.19-windowsservercore-1809, 2.7-7.3-windowsservercore-1809, 2.7-7-windowsservercore-1809, 2.7-windowsservercore-1809, 2-7.3.19-windowsservercore-1809, 2-7.3-windowsservercore-1809, 2-7-windowsservercore-1809, 2-windowsservercore-1809
 SharedTags: 2.7-7.3.19, 2.7-7.3, 2.7-7, 2.7, 2-7.3.19, 2-7.3, 2-7, 2, 2.7-7.3.19-windowsservercore, 2.7-7.3-windowsservercore, 2.7-7-windowsservercore, 2.7-windowsservercore, 2-7.3.19-windowsservercore, 2-7.3-windowsservercore, 2-7-windowsservercore, 2-windowsservercore
 Architectures: windows-amd64
-GitCommit: ab2445dcc9cf1d9c0337ac9011440513b0828355
+GitCommit: 36a974d67789b4535820e4673345c79740c1a4e2
 Directory: 2.7/windows/windowsservercore-1809
 Constraints: windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/pypy/commit/8c181ff: Merge pull request https://github.com/docker-library/pypy/pull/89 from infosiftr/ensurepip
- https://github.com/docker-library/pypy/commit/36a974d: Explicitly install "wheel" in <3.12 (all versions for now)
- https://github.com/docker-library/pypy/commit/903a200: Swap from explicit `get-pip.py` to `ensurepip`
- ~~https://github.com/docker-library/pypy/commit/94d8ce9: Update 3.10 to python 3.10.16~~