### PR TITLE
Update Monica to v5.0.0-beta.5

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -1,4 +1,4 @@
-# This file is generated via https://github.com/monicahq/docker/blob/7982fc66d4eb5569cfd6fd19202ac5a86dbdef93/generate-stackbrew-library.sh
+# This file is generated via https://github.com/monicahq/docker/blob/8c3bcc8d3ab01315ca762c995338083d71c5611e/generate-stackbrew-library.sh
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 GitFetch: refs/heads/main
@@ -6,29 +6,29 @@ GitFetch: refs/heads/main
 Tags: 4.1.2-apache, 4.1-apache, 4-apache, apache, 4.1.2, 4.1, 4, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 4/apache
-GitCommit: 7982fc66d4eb5569cfd6fd19202ac5a86dbdef93
+GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
 
 Tags: 4.1.2-fpm-alpine, 4.1-fpm-alpine, 4-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 4/fpm-alpine
-GitCommit: 7982fc66d4eb5569cfd6fd19202ac5a86dbdef93
+GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
 
 Tags: 4.1.2-fpm, 4.1-fpm, 4-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 4/fpm
-GitCommit: 7982fc66d4eb5569cfd6fd19202ac5a86dbdef93
+GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
 
-Tags: 5.0.0-beta.4-apache, 5.0.0-beta-apache, 5.0-apache
+Tags: 5.0.0-beta.5-apache, 5.0.0-beta-apache, 5.0-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5/apache
-GitCommit: 7982fc66d4eb5569cfd6fd19202ac5a86dbdef93
+GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
 
-Tags: 5.0.0-beta.4-fpm-alpine, 5.0.0-beta-fpm-alpine, 5.0-fpm-alpine
+Tags: 5.0.0-beta.5-fpm-alpine, 5.0.0-beta-fpm-alpine, 5.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 5/fpm-alpine
-GitCommit: 7982fc66d4eb5569cfd6fd19202ac5a86dbdef93
+GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
 
-Tags: 5.0.0-beta.4-fpm, 5.0.0-beta-fpm, 5.0-fpm
+Tags: 5.0.0-beta.5-fpm, 5.0.0-beta-fpm, 5.0-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: 5/fpm
-GitCommit: 7982fc66d4eb5569cfd6fd19202ac5a86dbdef93
+GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e


### PR DESCRIPTION
Update Monica to [v5.0.0-beta.5](https://github.com/monicahq/monica/releases/tag/v5.0.0-beta.5).