### PR TITLE
Update couchbase-server

### DIFF
--- a/library/couchbase
+++ b/library/couchbase
@@ -22,81 +22,81 @@ Directory: enterprise/couchbase-server/7.6.3
 Architectures: amd64, arm64v8
 
 Tags: 7.6.2, enterprise-7.6.2
-GitCommit: ba43d566538a8e0b6315569b94f0a7cf835c222b
+GitCommit: ce13f602d2c95f76835c67a8855d5e73480973a6
 Directory: enterprise/couchbase-server/7.6.2
 Architectures: amd64, arm64v8
 
 Tags: community, community-7.6.2
-GitCommit: 34bb6684dc575f4e0b8b0f16127f5d4188015d8d
+GitCommit: 3f81af158b7f307e42f8c42ceaf7657b2690bfca
 Directory: community/couchbase-server/7.6.2
 Architectures: amd64, arm64v8
 
 Tags: 7.6.1, enterprise-7.6.1
-GitCommit: 5268f3a009878a85c70b1461ef32cf8ce21debec
+GitCommit: 966143f937bfe6979b7c09b86684004fdd21e5b8
 Directory: enterprise/couchbase-server/7.6.1
 Architectures: amd64, arm64v8
 
 Tags: community-7.6.1
-GitCommit: 6eb060cef1909e850b0ad4a930cd577a89a6d269
+GitCommit: a18464c9b23efba391317fd21f898bf64dff6ec1
 Directory: community/couchbase-server/7.6.1
 Architectures: amd64, arm64v8
 
 Tags: 7.6.0, enterprise-7.6.0
-GitCommit: 203e62f36ce055be75955e073d0000249bf2c040
+GitCommit: 9bdcf41deedd86da4c71347ffeea350a9895d816
 Directory: enterprise/couchbase-server/7.6.0
 Architectures: amd64, arm64v8
 
 Tags: community-7.6.0
-GitCommit: 7148bc241bcdcf8961c34f8adf76ebfb2860ed83
+GitCommit: 6d669d0e34e6990b43c1b91ea74720235c96c4ac
 Directory: community/couchbase-server/7.6.0
 Architectures: amd64, arm64v8
 
 Tags: 7.2.7, enterprise-7.2.7
-GitCommit: ae9a971db27050a4da598137fce7bd3d63396c24
+GitCommit: 23887cae4fd6ce054f383d524a7975d2e3a6b72e
 Directory: enterprise/couchbase-server/7.2.7
 Architectures: amd64, arm64v8
 
 Tags: 7.2.6, enterprise-7.2.6
-GitCommit: 857d7bcc814e241fd36aa4dc326dcab37e1d1e73
+GitCommit: 181af64dcbedc1abf6e0916d9f5373cf1c18cb6e
 Directory: enterprise/couchbase-server/7.2.6
 Architectures: amd64, arm64v8
 
 Tags: 7.2.5, enterprise-7.2.5
-GitCommit: 58e0549b1e021259a1ce9bb70d70aac4cc5e71da
+GitCommit: 94d97d9eea3d4057846be28f319940927d5166cb
 Directory: enterprise/couchbase-server/7.2.5
 Architectures: amd64, arm64v8
 
 Tags: 7.2.4, enterprise-7.2.4
-GitCommit: 24bae6aab6520dc97c362b56150db9658d041873
+GitCommit: 15c1c3c0b4717a8b23ef7962f3fde28fe68e4311
 Directory: enterprise/couchbase-server/7.2.4
 Architectures: amd64, arm64v8
 
 Tags: community-7.2.4
-GitCommit: 9fc1cf481a8fe8e78d7539cee3a25cdbaa7b5e1e
+GitCommit: 7c8453ef8584ff18f7b6c052828758693af4f72c
 Directory: community/couchbase-server/7.2.4
 Architectures: amd64, arm64v8
 
 Tags: 7.2.3, enterprise-7.2.3
-GitCommit: 3a446520433f63e3d270f01063b14cb6b6ade12a
+GitCommit: b54049418018144369816d18c63d9bf76e34bc9f
 Directory: enterprise/couchbase-server/7.2.3
 Architectures: amd64, arm64v8
 
 Tags: 7.2.2, enterprise-7.2.2
-GitCommit: 00de0b8de802ff6909be789b1f86a65d934a38f8
+GitCommit: 3515fb617a469a5f46d492cf6910dddff8efb825
 Directory: enterprise/couchbase-server/7.2.2
 Architectures: amd64, arm64v8
 
 Tags: community-7.2.2
-GitCommit: 855d163127ee5e4bc6854714ecd6911f70f27906
+GitCommit: c7a25ac7f38a81a465aa97f1a1d753a6c579954f
 Directory: community/couchbase-server/7.2.2
 Architectures: amd64, arm64v8
 
 Tags: 7.2.0, enterprise-7.2.0
-GitCommit: 1985fb8f6774c71cb0f00e37a62c0741fad59ece
+GitCommit: 4e769975179dc4e5bf4138349818bc8a0e191c9f
 Directory: enterprise/couchbase-server/7.2.0
 Architectures: amd64, arm64v8
 
 Tags: community-7.2.0
-GitCommit: 2bd177d6887d051b6981c8c2591af6eed3ae9505
+GitCommit: 71596d088ce2bc0218418187ac40ffccb08dbc36
 Directory: community/couchbase-server/7.2.0
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This change updates our images which are currently based on ubuntu:20.04 to 22.04/24.04.