### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 9.2.0, 9.2, 9, innovation, latest, 9.2.0-oraclelinux9, 9.2-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.2.0-oracle, 9.2-oracle, 9-oracle, innovation-oracle, oracle
+Tags: 9.3.0, 9.3, 9, innovation, latest, 9.3.0-oraclelinux9, 9.3-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.3.0-oracle, 9.3-oracle, 9-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: df3a5c483a5e8c3c4d1eae61678fa5372c403bf0
+GitCommit: 1b9d0c10ad8569c9419d76aacec9dbab23c48e9e
 Directory: innovation
 File: Dockerfile.oracle
 
-Tags: 8.4.4, 8.4, 8, lts, 8.4.4-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.4-oracle, 8.4-oracle, 8-oracle, lts-oracle
+Tags: 8.4.5, 8.4, 8, lts, 8.4.5-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.5-oracle, 8.4-oracle, 8-oracle, lts-oracle
 Architectures: amd64, arm64v8
-GitCommit: 42386a0efb57a032d707e822086feea263088ad9
+GitCommit: 56251691b082d1aca21065a79a9d8e796daf3ea6
 Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.41, 8.0, 8.0.41-oraclelinux9, 8.0-oraclelinux9, 8.0.41-oracle, 8.0-oracle
+Tags: 8.0.42, 8.0, 8.0.42-oraclelinux9, 8.0-oraclelinux9, 8.0.42-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 6978e12b0d46abf24015045bd22a0cf11b19c150
+GitCommit: 94583e54d3bc02af523af720fdd58f8215287da9
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.41-bookworm, 8.0-bookworm, 8.0.41-debian, 8.0-debian
+Tags: 8.0.42-bookworm, 8.0-bookworm, 8.0.42-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 6978e12b0d46abf24015045bd22a0cf11b19c150
+GitCommit: 94583e54d3bc02af523af720fdd58f8215287da9
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/1b9d0c1: Update innovation to 9.3.0, oracle 9.3.0-1.el9, mysql-shell 9.3.0-1.el9
- https://github.com/docker-library/mysql/commit/5625169: Update 8.4 to 8.4.5, oracle 8.4.5-1.el9, mysql-shell 8.4.4-1.el9
- https://github.com/docker-library/mysql/commit/94583e5: Update 8.0 to 8.0.42, debian 8.0.42-1debian12, oracle 8.0.42-1.el9, mysql-shell 8.0.42-1.el9
- https://github.com/docker-library/mysql/commit/3eee88b: Update shebang from /bin/bash to /usr/bin/env bash
- https://github.com/docker-library/mysql/commit/622dadf: Update shebang from /bin/bash to /usr/bin/env bash