### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -11,12 +11,12 @@ GitCommit: a842bfea737b1127a922a27d768df7e382f740af
 Directory: 15
 # Docker EOL: 2026-10-25
 
-# Last Modified: 2024-08-01
-Tags: 14.2.0, 14.2, 14, 14.2.0-bookworm, 14.2-bookworm, 14-bookworm
+# Last Modified: 2025-05-23
+Tags: 14.3.0, 14.3, 14, 14.3.0-bookworm, 14.3-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 22c26a9e4edb4ce4f7676dfa100afc80fc2ccbea
+GitCommit: d262936418fbf062bb25907d5126a178578ab58b
 Directory: 14
-# Docker EOL: 2026-02-01
+# Docker EOL: 2026-11-23
 
 # Last Modified: 2024-05-21
 Tags: 13.3.0, 13.3, 13, 13.3.0-bookworm, 13.3-bookworm, 13-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/d262936: Update 14 to 14.3.0