### PR TITLE
Add JRuby 10.0-dev and 9.4-dev images

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -3,7 +3,7 @@ Maintainers: JRuby Admin <admin@jruby.org> (@jruby),
              Thomas E Enebo <tom.enebo@gmail.com> (@enebo)
 GitRepo: https://github.com/jruby/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: fc0883dada1cb29607c6a8aa7edce14aac7642e0
+GitCommit: 5112552613c233f36b798ba480cbddd86bae614d
 
 Tags: latest, 10, 10.0, 10.0.0, 10.0-jre, 10.0-jre21, 10.0.0-jre, 10.0.0-jre21, 10.0.0.1, 10.0.0.1-jre, 10.0.0.1-jre21
 Architectures: amd64, arm64v8
@@ -84,4 +84,52 @@ Directory: 9.3/jdk21
 Tags: 9.3-jre21, 9.3.15-jre21, 9.3.15.0-jre21
 Architectures: amd64, arm64v8
 Directory: 9.3/jre21
+
+Tags: 10.0-dev-jre21
+Architectures: amd64, arm64v8
+Directory: 10.0-dev/jre21
+
+Tags: 10.0-dev-jdk21
+Architectures: amd64, arm64v8
+Directory: 10.0-dev/jdk21
+
+Tags: 10.0-dev-jre24
+Architectures: amd64, arm64v8
+Directory: 10.0-dev/jre24
+
+Tags: 10.0-dev-jdk24
+Architectures: amd64, arm64v8
+Directory: 10.0-dev/jdk24
+
+Tags: 9.4-dev-jre8
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jre8
+
+Tags: 9.4-dev-jdk8
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jdk8
+
+Tags: 9.4-dev-jre11
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jre11
+
+Tags: 9.4-dev-jdk11
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jdk11
+
+Tags: 9.4-dev-jdk17
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jdk17
+
+Tags: 9.4-dev-jre17
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jre17
+
+Tags: 9.4-dev-jdk21
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jdk21
+
+Tags: 9.4-dev-jre21
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jre21
 


### PR DESCRIPTION
This adds development snapshot images for JRuby 10.0.x and 9.4.x. They will be updated periodically as needed.

If there's a better pattern to follow for pushing development images or snapshots or nightly builds to Hub, please link me to appropriate docs.