### PR TITLE
chore: Bump to rust version 1.87.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,36 +1,36 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/34adb91f94a518191d60abfcc81f0f6b32db0ad8/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.86-bullseye, 1.86.0-bullseye, bullseye
+Tags: 1-bullseye, 1.87-bullseye, 1.87.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
+GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.86-slim-bullseye, 1.86.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.87-slim-bullseye, 1.87.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
+GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.86-bookworm, 1.86.0-bookworm, bookworm, 1, 1.86, 1.86.0, latest
+Tags: 1-bookworm, 1.87-bookworm, 1.87.0-bookworm, bookworm, 1, 1.87, 1.87.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
+GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.86-slim-bookworm, 1.86.0-slim-bookworm, slim-bookworm, 1-slim, 1.86-slim, 1.86.0-slim, slim
+Tags: 1-slim-bookworm, 1.87-slim-bookworm, 1.87.0-slim-bookworm, slim-bookworm, 1-slim, 1.87-slim, 1.87.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
+GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.20, 1.86-alpine3.20, 1.86.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.87-alpine3.20, 1.87.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
+GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.86-alpine3.21, 1.86.0-alpine3.21, alpine3.21, 1-alpine, 1.86-alpine, 1.86.0-alpine, alpine
+Tags: 1-alpine3.21, 1.87-alpine3.21, 1.87.0-alpine3.21, alpine3.21, 1-alpine, 1.87-alpine, 1.87.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 4c319c1b759ebc1f3452f2c3b62f75b509baa4e6
+GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
 Directory: stable/alpine3.21
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.87.0
https://blog.rust-lang.org/2025/05/15/Rust-1.87.0.html
