### PR TITLE
archlinux: Release 20250622.0.370030

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250615.0.365905
-GitCommit: 32394b3e1408dc4b6da04e3fb655160707e1db93
-GitFetch: refs/tags/v20250615.0.365905
+Tags: latest, base, base-20250622.0.370030
+GitCommit: 70aed63144eeef75586bec5419a9dcb99f294c43
+GitFetch: refs/tags/v20250622.0.370030
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250615.0.365905
-GitCommit: 32394b3e1408dc4b6da04e3fb655160707e1db93
-GitFetch: refs/tags/v20250615.0.365905
+Tags: base-devel, base-devel-20250622.0.370030
+GitCommit: 70aed63144eeef75586bec5419a9dcb99f294c43
+GitFetch: refs/tags/v20250622.0.370030
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250615.0.365905
-GitCommit: 32394b3e1408dc4b6da04e3fb655160707e1db93
-GitFetch: refs/tags/v20250615.0.365905
+Tags: multilib-devel, multilib-devel-20250622.0.370030
+GitCommit: 70aed63144eeef75586bec5419a9dcb99f294c43
+GitFetch: refs/tags/v20250622.0.370030
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks