### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5af892138fe6cd215b41b6aa9558be9d6e6f875c
 Directory: 3.2/alpine
 
-Tags: 3.1.6, 3.1, latest, 3.1.6-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.7, 3.1, latest, 3.1.7-bookworm, 3.1-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2568abb822486a3abd10fa1942b98cfe5e1d5af7
+GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
 Directory: 3.1
 
-Tags: 3.1.6-alpine, 3.1-alpine, alpine, 3.1.6-alpine3.21, 3.1-alpine3.21, alpine3.21
+Tags: 3.1.7-alpine, 3.1-alpine, alpine, 3.1.7-alpine3.21, 3.1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2568abb822486a3abd10fa1942b98cfe5e1d5af7
+GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
 Directory: 3.1/alpine
 
 Tags: 3.0.9, 3.0, lts, 3.0.9-bookworm, 3.0-bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/923a926: Update 3.1 to 3.1.7