### PR TITLE
archlinux: Release 20250518.0.352066

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250511.0.348143
-GitCommit: ebb381b644ed8f3d3e1f4319975e18a65f638d66
-GitFetch: refs/tags/v20250511.0.348143
+Tags: latest, base, base-20250518.0.352066
+GitCommit: fc983c8f72b0684b9c8559999485ac1ac58c3c47
+GitFetch: refs/tags/v20250518.0.352066
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250511.0.348143
-GitCommit: ebb381b644ed8f3d3e1f4319975e18a65f638d66
-GitFetch: refs/tags/v20250511.0.348143
+Tags: base-devel, base-devel-20250518.0.352066
+GitCommit: fc983c8f72b0684b9c8559999485ac1ac58c3c47
+GitFetch: refs/tags/v20250518.0.352066
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250511.0.348143
-GitCommit: ebb381b644ed8f3d3e1f4319975e18a65f638d66
-GitFetch: refs/tags/v20250511.0.348143
+Tags: multilib-devel, multilib-devel-20250518.0.352066
+GitCommit: fc983c8f72b0684b9c8559999485ac1ac58c3c47
+GitFetch: refs/tags/v20250518.0.352066
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks