### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev14, 3.2-dev, 3.2-dev14-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev15, 3.2-dev, 3.2-dev15-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b0ab3d704bc22f8f92bb923ee3b5d79c91402a3e
+GitCommit: 40ab67138f90c67f0c898b1c7bb13719190d337b
 Directory: 3.2
 
-Tags: 3.2-dev14-alpine, 3.2-dev-alpine, 3.2-dev14-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev15-alpine, 3.2-dev-alpine, 3.2-dev15-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b0ab3d704bc22f8f92bb923ee3b5d79c91402a3e
+GitCommit: 40ab67138f90c67f0c898b1c7bb13719190d337b
 Directory: 3.2/alpine
 
 Tags: 3.1.7, 3.1, latest, 3.1.7-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/40ab671: Update 3.2 to 3.2-dev15