### PR TITLE
Update KrakenD to v2.9.4

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -3,7 +3,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakendio/docker-library.git
 
 # Alpine images
-Tags: 2.9.3, 2.9, 2, latest
+Tags: 2.9.4, 2.9, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: bac1c35e5818831f0669176ab140e34705185b55
-Directory: 2.9.3
+GitCommit: 899edf02008935285c06b651706d74c275459420
+Directory: 2.9.4


### PR DESCRIPTION
Update KrakenD to v2.9.4 to fix [CVE-2025-30204](https://nvd.nist.gov/vuln/detail/CVE-2025-30204) and [CVE-2025-22871](https://nvd.nist.gov/vuln/detail/CVE-2025-22871).