### PR TITLE
Update fluentd (remove `apt-get upgrade`)

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -6,14 +6,14 @@ GitRepo: https://github.com/fluent/fluentd-docker-image.git
 Tags: v1.16.9-1.0, v1.16-1
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 GitFetch: refs/heads/v1.16
-GitCommit: 35463e85d2b17fbb34e82345d253e62ad0af710b
+GitCommit: 505a1af75b4a4adb40d576df7b18cebab853264e
 Directory: v1.16/alpine
 
 # Debian images
 Tags: v1.16.9-debian-1.0, v1.16-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitFetch: refs/heads/v1.16
-GitCommit: 35463e85d2b17fbb34e82345d253e62ad0af710b
+GitCommit: 505a1af75b4a4adb40d576df7b18cebab853264e
 Directory: v1.16/debian
 
 # Alpine images


### PR DESCRIPTION
Follow-up to https://github.com/docker-library/official-images/pull/19076#issuecomment-2901911040 (https://github.com/fluent/fluentd-docker-image/pull/438).