### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250512.0
+Tags: 2023, latest, 2023.7.20250609.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: dacb9d52e9344a2977503cb4ecfc0879b69de878
+amd64-GitCommit: 4d953066c54d4022977eb64aa0b6bcd82e350f2f
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: a37632ff24fdf2d838fe84fc358d8844ecdcd365
+arm64v8-GitCommit: c261566026ff781e5efa379ecdd72d057abcefbd
 
-Tags: 2, 2.0.20250512.0
+Tags: 2, 2.0.20250610.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 943ba6f33d9edd4b4dce773a0501b914af2d39f8
+amd64-GitCommit: 890e843557c587dec993e9be443d9220e663580b
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 9194c0e5c6b27fe9a7c575b783debdf946cafe84
+arm64v8-GitCommit: bf0313fde8d73904f008a24d12f18d9d0d9a37c5
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- ca-certificates-2025.2.76-1.amzn2.0.2
- libgpg-error-1.31-1.amzn2.0.1
- libxml2-2.9.1-6.amzn2.5.17
- glib2-2.56.1-9.amzn2.0.11
- libtasn1-4.10-1.amzn2.0.7

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.7.20250609-0.amzn2023
- system-release-2023.7.20250609-0.amzn2023
- libtasn1-4.19.0-1.amzn2023.0.5
- ca-certificates-2025.2.76-1.0.amzn2023.0.1
- gpgme-1.23.2-182.amzn2023.0.1
- python3-gpg-1.23.2-182.amzn2023.0.1
- glibc-minimal-langpack-2.34-196.amzn2023.0.1
- glibc-2.34-196.amzn2023.0.1
- python3-setuptools-wheel-59.6.0-2.amzn2023.0.6
- glibc-common-2.34-196.amzn2023.0.1