### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-3828"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5103c10a3d63171ae41d0672130411abef9fbd1a
+amd64-GitCommit: 1f586f61cc5d83b8d9ca8e6b4ee1fed09a797669
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ce27984bf7dcb5e4a8a250fe9b04d3bd5d3994e7
+arm64v8-GitCommit: 63cd7e3a69cdb5b792c50d162b491674dfadd385
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-0395, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-3828.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
