### PR TITLE
2025 Q2 maintaince release of MariaDB 10.5.29, 10.6.22, 10.11.13 11.4.7

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/58570c6f1988c033d052ea1442675f637d881706/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/9bc98d6905a26282e6209da20970d9d4b055a384/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
@@ -26,37 +26,42 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 853447019725b35685d5ec3c007096a266399bea
 Directory: 11.7
 
-Tags: 11.4.5-ubi9, 11.4-ubi9, lts-ubi9, 11.4.5-ubi, 11.4-ubi, lts-ubi
+Tags: 11.4.7-ubi9, 11.4-ubi9, lts-ubi9, 11.4.7-ubi, 11.4-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: a272347802e1764dd8c0e15ba2b2abfeeadb3bb6
 Directory: 11.4-ubi
 
-Tags: 11.4.5-noble, 11.4-noble, lts-noble, 11.4.5, 11.4, lts
+Tags: 11.4.7-noble, 11.4-noble, lts-noble, 11.4.7, 11.4, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: a272347802e1764dd8c0e15ba2b2abfeeadb3bb6
 Directory: 11.4
 
-Tags: 10.11.11-ubi9, 10.11-ubi9, 10-ubi9, 10.11.11-ubi, 10.11-ubi, 10-ubi
+Tags: 10.11.13-ubi9, 10.11-ubi9, 10-ubi9, 10.11.13-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: a272347802e1764dd8c0e15ba2b2abfeeadb3bb6
 Directory: 10.11-ubi
 
-Tags: 10.11.11-jammy, 10.11-jammy, 10-jammy, 10.11.11, 10.11, 10
+Tags: 10.11.13-jammy, 10.11-jammy, 10-jammy, 10.11.13, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: a272347802e1764dd8c0e15ba2b2abfeeadb3bb6
 Directory: 10.11
 
-Tags: 10.6.21-ubi9, 10.6-ubi9, 10.6.21-ubi, 10.6-ubi
+Tags: 10.6.22-ubi9, 10.6-ubi9, 10.6.22-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: c5669903a1c1f711039de61e480fbfd3549e1f86
 Directory: 10.6-ubi
 
-Tags: 10.6.21-focal, 10.6-focal, 10.6.21, 10.6
+Tags: 10.6.22-jammy, 10.6-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: 9bc98d6905a26282e6209da20970d9d4b055a384
+Directory: 10.6-jammy
+
+Tags: 10.6.22-focal, 10.6-focal, 10.6.22, 10.6
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: c5669903a1c1f711039de61e480fbfd3549e1f86
 Directory: 10.6
 
-Tags: 10.5.28-focal, 10.5-focal, 10.5.28, 10.5
+Tags: 10.5.29-focal, 10.5-focal, 10.5.29, 10.5
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3bfeae408bde492aad0444cbb13d55a70ceec6e5
+GitCommit: c5669903a1c1f711039de61e480fbfd3549e1f86
 Directory: 10.5


### PR DESCRIPTION
Notably skips the 10.11.12/11.4.6 due to a last minute serious regression.

As Ubuntu 20.04 is EOL the 10.6 release includes a 10.6-jammy release. Per #MariaDB/mariadb-docker/issues/553 the next release on 10.6 will be jammy only.

The 10.5 is the last release of its series so this isn't getting the same treatment.