### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.125.1, 5.125, 5, latest
+Tags: 5.126.0, 5.126, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f192ab96781889a1452aca93916e67850c1294f2
+GitCommit: 1f30930f32ebab134e804747bb7012f39db1587a
 Directory: 5/debian
 
-Tags: 5.125.1-alpine, 5.125-alpine, 5-alpine, alpine
+Tags: 5.126.0-alpine, 5.126-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f192ab96781889a1452aca93916e67850c1294f2
+GitCommit: 1f30930f32ebab134e804747bb7012f39db1587a
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1f30930: Update to 5.126.0, ghost-cli 1.27.0