### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,24 +24,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 3.2/alpine
 
-Tags: 3.1.7, 3.1, 3.1.7-bookworm, 3.1-bookworm
+Tags: 3.1.8, 3.1, 3.1.8-bookworm, 3.1-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: d9460179b64eac94bd181a488a74d8e6df7bdbf5
 Directory: 3.1
 
-Tags: 3.1.7-alpine, 3.1-alpine, 3.1.7-alpine3.22, 3.1-alpine3.22
+Tags: 3.1.8-alpine, 3.1-alpine, 3.1.8-alpine3.22, 3.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: d9460179b64eac94bd181a488a74d8e6df7bdbf5
 Directory: 3.1/alpine
 
-Tags: 3.0.10, 3.0, 3.0.10-bookworm, 3.0-bookworm
+Tags: 3.0.11, 3.0, 3.0.11-bookworm, 3.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 6fa540dd7d9d82634605e727a8e1c726a23d8b0d
 Directory: 3.0
 
-Tags: 3.0.10-alpine, 3.0-alpine, 3.0.10-alpine3.22, 3.0-alpine3.22
+Tags: 3.0.11-alpine, 3.0-alpine, 3.0.11-alpine3.22, 3.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: 6fa540dd7d9d82634605e727a8e1c726a23d8b0d
 Directory: 3.0/alpine
 
 Tags: 2.8.15, 2.8, 2.8.15-bookworm, 2.8-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/d946017: Update 3.1 to 3.1.8
- https://github.com/docker-library/haproxy/commit/6fa540d: Update 3.0 to 3.0.11