### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.117.0, 5.117, 5, latest
+Tags: 5.118.0, 5.118, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: c7a646293bc04301c42cc1e6ad63b865cd4aa180
+GitCommit: a85dca645ff5c1a654aa8968c4ad180459485ae7
 Directory: 5/debian
 
-Tags: 5.117.0-alpine, 5.117-alpine, 5-alpine, alpine
+Tags: 5.118.0-alpine, 5.118-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: c7a646293bc04301c42cc1e6ad63b865cd4aa180
+GitCommit: a85dca645ff5c1a654aa8968c4ad180459485ae7
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/a85dca6: Update to 5.118.0, ghost-cli 1.27.0