### PR TITLE
Odoo: update 16.0-18.0 to release 20250520

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 4cb56b39df0cc06093b6185a609609e1cf264371
+GitCommit: 5d67b9585c0e29c9dccc0b3f484eedc4e5c46714
 
-Tags: 18.0-20250428, 18.0, 18, latest
+Tags: 18.0-20250520, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250428, 17.0, 17
+Tags: 17.0-20250520, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250428, 16.0, 16
+Tags: 16.0-20250520, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks