### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-4051 ELSA-2025-4049"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5b650b394ebca3e07ef2c48d0574064eceebc344
+amd64-GitCommit: 194c7b3107251eb0f8d92e95e2c7ff918acf8434
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 29dc9eb580a1e586da09f20d55b6015a8878ed37
+arm64v8-GitCommit: 76ea84ce88cfd9925f07c37892a1cdabc59c445a
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-12243, CVE-2024-12133, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-4051.html
https://linux.oracle.com/errata/ELSA-2025-4049.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
