### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,14 +34,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
 Directory: 3.0/alpine
 
-Tags: 2.8.14, 2.8, 2.8.14-bookworm, 2.8-bookworm
+Tags: 2.8.15, 2.8, 2.8.15-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c491c7f23708215e6f6d3e6cc9339acfda331821
+GitCommit: 82d8d0e917b2dbba726f6cf853688d1bb6eed5fc
 Directory: 2.8
 
-Tags: 2.8.14-alpine, 2.8-alpine, 2.8.14-alpine3.21, 2.8-alpine3.21
+Tags: 2.8.15-alpine, 2.8-alpine, 2.8.15-alpine3.21, 2.8-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c491c7f23708215e6f6d3e6cc9339acfda331821
+GitCommit: 82d8d0e917b2dbba726f6cf853688d1bb6eed5fc
 Directory: 2.8/alpine
 
 Tags: 2.6.22, 2.6, 2.6.22-bookworm, 2.6-bookworm
@@ -64,7 +64,7 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: d5e3fa1fab9349226162c5a160ed667d0f62e688
 Directory: 2.4/alpine
 
-Tags: 2.2.33, 2.2, 2.2.33-bullseye, 2.2-bullseye
+Tags: 2.2.34, 2.2, 2.2.34-bullseye, 2.2-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 8b639f8d7d8d5d3bc42273e509fd7ef0cabdb356
+GitCommit: fcee7759df612f1047d4b41b42c9f628dac925bf
 Directory: 2.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fcee775: Update 2.2 to 2.2.34
- https://github.com/docker-library/haproxy/commit/82d8d0e: Update 2.8 to 2.8.15