### PR TITLE
Release of GeoNetwork 4.2.13 and 4.4.8

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/85ed3fb1d5ee6de12ef3da11bd8204913cb711a0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/4bacba930373302a0b896e03409f4fa37fc75d9f/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
      Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp),
@@ -16,12 +16,12 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 17278beab34080c90454c0b7059bd6b49701f979
 Directory: 3.12.12/postgres
 
-Tags: 4.2.12, 4.2
+Tags: 4.2.13, 4.2
 Architectures: amd64, arm64v8
-GitCommit: a3e15b94330e69449238b4bb0c6e6909f958afa2
-Directory: 4.2.12
+GitCommit: ca0637409ff44e32b5138a3ef76a48533ba1d595
+Directory: 4.2.13
 
-Tags: 4.4.7, 4.4, 4, latest
+Tags: 4.4.8, 4.4, 4, latest
 Architectures: amd64, arm64v8
-GitCommit: 87a25196b8dd3a8a1bd2bc8644f86c878de2b1d4
-Directory: 4.4.7
+GitCommit: ca0637409ff44e32b5138a3ef76a48533ba1d595
+Directory: 4.4.8


### PR DESCRIPTION
Release of GeoNetwork versions 4.2.13 and 4.4.8.

These new images use Jetty 9-jre instead 9-jdk. This base image
is based on Ubuntu Noble 24.04 instead of Ubuntu Focal 20.04 that
has reached the end of life.

See https://github.com/docker-library/official-images/pull/19167 for reference.
