### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/3652ad1f432bb79031af9082e84c752a2c8f3959/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/94ba89529124e6536c4939f43c6b37d7ff7e2cb4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 3652ad1f432bb79031af9082e84c752a2c8f3959
+GitCommit: 94ba89529124e6536c4939f43c6b37d7ff7e2cb4
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 18ac409c9b1874d7b7e63634c909d29f0cd0207c
+amd64-GitCommit: b5c9df2db88f6fb3cb22e05ecc02479c53b29199
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 7e9cece36904f8f80c44c7ca6e0d826c091a1ee7
+arm32v5-GitCommit: 761da8bcb2f5aac98cd67ecba0075f97bac42dd4
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 2934602fcbf4ad198a5ffbef5a678b852d3b1666
+arm32v6-GitCommit: 67c36f8180c307cf52c36318ba1cd23dfd1ac0cf
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: b78fb9141fda729c41061c0ce51a8d9e14f78e9c
+arm32v7-GitCommit: d71b79cb7714e47032b6ed033ce7c5e0591cea04
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 498afd94774b792e7048ee644f310b2df83e9777
+arm64v8-GitCommit: 6a2a9d4d534eb6e8fbbe99ebb43b58e17064a0dd
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: ea49e56359533cc265482ec3d18821f60e3fccc1
+i386-GitCommit: f9b7148533cadbfe624019600f9dc13cef705ec6
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: ee390b2a5a927ba569609b96ab94f4af662ab027
+mips64le-GitCommit: 93df7d3a592cf7318c20a774f1acd7996a64415f
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: d0c7070ff8c6221fa9f7f12cd6d41ec21199db35
+ppc64le-GitCommit: 72152b094d10a10e92dc5ba865ddd9b5563a95c1
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: f06a3c65b6b1ef1f26fcd8b4508a67b091a4d8e6
+riscv64-GitCommit: ca4cc38e2da20b2c9f24733ed37701f71dc808e8
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 643ad3d3a55b82ec4b0b1173f69c47aa576042af
+s390x-GitCommit: dc04ec292d79c84098f143676eb387a9d669e353
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/94ba895: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/bd72b84: Update metadata for i386
- https://github.com/docker-library/busybox/commit/ff1891e: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/20d0d41: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/6ef0798: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/a190d8e: Merge pull request https://github.com/docker-library/busybox/pull/222 from infosiftr/buildroot-2025.02.1
- https://github.com/docker-library/busybox/commit/7950939: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/f843c6a: Update buildroot to 2025.02.1
- https://github.com/docker-library/busybox/commit/3652ad1: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/f12b6f6: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/1929b8e: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/891544d: Update metadata for i386
- https://github.com/docker-library/busybox/commit/ffe425a: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/42f06e9: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/38d467e: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/daf5470: Merge pull request https://github.com/docker-library/busybox/pull/220 from infosiftr/buildroot-2025.02
- https://github.com/docker-library/busybox/commit/9a2d579: Update metadata for amd64