### PR TITLE
archlinux: Release 20250427.0.341977

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250420.0.338771
-GitCommit: 645668bdc8d5440f20c54d6371373c197fc97c35
-GitFetch: refs/tags/v20250420.0.338771
+Tags: latest, base, base-20250427.0.341977
+GitCommit: 209e8524c779119dbdd6e05ab9a515e5da5074bd
+GitFetch: refs/tags/v20250427.0.341977
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250420.0.338771
-GitCommit: 645668bdc8d5440f20c54d6371373c197fc97c35
-GitFetch: refs/tags/v20250420.0.338771
+Tags: base-devel, base-devel-20250427.0.341977
+GitCommit: 209e8524c779119dbdd6e05ab9a515e5da5074bd
+GitFetch: refs/tags/v20250427.0.341977
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250420.0.338771
-GitCommit: 645668bdc8d5440f20c54d6371373c197fc97c35
-GitFetch: refs/tags/v20250420.0.338771
+Tags: multilib-devel, multilib-devel-20250427.0.341977
+GitCommit: 209e8524c779119dbdd6e05ab9a515e5da5074bd
+GitFetch: refs/tags/v20250427.0.341977
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks