### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-8686"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1c53c87556765c7231665e194ac18efd33497869
+amd64-GitCommit: 02ca74605019488bc95c56333529b01009fd1e6c
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b863530e21f60b036522dfd40b8516e5c40f622f
+arm64v8-GitCommit: 47da17c6fe9a47a6fa832f8279aba639373c0870
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-4802, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-8686.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
