### PR TITLE
Remove or comment out Alpine 3.18-based images

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -36,11 +36,6 @@ Architectures: amd64, arm64v8
 GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
 Directory: 4.3/alpine3.19
 
-Tags: 4.3.6-alpine3.18, 4.3-alpine3.18
-Architectures: amd64, arm64v8
-GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
-Directory: 4.3/alpine3.18
-
 Tags: 4.2.5-bookworm, 4.2-bookworm
 SharedTags: 4.2.5, 4.2
 Architectures: amd64, arm32v7, arm64v8
@@ -76,11 +71,6 @@ Architectures: amd64, arm64v8
 GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
 Directory: 4.2/alpine3.19
 
-Tags: 4.2.5-alpine3.18, 4.2-alpine3.18
-Architectures: amd64, arm64v8
-GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
-Directory: 4.2/alpine3.18
-
 Tags: 4.1.5-bullseye, 4.1-bullseye
 SharedTags: 4.1.5, 4.1
 Architectures: amd64, arm32v7, arm64v8
@@ -111,11 +101,6 @@ Architectures: amd64, arm64v8
 GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
 Directory: 4.1/alpine3.19
 
-Tags: 4.1.5-alpine3.18, 4.1-alpine3.18
-Architectures: amd64, arm64v8
-GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
-Directory: 4.1/alpine3.18
-
 Tags: 4.0.5-bullseye, 4.0-bullseye
 SharedTags: 4.0.5, 4.0
 Architectures: amd64, arm32v7, arm64v8
@@ -145,9 +130,3 @@ Tags: 4.0.5-alpine3.19, 4.0-alpine3.19
 Architectures: amd64, arm64v8
 GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
 Directory: 4.0/alpine3.19
-
-Tags: 4.0.5-alpine3.18, 4.0-alpine3.18
-Architectures: amd64, arm64v8
-GitCommit: 483c3e2b958d83239d03f4469ea9e745c0852326
-Directory: 4.0/alpine3.18
-

--- a/library/kong
+++ b/library/kong
@@ -31,11 +31,15 @@ GitFetch: refs/tags/3.4.2
 Directory: ubuntu
 Architectures: amd64, arm64v8
 
-Tags: 2.8.5-alpine, 2.8-alpine, 2.8.5, 2.8, 2
-GitCommit: cdf93ae2106f998a2245a3eee6814b1ae68781af
-GitFetch: refs/tags/2.8.5
-Directory: alpine
-Architectures: amd64
+#
+# Alpine 3.18 is EOL
+# https://github.com/docker-library/official-images/issues/19034
+#
+#Tags: 2.8.5-alpine, 2.8-alpine, 2.8.5, 2.8, 2
+#GitCommit: cdf93ae2106f998a2245a3eee6814b1ae68781af
+#GitFetch: refs/tags/2.8.5
+#Directory: alpine
+#Architectures: amd64
 
 Tags: 2.8.5-ubuntu, 2.8-ubuntu
 GitCommit: cdf93ae2106f998a2245a3eee6814b1ae68781af

--- a/library/mongo-express
+++ b/library/mongo-express
@@ -5,22 +5,27 @@ Maintainers: Nick Cox <nickcox1008@gmail.com> (@knickers),
 GitRepo: https://github.com/mongo-express/mongo-express-docker.git
 GitCommit: 075234363b3c008c7c2e97de8a3639e23a75cfcd
 
-Tags: 1.0.2-20-alpine3.19, 1.0-20-alpine3.19, 1-20-alpine3.19
-Architectures: amd64, arm64v8
-GitCommit: 403467f350d819b404f3d5150be7776217e810b7
-Directory: 1.0/20-alpine3.19
-
-Tags: 1.0.2-20, 1.0-20, 1-20, 1.0.2-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
-Architectures: amd64, arm64v8
-GitCommit: 403467f350d819b404f3d5150be7776217e810b7
-Directory: 1.0/20-alpine3.18
-
-Tags: 1.0.2-18-alpine3.19, 1.0-18-alpine3.19, 1-18-alpine3.19
-Architectures: amd64, arm64v8
-GitCommit: 403467f350d819b404f3d5150be7776217e810b7
-Directory: 1.0/18-alpine3.19
-
-Tags: 1.0.2, 1.0, 1, 1.0.2-18, 1.0-18, 1-18, 1.0.2-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18, latest
-Architectures: amd64, arm64v8
-GitCommit: 403467f350d819b404f3d5150be7776217e810b7
-Directory: 1.0/18-alpine3.18
+#
+# Alpine 3.18 is EOL: https://github.com/docker-library/official-images/issues/19034
+# Node.js 18 is EOL: https://github.com/docker-library/official-images/pull/19118
+# Node.js no longer supports Alpine 3.19: https://github.com/docker-library/official-images/pull/18045
+#
+#Tags: 1.0.2-20-alpine3.19, 1.0-20-alpine3.19, 1-20-alpine3.19
+#Architectures: amd64, arm64v8
+#GitCommit: 403467f350d819b404f3d5150be7776217e810b7
+#Directory: 1.0/20-alpine3.19
+#
+#Tags: 1.0.2-20, 1.0-20, 1-20, 1.0.2-20-alpine3.18, 1.0-20-alpine3.18, 1-20-alpine3.18
+#Architectures: amd64, arm64v8
+#GitCommit: 403467f350d819b404f3d5150be7776217e810b7
+#Directory: 1.0/20-alpine3.18
+#
+#Tags: 1.0.2-18-alpine3.19, 1.0-18-alpine3.19, 1-18-alpine3.19
+#Architectures: amd64, arm64v8
+#GitCommit: 403467f350d819b404f3d5150be7776217e810b7
+#Directory: 1.0/18-alpine3.19
+#
+#Tags: 1.0.2, 1.0, 1, 1.0.2-18, 1.0-18, 1-18, 1.0.2-18-alpine3.18, 1.0-18-alpine3.18, 1-18-alpine3.18, latest
+#Architectures: amd64, arm64v8
+#GitCommit: 403467f350d819b404f3d5150be7776217e810b7
+#Directory: 1.0/18-alpine3.18

--- a/library/registry
+++ b/library/registry
@@ -6,7 +6,3 @@ GitFetch: refs/heads/master
 Tags: 3.0.0, 3.0, 3, latest
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x, riscv64
 GitCommit: f83883590f5afda69afafbc5aaa5fde3686f47cf
-
-Tags: 2.8.3, 2.8, 2
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, s390x
-GitCommit: 39dd72feaab7066334829d6945c54bc51a0aee98

--- a/library/teamspeak
+++ b/library/teamspeak
@@ -2,6 +2,10 @@ Maintainers: Thorsten Weinz <thorsten.weinz@teamspeak.com> (@thorwe),
              Hubert Nöbauer <hubert.noebauer@teamspeak.com> (@HuppiN)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
-Tags: 3.13, 3.13.7, latest
-GitCommit: f5f1e7f6142e8eeebb8d46d7b493b5d3ec01d599
-Directory: alpine
+#
+# Alpine 3.18 is EOL
+# https://github.com/docker-library/official-images/issues/19034
+#
+#Tags: 3.13, 3.13.7, latest
+#GitCommit: f5f1e7f6142e8eeebb8d46d7b493b5d3ec01d599
+#Directory: alpine


### PR DESCRIPTION
- https://github.com/docker-library/official-images/issues/19034

---

- `haxe:4.3.6-alpine3.18`
- `haxe:4.2.5-alpine3.18`
- `haxe:4.1.5-alpine3.18`
- `haxe:4.0.5-alpine3.18`
- `kong:2.8.5-alpine`
- `registry:2.8.3`
- `teamspeak:3.13`