### PR TITLE
Bump Traefik to v2.11.25 and v3.4.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -27,33 +27,6 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
 Directory: v3.4/alpine
 
-Tags: v3.3.7-windowsservercore-ltsc2022, 3.3.7-windowsservercore-ltsc2022, v3.3-windowsservercore-ltsc2022, 3.3-windowsservercore-ltsc2022, saintnectaire-windowsservercore-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
-Directory: v3.3/windows/servercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: v3.3.7-windowsservercore-1809, 3.3.7-windowsservercore-1809, v3.3-windowsservercore-1809, 3.3-windowsservercore-1809, saintnectaire-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
-Directory: v3.3/windows/1809
-Constraints: windowsservercore-1809
-
-Tags: v3.3.7-nanoserver-ltsc2022, 3.3.7-nanoserver-ltsc2022, v3.3-nanoserver-ltsc2022, 3.3-nanoserver-ltsc2022, saintnectaire-nanoserver-ltsc2022
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
-Directory: v3.3/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: v3.3.7, 3.3.7, v3.3, 3.3, saintnectaire
-Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f85d75511c3d417080b2d29bda42b794c43f4aac
-Directory: v3.3/alpine
-
 Tags: v2.11.25-windowsservercore-ltsc2022, 2.11.25-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.25](https://github.com/traefik/traefik/releases/tag/v2.11.25) and [v3.4.1](https://github.com/traefik/traefik/releases/tag/v3.4.1).

/cc @nmengin @mmatur @rtribotte