### PR TITLE
Update Spark 3.5 from 3.5.5 to 3.5.6

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -41,42 +41,42 @@ Architectures: amd64, arm64v8
 GitCommit: 4bd1dbce94797b5b387b784db6b378069a8b6328
 Directory: ./4.0.0/scala2.13-java17-python3-r-ubuntu
 
-Tags: 3.5.5-scala2.12-java17-python3-ubuntu, 3.5.5-java17-python3, 3.5.5-java17
+Tags: 3.5.6-scala2.12-java17-python3-ubuntu, 3.5.6-java17-python3, 3.5.6-java17
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java17-python3-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java17-python3-ubuntu
 
-Tags: 3.5.5-scala2.12-java17-r-ubuntu, 3.5.5-java17-r
+Tags: 3.5.6-scala2.12-java17-r-ubuntu, 3.5.6-java17-r
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java17-r-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java17-r-ubuntu
 
-Tags: 3.5.5-scala2.12-java17-ubuntu, 3.5.5-java17-scala
+Tags: 3.5.6-scala2.12-java17-ubuntu, 3.5.6-java17-scala
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java17-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java17-ubuntu
 
-Tags: 3.5.5-scala2.12-java17-python3-r-ubuntu
+Tags: 3.5.6-scala2.12-java17-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java17-python3-r-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java17-python3-r-ubuntu
 
-Tags: 3.5.5-scala2.12-java11-python3-ubuntu, 3.5.5-python3, 3.5.5
+Tags: 3.5.6-scala2.12-java11-python3-ubuntu, 3.5.6-python3, 3.5.6
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java11-python3-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java11-python3-ubuntu
 
-Tags: 3.5.5-scala2.12-java11-r-ubuntu, 3.5.5-r
+Tags: 3.5.6-scala2.12-java11-r-ubuntu, 3.5.6-r
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java11-r-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java11-r-ubuntu
 
-Tags: 3.5.5-scala2.12-java11-ubuntu, 3.5.5-scala
+Tags: 3.5.6-scala2.12-java11-ubuntu, 3.5.6-scala
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java11-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java11-ubuntu
 
-Tags: 3.5.5-scala2.12-java11-python3-r-ubuntu
+Tags: 3.5.6-scala2.12-java11-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 86f243f6df77cf247f8eb9931558d719e0c56144
-Directory: ./3.5.5/scala2.12-java11-python3-r-ubuntu
+GitCommit: c264d48dc510018095700ed33e700ccc34268bf2
+Directory: ./3.5.6/scala2.12-java11-python3-r-ubuntu


### PR DESCRIPTION
This PR proposes to update Spark 3.5 to its latest 3.5.6.