### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-8655"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c39258e425d98b54e525e5f9ddbbcecd838a3d3e
+amd64-GitCommit: 1c53c87556765c7231665e194ac18efd33497869
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1b5e952c2d7fb5c576ba6de5214d321d5ba4d9bd
+arm64v8-GitCommit: b863530e21f60b036522dfd40b8516e5c40f622f
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-4802, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-8655.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
