### PR TITLE
archlinux: Release 20250608.0.361578

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250601.0.358000
-GitCommit: de7defab6a4087b48add0be9c82b5bb3548d3706
-GitFetch: refs/tags/v20250601.0.358000
+Tags: latest, base, base-20250608.0.361578
+GitCommit: 7854bdb0232d4aecf8d361c351c92bfa18bf3add
+GitFetch: refs/tags/v20250608.0.361578
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250601.0.358000
-GitCommit: de7defab6a4087b48add0be9c82b5bb3548d3706
-GitFetch: refs/tags/v20250601.0.358000
+Tags: base-devel, base-devel-20250608.0.361578
+GitCommit: 7854bdb0232d4aecf8d361c351c92bfa18bf3add
+GitFetch: refs/tags/v20250608.0.361578
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250601.0.358000
-GitCommit: de7defab6a4087b48add0be9c82b5bb3548d3706
-GitFetch: refs/tags/v20250601.0.358000
+Tags: multilib-devel, multilib-devel-20250608.0.361578
+GitCommit: 7854bdb0232d4aecf8d361c351c92bfa18bf3add
+GitFetch: refs/tags/v20250608.0.361578
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks