### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.3
 
-Tags: 3.3-dev0-alpine, 3.3-dev-alpine, 3.3-dev0-alpine3.21, 3.3-dev-alpine3.21
+Tags: 3.3-dev0-alpine, 3.3-dev-alpine, 3.3-dev0-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 3.3/alpine
 
 Tags: 3.2.0, 3.2, latest, lts, 3.2.0-bookworm, 3.2-bookworm, bookworm, lts-bookworm
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.2
 
-Tags: 3.2.0-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.0-alpine3.21, 3.2-alpine3.21, alpine3.21, lts-alpine3.21
+Tags: 3.2.0-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.0-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 3.2/alpine
 
 Tags: 3.1.7, 3.1, 3.1.7-bookworm, 3.1-bookworm
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.1
 
-Tags: 3.1.7-alpine, 3.1-alpine, 3.1.7-alpine3.21, 3.1-alpine3.21
+Tags: 3.1.7-alpine, 3.1-alpine, 3.1.7-alpine3.22, 3.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 3.1/alpine
 
 Tags: 3.0.10, 3.0, 3.0.10-bookworm, 3.0-bookworm
@@ -39,9 +39,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 3.0
 
-Tags: 3.0.10-alpine, 3.0-alpine, 3.0.10-alpine3.21, 3.0-alpine3.21
+Tags: 3.0.10-alpine, 3.0-alpine, 3.0.10-alpine3.22, 3.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 3.0/alpine
 
 Tags: 2.8.15, 2.8, 2.8.15-bookworm, 2.8-bookworm
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.8
 
-Tags: 2.8.15-alpine, 2.8-alpine, 2.8.15-alpine3.21, 2.8-alpine3.21
+Tags: 2.8.15-alpine, 2.8-alpine, 2.8.15-alpine3.22, 2.8-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 2.8/alpine
 
 Tags: 2.6.22, 2.6, 2.6.22-bookworm, 2.6-bookworm
@@ -59,9 +59,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.6
 
-Tags: 2.6.22-alpine, 2.6-alpine, 2.6.22-alpine3.21, 2.6-alpine3.21
+Tags: 2.6.22-alpine, 2.6-alpine, 2.6.22-alpine3.22, 2.6-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 2.6/alpine
 
 Tags: 2.4.29, 2.4, 2.4.29-bookworm, 2.4-bookworm
@@ -69,7 +69,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
 Directory: 2.4
 
-Tags: 2.4.29-alpine, 2.4-alpine, 2.4.29-alpine3.21, 2.4-alpine3.21
+Tags: 2.4.29-alpine, 2.4-alpine, 2.4.29-alpine3.22, 2.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/12770dc: Merge pull request https://github.com/docker-library/haproxy/pull/248 from infosiftr/alpine3.22
- https://github.com/docker-library/haproxy/commit/3117d24: Update to Alpine 3.22