### PR TITLE
Fix creating new labels

### DIFF
--- a/.github/workflows/munge-pr.yml
+++ b/.github/workflows/munge-pr.yml
@@ -88,6 +88,14 @@ jobs:
     name: Apply Labels
     runs-on: ubuntu-latest
     needs: gather
+    permissions:
+      contents: read
+      pull-requests: write
+      # "issues: write" is now needed to create new labels
+      # https://github.com/orgs/community/discussions/156181
+      # but documentation still shows that pull-requests write should be enough 😓
+      # https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#create-a-label
+      issues: write
     if: fromJSON(needs.gather.outputs.images).imagesAndExternalPinsCount > 0
     steps:
       - name: Apply Labels


### PR DESCRIPTION
For some reason, `pull-request: write` is no longer enough to create new labels (https://github.com/orgs/community/discussions/156181), so `issues: write` is necessary even though the documentation still shows that pull-requests write should be enough 😓 (https://docs.github.com/en/rest/issues/labels?apiVersion=2022-11-28#create-a-label).

(Unknown if `pull-request: write` would now not be necessary on the `apply-labels` job)