### PR TITLE
archlinux: Release 20250413.0.335299

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250406.0.331908
-GitCommit: cbc122e627cf8abf286b2e1a306909a57711f13d
-GitFetch: refs/tags/v20250406.0.331908
+Tags: latest, base, base-20250413.0.335299
+GitCommit: 2ebfad10c5e39ef6dbf3c8f305989de313ddab68
+GitFetch: refs/tags/v20250413.0.335299
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250406.0.331908
-GitCommit: cbc122e627cf8abf286b2e1a306909a57711f13d
-GitFetch: refs/tags/v20250406.0.331908
+Tags: base-devel, base-devel-20250413.0.335299
+GitCommit: 2ebfad10c5e39ef6dbf3c8f305989de313ddab68
+GitFetch: refs/tags/v20250413.0.335299
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250406.0.331908
-GitCommit: cbc122e627cf8abf286b2e1a306909a57711f13d
-GitFetch: refs/tags/v20250406.0.331908
+Tags: multilib-devel, multilib-devel-20250413.0.335299
+GitCommit: 2ebfad10c5e39ef6dbf3c8f305989de313ddab68
+GitFetch: refs/tags/v20250413.0.335299
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks