### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,14 +5,53 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 Builder: buildkit
 
+Tags: 28.2.0-rc.1-cli, 28-rc-cli, rc-cli, 28.2.0-rc.1-cli-alpine3.21
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+GitCommit: 8daf44089ceb1c4996c1985f1ae6a17a70d52dfc
+Directory: 28-rc/cli
+
+Tags: 28.2.0-rc.1-dind, 28-rc-dind, rc-dind, 28.2.0-rc.1-dind-alpine3.21, 28.2.0-rc.1, 28-rc, rc, 28.2.0-rc.1-alpine3.21
+Architectures: amd64, arm32v6, arm32v7, arm64v8
+GitCommit: 861512c7e2e4945f0878d043e55262dd330843a4
+Directory: 28-rc/dind
+
+Tags: 28.2.0-rc.1-dind-rootless, 28-rc-dind-rootless, rc-dind-rootless
+Architectures: amd64, arm64v8
+GitCommit: 8daf44089ceb1c4996c1985f1ae6a17a70d52dfc
+Directory: 28-rc/dind-rootless
+
+Tags: 28.2.0-rc.1-windowsservercore-ltsc2025, 28-rc-windowsservercore-ltsc2025, rc-windowsservercore-ltsc2025
+SharedTags: 28.2.0-rc.1-windowsservercore, 28-rc-windowsservercore, rc-windowsservercore
+Architectures: windows-amd64
+GitCommit: 8daf44089ceb1c4996c1985f1ae6a17a70d52dfc
+Directory: 28-rc/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+Builder: classic
+
+Tags: 28.2.0-rc.1-windowsservercore-ltsc2022, 28-rc-windowsservercore-ltsc2022, rc-windowsservercore-ltsc2022
+SharedTags: 28.2.0-rc.1-windowsservercore, 28-rc-windowsservercore, rc-windowsservercore
+Architectures: windows-amd64
+GitCommit: 8daf44089ceb1c4996c1985f1ae6a17a70d52dfc
+Directory: 28-rc/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+Builder: classic
+
+Tags: 28.2.0-rc.1-windowsservercore-1809, 28-rc-windowsservercore-1809, rc-windowsservercore-1809
+SharedTags: 28.2.0-rc.1-windowsservercore, 28-rc-windowsservercore, rc-windowsservercore
+Architectures: windows-amd64
+GitCommit: 8daf44089ceb1c4996c1985f1ae6a17a70d52dfc
+Directory: 28-rc/windows/windowsservercore-1809
+Constraints: windowsservercore-1809
+Builder: classic
+
 Tags: 28.1.1-cli, 28.1-cli, 28-cli, cli, 28.1.1-cli-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 3dba50562769bdfb0ed701bcfc2bbbde4304c72a
+GitCommit: d370b5c8bac568d44d901ed2243868d61b48d3a4
 Directory: 28/cli
 
 Tags: 28.1.1-dind, 28.1-dind, 28-dind, dind, 28.1.1-dind-alpine3.21, 28.1.1, 28.1, 28, latest, 28.1.1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 84fa8e735cf571bd16f439e8431ad23913dd19f4
+GitCommit: 52c8bfa9869c9c5605c6c03dc9a82cfe426ace77
 Directory: 28/dind
 
 Tags: 28.1.1-dind-rootless, 28.1-dind-rootless, 28-dind-rootless, dind-rootless
@@ -23,7 +62,7 @@ Directory: 28/dind-rootless
 Tags: 28.1.1-windowsservercore-ltsc2025, 28.1-windowsservercore-ltsc2025, 28-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 SharedTags: 28.1.1-windowsservercore, 28.1-windowsservercore, 28-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 3dba50562769bdfb0ed701bcfc2bbbde4304c72a
+GitCommit: d370b5c8bac568d44d901ed2243868d61b48d3a4
 Directory: 28/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 Builder: classic
@@ -31,7 +70,7 @@ Builder: classic
 Tags: 28.1.1-windowsservercore-ltsc2022, 28.1-windowsservercore-ltsc2022, 28-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 28.1.1-windowsservercore, 28.1-windowsservercore, 28-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 3dba50562769bdfb0ed701bcfc2bbbde4304c72a
+GitCommit: d370b5c8bac568d44d901ed2243868d61b48d3a4
 Directory: 28/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic
@@ -39,7 +78,7 @@ Builder: classic
 Tags: 28.1.1-windowsservercore-1809, 28.1-windowsservercore-1809, 28-windowsservercore-1809, windowsservercore-1809
 SharedTags: 28.1.1-windowsservercore, 28.1-windowsservercore, 28-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: 3dba50562769bdfb0ed701bcfc2bbbde4304c72a
+GitCommit: d370b5c8bac568d44d901ed2243868d61b48d3a4
 Directory: 28/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/861512c: Update 28-rc
- https://github.com/docker-library/docker/commit/8979f92: Merge pull request https://github.com/docker-library/docker/pull/536 from jnoordsij/add-ssl-ext
- https://github.com/docker-library/docker/commit/8daf440: Update 28-rc to 28.2.0-rc.1, buildx 0.23.0, compose 2.36.1
- https://github.com/docker-library/docker/commit/d370b5c: Update 28 to compose 2.36.1
- https://github.com/docker-library/docker/commit/52c8bfa: Add keyUsage extension to dind generated CA cert
- https://github.com/docker-library/docker/commit/b5332f2: Add extendedKeyUsage = serverAuth to dind generated server cert