### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 0f32c04c976068ddf4b094044bd333ca46d42887
 Directory: 5.0
 
-Tags: 4.1.8, 4.1, 4, 4.1.8-jammy, 4.1-jammy, 4-jammy
+Tags: 4.1.9, 4.1, 4, 4.1.9-jammy, 4.1-jammy, 4-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
+GitCommit: 8b125f8e4cb082768e6d299130722ed3547e2206
 Directory: 4.1
 
 Tags: 4.0.17, 4.0, 4.0.17-jammy, 4.0-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/8b125f8: Update 4.1 to 4.1.9