### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 17.4, 17, latest, 17.4-bookworm, 17-bookworm, bookworm
+Tags: 17.5, 17, latest, 17.5-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 17/bookworm
 
-Tags: 17.4-bullseye, 17-bullseye, bullseye
+Tags: 17.5-bullseye, 17-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 17/bullseye
 
-Tags: 17.4-alpine3.21, 17-alpine3.21, alpine3.21, 17.4-alpine, 17-alpine, alpine
+Tags: 17.5-alpine3.21, 17-alpine3.21, alpine3.21, 17.5-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 17/alpine3.21
 
-Tags: 17.4-alpine3.20, 17-alpine3.20, alpine3.20
+Tags: 17.5-alpine3.20, 17-alpine3.20, alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 17/alpine3.20
 
-Tags: 16.8, 16, 16.8-bookworm, 16-bookworm
+Tags: 16.9, 16, 16.9-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 16/bookworm
 
-Tags: 16.8-bullseye, 16-bullseye
+Tags: 16.9-bullseye, 16-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 16/bullseye
 
-Tags: 16.8-alpine3.21, 16-alpine3.21, 16.8-alpine, 16-alpine
+Tags: 16.9-alpine3.21, 16-alpine3.21, 16.9-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 16/alpine3.21
 
-Tags: 16.8-alpine3.20, 16-alpine3.20
+Tags: 16.9-alpine3.20, 16-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 16/alpine3.20
 
-Tags: 15.12, 15, 15.12-bookworm, 15-bookworm
+Tags: 15.13, 15, 15.13-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 15/bookworm
 
-Tags: 15.12-bullseye, 15-bullseye
+Tags: 15.13-bullseye, 15-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 15/bullseye
 
-Tags: 15.12-alpine3.21, 15-alpine3.21, 15.12-alpine, 15-alpine
+Tags: 15.13-alpine3.21, 15-alpine3.21, 15.13-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 15/alpine3.21
 
-Tags: 15.12-alpine3.20, 15-alpine3.20
+Tags: 15.13-alpine3.20, 15-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 15/alpine3.20
 
-Tags: 14.17, 14, 14.17-bookworm, 14-bookworm
+Tags: 14.18, 14, 14.18-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 14/bookworm
 
-Tags: 14.17-bullseye, 14-bullseye
+Tags: 14.18-bullseye, 14-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 14/bullseye
 
-Tags: 14.17-alpine3.21, 14-alpine3.21, 14.17-alpine, 14-alpine
+Tags: 14.18-alpine3.21, 14-alpine3.21, 14.18-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 14/alpine3.21
 
-Tags: 14.17-alpine3.20, 14-alpine3.20
+Tags: 14.18-alpine3.20, 14-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 14/alpine3.20
 
-Tags: 13.20, 13, 13.20-bookworm, 13-bookworm
+Tags: 13.21, 13, 13.21-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 13/bookworm
 
-Tags: 13.20-bullseye, 13-bullseye
+Tags: 13.21-bullseye, 13-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: 266748257c85f28eb01a276e84860013ade2eb14
 Directory: 13/bullseye
 
-Tags: 13.20-alpine3.21, 13-alpine3.21, 13.20-alpine, 13-alpine
+Tags: 13.21-alpine3.21, 13-alpine3.21, 13.21-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 13/alpine3.21
 
-Tags: 13.20-alpine3.20, 13-alpine3.20
+Tags: 13.21-alpine3.20, 13-alpine3.20
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc254e85ed86e1f8c9052f9cbf0e3320324f0421
+GitCommit: b23470265cc9c4bc283a88bf6c5054e3fca87c16
 Directory: 13/alpine3.20


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/437897c: Merge pull request https://github.com/docker-library/postgres/pull/1340 from infosiftr/update
- https://github.com/docker-library/postgres/commit/b234702: Remove explicit config.guess/config.sub updates
- https://github.com/docker-library/postgres/commit/2667482: Update to 17.5, 16.9, 15.13, 14.18, 13.21