### PR TITLE
[oraclelinux] Release Oracle Linux 9 Update 6

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: dcecdbc89593ae8c411dc5934612db19e80845d4
+amd64-GitCommit: 73c1147a780418c151030003d2c6d8136a7c863d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6195741453f7b141203203a43d0e0a4db8530c22
+arm64v8-GitCommit: 8d5f530c006cbc52e1ac9340ddbe0d80ef804c3e
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for Oracle Linux 9 Update 6.

See the following for details:

https://docs.oracle.com/en/operating-systems/oracle-linux/9/relnotes9.6/


Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
