### PR TITLE
[ros] install dedicated deb to setup apt gpg key instead of installing keys the old way

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: noetic-ros-core, noetic-ros-core-focal
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: b525e9ef659ce448db6150fd5407ef62b2c5b265
 Directory: ros/noetic/ubuntu/focal/ros-core
 
 Tags: noetic-ros-base, noetic-ros-base-focal, noetic
@@ -36,7 +36,7 @@ Directory: ros/noetic/ubuntu/focal/perception
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble
@@ -58,7 +58,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
@@ -80,7 +80,7 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: kilted-ros-core, kilted-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/kilted/ubuntu/noble/ros-core
 
 Tags: kilted-ros-base, kilted-ros-base-noble, kilted
@@ -102,7 +102,7 @@ Directory: ros/kilted/ubuntu/noble/perception
 
 Tags: rolling-ros-core, rolling-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: 6610eeddd6026e93db33578f6967bac23fa21ac0
+GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
 Directory: ros/rolling/ubuntu/noble/ros-core
 
 Tags: rolling-ros-base, rolling-ros-base-noble, rolling


### PR DESCRIPTION
The ROS package GPG keys are now managed by a dedicated package: https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/4

The GPG expires on June 1st so this PR is needed for images to keep building.