### PR TITLE
archlinux: Release 20250420.0.338771

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250413.0.335299
-GitCommit: 2ebfad10c5e39ef6dbf3c8f305989de313ddab68
-GitFetch: refs/tags/v20250413.0.335299
+Tags: latest, base, base-20250420.0.338771
+GitCommit: 645668bdc8d5440f20c54d6371373c197fc97c35
+GitFetch: refs/tags/v20250420.0.338771
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250413.0.335299
-GitCommit: 2ebfad10c5e39ef6dbf3c8f305989de313ddab68
-GitFetch: refs/tags/v20250413.0.335299
+Tags: base-devel, base-devel-20250420.0.338771
+GitCommit: 645668bdc8d5440f20c54d6371373c197fc97c35
+GitFetch: refs/tags/v20250420.0.338771
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250413.0.335299
-GitCommit: 2ebfad10c5e39ef6dbf3c8f305989de313ddab68
-GitFetch: refs/tags/v20250413.0.335299
+Tags: multilib-devel, multilib-devel-20250420.0.338771
+GitCommit: 645668bdc8d5440f20c54d6371373c197fc97c35
+GitFetch: refs/tags/v20250420.0.338771
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks