### PR TITLE
Add tomcat version fallback method for Semeru containers

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -5,109 +5,109 @@ GitRepo: https://github.com/ibmruntimes/semeru-containers.git
 GitFetch: refs/heads/ibm
 
 #-----------------------------openj9 v8 images---------------------------------
-#Tags: open-8u452-b09-jdk-jammy, open-8-jdk-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 8/jdk/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-8u452-b09-jdk-jammy, open-8-jdk-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 8/jdk/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-8u452-b09-jdk-noble, open-8-jdk-noble
-#SharedTags: open-8u452-b09-jdk, open-8-jdk
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 8/jdk/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-8u452-b09-jdk-noble, open-8-jdk-noble
+SharedTags: open-8u452-b09-jdk, open-8-jdk
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 8/jdk/ubuntu/noble
+File: Dockerfile.open.releases.full
 
-#Tags: open-8u452-b09-jre-jammy, open-8-jre-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 8/jre/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-8u452-b09-jre-jammy, open-8-jre-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 8/jre/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-8u452-b09-jre-noble, open-8-jre-noble
-#SharedTags: open-8u452-b09-jre, open-8-jre
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 8/jre/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-8u452-b09-jre-noble, open-8-jre-noble
+SharedTags: open-8u452-b09-jre, open-8-jre
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 8/jre/ubuntu/noble
+File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
-#Tags: open-11.0.27_6-jdk-jammy, open-11-jdk-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 11/jdk/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-11.0.27_6-jdk-jammy, open-11-jdk-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 11/jdk/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-11.0.27_6-jdk-noble, open-11-jdk-noble
-#SharedTags: open-11.0.27_6-jdk, open-11-jdk
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 11/jdk/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-11.0.27_6-jdk-noble, open-11-jdk-noble
+SharedTags: open-11.0.27_6-jdk, open-11-jdk
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 11/jdk/ubuntu/noble
+File: Dockerfile.open.releases.full
 
-#Tags: open-11.0.27_6-jre-jammy, open-11-jre-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 11/jre/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-11.0.27_6-jre-jammy, open-11-jre-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 11/jre/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-11.0.27_6-jre-noble, open-11-jre-noble
-#SharedTags: open-11.0.27_6-jre, open-11-jre
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 11/jre/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-11.0.27_6-jre-noble, open-11-jre-noble
+SharedTags: open-11.0.27_6-jre, open-11-jre
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 11/jre/ubuntu/noble
+File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
-#Tags: open-17.0.15_6-jdk-jammy, open-17-jdk-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 17/jdk/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-17.0.15_6-jdk-jammy, open-17-jdk-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 17/jdk/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-17.0.15_6-jdk-noble, open-17-jdk-noble
-#SharedTags: open-17.0.15_6-jdk, open-17-jdk
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 17/jdk/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-17.0.15_6-jdk-noble, open-17-jdk-noble
+SharedTags: open-17.0.15_6-jdk, open-17-jdk
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 17/jdk/ubuntu/noble
+File: Dockerfile.open.releases.full
 
-#Tags: open-17.0.15_6-jre-jammy, open-17-jre-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 17/jre/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-17.0.15_6-jre-jammy, open-17-jre-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 17/jre/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-17.0.15_6-jre-noble, open-17-jre-noble
-#SharedTags: open-17.0.15_6-jre, open-17-jre
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 17/jre/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-17.0.15_6-jre-noble, open-17-jre-noble
+SharedTags: open-17.0.15_6-jre, open-17-jre
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 17/jre/ubuntu/noble
+File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v21 images---------------------------------
-#Tags: open-21.0.7_6-jdk-jammy, open-21-jdk-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 21/jdk/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-21.0.7_6-jdk-jammy, open-21-jdk-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 21/jdk/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-21.0.7_6-jdk-noble, open-21-jdk-noble
-#SharedTags: open-21.0.7_6-jdk, open-21-jdk
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 21/jdk/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-21.0.7_6-jdk-noble, open-21-jdk-noble
+SharedTags: open-21.0.7_6-jdk, open-21-jdk
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 21/jdk/ubuntu/noble
+File: Dockerfile.open.releases.full
 
-#Tags: open-21.0.7_6-jre-jammy, open-21-jre-jammy
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 21/jre/ubuntu/jammy
-#File: Dockerfile.open.releases.full
+Tags: open-21.0.7_6-jre-jammy, open-21-jre-jammy
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 21/jre/ubuntu/jammy
+File: Dockerfile.open.releases.full
 
-#Tags: open-21.0.7_6-jre-noble, open-21-jre-noble
-#SharedTags: open-21.0.7_6-jre, open-21-jre
-#Architectures: amd64, ppc64le, s390x, arm64v8
-#GitCommit: a1003659cad2232a0bb4e0ed49ae1c428e4d8b63
-#Directory: 21/jre/ubuntu/noble
-#File: Dockerfile.open.releases.full
+Tags: open-21.0.7_6-jre-noble, open-21-jre-noble
+SharedTags: open-21.0.7_6-jre, open-21-jre
+Architectures: amd64, ppc64le, s390x, arm64v8
+GitCommit: faa20429d12e88ada8d6b38dbcbca8741853e8e8
+Directory: 21/jre/ubuntu/noble
+File: Dockerfile.open.releases.full


### PR DESCRIPTION
Semeru Container Dockerfiles are updated to pick tomcat version from either https://archive.apache.org/dist/tomcat/tomcat-9 or https://dlcdn.apache.org/tomcat/tomcat-9/ 