### PR TITLE
Update hylang

### DIFF
--- a/library/hylang
+++ b/library/hylang
@@ -13,11 +13,11 @@ Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.13-bullseye
 
 Tags: 1.1.0-python3.13-alpine3.21, 1.1-python3.13-alpine3.21, 1-python3.13-alpine3.21, python3.13-alpine3.21, 1.1.0-alpine3.21, 1.1-alpine3.21, 1-alpine3.21, alpine3.21, 1.1.0-python3.13-alpine, 1.1-python3.13-alpine, 1-python3.13-alpine, python3.13-alpine, 1.1.0-alpine, 1.1-alpine, 1-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.13-alpine3.21
 
 Tags: 1.1.0-python3.13-alpine3.20, 1.1-python3.13-alpine3.20, 1-python3.13-alpine3.20, python3.13-alpine3.20, 1.1.0-alpine3.20, 1.1-alpine3.20, 1-alpine3.20, alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.13-alpine3.20
 
 Tags: 1.1.0-python3.13-windowsservercore-ltsc2025, 1.1-python3.13-windowsservercore-ltsc2025, 1-python3.13-windowsservercore-ltsc2025, python3.13-windowsservercore-ltsc2025, 1.1.0-windowsservercore-ltsc2025, 1.1-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
@@ -48,11 +48,11 @@ Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.12-bullseye
 
 Tags: 1.1.0-python3.12-alpine3.21, 1.1-python3.12-alpine3.21, 1-python3.12-alpine3.21, python3.12-alpine3.21, 1.1.0-python3.12-alpine, 1.1-python3.12-alpine, 1-python3.12-alpine, python3.12-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.12-alpine3.21
 
 Tags: 1.1.0-python3.12-alpine3.20, 1.1-python3.12-alpine3.20, 1-python3.12-alpine3.20, python3.12-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.12-alpine3.20
 
 Tags: 1.1.0-python3.12-windowsservercore-ltsc2025, 1.1-python3.12-windowsservercore-ltsc2025, 1-python3.12-windowsservercore-ltsc2025, python3.12-windowsservercore-ltsc2025
@@ -83,11 +83,11 @@ Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.11-bullseye
 
 Tags: 1.1.0-python3.11-alpine3.21, 1.1-python3.11-alpine3.21, 1-python3.11-alpine3.21, python3.11-alpine3.21, 1.1.0-python3.11-alpine, 1.1-python3.11-alpine, 1-python3.11-alpine, python3.11-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.11-alpine3.21
 
 Tags: 1.1.0-python3.11-alpine3.20, 1.1-python3.11-alpine3.20, 1-python3.11-alpine3.20, python3.11-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 File: Dockerfile.python3.11-alpine3.20
 
 Tags: 1.1.0-python3.10-bookworm, 1.1-python3.10-bookworm, 1-python3.10-bookworm, python3.10-bookworm
@@ -134,11 +134,11 @@ Architectures: amd64, arm32v7, arm64v8, i386
 File: Dockerfile.python3.14-rc-bullseye
 
 Tags: 1.1.0-python3.14-rc-alpine3.21, 1.1-python3.14-rc-alpine3.21, 1-python3.14-rc-alpine3.21, python3.14-rc-alpine3.21, 1.1.0-python3.14-rc-alpine, 1.1-python3.14-rc-alpine, 1-python3.14-rc-alpine, python3.14-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64
 File: Dockerfile.python3.14-rc-alpine3.21
 
 Tags: 1.1.0-python3.14-rc-alpine3.20, 1.1-python3.14-rc-alpine3.20, 1-python3.14-rc-alpine3.20, python3.14-rc-alpine3.20
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64
 File: Dockerfile.python3.14-rc-alpine3.20
 
 Tags: 1.1.0-python3.14-rc-windowsservercore-ltsc2025, 1.1-python3.14-rc-windowsservercore-ltsc2025, 1-python3.14-rc-windowsservercore-ltsc2025, python3.14-rc-windowsservercore-ltsc2025


### PR DESCRIPTION
Follow up to https://github.com/docker-library/python/pull/1038; more `riscv64`.