### PR TITLE
Add images for ROS 2 Kilted Kaiju

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -73,6 +73,28 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 
 ################################################################################
+# Release: kilted
+
+########################################
+# Distro: ubuntu:noble
+
+Tags: kilted-ros-core, kilted-ros-core-noble
+Architectures: amd64, arm64v8
+GitCommit: 1b70e5cc37eb565bdf4b0a60ee02d1e1a52df0b4
+Directory: ros/kilted/ubuntu/noble/ros-core
+
+Tags: kilted-ros-base, kilted-ros-base-noble, kilted, latest
+Architectures: amd64, arm64v8
+GitCommit: 1b70e5cc37eb565bdf4b0a60ee02d1e1a52df0b4
+Directory: ros/kilted/ubuntu/noble/ros-base
+
+Tags: kilted-perception, kilted-perception-noble
+Architectures: amd64, arm64v8
+GitCommit: 1b70e5cc37eb565bdf4b0a60ee02d1e1a52df0b4
+Directory: ros/kilted/ubuntu/noble/perception
+
+
+################################################################################
 # Release: rolling
 
 ########################################

--- a/library/ros
+++ b/library/ros
@@ -80,17 +80,17 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: kilted-ros-core, kilted-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 1b70e5cc37eb565bdf4b0a60ee02d1e1a52df0b4
+GitCommit: b835a530495c0b411a0d15db858710a2748ee0a0
 Directory: ros/kilted/ubuntu/noble/ros-core
 
-Tags: kilted-ros-base, kilted-ros-base-noble, kilted, latest
+Tags: kilted-ros-base, kilted-ros-base-noble, kilted
 Architectures: amd64, arm64v8
-GitCommit: 1b70e5cc37eb565bdf4b0a60ee02d1e1a52df0b4
+GitCommit: b835a530495c0b411a0d15db858710a2748ee0a0
 Directory: ros/kilted/ubuntu/noble/ros-base
 
 Tags: kilted-perception, kilted-perception-noble
 Architectures: amd64, arm64v8
-GitCommit: 1b70e5cc37eb565bdf4b0a60ee02d1e1a52df0b4
+GitCommit: b835a530495c0b411a0d15db858710a2748ee0a0
 Directory: ros/kilted/ubuntu/noble/perception
 
 


### PR DESCRIPTION
ROS Kilted was released on Friday May 23rd, 2025.

Cross-referencing: osrf/docker_images#803
Cross-referencing: osrf/docker_images#804