### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -18,12 +18,12 @@ GitCommit: d262936418fbf062bb25907d5126a178578ab58b
 Directory: 14
 # Docker EOL: 2026-11-23
 
-# Last Modified: 2024-05-21
-Tags: 13.3.0, 13.3, 13, 13.3.0-bookworm, 13.3-bookworm, 13-bookworm
+# Last Modified: 2025-06-05
+Tags: 13.4.0, 13.4, 13, 13.4.0-bookworm, 13.4-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b5055bcc1551a7e271af315158e1c260c212409c
+GitCommit: 118c07a8e6467baababb4634b6cfde14a67c24b0
 Directory: 13
-# Docker EOL: 2025-11-21
+# Docker EOL: 2026-12-05
 
 # Last Modified: 2024-06-20
 Tags: 12.4.0, 12.4, 12, 12.4.0-bookworm, 12.4-bookworm, 12-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/118c07a: Update 13 to 13.4.0