### PR TITLE
Update KrakenD to v2.10.1

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -3,7 +3,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakendio/docker-library.git
 
 # Alpine images
-Tags: 2.10.0, 2.10, 2, latest
+Tags: 2.10.1, 2.10, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: e251c6c6db51dcd34e11cc507830cfc200d652c1
-Directory: 2.10.0
+GitCommit: 12b7569e8fd292713ce18bcc4eb1e4e033e1f721
+Directory: 2.10.1


### PR DESCRIPTION
Security fixes for:
- [CVE-2025-4673](https://nvd.nist.gov/vuln/detail/CVE-2025-4673) 
- [CVE-2025-22874](https://nvd.nist.gov/vuln/detail/CVE-2025-22874)
- [CVE-2025-22868](https://nvd.nist.gov/vuln/detail/CVE-2025-22868)