### PR TITLE
Update to R 4.5.0 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.4.3, latest
+Tags: 4.5.0, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6fcc5d8dad96fa24438df79cb46451c5534c04ae
-Directory: r-base/4.4.3
+GitCommit: 995a8e88700f11166ab858fed1356948b9834545
+Directory: r-base/4.5.0
 


### PR DESCRIPTION
Standard update to the new R release made by upstream this morning, and using the Debian (unstable, as made today) package prepared earlier.  

No changes in the container setup or build besides the upgrade from R 4.4.3 to R 4.5.0