### PR TITLE
chore: update influxdb3 core and enterprise to 3.2.0

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,7 +6,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 063caa0d729da41b70760c8f7362345f1bb79779
+GitCommit: abb94994d78be45ccaa56282f36c36ad16bd5a5e
 
 Tags: 1.11, 1.11.8
 Architectures: amd64, arm64v8
@@ -48,10 +48,10 @@ Tags: 2-alpine, 2.7-alpine, 2.7.11-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.7/alpine
 
-Tags: 3-core, 3.1-core, 3.1.0-core, core
+Tags: 3-core, 3.2-core, 3.2.0-core, core
 Architectures: amd64, arm64v8
-Directory: influxdb/3.1-core
+Directory: influxdb/3.2-core
 
-Tags: 3-enterprise, 3.1-enterprise, 3.1.0-enterprise, enterprise
+Tags: 3-enterprise, 3.2-enterprise, 3.2.0-enterprise, enterprise
 Architectures: amd64, arm64v8
-Directory: influxdb/3.1-enterprise
+Directory: influxdb/3.2-enterprise


### PR DESCRIPTION
Update influxdb3 core and enterprise to v3.2.0