### PR TITLE
archlinux: Release 20250525.0.354646

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250518.0.352066
-GitCommit: fc983c8f72b0684b9c8559999485ac1ac58c3c47
-GitFetch: refs/tags/v20250518.0.352066
+Tags: latest, base, base-20250525.0.354646
+GitCommit: 560d50ec5c619455df1b4d015bf93e8cf820f28b
+GitFetch: refs/tags/v20250525.0.354646
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250518.0.352066
-GitCommit: fc983c8f72b0684b9c8559999485ac1ac58c3c47
-GitFetch: refs/tags/v20250518.0.352066
+Tags: base-devel, base-devel-20250525.0.354646
+GitCommit: 560d50ec5c619455df1b4d015bf93e8cf820f28b
+GitFetch: refs/tags/v20250525.0.354646
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250518.0.352066
-GitCommit: fc983c8f72b0684b9c8559999485ac1ac58c3c47
-GitFetch: refs/tags/v20250518.0.352066
+Tags: multilib-devel, multilib-devel-20250525.0.354646
+GitCommit: 560d50ec5c619455df1b4d015bf93e8cf820f28b
+GitFetch: refs/tags/v20250525.0.354646
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks