### PR TITLE
[varnish] update vmod-dynamic to 7.7

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,16 +1,16 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/bb0f2990f25fcd852f3fd66f7e7bc254c436226d/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/ed86c8d78292bb13fe129ba5dcccfd8d11ed1481/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 7.7.1, 7, 7.7, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: ea97ed35f2b0eb438ccd6a9250c36567686bfb4a
+GitCommit: ed86c8d78292bb13fe129ba5dcccfd8d11ed1481
 
 Tags: fresh-alpine, 7.7.1-alpine, 7-alpine, 7.7-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: ea97ed35f2b0eb438ccd6a9250c36567686bfb4a
+GitCommit: ed86c8d78292bb13fe129ba5dcccfd8d11ed1481
 
 Tags: old, 7.6.3, 7.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
we were previously pointing at a 7.6 commit, but now there's a proper branch, so let's use it