### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev12, 3.2-dev, 3.2-dev12-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev13, 3.2-dev, 3.2-dev13-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5eacb570033bf5a53b9de5e1d9ec477fdc81d64e
+GitCommit: ae4952747884968e13bfdf87faf659fb882b14b0
 Directory: 3.2
 
-Tags: 3.2-dev12-alpine, 3.2-dev-alpine, 3.2-dev12-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev13-alpine, 3.2-dev-alpine, 3.2-dev13-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5eacb570033bf5a53b9de5e1d9ec477fdc81d64e
+GitCommit: ae4952747884968e13bfdf87faf659fb882b14b0
 Directory: 3.2/alpine
 
 Tags: 3.1.7, 3.1, latest, 3.1.7-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ae49527: Update 3.2 to 3.2-dev13