### PR TITLE
 Bump Traefik to v3.3.7 and v3.4.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,31 +27,31 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 48eccfc76cf8936cd5c4e07c756e6248e9999c6b
 Directory: v3.4/alpine
 
-Tags: v3.3.6-windowsservercore-ltsc2022, 3.3.6-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.3.7-windowsservercore-ltsc2022, 3.3.7-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: acca84c01faba97c6a6bcfdde5d6cb8d0b92a9af
+GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
 Directory: v3.3/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.3.6-windowsservercore-1809, 3.3.6-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, saintnectaire-windowsservercore-1809, windowsservercore-1809
+Tags: v3.3.7-windowsservercore-1809, 3.3.7-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, saintnectaire-windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: acca84c01faba97c6a6bcfdde5d6cb8d0b92a9af
+GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
 Directory: v3.3/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.3.6-nanoserver-ltsc2022, 3.3.6-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.3.7-nanoserver-ltsc2022, 3.3.7-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: acca84c01faba97c6a6bcfdde5d6cb8d0b92a9af
+GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
 Directory: v3.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.3.6, 3.3.6, v3.3, 3.3, v3, 3, saintnectaire, latest
+Tags: v3.3.7, 3.3.7, v3.3, 3.3, saintnectaire
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: acca84c01faba97c6a6bcfdde5d6cb8d0b92a9af
+GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
 Directory: v3.3/alpine
 
 Tags: v2.11.24-windowsservercore-ltsc2022, 2.11.24-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022

--- a/library/traefik
+++ b/library/traefik
@@ -1,30 +1,30 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.4.0-rc2-windowsservercore-ltsc2022, 3.4.0-rc2-windowsservercore-ltsc2022, chaource-windowsservercore-ltsc2022
+Tags: v3.4.0-windowsservercore-ltsc2022, 3.4.0-windowsservercore-ltsc2022, v3.4-windowsservercore-ltsc2022, 3.4-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chaource-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 48eccfc76cf8936cd5c4e07c756e6248e9999c6b
+GitCommit: 8b16bf1c51046631b81b5acc469edb982f5c237d
 Directory: v3.4/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.4.0-rc2-windowsservercore-1809, 3.4.0-rc2-windowsservercore-1809, chaource-windowsservercore-1809
+Tags: v3.4.0-windowsservercore-1809, 3.4.0-windowsservercore-1809, v3.4-windowsservercore-1809, 3.4-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, chaource-windowsservercore-1809, windowsservercore-1809
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 48eccfc76cf8936cd5c4e07c756e6248e9999c6b
+GitCommit: 8b16bf1c51046631b81b5acc469edb982f5c237d
 Directory: v3.4/windows/1809
 Constraints: windowsservercore-1809
 
-Tags: v3.4.0-rc2-nanoserver-ltsc2022, 3.4.0-rc2-nanoserver-ltsc2022, chaource-nanoserver-ltsc2022
+Tags: v3.4.0-nanoserver-ltsc2022, 3.4.0-nanoserver-ltsc2022, v3.4-nanoserver-ltsc2022, 3.4-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chaource-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 48eccfc76cf8936cd5c4e07c756e6248e9999c6b
+GitCommit: 8b16bf1c51046631b81b5acc469edb982f5c237d
 Directory: v3.4/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.4.0-rc2, 3.4.0-rc2, chaource
+Tags: v3.4.0, 3.4.0, v3.4, 3.4, v3, 3, chaource, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 48eccfc76cf8936cd5c4e07c756e6248e9999c6b
+GitCommit: 8b16bf1c51046631b81b5acc469edb982f5c237d
 Directory: v3.4/alpine
 
 Tags: v3.3.7-windowsservercore-ltsc2022, 3.3.7-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.3.7](https://github.com/traefik/traefik/releases/tag/v3.3.7) and [v3.4.0](https://github.com/traefik/traefik/releases/tag/v3.4.0).

/cc @nmengin @mmatur @rtribotte

Cheers
