### PR TITLE
caddy: Drop windows 1809, add ltsc2025

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/aa3e73e0731fbca665be75edef9fbb60d3169278/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/b4226f27405e98d9330ca807a80807d5d523ebba/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
@@ -18,14 +18,6 @@ Directory: 2.10/builder
 GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.10.0-windowsservercore-1809, 2.10-windowsservercore-1809, 2-windowsservercore-1809, windowsservercore-1809
-SharedTags: 2.10.0-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.0, 2.10, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows/1809
-GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
-Architectures: windows-amd64
-Constraints: windowsservercore-1809
-
 Tags: 2.10.0-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 2.10.0-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.0, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
@@ -34,13 +26,13 @@ GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.10.0-builder-windowsservercore-1809, 2.10-builder-windowsservercore-1809, 2-builder-windowsservercore-1809, builder-windowsservercore-1809
-SharedTags: 2.10.0-builder, 2.10-builder, 2-builder, builder
+Tags: 2.10.0-windowsservercore-ltsc2025, 2.10-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 2.10.0-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.0, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows-builder/1809
-GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
+Directory: 2.10/windows/ltsc2025
+GitCommit: b4226f27405e98d9330ca807a80807d5d523ebba
 Architectures: windows-amd64
-Constraints: windowsservercore-1809
+Constraints: windowsservercore-ltsc2025
 
 Tags: 2.10.0-builder-windowsservercore-ltsc2022, 2.10-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
 SharedTags: 2.10.0-builder, 2.10-builder, 2-builder, builder
@@ -49,4 +41,12 @@ Directory: 2.10/windows-builder/ltsc2022
 GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
+
+Tags: 2.10.0-builder-windowsservercore-ltsc2025, 2.10-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
+SharedTags: 2.10.0-builder, 2.10-builder, 2-builder, builder
+GitRepo: https://github.com/caddyserver/caddy-docker.git
+Directory: 2.10/windows-builder/ltsc2025
+GitCommit: b4226f27405e98d9330ca807a80807d5d523ebba
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2025
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy-docker/pull/403

As per recommendations in https://github.com/docker-library/official-images/issues/18910 and https://github.com/docker-library/official-images/pull/19138

/cc @tianon 