### PR TITLE
Release 11.8 GA and 12.0RC

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -6,32 +6,32 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 Builder: buildkit
 
-Tags: 11.8.1-ubi9-rc, 11.8-ubi9-rc, 11.8.1-ubi-rc, 11.8-ubi-rc
+Tags: 12.0.1-ubi9-rc, 12.0-ubi9-rc, 12.0.1-ubi-rc, 12.0-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 2d5103917774c4c53ec6bf3c6fdfc7b210e85690
+GitCommit: e9903b927ef46dc55fc6900ab015e4314349699a
+Directory: 12.0-ubi
+
+Tags: 12.0.1-noble-rc, 12.0-noble-rc, 12.0.1-rc, 12.0-rc
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: e9903b927ef46dc55fc6900ab015e4314349699a
+Directory: 12.0
+
+Tags: 11.8.2-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.2-ubi, 11.8-ubi, 11-ubi, lts-ubi
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: 4c5048803b4785a1ef057c2d4c48b126a08348c6
 Directory: 11.8-ubi
 
-Tags: 11.8.1-noble-rc, 11.8-noble-rc, 11.8.1-rc, 11.8-rc
+Tags: 11.8.2-noble, 11.8-noble, 11-noble, noble, lts-noble, 11.8.2, 11.8, 11, latest, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 2d5103917774c4c53ec6bf3c6fdfc7b210e85690
+GitCommit: 4c5048803b4785a1ef057c2d4c48b126a08348c6
 Directory: 11.8
 
-Tags: 11.7.2-ubi9, 11.7-ubi9, 11-ubi9, 11.7.2-ubi, 11.7-ubi, 11-ubi
-Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 853447019725b35685d5ec3c007096a266399bea
-Directory: 11.7-ubi
-
-Tags: 11.7.2-noble, 11.7-noble, 11-noble, noble, 11.7.2, 11.7, 11, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 853447019725b35685d5ec3c007096a266399bea
-Directory: 11.7
-
-Tags: 11.4.7-ubi9, 11.4-ubi9, lts-ubi9, 11.4.7-ubi, 11.4-ubi, lts-ubi
+Tags: 11.4.7-ubi9, 11.4-ubi9, 11.4.7-ubi, 11.4-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
 GitCommit: a272347802e1764dd8c0e15ba2b2abfeeadb3bb6
 Directory: 11.4-ubi
 
-Tags: 11.4.7-noble, 11.4-noble, lts-noble, 11.4.7, 11.4, lts
+Tags: 11.4.7-noble, 11.4-noble, 11.4.7, 11.4
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: a272347802e1764dd8c0e15ba2b2abfeeadb3bb6
 Directory: 11.4
@@ -55,13 +55,3 @@ Tags: 10.6.22-jammy, 10.6-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 9bc98d6905a26282e6209da20970d9d4b055a384
 Directory: 10.6-jammy
-
-Tags: 10.6.22-focal, 10.6-focal, 10.6.22, 10.6
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c5669903a1c1f711039de61e480fbfd3549e1f86
-Directory: 10.6
-
-Tags: 10.5.29-focal, 10.5-focal, 10.5.29, 10.5
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: c5669903a1c1f711039de61e480fbfd3549e1f86
-Directory: 10.5


### PR DESCRIPTION
Consequently 11.7 is EOL.

Because of Ubuntu 20.04 being EOL these images
where removed. Note ably there stil is 10.6-jammy
but leaving it to Docker Official Images to have
10.6 previous tag pointing to the older focal based image.

Next release will replace 10.6 with the jammy based image in a few months.

Closes #MariaDB/mariadb-docker/issues/647