### PR TITLE
alpine: add 3.22.0 as latest, remove EOL 3.18

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,7 +14,20 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.21.3, 3.21, 3, latest
+Tags: 3.22.0, 3.22, 3, latest
+Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
+GitFetch: refs/heads/v3.22
+GitCommit: 5213c5a71c73d39d5896657909e753effb1c05ff
+arm64v8-Directory: aarch64/
+arm32v6-Directory: armhf/
+arm32v7-Directory: armv7/
+ppc64le-Directory: ppc64le/
+riscv64-Directory: riscv64/
+s390x-Directory: s390x/
+i386-Directory: x86/
+amd64-Directory: x86_64/
+
+Tags: 3.21.3, 3.21
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.21
 GitCommit: 17fe3d1e2d2cbf54d745139eab749c252e35b883
@@ -44,18 +57,6 @@ Tags: 3.19.7, 3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.19
 GitCommit: 7cfdb838c6f47bb3845c25f1674a9c3a44d8bafb
-arm64v8-Directory: aarch64/
-arm32v6-Directory: armhf/
-arm32v7-Directory: armv7/
-ppc64le-Directory: ppc64le/
-s390x-Directory: s390x/
-i386-Directory: x86/
-amd64-Directory: x86_64/
-
-Tags: 3.18.12, 3.18
-Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
-GitFetch: refs/heads/v3.18
-GitCommit: f92f1c2b3b7025f08b05dc11b70534568a973903
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Closes #19034