### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-3913"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1f586f61cc5d83b8d9ca8e6b4ee1fed09a797669
+amd64-GitCommit: 5b650b394ebca3e07ef2c48d0574064eceebc344
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 63cd7e3a69cdb5b792c50d162b491674dfadd385
+arm64v8-GitCommit: 29dc9eb580a1e586da09f20d55b6015a8878ed37
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-8176, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-3913.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
