### PR TITLE
Update maintainer for elasticsearch

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -1,4 +1,4 @@
-Maintainers: Mark Vieira (@mark-vieira)
+Maintainers: Rene Groeschke (@breskeby)
 GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: elasticsearch
 Builder: buildkit


### PR DESCRIPTION
Within the elasticsearch org the maintainer for the elasticsearch docker images have changed from @mark-vieira to @breskeby. 
