### PR TITLE
Update Clear Linux OS to 43280

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: aad33d30f672c97befac5e431ddd877709392739
-GitFetch: refs/heads/base-43250
+GitCommit: afc50176ee4a6effaa12831b24ea46a96283d107
+GitFetch: refs/heads/base-43280


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 43280

@bryteise @djklimes @bryteise