### PR TITLE
Update Traefik to remove windows Server 2019 / 1809

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -7,13 +7,6 @@ GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
 Directory: v3.4/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.4.1-windowsservercore-1809, 3.4.1-windowsservercore-1809, v3.4-windowsservercore-1809, 3.4-windowsservercore-1809, v3-windowsservercore-1809, 3-windowsservercore-1809, chaource-windowsservercore-1809, windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
-Directory: v3.4/windows/1809
-Constraints: windowsservercore-1809
-
 Tags: v3.4.1-nanoserver-ltsc2022, 3.4.1-nanoserver-ltsc2022, v3.4-nanoserver-ltsc2022, 3.4-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chaource-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
@@ -33,13 +26,6 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 8deaff57a2d889d1198c81e081cb0fdb6819c12a
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
-
-Tags: v2.11.25-windowsservercore-1809, 2.11.25-windowsservercore-1809, v2.11-windowsservercore-1809, 2.11-windowsservercore-1809, v2-windowsservercore-1809, 2-windowsservercore-1809, mimolette-windowsservercore-1809
-Architectures: windows-amd64
-GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8deaff57a2d889d1198c81e081cb0fdb6819c12a
-Directory: v2.11/windows/1809
-Constraints: windowsservercore-1809
 
 Tags: v2.11.25-nanoserver-ltsc2022, 2.11.25-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64


### PR DESCRIPTION
This PR removes the windows Server 2019 / 1809 variant: https://github.com/docker-library/official-images/pull/19138#issuecomment-2923001080