### PR TITLE
Updated stable nginx to 1.28.0.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/nginx/docker-nginx/blob/66df4d84e7217fcb23a28f66598af31d849c04ab/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nginx/docker-nginx/blob/025c52f4168ed96e503e165741b0ba39ca80bd76/generate-stackbrew-library.sh
 
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
@@ -38,37 +38,37 @@ Architectures: amd64, arm64v8
 GitCommit: 4e08af2988063a3b02420ef0040e2e13fc9d93d6
 Directory: mainline/alpine-otel
 
-Tags: 1.26.3, stable, 1.26, 1.26.3-bookworm, stable-bookworm, 1.26-bookworm
+Tags: 1.28.0, stable, 1.28, 1.28.0-bookworm, stable-bookworm, 1.28-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/debian
 
-Tags: 1.26.3-perl, stable-perl, 1.26-perl, 1.26.3-bookworm-perl, stable-bookworm-perl, 1.26-bookworm-perl
+Tags: 1.28.0-perl, stable-perl, 1.28-perl, 1.28.0-bookworm-perl, stable-bookworm-perl, 1.28-bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/debian-perl
 
-Tags: 1.26.3-otel, stable-otel, 1.26-otel, 1.26.3-bookworm-otel, stable-bookworm-otel, 1.26-bookworm-otel
+Tags: 1.28.0-otel, stable-otel, 1.28-otel, 1.28.0-bookworm-otel, stable-bookworm-otel, 1.28-bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/debian-otel
 
-Tags: 1.26.3-alpine, stable-alpine, 1.26-alpine, 1.26.3-alpine3.20, stable-alpine3.20, 1.26-alpine3.20
+Tags: 1.28.0-alpine, stable-alpine, 1.28-alpine, 1.28.0-alpine3.21, stable-alpine3.21, 1.28-alpine3.21
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/alpine
 
-Tags: 1.26.3-alpine-perl, stable-alpine-perl, 1.26-alpine-perl, 1.26.3-alpine3.20-perl, stable-alpine3.20-perl, 1.26-alpine3.20-perl
+Tags: 1.28.0-alpine-perl, stable-alpine-perl, 1.28-alpine-perl, 1.28.0-alpine3.21-perl, stable-alpine3.21-perl, 1.28-alpine3.21-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/alpine-perl
 
-Tags: 1.26.3-alpine-slim, stable-alpine-slim, 1.26-alpine-slim, 1.26.3-alpine3.20-slim, stable-alpine3.20-slim, 1.26-alpine3.20-slim
+Tags: 1.28.0-alpine-slim, stable-alpine-slim, 1.28-alpine-slim, 1.28.0-alpine3.21-slim, stable-alpine3.21-slim, 1.28-alpine3.21-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: bd3e501c6d800f0a541fe7c965ef905f470cd75f
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/alpine-slim
 
-Tags: 1.26.3-alpine-otel, stable-alpine-otel, 1.26-alpine-otel, 1.26.3-alpine3.20-otel, stable-alpine3.20-otel, 1.26-alpine3.20-otel
+Tags: 1.28.0-alpine-otel, stable-alpine-otel, 1.28-alpine-otel, 1.28.0-alpine3.21-otel, stable-alpine3.21-otel, 1.28-alpine3.21-otel
 Architectures: amd64, arm64v8
-GitCommit: cffeb933620093bc0c08c0b28c3d5cbaec79d729
+GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
 Directory: stable/alpine-otel


### PR DESCRIPTION
While at it, bump underlying OS to Alpine 3.21, and bump njs/otel modules versions for stable as well.