### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -83,3 +83,63 @@ Tags: cli-2.11.0-php8.4, cli-2.11-php8.4, cli-2-php8.4, cli-php8.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a52039a5d8059d24403af1892d34d49ebe052323
 Directory: cli/php8.4/alpine
+
+Tags: beta-6.8.1-RC1-php8.1-apache, beta-6.8.1-php8.1-apache, beta-6.8-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.8.1-RC1-php8.1, beta-6.8.1-php8.1, beta-6.8-php8.1, beta-6-php8.1, beta-php8.1
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.1/apache
+
+Tags: beta-6.8.1-RC1-php8.1-fpm, beta-6.8.1-php8.1-fpm, beta-6.8-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.1/fpm
+
+Tags: beta-6.8.1-RC1-php8.1-fpm-alpine, beta-6.8.1-php8.1-fpm-alpine, beta-6.8-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.1/fpm-alpine
+
+Tags: beta-6.8.1-RC1-apache, beta-6.8.1-apache, beta-6.8-apache, beta-6-apache, beta-apache, beta-6.8.1-RC1, beta-6.8.1, beta-6.8, beta-6, beta, beta-6.8.1-RC1-php8.2-apache, beta-6.8.1-php8.2-apache, beta-6.8-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.8.1-RC1-php8.2, beta-6.8.1-php8.2, beta-6.8-php8.2, beta-6-php8.2, beta-php8.2
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.2/apache
+
+Tags: beta-6.8.1-RC1-fpm, beta-6.8.1-fpm, beta-6.8-fpm, beta-6-fpm, beta-fpm, beta-6.8.1-RC1-php8.2-fpm, beta-6.8.1-php8.2-fpm, beta-6.8-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.2/fpm
+
+Tags: beta-6.8.1-RC1-fpm-alpine, beta-6.8.1-fpm-alpine, beta-6.8-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.8.1-RC1-php8.2-fpm-alpine, beta-6.8.1-php8.2-fpm-alpine, beta-6.8-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.2/fpm-alpine
+
+Tags: beta-6.8.1-RC1-php8.3-apache, beta-6.8.1-php8.3-apache, beta-6.8-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.8.1-RC1-php8.3, beta-6.8.1-php8.3, beta-6.8-php8.3, beta-6-php8.3, beta-php8.3
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.3/apache
+
+Tags: beta-6.8.1-RC1-php8.3-fpm, beta-6.8.1-php8.3-fpm, beta-6.8-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.3/fpm
+
+Tags: beta-6.8.1-RC1-php8.3-fpm-alpine, beta-6.8.1-php8.3-fpm-alpine, beta-6.8-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.3/fpm-alpine
+
+Tags: beta-6.8.1-RC1-php8.4-apache, beta-6.8.1-php8.4-apache, beta-6.8-php8.4-apache, beta-6-php8.4-apache, beta-php8.4-apache, beta-6.8.1-RC1-php8.4, beta-6.8.1-php8.4, beta-6.8-php8.4, beta-6-php8.4, beta-php8.4
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.4/apache
+
+Tags: beta-6.8.1-RC1-php8.4-fpm, beta-6.8.1-php8.4-fpm, beta-6.8-php8.4-fpm, beta-6-php8.4-fpm, beta-php8.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.4/fpm
+
+Tags: beta-6.8.1-RC1-php8.4-fpm-alpine, beta-6.8.1-php8.4-fpm-alpine, beta-6.8-php8.4-fpm-alpine, beta-6-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 4ae0a8487a0f41d7c1fe811c219b77183b559767
+Directory: beta/php8.4/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/4ae0a84: Update beta to 6.8.1-RC1