### PR TITLE
Update Clear Linux OS to 43580

### DIFF
--- a/library/clearlinux
+++ b/library/clearlinux
@@ -2,5 +2,5 @@ Maintainers: William Douglas <william.douglas@intel.com> (@bryteise)
 GitRepo: https://github.com/clearlinux/docker-brew-clearlinux.git
 
 Tags: latest, base
-GitCommit: 26562d8268c7e77024c64721a4950cc20af04b5e
-GitFetch: refs/heads/base-43550
+GitCommit: 2654783fe5c1032d4c2d9a26971b22cc58f0940b
+GitFetch: refs/heads/base-43580


### PR DESCRIPTION
Update Clear Linux OS latest+base images to release 43580

@bryteise @djklimes @bryteise