### PR TITLE
Remove mips64le from buildpack-deps:trixie*

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -50,17 +50,17 @@ GitCommit: 2b3a8b7d1f8875865034be3bab98ddd737e37d5e
 Directory: debian/sid
 
 Tags: trixie-curl, testing-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie/curl
 
 Tags: trixie-scm, testing-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie/scm
 
 Tags: trixie, testing
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1f4fe499c668d9a2e1578aa8db4f0b2d14482cf5
 Directory: debian/trixie
 


### PR DESCRIPTION
See https://lists.debian.org/debian-devel-announce/2025/05/msg00004.html (https://github.com/docker-library/official-images/pull/19068#issuecomment-2896649696)