### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250512.0
+Tags: 2023, latest, 2023.7.20250527.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: dacb9d52e9344a2977503cb4ecfc0879b69de878
+amd64-GitCommit: 791138cf5b11d689545cabd14f936714b9a9ef73
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: a37632ff24fdf2d838fe84fc358d8844ecdcd365
+arm64v8-GitCommit: c5f492d9b908945d049f5e1268363bb64f24edcb
 
-Tags: 2, 2.0.20250512.0
+Tags: 2, 2.0.20250605.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 943ba6f33d9edd4b4dce773a0501b914af2d39f8
+amd64-GitCommit: a6c35ab38ef86b30726b18677356d87a575ab0de
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 9194c0e5c6b27fe9a7c575b783debdf946cafe84
+arm64v8-GitCommit: 075f37bfc9cd1c84cd7383463287e046a1c168df
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- libgpg-error-1.31-1.amzn2.0.1
- libxml2-2.9.1-6.amzn2.5.17
- glib2-2.56.1-9.amzn2.0.11
- ca-certificates-2025.2.76-1.amzn2.0.2

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.7.20250527-0.amzn2023
- system-release-2023.7.20250527-0.amzn2023
- glibc-minimal-langpack-2.34-181.amzn2023.0.1
- glibc-2.34-181.amzn2023.0.1
- libtasn1-4.19.0-1.amzn2023.0.5
- ca-certificates-2025.2.76-1.0.amzn2023.0.1
- gpgme-1.23.2-182.amzn2023.0.1
- glibc-common-2.34-181.amzn2023.0.1
- python3-gpg-1.23.2-182.amzn2023.0.1