### PR TITLE
Update Semeru release versions

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -5,196 +5,158 @@ GitRepo: https://github.com/ibmruntimes/semeru-containers.git
 GitFetch: refs/heads/ibm
 
 #-----------------------------openj9 v8 images---------------------------------
-Tags: open-8u442-b06-jdk-focal, open-8-jdk-focal
+Tags: open-8u452-b09-jdk-focal, open-8-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 8/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-8u442-b06-jdk-jammy, open-8-jdk-jammy
+Tags: open-8u452-b09-jdk-jammy, open-8-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u442-b06-jdk-noble, open-8-jdk-noble
-SharedTags: open-8u442-b06-jdk, open-8-jdk
+Tags: open-8u452-b09-jdk-noble, open-8-jdk-noble
+SharedTags: open-8u452-b09-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 8/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-8u442-b06-jre-focal, open-8-jre-focal
+Tags: open-8u452-b09-jre-focal, open-8-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 8/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-8u442-b06-jre-jammy, open-8-jre-jammy
+Tags: open-8u452-b09-jre-jammy, open-8-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u442-b06-jre-noble, open-8-jre-noble
-SharedTags: open-8u442-b06-jre, open-8-jre
+Tags: open-8u452-b09-jre-noble, open-8-jre-noble
+SharedTags: open-8u452-b09-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 8/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
-Tags: open-11.0.26_4-jdk-focal, open-11-jdk-focal
+Tags: open-11.0.27_6-jdk-focal, open-11-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 11/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.26_4-jdk-jammy, open-11-jdk-jammy
+Tags: open-11.0.27_6-jdk-jammy, open-11-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.26_4-jdk-noble, open-11-jdk-noble
-SharedTags: open-11.0.26_4-jdk, open-11-jdk
+Tags: open-11.0.27_6-jdk-noble, open-11-jdk-noble
+SharedTags: open-11.0.27_6-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 11/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.26_4-jre-focal, open-11-jre-focal
+Tags: open-11.0.27_6-jre-focal, open-11-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 11/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.26_4-jre-jammy, open-11-jre-jammy
+Tags: open-11.0.27_6-jre-jammy, open-11-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.26_4-jre-noble, open-11-jre-noble
-SharedTags: open-11.0.26_4-jre, open-11-jre
+Tags: open-11.0.27_6-jre-noble, open-11-jre-noble
+SharedTags: open-11.0.27_6-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 11/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
-Tags: open-17.0.14_7-jdk-focal, open-17-jdk-focal
+Tags: open-17.0.15_6-jdk-focal, open-17-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 17/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.14_7-jdk-jammy, open-17-jdk-jammy
+Tags: open-17.0.15_6-jdk-jammy, open-17-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.14_7-jdk-noble, open-17-jdk-noble
-SharedTags: open-17.0.14_7-jdk, open-17-jdk
+Tags: open-17.0.15_6-jdk-noble, open-17-jdk-noble
+SharedTags: open-17.0.15_6-jdk, open-17-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 17/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.14_7-jre-focal, open-17-jre-focal
+Tags: open-17.0.15_6-jre-focal, open-17-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 17/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.14_7-jre-jammy, open-17-jre-jammy
+Tags: open-17.0.15_6-jre-jammy, open-17-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.14_7-jre-noble, open-17-jre-noble
-SharedTags: open-17.0.14_7-jre, open-17-jre
+Tags: open-17.0.15_6-jre-noble, open-17-jre-noble
+SharedTags: open-17.0.15_6-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 17/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v21 images---------------------------------
-Tags: open-21.0.6_7-jdk-focal, open-21-jdk-focal
+Tags: open-21.0.7_6-jdk-focal, open-21-jdk-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 21/jdk/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.6_7-jdk-jammy, open-21-jdk-jammy
+Tags: open-21.0.7_6-jdk-jammy, open-21-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 21/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.6_7-jdk-noble, open-21-jdk-noble
-SharedTags: open-21.0.6_7-jdk, open-21-jdk
+Tags: open-21.0.7_6-jdk-noble, open-21-jdk-noble
+SharedTags: open-21.0.7_6-jdk, open-21-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 21/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.6_7-jre-focal, open-21-jre-focal
+Tags: open-21.0.7_6-jre-focal, open-21-jre-focal
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 21/jre/ubuntu/focal
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.6_7-jre-jammy, open-21-jre-jammy
+Tags: open-21.0.7_6-jre-jammy, open-21-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 21/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.6_7-jre-noble, open-21-jre-noble
-SharedTags: open-21.0.6_7-jre, open-21-jre
+Tags: open-21.0.7_6-jre-noble, open-21-jre-noble
+SharedTags: open-21.0.7_6-jre, open-21-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
+GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
 Directory: 21/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-#-----------------------------openj9 v23 images---------------------------------
-Tags: open-23.0.2_7-jdk-focal, open-23-jdk-focal
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
-Directory: 23/jdk/ubuntu/focal
-File: Dockerfile.open.releases.full
-
-Tags: open-23.0.2_7-jdk-jammy, open-23-jdk-jammy
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
-Directory: 23/jdk/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-23.0.2_7-jdk-noble, open-23-jdk-noble
-SharedTags: open-23.0.2_7-jdk, open-23-jdk
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
-Directory: 23/jdk/ubuntu/noble
-File: Dockerfile.open.releases.full
-
-Tags: open-23.0.2_7-jre-focal, open-23-jre-focal
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
-Directory: 23/jre/ubuntu/focal
-File: Dockerfile.open.releases.full
-
-Tags: open-23.0.2_7-jre-jammy, open-23-jre-jammy
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
-Directory: 23/jre/ubuntu/jammy
-File: Dockerfile.open.releases.full
-
-Tags: open-23.0.2_7-jre-noble, open-23-jre-noble
-SharedTags: open-23.0.2_7-jre, open-23-jre
-Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 4b7a7c4704cf1d6b2241aa09f8dacef518cf6e74
-Directory: 23/jre/ubuntu/noble
-File: Dockerfile.open.releases.full


### PR DESCRIPTION
- Semeru 8/11/17 and 21 release versions are updated. 
- Semeru 23 is removed from list as it reached EOS. 