### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/f60ffd8842e34ca4d65267b72139c32dc821736b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/c153740fe581f5c43c6c5571acd00055e49e478d/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,75 +6,70 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 3.3-dev0, 3.3-dev, 3.3-dev0-bookworm, 3.3-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f60ffd8842e34ca4d65267b72139c32dc821736b
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.3
 
 Tags: 3.3-dev0-alpine, 3.3-dev-alpine, 3.3-dev0-alpine3.21, 3.3-dev-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f60ffd8842e34ca4d65267b72139c32dc821736b
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.3/alpine
 
 Tags: 3.2.0, 3.2, latest, lts, 3.2.0-bookworm, 3.2-bookworm, bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 788f34715b0b1ef626761dcca1a4e996316a9c6e
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.2
 
 Tags: 3.2.0-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.0-alpine3.21, 3.2-alpine3.21, alpine3.21, lts-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 788f34715b0b1ef626761dcca1a4e996316a9c6e
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.2/alpine
 
 Tags: 3.1.7, 3.1, 3.1.7-bookworm, 3.1-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.1
 
 Tags: 3.1.7-alpine, 3.1-alpine, 3.1.7-alpine3.21, 3.1-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 923a92620c9c0277c5d52f3c8734fefe612cadfd
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.1/alpine
 
 Tags: 3.0.10, 3.0, 3.0.10-bookworm, 3.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.0
 
 Tags: 3.0.10-alpine, 3.0-alpine, 3.0.10-alpine3.21, 3.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dccf0f4e3aa2c74e30a89954cba69305e52edf7f
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.0/alpine
 
 Tags: 2.8.15, 2.8, 2.8.15-bookworm, 2.8-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 82d8d0e917b2dbba726f6cf853688d1bb6eed5fc
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.8
 
 Tags: 2.8.15-alpine, 2.8-alpine, 2.8.15-alpine3.21, 2.8-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 82d8d0e917b2dbba726f6cf853688d1bb6eed5fc
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.8/alpine
 
 Tags: 2.6.22, 2.6, 2.6.22-bookworm, 2.6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b2272eca1be0415af128438e91ffb721d758eef7
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.6
 
 Tags: 2.6.22-alpine, 2.6-alpine, 2.6.22-alpine3.21, 2.6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b2272eca1be0415af128438e91ffb721d758eef7
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.6/alpine
 
 Tags: 2.4.29, 2.4, 2.4.29-bookworm, 2.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d5e3fa1fab9349226162c5a160ed667d0f62e688
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.4
 
 Tags: 2.4.29-alpine, 2.4-alpine, 2.4.29-alpine3.21, 2.4-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d5e3fa1fab9349226162c5a160ed667d0f62e688
+GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.4/alpine
-
-Tags: 2.2.34, 2.2, 2.2.34-bullseye, 2.2-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: fcee7759df612f1047d4b41b42c9f628dac925bf
-Directory: 2.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/2bb080e: Merge pull request https://github.com/docker-library/haproxy/pull/247 from TimWolla/2.2-eol
- https://github.com/docker-library/haproxy/commit/c153740: Remove EOL 2.2