### PR TITLE
Update amazoncorretto for 8.452.09.2 release

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,7 +15,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: ad49ae5d8f8d052939527c9ff28ebbcbc0d7bd44
+GitCommit: 5863f873696768f24eb1640f9598b777d0c712d4
 
 Tags: 8, 8u452, 8u452-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u452-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update GitCommit in amazoncorretto to support new 8.452.09.2 release. For further details, see:
- https://github.com/corretto/corretto-docker/commit/5863f873696768f24eb1640f9598b777d0c712d4
- https://github.com/corretto/corretto-8/releases/tag/8.452.09.2