### PR TITLE
Odoo: update 16.0-18.0 to release 20250606

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5d67b9585c0e29c9dccc0b3f484eedc4e5c46714
+GitCommit: 5baa064da27446d2c9aa4b087cc5ead956bc2a20
 
-Tags: 18.0-20250520, 18.0, 18, latest
+Tags: 18.0-20250606, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250520, 17.0, 17
+Tags: 17.0-20250606, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250520, 16.0, 16
+Tags: 16.0-20250606, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks