### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,35 +1,45 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/59112301dd30c2377084770b78fa9cc33fdfb759/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/f60ffd8842e34ca4d65267b72139c32dc821736b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.2-dev17, 3.2-dev, 3.2-dev17-bookworm, 3.2-dev-bookworm
+Tags: 3.3-dev0, 3.3-dev, 3.3-dev0-bookworm, 3.3-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 70c305c6007707c7647fb1d019632a9bbfb6a739
+GitCommit: f60ffd8842e34ca4d65267b72139c32dc821736b
+Directory: 3.3
+
+Tags: 3.3-dev0-alpine, 3.3-dev-alpine, 3.3-dev0-alpine3.21, 3.3-dev-alpine3.21
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: f60ffd8842e34ca4d65267b72139c32dc821736b
+Directory: 3.3/alpine
+
+Tags: 3.2.0, 3.2, latest, lts, 3.2.0-bookworm, 3.2-bookworm, bookworm, lts-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 788f34715b0b1ef626761dcca1a4e996316a9c6e
 Directory: 3.2
 
-Tags: 3.2-dev17-alpine, 3.2-dev-alpine, 3.2-dev17-alpine3.21, 3.2-dev-alpine3.21
+Tags: 3.2.0-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.0-alpine3.21, 3.2-alpine3.21, alpine3.21, lts-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 70c305c6007707c7647fb1d019632a9bbfb6a739
+GitCommit: 788f34715b0b1ef626761dcca1a4e996316a9c6e
 Directory: 3.2/alpine
 
-Tags: 3.1.7, 3.1, latest, 3.1.7-bookworm, 3.1-bookworm, bookworm
+Tags: 3.1.7, 3.1, 3.1.7-bookworm, 3.1-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
 Directory: 3.1
 
-Tags: 3.1.7-alpine, 3.1-alpine, alpine, 3.1.7-alpine3.21, 3.1-alpine3.21, alpine3.21
+Tags: 3.1.7-alpine, 3.1-alpine, 3.1.7-alpine3.21, 3.1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
 Directory: 3.1/alpine
 
-Tags: 3.0.10, 3.0, lts, 3.0.10-bookworm, 3.0-bookworm, lts-bookworm
+Tags: 3.0.10, 3.0, 3.0.10-bookworm, 3.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
 Directory: 3.0
 
-Tags: 3.0.10-alpine, 3.0-alpine, lts-alpine, 3.0.10-alpine3.21, 3.0-alpine3.21, lts-alpine3.21
+Tags: 3.0.10-alpine, 3.0-alpine, 3.0.10-alpine3.21, 3.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
 Directory: 3.0/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fa46153: Merge pull request https://github.com/docker-library/haproxy/pull/246 from infosiftr/3.3
- https://github.com/docker-library/haproxy/commit/f60ffd8: Add 3.3, update "latest" and "lts" to 3.2
- https://github.com/docker-library/haproxy/commit/788f347: Update 3.2 to 3.2.0