### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -64,22 +64,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b8721d7271bf763d999285985277d61e78c584aa
 Directory: latest/php8.4/fpm-alpine
 
-Tags: cli-2.11.0-php8.1, cli-2.11-php8.1, cli-2-php8.1, cli-php8.1
+Tags: cli-2.12.0-php8.1, cli-2.12-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a52039a5d8059d24403af1892d34d49ebe052323
+GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.11.0, cli-2.11, cli-2, cli, cli-2.11.0-php8.2, cli-2.11-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.12.0, cli-2.12, cli-2, cli, cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a52039a5d8059d24403af1892d34d49ebe052323
+GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.2/alpine
 
-Tags: cli-2.11.0-php8.3, cli-2.11-php8.3, cli-2-php8.3, cli-php8.3
+Tags: cli-2.12.0-php8.3, cli-2.12-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a52039a5d8059d24403af1892d34d49ebe052323
+GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.3/alpine
 
-Tags: cli-2.11.0-php8.4, cli-2.11-php8.4, cli-2-php8.4, cli-php8.4
+Tags: cli-2.12.0-php8.4, cli-2.12-php8.4, cli-2-php8.4, cli-php8.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a52039a5d8059d24403af1892d34d49ebe052323
+GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/50da133: Update cli to 2.12.0