### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev16, 3.2-dev, 3.2-dev16-bookworm, 3.2-dev-bookworm
+Tags: 3.2-dev17, 3.2-dev, 3.2-dev17-bookworm, 3.2-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7cf95bc0438dd2aa3973dacf392c74a0c31abb2d
+GitCommit: 70c305c6007707c7647fb1d019632a9bbfb6a739
 Directory: 3.2
 
-Tags: 3.2-dev16-alpine, 3.2-dev-alpine, 3.2-dev16-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2-dev17-alpine, 3.2-dev-alpine, 3.2-dev17-alpine3.21, 3.2-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7cf95bc0438dd2aa3973dacf392c74a0c31abb2d
+GitCommit: 70c305c6007707c7647fb1d019632a9bbfb6a739
 Directory: 3.2/alpine
 
 Tags: 3.1.7, 3.1, latest, 3.1.7-bookworm, 3.1-bookworm, bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/70c305c: Update 3.2 to 3.2-dev17