### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,75 +4,75 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 25-ea-21-jdk-oraclelinux9, 25-ea-21-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-21-jdk-oracle, 25-ea-21-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-21-jdk, 25-ea-21, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-22-jdk-oraclelinux9, 25-ea-22-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-22-jdk-oracle, 25-ea-22-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-22-jdk, 25-ea-22, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-21-jdk-oraclelinux8, 25-ea-21-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-22-jdk-oraclelinux8, 25-ea-22-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-21-jdk-bookworm, 25-ea-21-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-22-jdk-bookworm, 25-ea-22-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-21-jdk-slim-bookworm, 25-ea-21-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-21-jdk-slim, 25-ea-21-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-22-jdk-slim-bookworm, 25-ea-22-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-22-jdk-slim, 25-ea-22-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-21-jdk-bullseye, 25-ea-21-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-22-jdk-bullseye, 25-ea-22-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-21-jdk-slim-bullseye, 25-ea-21-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-22-jdk-slim-bullseye, 25-ea-22-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-21-jdk-windowsservercore-ltsc2025, 25-ea-21-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
-SharedTags: 25-ea-21-jdk-windowsservercore, 25-ea-21-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-21-jdk, 25-ea-21, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-22-jdk-windowsservercore-ltsc2025, 25-ea-22-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-ea-22-jdk-windowsservercore, 25-ea-22-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-22-jdk, 25-ea-22, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 25-ea-21-jdk-windowsservercore-ltsc2022, 25-ea-21-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-21-jdk-windowsservercore, 25-ea-21-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-21-jdk, 25-ea-21, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-22-jdk-windowsservercore-ltsc2022, 25-ea-22-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-22-jdk-windowsservercore, 25-ea-22-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-22-jdk, 25-ea-22, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-21-jdk-windowsservercore-1809, 25-ea-21-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
-SharedTags: 25-ea-21-jdk-windowsservercore, 25-ea-21-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-21-jdk, 25-ea-21, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-22-jdk-windowsservercore-1809, 25-ea-22-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
+SharedTags: 25-ea-22-jdk-windowsservercore, 25-ea-22-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-22-jdk, 25-ea-22, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 25-ea-21-jdk-nanoserver-ltsc2025, 25-ea-21-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
-SharedTags: 25-ea-21-jdk-nanoserver, 25-ea-21-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-22-jdk-nanoserver-ltsc2025, 25-ea-22-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-ea-22-jdk-nanoserver, 25-ea-22-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 25-ea-21-jdk-nanoserver-ltsc2022, 25-ea-21-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
-SharedTags: 25-ea-21-jdk-nanoserver, 25-ea-21-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-22-jdk-nanoserver-ltsc2022, 25-ea-22-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-ea-22-jdk-nanoserver, 25-ea-22-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 25-ea-21-jdk-nanoserver-1809, 25-ea-21-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
-SharedTags: 25-ea-21-jdk-nanoserver, 25-ea-21-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-22-jdk-nanoserver-1809, 25-ea-22-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
+SharedTags: 25-ea-22-jdk-nanoserver, 25-ea-22-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 89d4cf3aac108139233c973cfc7b72bdd4e448d7
+GitCommit: 02e8a2ffc4f72b17e5f42980b1025c14d17ac9f7
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/02e8a2f: Update 25 to 25-ea+22