### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250414.0
+Tags: 2023, latest, 2023.7.20250428.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: bdbf0417982cca662b4614c15d65d2c3014c4033
+amd64-GitCommit: 8913d60448e6afb76886c1d50ae38d4fc6642512
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 0f1136f443c494816d3c728ac9ce192665970427
+arm64v8-GitCommit: f4e3821ed8835b7815c8acfcd935e98450daffe2
 
-Tags: 2, 2.0.20250414.0
+Tags: 2, 2.0.20250428.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 35f42e6f95e02060e4957600610e5c7ecf7ecc2e
+amd64-GitCommit: cc127d58207194b46ffb9fa9a478501faee11a81
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: b1cfb8065a96fd07f1f4994ed6c832928323634f
+arm64v8-GitCommit: 64377d80f10bc86b9bd835a491d85da84f44d7a4
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- libcurl-8.3.0-1.amzn2.0.9
- curl-8.3.0-1.amzn2.0.9
#### Packages addressing CVES:

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.7.20250428-0.amzn2023
- system-release-2023.7.20250428-0.amzn2023
- curl-minimal-8.5.0-1.amzn2023.0.5
- libcap-2.73-1.amzn2023.0.2
- libcurl-minimal-8.5.0-1.amzn2023.0.5
#### Packages addressing CVES:
N/A