### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,75 +4,75 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 25-ea-23-jdk-oraclelinux9, 25-ea-23-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-23-jdk-oracle, 25-ea-23-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-23-jdk, 25-ea-23, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-24-jdk-oraclelinux9, 25-ea-24-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-24-jdk-oracle, 25-ea-24-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-24-jdk, 25-ea-24, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-23-jdk-oraclelinux8, 25-ea-23-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-24-jdk-oraclelinux8, 25-ea-24-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-23-jdk-bookworm, 25-ea-23-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-24-jdk-bookworm, 25-ea-24-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-23-jdk-slim-bookworm, 25-ea-23-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-23-jdk-slim, 25-ea-23-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-24-jdk-slim-bookworm, 25-ea-24-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-24-jdk-slim, 25-ea-24-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-23-jdk-bullseye, 25-ea-23-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-24-jdk-bullseye, 25-ea-24-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-23-jdk-slim-bullseye, 25-ea-23-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-24-jdk-slim-bullseye, 25-ea-24-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-23-jdk-windowsservercore-ltsc2025, 25-ea-23-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
-SharedTags: 25-ea-23-jdk-windowsservercore, 25-ea-23-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-23-jdk, 25-ea-23, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-24-jdk-windowsservercore-ltsc2025, 25-ea-24-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-ea-24-jdk-windowsservercore, 25-ea-24-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-24-jdk, 25-ea-24, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 25-ea-23-jdk-windowsservercore-ltsc2022, 25-ea-23-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-23-jdk-windowsservercore, 25-ea-23-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-23-jdk, 25-ea-23, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-24-jdk-windowsservercore-ltsc2022, 25-ea-24-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-24-jdk-windowsservercore, 25-ea-24-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-24-jdk, 25-ea-24, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-23-jdk-windowsservercore-1809, 25-ea-23-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
-SharedTags: 25-ea-23-jdk-windowsservercore, 25-ea-23-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-23-jdk, 25-ea-23, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-24-jdk-windowsservercore-1809, 25-ea-24-windowsservercore-1809, 25-ea-jdk-windowsservercore-1809, 25-ea-windowsservercore-1809, 25-jdk-windowsservercore-1809, 25-windowsservercore-1809
+SharedTags: 25-ea-24-jdk-windowsservercore, 25-ea-24-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-24-jdk, 25-ea-24, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/windows/windowsservercore-1809
 Constraints: windowsservercore-1809
 
-Tags: 25-ea-23-jdk-nanoserver-ltsc2025, 25-ea-23-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
-SharedTags: 25-ea-23-jdk-nanoserver, 25-ea-23-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-24-jdk-nanoserver-ltsc2025, 25-ea-24-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-ea-24-jdk-nanoserver, 25-ea-24-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 25-ea-23-jdk-nanoserver-ltsc2022, 25-ea-23-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
-SharedTags: 25-ea-23-jdk-nanoserver, 25-ea-23-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-24-jdk-nanoserver-ltsc2022, 25-ea-24-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-ea-24-jdk-nanoserver, 25-ea-24-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 25-ea-23-jdk-nanoserver-1809, 25-ea-23-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
-SharedTags: 25-ea-23-jdk-nanoserver, 25-ea-23-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-24-jdk-nanoserver-1809, 25-ea-24-nanoserver-1809, 25-ea-jdk-nanoserver-1809, 25-ea-nanoserver-1809, 25-jdk-nanoserver-1809, 25-nanoserver-1809
+SharedTags: 25-ea-24-jdk-nanoserver, 25-ea-24-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 8439e8d6ea8b201c9520bba03ba5eb8c4ff71309
+GitCommit: 6e232089a1c9fae7f1c52fb019389c22322b7b65
 Directory: 25/jdk/windows/nanoserver-1809
 Constraints: nanoserver-1809, windowsservercore-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/6e23208: Update 25 to 25-ea+24