### PR TITLE
New Redis versions 8.0.2, 7.4.4, 7.2.9

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -5,36 +5,36 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Dagan Sandler <dagan.sandler@redis.com> (@dagansandler)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.0.1, 8.0, 8, 8.0.1-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.0.2, 8.0, 8, 8.0.2-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe864e383ae7c5c891a694f9e0c16f8459a62234
+GitCommit: 5151eacdaf46f588f330c2e45fbed7fa0a7c192e
 GitFetch: refs/heads/release/8.0
 Directory: debian
 
-Tags: 8.0.1-alpine, 8.0-alpine, 8-alpine, 8.0.1-alpine3.21, 8.0-alpine3.21, 8-alpine3.21, alpine, alpine3.21
+Tags: 8.0.2-alpine, 8.0-alpine, 8-alpine, 8.0.2-alpine3.21, 8.0-alpine3.21, 8-alpine3.21, alpine, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe864e383ae7c5c891a694f9e0c16f8459a62234
+GitCommit: 5151eacdaf46f588f330c2e45fbed7fa0a7c192e
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
-Tags: 7.4.3, 7.4, 7, 7.4.3-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.4, 7.4, 7, 7.4.4-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 27cd071c3e9d903a19c79577ddb82fb322ef5ed6
+GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
 Directory: 7.4/debian
 
-Tags: 7.4.3-alpine, 7.4-alpine, 7-alpine, 7.4.3-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.4-alpine, 7.4-alpine, 7-alpine, 7.4.4-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 27cd071c3e9d903a19c79577ddb82fb322ef5ed6
+GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
 Directory: 7.4/alpine
 
-Tags: 7.2.8, 7.2, 7.2.8-bookworm, 7.2-bookworm
+Tags: 7.2.9, 7.2, 7.2.9-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 27cd071c3e9d903a19c79577ddb82fb322ef5ed6
+GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
 Directory: 7.2/debian
 
-Tags: 7.2.8-alpine, 7.2-alpine, 7.2.8-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.9-alpine, 7.2-alpine, 7.2.9-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 27cd071c3e9d903a19c79577ddb82fb322ef5ed6
+GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
 Directory: 7.2/alpine
 
 Tags: 6.2.18, 6.2, 6, 6.2.18-bookworm, 6.2-bookworm, 6-bookworm


### PR DESCRIPTION
Also documentation PR to reflect changes in the upcoming Redis image version 8.0.2 https://github.com/docker-library/docs/pull/2579