### PR TITLE
archlinux: Release 20250511.0.348143

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250504.0.344409
-GitCommit: ea8b6bc31f9b4089b14fae4b6489bd3a7379c1ef
-GitFetch: refs/tags/v20250504.0.344409
+Tags: latest, base, base-20250511.0.348143
+GitCommit: ebb381b644ed8f3d3e1f4319975e18a65f638d66
+GitFetch: refs/tags/v20250511.0.348143
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250504.0.344409
-GitCommit: ea8b6bc31f9b4089b14fae4b6489bd3a7379c1ef
-GitFetch: refs/tags/v20250504.0.344409
+Tags: base-devel, base-devel-20250511.0.348143
+GitCommit: ebb381b644ed8f3d3e1f4319975e18a65f638d66
+GitFetch: refs/tags/v20250511.0.348143
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250504.0.344409
-GitCommit: ea8b6bc31f9b4089b14fae4b6489bd3a7379c1ef
-GitFetch: refs/tags/v20250504.0.344409
+Tags: multilib-devel, multilib-devel-20250511.0.348143
+GitCommit: ebb381b644ed8f3d3e1f4319975e18a65f638d66
+GitFetch: refs/tags/v20250511.0.348143
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks