### PR TITLE
Updated nginx mainline to 1.27.5.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/nginxinc/docker-nginx/blob/9bef259b010ed747bc3352dd2aaad8cdf66d4444/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nginx/docker-nginx/blob/66df4d84e7217fcb23a28f66598af31d849c04ab/generate-stackbrew-library.sh
 
-Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginxinc)
-GitRepo: https://github.com/nginxinc/docker-nginx.git
+Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
+GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.27.4, mainline, 1, 1.27, latest, 1.27.4-bookworm, mainline-bookworm, 1-bookworm, 1.27-bookworm, bookworm
+Tags: 1.27.5, mainline, 1, 1.27, latest, 1.27.5-bookworm, mainline-bookworm, 1-bookworm, 1.27-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: eaf8875a1967d24cea6ed8b37109075e39ed9e43
 Directory: mainline/debian
 
-Tags: 1.27.4-perl, mainline-perl, 1-perl, 1.27-perl, perl, 1.27.4-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.27-bookworm-perl, bookworm-perl
+Tags: 1.27.5-perl, mainline-perl, 1-perl, 1.27-perl, perl, 1.27.5-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.27-bookworm-perl, bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: eaf8875a1967d24cea6ed8b37109075e39ed9e43
 Directory: mainline/debian-perl
 
-Tags: 1.27.4-otel, mainline-otel, 1-otel, 1.27-otel, otel, 1.27.4-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.27-bookworm-otel, bookworm-otel
+Tags: 1.27.5-otel, mainline-otel, 1-otel, 1.27-otel, otel, 1.27.5-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.27-bookworm-otel, bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 4e08af2988063a3b02420ef0040e2e13fc9d93d6
 Directory: mainline/debian-otel
 
-Tags: 1.27.4-alpine, mainline-alpine, 1-alpine, 1.27-alpine, alpine, 1.27.4-alpine3.21, mainline-alpine3.21, 1-alpine3.21, 1.27-alpine3.21, alpine3.21
+Tags: 1.27.5-alpine, mainline-alpine, 1-alpine, 1.27-alpine, alpine, 1.27.5-alpine3.21, mainline-alpine3.21, 1-alpine3.21, 1.27-alpine3.21, alpine3.21
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: eaf8875a1967d24cea6ed8b37109075e39ed9e43
 Directory: mainline/alpine
 
-Tags: 1.27.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.27-alpine-perl, alpine-perl, 1.27.4-alpine3.21-perl, mainline-alpine3.21-perl, 1-alpine3.21-perl, 1.27-alpine3.21-perl, alpine3.21-perl
+Tags: 1.27.5-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.27-alpine-perl, alpine-perl, 1.27.5-alpine3.21-perl, mainline-alpine3.21-perl, 1-alpine3.21-perl, 1.27-alpine3.21-perl, alpine3.21-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: eaf8875a1967d24cea6ed8b37109075e39ed9e43
 Directory: mainline/alpine-perl
 
-Tags: 1.27.4-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.27-alpine-slim, alpine-slim, 1.27.4-alpine3.21-slim, mainline-alpine3.21-slim, 1-alpine3.21-slim, 1.27-alpine3.21-slim, alpine3.21-slim
+Tags: 1.27.5-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.27-alpine-slim, alpine-slim, 1.27.5-alpine3.21-slim, mainline-alpine3.21-slim, 1-alpine3.21-slim, 1.27-alpine3.21-slim, alpine3.21-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: eaf8875a1967d24cea6ed8b37109075e39ed9e43
 Directory: mainline/alpine-slim
 
-Tags: 1.27.4-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.27-alpine-otel, alpine-otel, 1.27.4-alpine3.21-otel, mainline-alpine3.21-otel, 1-alpine3.21-otel, 1.27-alpine3.21-otel, alpine3.21-otel
+Tags: 1.27.5-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.27-alpine-otel, alpine-otel, 1.27.5-alpine3.21-otel, mainline-alpine3.21-otel, 1-alpine3.21-otel, 1.27-alpine3.21-otel, alpine3.21-otel
 Architectures: amd64, arm64v8
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 4e08af2988063a3b02420ef0040e2e13fc9d93d6
 Directory: mainline/alpine-otel
 
 Tags: 1.26.3, stable, 1.26, 1.26.3-bookworm, stable-bookworm, 1.26-bookworm
@@ -65,7 +65,7 @@ Directory: stable/alpine-perl
 
 Tags: 1.26.3-alpine-slim, stable-alpine-slim, 1.26-alpine-slim, 1.26.3-alpine3.20-slim, stable-alpine3.20-slim, 1.26-alpine3.20-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: bd3e501c6d800f0a541fe7c965ef905f470cd75f
 Directory: stable/alpine-slim
 
 Tags: 1.26.3-alpine-otel, stable-alpine-otel, 1.26-alpine-otel, 1.26.3-alpine3.20-otel, stable-alpine3.20-otel, 1.26-alpine3.20-otel


### PR DESCRIPTION
Along with nginx:
* njs updated to 0.8.10
* otel updated to 0.1.2

Not related to images themselves: dockerfiles where moved from `nginxinc` to `nginx` organisation in github as `docker-nginx` is a community project. The change is a part of tidying up repository structure in the company and doesn't change anything in regards to who maintains the project.