### PR TITLE
chore: update influxdb3 core and enterprise to 3.0.3

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,7 +6,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: cc4e58f76300b30b71d9fe854dbfdd4c8bee3f50
+GitCommit: a757de46ff8c42b19e05692e592c153bd52d2fc6
 
 Tags: 1.11, 1.11.8
 Architectures: amd64, arm64v8
@@ -48,10 +48,10 @@ Tags: 2-alpine, 2.7-alpine, 2.7.11-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.7/alpine
 
-Tags: 3-core, 3.0-core, 3.0.2-core, core
+Tags: 3-core, 3.0-core, 3.0.3-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.0-core
 
-Tags: 3-enterprise, 3.0-enterprise, 3.0.2-enterprise, enterprise
+Tags: 3-enterprise, 3.0-enterprise, 3.0.3-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.0-enterprise


### PR DESCRIPTION
CC @bnpfeife

[Release Notes](https://github.com/influxdata/influxdb/releases/tag/v3.0.3)