### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/94ba89529124e6536c4939f43c6b37d7ff7e2cb4/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/197f60005260939bb46ddbd164f4302aa5ccd83d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 94ba89529124e6536c4939f43c6b37d7ff7e2cb4
+GitCommit: 197f60005260939bb46ddbd164f4302aa5ccd83d
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b5c9df2db88f6fb3cb22e05ecc02479c53b29199
+amd64-GitCommit: c48244ec06971ec9da046a065764cff4d92c3c25
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 761da8bcb2f5aac98cd67ecba0075f97bac42dd4
+arm32v5-GitCommit: a1fc4bd98528ef14a83426d66b657fc38b69a639
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 67c36f8180c307cf52c36318ba1cd23dfd1ac0cf
+arm32v6-GitCommit: 44be573e7ccb16d20357a8f0460927b23e17abed
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: d71b79cb7714e47032b6ed033ce7c5e0591cea04
+arm32v7-GitCommit: 98e088530cacc7fd6563546bd3a9f5ed7c111f0d
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6a2a9d4d534eb6e8fbbe99ebb43b58e17064a0dd
+arm64v8-GitCommit: 0fae1545c2d3265166c4c1e890a4a87ec947ce15
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: f9b7148533cadbfe624019600f9dc13cef705ec6
+i386-GitCommit: 54af1ded53fec80b0d5d910d400a4b74f1d813d5
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 93df7d3a592cf7318c20a774f1acd7996a64415f
+mips64le-GitCommit: b0d1a8ccee5fe5846f00cdc2b327a46c963ac25f
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 72152b094d10a10e92dc5ba865ddd9b5563a95c1
+ppc64le-GitCommit: 6b329e71f246ece267ffcea0f5247c58f3f6ea3a
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: ca4cc38e2da20b2c9f24733ed37701f71dc808e8
+riscv64-GitCommit: 04a3d55bdf7170e88f190653ae5dca55adb9f9e6
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: dc04ec292d79c84098f143676eb387a9d669e353
+s390x-GitCommit: 9582ee112321369d9dce8d332097e9756cf364dd
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/67f502d: Merge pull request https://github.com/docker-library/busybox/pull/223 from infosiftr/buildroot
- https://github.com/docker-library/busybox/commit/fab3090: Update buildroot to 2025.02.3
- https://github.com/docker-library/busybox/commit/382e964: Merge pull request https://github.com/docker-library/busybox/pull/221 from infosiftr/license
- https://github.com/docker-library/busybox/commit/a190d8e: Merge pull request https://github.com/docker-library/busybox/pull/222 from infosiftr/buildroot-2025.02.1