### PR TITLE
Update hello-world

### DIFF
--- a/library/hello-world
+++ b/library/hello-world
@@ -1,9 +1,9 @@
-# this file is generated via https://github.com/docker-library/hello-world/blob/08987c71f648c985f54be2a80bed4223cbd0723b/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/hello-world/blob/d2ad81cd7a88c0114e152da6a3849aba64a68610/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/hello-world.git
-GitCommit: 08987c71f648c985f54be2a80bed4223cbd0723b
+GitCommit: d2ad81cd7a88c0114e152da6a3849aba64a68610
 
 Tags: linux
 SharedTags: latest
@@ -42,10 +42,3 @@ Architectures: windows-amd64
 windows-amd64-GitCommit: c816763efda4774cc0c628dca3c7dbd93c099928
 windows-amd64-Directory: amd64/hello-world/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022
-
-Tags: nanoserver-1809
-SharedTags: nanoserver, latest
-Architectures: windows-amd64
-windows-amd64-GitCommit: c816763efda4774cc0c628dca3c7dbd93c099928
-windows-amd64-Directory: amd64/hello-world/nanoserver-1809
-Constraints: nanoserver-1809


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/hello-world/commit/8ffde12: Merge pull request https://github.com/docker-library/hello-world/pull/128 from infosiftr/rm-1809
- https://github.com/docker-library/hello-world/commit/d2ad81c: Remove Windows Server 2019 / 1809
- https://github.com/docker-library/hello-world/commit/5b5487f: Update shebang from /bin/bash to /usr/bin/env bash
- https://github.com/docker-library/hello-world/commit/337f857: Merge pull request https://github.com/docker-library/hello-world/pull/127 from infosiftr/arm64-host
- https://github.com/docker-library/hello-world/commit/f689a8d: Support building on an arm64 host too