### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-8411"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 73c1147a780418c151030003d2c6d8136a7c863d
+amd64-GitCommit: c39258e425d98b54e525e5f9ddbbcecd838a3d3e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8d5f530c006cbc52e1ac9340ddbe0d80ef804c3e
+arm64v8-GitCommit: 1b5e952c2d7fb5c576ba6de5214d321d5ba4d9bd
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-3576, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-8411.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
