### PR TITLE
chore(rust): Update rustup to 1.28.2

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/db908c8cad6c5c2c205be2c0f1ec1145b344feea/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/34adb91f94a518191d60abfcc81f0f6b32db0ad8/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
@@ -6,31 +6,31 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
 
 Tags: 1-bullseye, 1.86-bullseye, 1.86.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
+GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
 Directory: stable/bullseye
 
 Tags: 1-slim-bullseye, 1.86-slim-bullseye, 1.86.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
+GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
 Directory: stable/bullseye/slim
 
 Tags: 1-bookworm, 1.86-bookworm, 1.86.0-bookworm, bookworm, 1, 1.86, 1.86.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
+GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
 Directory: stable/bookworm
 
 Tags: 1-slim-bookworm, 1.86-slim-bookworm, 1.86.0-slim-bookworm, slim-bookworm, 1-slim, 1.86-slim, 1.86.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
+GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
 Directory: stable/bookworm/slim
 
 Tags: 1-alpine3.20, 1.86-alpine3.20, 1.86.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
+GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
 Directory: stable/alpine3.20
 
 Tags: 1-alpine3.21, 1.86-alpine3.21, 1.86.0-alpine3.21, alpine3.21, 1-alpine, 1.86-alpine, 1.86.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: db908c8cad6c5c2c205be2c0f1ec1145b344feea
+GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
 Directory: stable/alpine3.21
 


### PR DESCRIPTION
Tag: https://github.com/rust-lang/rustup/releases/tag/1.28.2
Blog: https://blog.rust-lang.org/2025/05/05/Rustup-1.28.2/