### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2025-9432 ELSA-2025-9430 ELSA-2025-9431 ELSA-2025-9526"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7f68a61d5c74c5c6ed1b75ba0f114b98cd2f304d
+amd64-GitCommit: 595d60b2a49570b4ab0b3057a029c72f28a34723
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1c04083da47ec9ff2335cdf6e7fd84d6a704ac46
+arm64v8-GitCommit: 8cc4e15ad045217cfa3c03d9c604a9bb9d1de35f
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-47268, CVE-2025-3576, CVE-2025-25724, CVE-2025-6020, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-9432.html
https://linux.oracle.com/errata/ELSA-2025-9430.html
https://linux.oracle.com/errata/ELSA-2025-9431.html
https://linux.oracle.com/errata/ELSA-2025-9526.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
