### PR TITLE
Update irssi

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/jessfraz/irssi/blob/47d6f81f1b7da4d6e4b9eb0529085f51421562fb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/jessfraz/irssi/blob/0b6d8e4fba6d47b66ab7a2030d91bf2c4c3c981a/generate-stackbrew-library.sh
 
 Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
@@ -9,7 +9,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: b8ea417aaa1a29a6003756627d748450a5bf6abe
 Directory: debian
 
-Tags: 1.4.5-alpine, 1.4-alpine, 1-alpine, alpine, 1.4.5-alpine3.21, 1.4-alpine3.21, 1-alpine3.21, alpine3.21
+Tags: 1.4.5-alpine, 1.4-alpine, 1-alpine, alpine, 1.4.5-alpine3.22, 1.4-alpine3.22, 1-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1581d0c09544a0bd8de42ba3d185956be6a9935c
+GitCommit: 48233da7bca13e68f9792da75119fe595f6192c9
 Directory: alpine


### PR DESCRIPTION
Changes:

- https://github.com/jessfraz/irssi/commit/48233da: Update to Alpine 3.22 (https://github.com/jessfraz/irssi/pull/36)
- https://github.com/jessfraz/irssi/commit/0b6d8e4: Update shebang from /bin/bash to /usr/bin/env bash