### PR TITLE
[nats] Update Alpine 3.21 to 3.22, Windows Server 1809 to LTSC 2022

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,47 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 4751c3f9ca2be4c128c688c6be46af2a02c70b25
+GitCommit: 09997444258bc1900ab5db78dd781915eed04885
 GitFetch: refs/heads/main
 
-Tags: 2.11.4-alpine3.21, 2.11-alpine3.21, 2-alpine3.21, alpine3.21, 2.11.4-alpine, 2.11-alpine, 2-alpine, alpine
+Tags: 2.11.4-alpine3.22, 2.11-alpine3.22, 2-alpine3.22, alpine3.22, 2.11.4-alpine, 2.11-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
-Directory: 2.11.x/alpine3.21
+Directory: 2.11.x/alpine3.22
 
 Tags: 2.11.4-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.4-linux, 2.11-linux, 2-linux, linux
 SharedTags: 2.11.4, 2.11, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.4-windowsservercore-1809, 2.11-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
+Tags: 2.11.4-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 2.11.4-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
-Directory: 2.11.x/windowsservercore-1809
-Constraints: windowsservercore-1809
+Directory: 2.11.x/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.4-nanoserver-1809, 2.11-nanoserver-1809, 2-nanoserver-1809, nanoserver-1809
+Tags: 2.11.4-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
 SharedTags: 2.11.4-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.4, 2.11, 2, latest
 Architectures: windows-amd64
-Directory: 2.11.x/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
+Directory: 2.11.x/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.10.29-alpine3.21, 2.10-alpine3.21, 2.10.29-alpine, 2.10-alpine
+Tags: 2.10.29-alpine3.22, 2.10-alpine3.22, 2.10.29-alpine, 2.10-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
-Directory: 2.10.x/alpine3.21
+Directory: 2.10.x/alpine3.22
 
 Tags: 2.10.29-scratch, 2.10-scratch, 2.10.29-linux, 2.10-linux
 SharedTags: 2.10.29, 2.10
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.10.x/scratch
 
-Tags: 2.10.29-windowsservercore-1809, 2.10-windowsservercore-1809
+Tags: 2.10.29-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022
 SharedTags: 2.10.29-windowsservercore, 2.10-windowsservercore
 Architectures: windows-amd64
-Directory: 2.10.x/windowsservercore-1809
-Constraints: windowsservercore-1809
+Directory: 2.10.x/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
 
-Tags: 2.10.29-nanoserver-1809, 2.10-nanoserver-1809
+Tags: 2.10.29-nanoserver-ltsc2022, 2.10-nanoserver-ltsc2022
 SharedTags: 2.10.29-nanoserver, 2.10-nanoserver, 2.10.29, 2.10
 Architectures: windows-amd64
-Directory: 2.10.x/nanoserver-1809
-Constraints: nanoserver-1809, windowsservercore-1809
+Directory: 2.10.x/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Removing Server 1809 as per #19138 and updating Alpine to 3.22.