### PR TITLE
Update Jetty to version 12.0.22

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -47,7 +47,7 @@ GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
 Tags: 9.4.57-jdk8, 9.4-jdk8, 9-jdk8, 9.4.57-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
 Tags: 9.4.57-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.57-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
 Architectures: amd64
@@ -67,7 +67,7 @@ GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
 Tags: 9.4.57-jdk17, 9.4-jdk17, 9-jdk17, 9.4.57-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
 Tags: 9.4.57-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.57-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
@@ -77,57 +77,57 @@ GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
 Tags: 9.4.57-jdk11, 9.4-jdk11, 9-jdk11, 9.4.57-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
-Tags: 12.0.21-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.21-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.22-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.22-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jre21, 12.0-jre21, 12-jre21, 12.0.21-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.22-jre21, 12.0-jre21, 12-jre21, 12.0.22-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.21-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.22-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.22-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jre17, 12.0-jre17, 12-jre17, 12.0.21-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.22-jre17, 12.0-jre17, 12-jre17, 12.0.22-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk24-alpine, 12.0-jdk24-alpine, 12-jdk24-alpine, 12.0.21-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin, 12-jdk24-alpine-eclipse-temurin
+Tags: 12.0.22-jdk24-alpine, 12.0-jdk24-alpine, 12-jdk24-alpine, 12.0.22-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin, 12-jdk24-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk24-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk24, 12.0-jdk24, 12-jdk24, 12.0.21-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin, 12-jdk24-eclipse-temurin
+Tags: 12.0.22-jdk24, 12.0-jdk24, 12-jdk24, 12.0.22-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin, 12-jdk24-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk24
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.21-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.22-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.22-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21, 12.0, 12, 12.0.21-jdk21, 12.0-jdk21, 12-jdk21, 12.0.21-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.21-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.22, 12.0, 12, 12.0.22-jdk21, 12.0-jdk21, 12-jdk21, 12.0.22-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.22-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.21-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.22-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.22-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk17, 12.0-jdk17, 12-jdk17, 12.0.21-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.22-jdk17, 12.0-jdk17, 12-jdk17, 12.0.22-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
 Tags: 11.0.25-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.25-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
@@ -177,7 +177,7 @@ GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
 Tags: 11.0.25-jdk17, 11.0-jdk17, 11-jdk17, 11.0.25-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
 Tags: 11.0.25-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.25-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
@@ -187,7 +187,7 @@ GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
 Tags: 11.0.25-jdk11, 11.0-jdk11, 11-jdk11, 11.0.25-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
 Tags: 10.0.25-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.25-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
@@ -237,7 +237,7 @@ GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
 Tags: 10.0.25-jdk17, 10.0-jdk17, 10-jdk17, 10.0.25-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
 Tags: 10.0.25-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.25-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
@@ -247,7 +247,7 @@ GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
 Tags: 10.0.25-jdk11, 10.0-jdk11, 10-jdk11, 10.0.25-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
 
 Tags: 9.4.57-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -289,40 +289,40 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
 
-Tags: 12.0.21-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
+Tags: 12.0.22-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk24-al2023
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.22-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
+Tags: 12.0.22-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-al2023
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.21-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.22-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.22-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.22-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
+Tags: 12.0.22-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-al2023
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
-Tags: 12.0.21-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.22-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: 06d912a8ec1a1e8df456a953926ca1b1c7543c0c
+GitCommit: 23b358279dbdb246f24a3ebc52fa0bee11d91b74
 
 Tags: 11.0.25-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8


### PR DESCRIPTION
- update jetty version `12.0.21` -> `12.0.22`
- removed usage of ubuntu focal tags