### PR TITLE
Odoo: update 16.0-18.0 to release 20250415

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 564eb08e948bd8cb9cd5422e4aabdad72cdd952a
+GitCommit: 515f1249ead0e69758adecfe9a86584266074e85
 
-Tags: 18.0-20250401, 18.0, 18, latest
+Tags: 18.0-20250415, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250401, 17.0, 17
+Tags: 17.0-20250415, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250401, 16.0, 16
+Tags: 16.0-20250415, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.