### PR TITLE
[ros] temporarily enable ROS EOL builds to renew APT GPG key

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -2,30 +2,386 @@ Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
 
 ################################################################################
+# Release: indigo
+
+########################################
+# Distro: ubuntu:trusty
+
+Tags: indigo-ros-core, indigo-ros-core-trusty
+Architectures: amd64, arm32v7
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/indigo/ubuntu/trusty/ros-core
+
+Tags: indigo-ros-base, indigo-ros-base-trusty, indigo
+Architectures: amd64, arm32v7
+GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+Directory: ros/indigo/ubuntu/trusty/ros-base
+
+Tags: indigo-robot, indigo-robot-trusty
+Architectures: amd64, arm32v7
+GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+Directory: ros/indigo/ubuntu/trusty/robot
+
+Tags: indigo-perception, indigo-perception-trusty
+Architectures: amd64, arm32v7
+GitCommit: 20061b005b245d1b7e23626afd0ea2c39de9db49
+Directory: ros/indigo/ubuntu/trusty/perception
+
+
+################################################################################
+# Release: jade
+
+########################################
+# Distro: ubuntu:trusty
+
+Tags: jade-ros-core, jade-ros-core-trusty
+Architectures: amd64, arm32v7
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/jade/ubuntu/trusty/ros-core
+
+Tags: jade-ros-base, jade-ros-base-trusty, jade
+Architectures: amd64, arm32v7
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
+Directory: ros/jade/ubuntu/trusty/ros-base
+
+Tags: jade-robot, jade-robot-trusty
+Architectures: amd64, arm32v7
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
+Directory: ros/jade/ubuntu/trusty/robot
+
+Tags: jade-perception, jade-perception-trusty
+Architectures: amd64, arm32v7
+GitCommit: dbda2abfbee89ebab4b33bdb1cfaec6dc36a3822
+Directory: ros/jade/ubuntu/trusty/perception
+
+
+################################################################################
+# Release: kinetic
+
+########################################
+# Distro: ubuntu:xenial
+
+Tags: kinetic-ros-core, kinetic-ros-core-xenial
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+Directory: ros/kinetic/ubuntu/xenial/ros-core
+
+Tags: kinetic-ros-base, kinetic-ros-base-xenial, kinetic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/kinetic/ubuntu/xenial/ros-base
+
+Tags: kinetic-robot, kinetic-robot-xenial
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/kinetic/ubuntu/xenial/robot
+
+Tags: kinetic-perception, kinetic-perception-xenial
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/kinetic/ubuntu/xenial/perception
+
+########################################
+# Distro: debian:jessie
+
+Tags: kinetic-ros-core-jessie
+Architectures: amd64
+GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
+Directory: ros/kinetic/debian/jessie/ros-core
+
+Tags: kinetic-ros-base-jessie
+Architectures: amd64
+GitCommit: 974fbc89317b858efd413073417de5996467a6d5
+Directory: ros/kinetic/debian/jessie/ros-base
+
+Tags: kinetic-robot-jessie
+Architectures: amd64
+GitCommit: 974fbc89317b858efd413073417de5996467a6d5
+Directory: ros/kinetic/debian/jessie/robot
+
+Tags: kinetic-perception-jessie
+Architectures: amd64
+GitCommit: 974fbc89317b858efd413073417de5996467a6d5
+Directory: ros/kinetic/debian/jessie/perception
+
+
+################################################################################
+# Release: lunar
+
+########################################
+# Distro: ubuntu:xenial
+
+Tags: lunar-ros-core, lunar-ros-core-xenial
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/lunar/ubuntu/xenial/ros-core
+
+Tags: lunar-ros-base, lunar-ros-base-xenial, lunar
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+Directory: ros/lunar/ubuntu/xenial/ros-base
+
+Tags: lunar-robot, lunar-robot-xenial
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+Directory: ros/lunar/ubuntu/xenial/robot
+
+Tags: lunar-perception, lunar-perception-xenial
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: d81c0004d43383a6cd0f7b5a9b3020300f3cb1ca
+Directory: ros/lunar/ubuntu/xenial/perception
+
+########################################
+# Distro: ubuntu:zesty
+
+Tags: lunar-ros-core-zesty
+Architectures: amd64
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/lunar/ubuntu/zesty/ros-core
+
+Tags: lunar-ros-base-zesty
+Architectures: amd64
+GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
+Directory: ros/lunar/ubuntu/zesty/ros-base
+
+Tags: lunar-robot-zesty
+Architectures: amd64
+GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
+Directory: ros/lunar/ubuntu/zesty/robot
+
+Tags: lunar-perception-zesty
+Architectures: amd64
+GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
+Directory: ros/lunar/ubuntu/zesty/perception
+
+########################################
+# Distro: debian:stretch
+
+Tags: lunar-ros-core-stretch
+Architectures: amd64, arm64v8
+GitCommit: ec6423078023d024bd677b586f51c3b195af625b
+Directory: ros/lunar/debian/stretch/ros-core
+
+Tags: lunar-ros-base-stretch
+Architectures: amd64, arm64v8
+GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+Directory: ros/lunar/debian/stretch/ros-base
+
+Tags: lunar-robot-stretch
+Architectures: amd64, arm64v8
+GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+Directory: ros/lunar/debian/stretch/robot
+
+Tags: lunar-perception-stretch
+Architectures: amd64, arm64v8
+GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
+Directory: ros/lunar/debian/stretch/perception
+
+
+################################################################################
+# Release: melodic
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: melodic-ros-core, melodic-ros-core-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+Directory: ros/melodic/ubuntu/bionic/ros-core
+
+Tags: melodic-ros-base, melodic-ros-base-bionic, melodic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/melodic/ubuntu/bionic/ros-base
+
+Tags: melodic-robot, melodic-robot-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/melodic/ubuntu/bionic/robot
+
+Tags: melodic-perception, melodic-perception-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/melodic/ubuntu/bionic/perception
+
+########################################
+# Distro: debian:stretch
+
+Tags: melodic-ros-core-stretch
+Architectures: amd64, arm64v8
+GitCommit: d017429ffef82c2ae91e5f81a4a60640b2ad6c1b
+Directory: ros/melodic/debian/stretch/ros-core
+
+Tags: melodic-ros-base-stretch
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/melodic/debian/stretch/ros-base
+
+Tags: melodic-robot-stretch
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/melodic/debian/stretch/robot
+
+Tags: melodic-perception-stretch
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/melodic/debian/stretch/perception
+
+
+################################################################################
 # Release: noetic
+
+########################################
+# Distro: debian:buster
+
+Tags: noetic-ros-core-buster
+Architectures: amd64, arm64v8
+GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+Directory: ros/noetic/debian/buster/ros-core
+
+Tags: noetic-ros-base-buster
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/noetic/debian/buster/ros-base
+
+Tags: noetic-robot-buster
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/noetic/debian/buster/robot
+
+Tags: noetic-perception-buster
+Architectures: amd64, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/noetic/debian/buster/perception
+
+
+################################################################################
+# Release: ardent
+
+########################################
+# Distro: ubuntu:xenial
+
+Tags: ardent-ros-core, ardent-ros-core-xenial
+Architectures: amd64, arm64v8
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/ardent/ubuntu/xenial/ros-core
+
+Tags: ardent-ros-base, ardent-ros-base-xenial, ardent
+Architectures: amd64, arm64v8
+GitCommit: 9619e8b2fedc763707c07bd5568f2401bfc5b117
+Directory: ros/ardent/ubuntu/xenial/ros-base
+
+
+################################################################################
+# Release: bouncy
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: bouncy-ros-core, bouncy-ros-core-bionic
+Architectures: amd64, arm64v8
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/bouncy/ubuntu/bionic/ros-core
+
+Tags: bouncy-ros-base, bouncy-ros-base-bionic, bouncy
+Architectures: amd64, arm64v8
+GitCommit: 9619e8b2fedc763707c07bd5568f2401bfc5b117
+Directory: ros/bouncy/ubuntu/bionic/ros-base
+
+
+################################################################################
+# Release: crystal
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: crystal-ros-core, crystal-ros-core-bionic
+Architectures: amd64, arm64v8
+GitCommit: 51ba1c72c513b62e8825c3df015ca4d926ac688c
+Directory: ros/crystal/ubuntu/bionic/ros-core
+
+Tags: crystal-ros-base, crystal-ros-base-bionic, crystal
+Architectures: amd64, arm64v8
+GitCommit: 9619e8b2fedc763707c07bd5568f2401bfc5b117
+Directory: ros/crystal/ubuntu/bionic/ros-base
+
+
+################################################################################
+# Release: dashing
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: dashing-ros-core, dashing-ros-core-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+Directory: ros/dashing/ubuntu/bionic/ros-core
+
+Tags: dashing-ros-base, dashing-ros-base-bionic, dashing
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
+Directory: ros/dashing/ubuntu/bionic/ros-base
+
+Tags: dashing-ros1-bridge, dashing-ros1-bridge-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 87074e54828d12dacf84f15273e95e03eeb17d24
+Directory: ros/dashing/ubuntu/bionic/ros1-bridge
+
+
+################################################################################
+# Release: eloquent
+
+########################################
+# Distro: ubuntu:bionic
+
+Tags: eloquent-ros-core, eloquent-ros-core-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 3b5cbe2c25b25fa2b5acc9770f5f0b71143f864d
+Directory: ros/eloquent/ubuntu/bionic/ros-core
+
+Tags: eloquent-ros-base, eloquent-ros-base-bionic, eloquent
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: b3e79c3aef3687b56b3c1052ae38aa7010234834
+Directory: ros/eloquent/ubuntu/bionic/ros-base
+
+Tags: eloquent-ros1-bridge, eloquent-ros1-bridge-bionic
+Architectures: amd64, arm32v7, arm64v8
+GitCommit: 3b5cbe2c25b25fa2b5acc9770f5f0b71143f864d
+Directory: ros/eloquent/ubuntu/bionic/ros1-bridge
+
+
+################################################################################
+# Release: foxy
 
 ########################################
 # Distro: ubuntu:focal
 
-Tags: noetic-ros-core, noetic-ros-core-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: b525e9ef659ce448db6150fd5407ef62b2c5b265
-Directory: ros/noetic/ubuntu/focal/ros-core
+Tags: foxy-ros-core, foxy-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+Directory: ros/foxy/ubuntu/focal/ros-core
 
-Tags: noetic-ros-base, noetic-ros-base-focal, noetic
-Architectures: amd64, arm32v7, arm64v8
+Tags: foxy-ros-base, foxy-ros-base-focal, foxy
+Architectures: amd64, arm64v8
 GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/ubuntu/focal/ros-base
+Directory: ros/foxy/ubuntu/focal/ros-base
 
-Tags: noetic-robot, noetic-robot-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/ubuntu/focal/robot
 
-Tags: noetic-perception, noetic-perception-focal
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/noetic/ubuntu/focal/perception
+################################################################################
+# Release: galactic
+
+########################################
+# Distro: ubuntu:focal
+
+Tags: galactic-ros-core, galactic-ros-core-focal
+Architectures: amd64, arm64v8
+GitCommit: 9ab23751d41735b448da8cfa1580958279ae5101
+Directory: ros/galactic/ubuntu/focal/ros-core
+
+Tags: galactic-ros-base, galactic-ros-base-focal, galactic
+Architectures: amd64, arm64v8
+GitCommit: 6511d8fc0754616550b7f5ea31a40084c2462938
+Directory: ros/galactic/ubuntu/focal/ros-base
 
 
 ################################################################################
@@ -48,6 +404,28 @@ Tags: humble-perception, humble-perception-jammy
 Architectures: amd64, arm64v8
 GitCommit: 20d40c96b426b8956dec203e236abff2ec29b188
 Directory: ros/humble/ubuntu/jammy/perception
+
+
+################################################################################
+# Release: iron
+
+########################################
+# Distro: ubuntu:jammy
+
+Tags: iron-ros-core, iron-ros-core-jammy
+Architectures: amd64, arm64v8
+GitCommit: 2ad854492209b8dbab303578a5baedab4d5ab41d
+Directory: ros/iron/ubuntu/jammy/ros-core
+
+Tags: iron-ros-base, iron-ros-base-jammy, iron
+Architectures: amd64, arm64v8
+GitCommit: bca53bf4c09d771be3ff735da4157203b53ebc2b
+Directory: ros/iron/ubuntu/jammy/ros-base
+
+Tags: iron-perception, iron-perception-jammy
+Architectures: amd64, arm64v8
+GitCommit: bca53bf4c09d771be3ff735da4157203b53ebc2b
+Directory: ros/iron/ubuntu/jammy/perception
 
 
 ################################################################################

--- a/library/ros
+++ b/library/ros
@@ -81,29 +81,6 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/kinetic/ubuntu/xenial/perception
 
-########################################
-# Distro: debian:jessie
-
-Tags: kinetic-ros-core-jessie
-Architectures: amd64
-GitCommit: 7b6d0959808500b3531e8a5448756fc95dbb2d12
-Directory: ros/kinetic/debian/jessie/ros-core
-
-Tags: kinetic-ros-base-jessie
-Architectures: amd64
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/ros-base
-
-Tags: kinetic-robot-jessie
-Architectures: amd64
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/robot
-
-Tags: kinetic-perception-jessie
-Architectures: amd64
-GitCommit: 974fbc89317b858efd413073417de5996467a6d5
-Directory: ros/kinetic/debian/jessie/perception
-
 
 ################################################################################
 # Release: lunar
@@ -154,29 +131,6 @@ Architectures: amd64
 GitCommit: 4cfa1c7fd7e4f6ec638d1615f12133edbc100731
 Directory: ros/lunar/ubuntu/zesty/perception
 
-########################################
-# Distro: debian:stretch
-
-Tags: lunar-ros-core-stretch
-Architectures: amd64, arm64v8
-GitCommit: ec6423078023d024bd677b586f51c3b195af625b
-Directory: ros/lunar/debian/stretch/ros-core
-
-Tags: lunar-ros-base-stretch
-Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
-Directory: ros/lunar/debian/stretch/ros-base
-
-Tags: lunar-robot-stretch
-Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
-Directory: ros/lunar/debian/stretch/robot
-
-Tags: lunar-perception-stretch
-Architectures: amd64, arm64v8
-GitCommit: 4d697291568d826da713ef8b20be58fa8e86e4f5
-Directory: ros/lunar/debian/stretch/perception
-
 
 ################################################################################
 # Release: melodic
@@ -203,29 +157,6 @@ Tags: melodic-perception, melodic-perception-bionic
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
 Directory: ros/melodic/ubuntu/bionic/perception
-
-########################################
-# Distro: debian:stretch
-
-Tags: melodic-ros-core-stretch
-Architectures: amd64, arm64v8
-GitCommit: d017429ffef82c2ae91e5f81a4a60640b2ad6c1b
-Directory: ros/melodic/debian/stretch/ros-core
-
-Tags: melodic-ros-base-stretch
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/debian/stretch/ros-base
-
-Tags: melodic-robot-stretch
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/debian/stretch/robot
-
-Tags: melodic-perception-stretch
-Architectures: amd64, arm64v8
-GitCommit: df19ab7d5993d3b78a908362cdcd1479a8e78b35
-Directory: ros/melodic/debian/stretch/perception
 
 
 ################################################################################


### PR DESCRIPTION
Similar to https://github.com/docker-library/official-images/pull/15809 https://github.com/docker-library/official-images/pull/15809#issuecomment-1839829310

The snapshots.ros.org APT repo gpg key expired. It has now been renewed: https://discourse.ros.org/t/ros-signing-key-migration-guide/43937/41

Reenabling all ROS image builds to fetch the updated GPG key

---

One exception is ROS noetic that is going EOL and a separate PR to modify that image and any tag building bridge between ROS noetic and another ROS distro, tracked here https://github.com/osrf/docker_images/issues/808