### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev0, 3.3-dev, 3.3-dev0-bookworm, 3.3-dev-bookworm
+Tags: 3.3-dev1, 3.3-dev, 3.3-dev1-bookworm, 3.3-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: 44e407b80e8a05deb563724d1118d9efebf79e06
 Directory: 3.3
 
-Tags: 3.3-dev0-alpine, 3.3-dev-alpine, 3.3-dev0-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev1-alpine, 3.3-dev-alpine, 3.3-dev1-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: 44e407b80e8a05deb563724d1118d9efebf79e06
 Directory: 3.3/alpine
 
-Tags: 3.2.0, 3.2, latest, lts, 3.2.0-bookworm, 3.2-bookworm, bookworm, lts-bookworm
+Tags: 3.2.1, 3.2, latest, lts, 3.2.1-bookworm, 3.2-bookworm, bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+GitCommit: e57bdf9982a76d5391e3f40eec41ae0c6c477ae0
 Directory: 3.2
 
-Tags: 3.2.0-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.0-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.1-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.1-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: e57bdf9982a76d5391e3f40eec41ae0c6c477ae0
 Directory: 3.2/alpine
 
 Tags: 3.1.8, 3.1, 3.1.8-bookworm, 3.1-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/44e407b: Update 3.3 to 3.3-dev1
- https://github.com/docker-library/haproxy/commit/e57bdf9: Update 3.2 to 3.2.1