### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,27 +4,27 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.3, 5.0, 5, latest, 5.0.3-jammy, 5.0-jammy, 5-jammy, jammy
+Tags: 5.0.4, 5.0, 5, latest, 5.0.4-jammy, 5.0-jammy, 5-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 105daf8445a12fc96ef48a1314566e0f61f473b2
+GitCommit: 0f32c04c976068ddf4b094044bd333ca46d42887
 Directory: 5.0
 
 Tags: 4.1.8, 4.1, 4, 4.1.8-jammy, 4.1-jammy, 4-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f49e80e172f29e2cad0a9acd054806d9709a4205
+GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
 Directory: 4.1
 
 Tags: 4.0.17, 4.0, 4.0.17-jammy, 4.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 8b58b84f373e48382e49d59acd0b544b33b2c034
+GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
 Directory: 4.0
 
 Tags: 3.11.19, 3.11, 3, 3.11.19-jammy, 3.11-jammy, 3-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 011007d5b4f1b8e73835366ebb0a85ee89c29436
+GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
 Directory: 3.11
 
 Tags: 3.0.32, 3.0, 3.0.32-jammy, 3.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: d47ed59f99316e94a333126a10db20a440d4642d
+GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/0f32c04: Update 5.0 to 5.0.4
- https://github.com/docker-library/cassandra/commit/4acdd8c: Update shebang from /bin/bash to /usr/bin/env bash
- https://github.com/docker-library/cassandra/commit/e760eeb: Update shebang from /bin/bash to /usr/bin/env bash