### PR TITLE
MediaWiki 1.43.1 / 1.42.6 / 1.39.12 security releases

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,38 +3,38 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: aa20b593fa1190fa37dcf8a0ccedab375539ee81
+GitCommit: 76236dfa180c94c95410242a17d6dc8603ba3990
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable & lts version
-Tags: 1.43.0, 1.43, latest, stable, lts
+Tags: 1.43.1, 1.43, latest, stable, lts
 Directory: 1.43/apache
 
-Tags: 1.43.0-fpm, 1.43-fpm, stable-fpm, lts-fpm
+Tags: 1.43.1-fpm, 1.43-fpm, stable-fpm, lts-fpm
 Directory: 1.43/fpm
 
-Tags: 1.43.0-fpm-alpine, 1.43-fpm-alpine, stable-fpm-alpine, lts-fpm-alpine
+Tags: 1.43.1-fpm-alpine, 1.43-fpm-alpine, stable-fpm-alpine, lts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.43/fpm-alpine
 
 # current legacy versions
-Tags: 1.42.5, 1.42, legacy
+Tags: 1.42.6, 1.42, legacy
 Directory: 1.42/apache
 
-Tags: 1.42.5-fpm, 1.42-fpm, legacy-fpm
+Tags: 1.42.6-fpm, 1.42-fpm, legacy-fpm
 Directory: 1.42/fpm
 
-Tags: 1.42.5-fpm-alpine, 1.42-fpm-alpine, legacy-fpm-alpine
+Tags: 1.42.6-fpm-alpine, 1.42-fpm-alpine, legacy-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.42/fpm-alpine
 
 # current legacy lts version
-Tags: 1.39.11, 1.39
+Tags: 1.39.12, 1.39
 Directory: 1.39/apache
 
-Tags: 1.39.11-fpm, 1.39-fpm
+Tags: 1.39.12-fpm, 1.39-fpm
 Directory: 1.39/fpm
 
-Tags: 1.39.11-fpm-alpine, 1.39-fpm-alpine
+Tags: 1.39.12-fpm-alpine, 1.39-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.39/fpm-alpine


### PR DESCRIPTION
See https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/CIXFJVC57OFRBCCEIDRLZCLFGMYGEYTT/ for the maling list announcement.

Related to https://github.com/wikimedia/mediawiki-docker/pull/155

Signed-off-by: Christian Heusel <christian@heusel.eu>
