### PR TITLE
Redis 8.2-m01

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -5,6 +5,18 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Dagan Sandler <dagan.sandler@redis.com> (@dagansandler)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
+Tags: 8.2-m01, 8.2-m01-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: c0091fa744e1437a972c5ee5c8062dc1894e6ab7
+GitFetch: refs/heads/release/8.2
+Directory: debian
+
+Tags: 8.2-m01-alpine, 8.2-m01-alpine3.22
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: c0091fa744e1437a972c5ee5c8062dc1894e6ab7
+GitFetch: refs/heads/release/8.2
+Directory: alpine
+
 Tags: 8.0.2, 8.0, 8, 8.0.2-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 5151eacdaf46f588f330c2e45fbed7fa0a7c192e


### PR DESCRIPTION
- Add Redis 8.2-m01 Debian variant (8.2-m01, 8.2-m01-bookworm)
- Add Redis 8.2-m01 Alpine variant based on alpine3.22 (8.2-m01-alpine, 8.2-m01-alpine3.22)
- Use commit c0091fa744e1437a972c5ee5c8062dc1894e6ab7 from release/8.2 branch
- Based on upstream master for clean milestone release