### PR TITLE
[nats] Releases v2.11.2, v2.10.28

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,47 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 89f948f8e95c2a5b735ee8a129c33e77e641dd56
+GitCommit: 3c443abd2148069706713b4ea31826535b09f13a
 GitFetch: refs/heads/main
 
-Tags: 2.11.1-alpine3.21, 2.11-alpine3.21, 2-alpine3.21, alpine3.21, 2.11.1-alpine, 2.11-alpine, 2-alpine, alpine
+Tags: 2.11.2-alpine3.21, 2.11-alpine3.21, 2-alpine3.21, alpine3.21, 2.11.2-alpine, 2.11-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/alpine3.21
 
-Tags: 2.11.1-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.1-linux, 2.11-linux, 2-linux, linux
-SharedTags: 2.11.1, 2.11, 2, latest
+Tags: 2.11.2-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.2-linux, 2.11-linux, 2-linux, linux
+SharedTags: 2.11.2, 2.11, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.1-windowsservercore-1809, 2.11-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.11.1-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.11.2-windowsservercore-1809, 2.11-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+SharedTags: 2.11.2-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.11.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.11.1-nanoserver-1809, 2.11-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
-SharedTags: 2.11.1-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.1, 2.11, 2, latest
+Tags: 2.11.2-nanoserver-1809, 2.11-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+SharedTags: 2.11.2-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.2, 2.11, 2, latest
 Architectures: windows-amd64
 Directory: 2.11.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809
 
-Tags: 2.10.27-alpine3.21, 2.10-alpine3.21, 2.10.27-alpine, 2.10-alpine
+Tags: 2.10.28-alpine3.21, 2.10-alpine3.21, 2.10.28-alpine, 2.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/alpine3.21
 
-Tags: 2.10.27-scratch, 2.10-scratch, 2.10.27-linux, 2.10-linux
-SharedTags: 2.10.27, 2.10
+Tags: 2.10.28-scratch, 2.10-scratch, 2.10.28-linux, 2.10-linux
+SharedTags: 2.10.28, 2.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/scratch
 
-Tags: 2.10.27-windowsservercore-1809, 2.10-windowsservercore-1809
-SharedTags: 2.10.27-windowsservercore, 2.10-windowsservercore
+Tags: 2.10.28-windowsservercore-1809, 2.10-windowsservercore-1809
+SharedTags: 2.10.28-windowsservercore, 2.10-windowsservercore
 Architectures: windows-amd64
 Directory: 2.10.x/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 2.10.27-nanoserver-1809, 2.10-nanoserver-1809
-SharedTags: 2.10.27-nanoserver, 2.10-nanoserver, 2.10.27, 2.10
+Tags: 2.10.28-nanoserver-1809, 2.10-nanoserver-1809
+SharedTags: 2.10.28-nanoserver, 2.10-nanoserver, 2.10.28, 2.10
 Architectures: windows-amd64
 Directory: 2.10.x/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Release details:

- https://github.com/nats-io/nats-server/releases/tag/v2.11.2
- https://github.com/nats-io/nats-server/releases/tag/v2.10.28