### PR TITLE
fluentd: update to Fluentd v1.16.8

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,17 +3,17 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Alpine images
-Tags: v1.16.7-1.0, v1.16-1
+Tags: v1.16.8-1.0, v1.16-1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitFetch: refs/heads/v1.16
-GitCommit: 295ba669ac33fc7c997cd2643351cef31c2845b7
+GitCommit: 98155ec2dea1ae97a4cdedb8853e9be8ec7e7412
 Directory: v1.16/alpine
 
 # Debian images
-Tags: v1.16.7-debian-1.0, v1.16-debian-1
+Tags: v1.16.8-debian-1.0, v1.16-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitFetch: refs/heads/v1.16
-GitCommit: 295ba669ac33fc7c997cd2643351cef31c2845b7
+GitCommit: 98155ec2dea1ae97a4cdedb8853e9be8ec7e7412
 Directory: v1.16/debian
 
 # Alpine images


### PR DESCRIPTION
See https://www.fluentd.org/blog/fluentd-v1.16.8-has-been-released