### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-8958"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 02ca74605019488bc95c56333529b01009fd1e6c
+amd64-GitCommit: 7f68a61d5c74c5c6ed1b75ba0f114b98cd2f304d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 47da17c6fe9a47a6fa832f8279aba639373c0870
+arm64v8-GitCommit: 1c04083da47ec9ff2335cdf6e7fd84d6a704ac46
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-32414, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-8958.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
