### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -8,23 +8,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Preston Carpenter (@timidger),
              Miriam Clark (@mgclark001),
              Ade Adetayo (@dadetayo),
-             Jason Jiannuo Pei (@peijiannuo)
+             Jason Jiannuo Pei (@peijiannuo),
+             Michael Mammo (@MichaelAbebaw)
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250428.1
+Tags: 2023, latest, 2023.7.20250512.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 8913d60448e6afb76886c1d50ae38d4fc6642512
+amd64-GitCommit: dacb9d52e9344a2977503cb4ecfc0879b69de878
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: f4e3821ed8835b7815c8acfcd935e98450daffe2
+arm64v8-GitCommit: a37632ff24fdf2d838fe84fc358d8844ecdcd365
 
-Tags: 2, 2.0.20250428.0
+Tags: 2, 2.0.20250512.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: cc127d58207194b46ffb9fa9a478501faee11a81
+amd64-GitCommit: 943ba6f33d9edd4b4dce773a0501b914af2d39f8
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 64377d80f10bc86b9bd835a491d85da84f44d7a4
+arm64v8-GitCommit: 9194c0e5c6b27fe9a7c575b783debdf946cafe84
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- rpm-4.11.3-48.amzn2.0.5
- python2-rpm-4.11.3-48.amzn2.0.5
- rpm-libs-4.11.3-48.amzn2.0.5
- rpm-build-libs-4.11.3-48.amzn2.0.5

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.7.20250512-0.amzn2023
- system-release-2023.7.20250512-0.amzn2023
- libxml2-2.10.4-1.amzn2023.0.10
- elfutils-libelf-0.188-3.amzn2023.0.3
- python3-3.9.22-1.amzn2023.0.1
- elfutils-libs-0.188-3.amzn2023.0.3
- sqlite-libs-3.40.0-1.amzn2023.0.5
- python3-libs-3.9.22-1.amzn2023.0.1
- elfutils-default-yama-scope-0.188-3.amzn2023.0.3