### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
 Directory: 3.1/alpine
 
-Tags: 3.0.9, 3.0, lts, 3.0.9-bookworm, 3.0-bookworm, lts-bookworm
+Tags: 3.0.10, 3.0, lts, 3.0.10-bookworm, 3.0-bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a4ad1d171a2056e3c1215ccac0005d012e2eced1
+GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
 Directory: 3.0
 
-Tags: 3.0.9-alpine, 3.0-alpine, lts-alpine, 3.0.9-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
+Tags: 3.0.10-alpine, 3.0-alpine, lts-alpine, 3.0.10-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a4ad1d171a2056e3c1215ccac0005d012e2eced1
+GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
 Directory: 3.0/alpine
 
 Tags: 2.8.14, 2.8, 2.8.14-bookworm, 2.8-bookworm
@@ -44,24 +44,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c491c7f23708215e6f6d3e6cc9339acfda331821
 Directory: 2.8/alpine
 
-Tags: 2.6.21, 2.6, 2.6.21-bookworm, 2.6-bookworm
+Tags: 2.6.22, 2.6, 2.6.22-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 1d0ad8c9e8dd1b976f8cc81b263f18bcfc1d9be2
+GitCommit: b2272eca1be0415af128438e91ffb721d758eef7
 Directory: 2.6
 
-Tags: 2.6.21-alpine, 2.6-alpine, 2.6.21-alpine3.21, 2.6-alpine3.21
+Tags: 2.6.22-alpine, 2.6-alpine, 2.6.22-alpine3.21, 2.6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1d0ad8c9e8dd1b976f8cc81b263f18bcfc1d9be2
+GitCommit: b2272eca1be0415af128438e91ffb721d758eef7
 Directory: 2.6/alpine
 
-Tags: 2.4.28, 2.4, 2.4.28-bookworm, 2.4-bookworm
+Tags: 2.4.29, 2.4, 2.4.29-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a59d80d27242e98cb3fa234e5fa9c81a3968be18
+GitCommit: d5e3fa1fab9349226162c5a160ed667d0f62e688
 Directory: 2.4
 
-Tags: 2.4.28-alpine, 2.4-alpine, 2.4.28-alpine3.21, 2.4-alpine3.21
+Tags: 2.4.29-alpine, 2.4-alpine, 2.4.29-alpine3.21, 2.4-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34494c3b5479daab25cc47dd4790d93dfaebe9ac
+GitCommit: d5e3fa1fab9349226162c5a160ed667d0f62e688
 Directory: 2.4/alpine
 
 Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/dccf0f4: Update 3.0 to 3.0.10
- https://github.com/docker-library/haproxy/commit/b2272ec: Update 2.6 to 2.6.22
- https://github.com/docker-library/haproxy/commit/d5e3fa1: Update 2.4 to 2.4.29