### PR TITLE
arangodb 3.12.5

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -1,13 +1,8 @@
-Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart), Vadim Kondratyev <vadim@arangodb.org> (@KVS85)
+Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.goesgens@arangodb.org> (@dothebart), Vadim Kondratev <vadim@arangodb.org> (@KVS85)
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.11, 3.11.14
+Tags: 3.12, 3.12.5, latest
 Architectures: amd64, arm64v8
-GitCommit: 8b486ff8c7b63e75c19f2bee37b756e9c0ba620f
-Directory: alpine/3.11.14
-
-Tags: 3.12, 3.12.4.3, latest
-Architectures: amd64, arm64v8
-GitCommit: 351d27922fd2060deb86a76a26a99ff1bb2f3c12
-Directory: alpine/3.12.4.3
+GitCommit: 4b0e7ca61aaaa24cf0d65d1ff96ed6068bcf5e9a
+Directory: alpine/3.12.5


### PR DESCRIPTION
Updated ArangoDB 3.12 to 3.12.5 and removed 3.11 (EoL).