### PR TITLE
Bump Traefik to v2.11.26 and v3.4.3 and v3.5.0-rc1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,22 +20,22 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
 Directory: v3.4/alpine
 
-Tags: v2.11.25-windowsservercore-ltsc2022, 2.11.25-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.26-windowsservercore-ltsc2022, 2.11.26-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8deaff57a2d889d1198c81e081cb0fdb6819c12a
+GitCommit: afab22bec71b19bf593216d6774e98b66e93e6c2
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.25-nanoserver-ltsc2022, 2.11.25-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.26-nanoserver-ltsc2022, 2.11.26-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8deaff57a2d889d1198c81e081cb0fdb6819c12a
+GitCommit: afab22bec71b19bf593216d6774e98b66e93e6c2
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.25, 2.11.25, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.26, 2.11.26, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8deaff57a2d889d1198c81e081cb0fdb6819c12a
+GitCommit: afab22bec71b19bf593216d6774e98b66e93e6c2
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,25 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
+Tags: v3.5.0-rc1-windowsservercore-ltsc2022, 3.5.0-rc1-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 3d170dece52062e6a27ddc1f4b553b3d92a7c756
+Directory: v3.5/windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: v3.5.0-rc1-nanoserver-ltsc2022, 3.5.0-rc1-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 3d170dece52062e6a27ddc1f4b553b3d92a7c756
+Directory: v3.5/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: v3.5.0-rc1, 3.5.0-rc1, chabichou
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 3d170dece52062e6a27ddc1f4b553b3d92a7c756
+Directory: v3.5/alpine
+
 Tags: v3.4.3-windowsservercore-ltsc2022, 3.4.3-windowsservercore-ltsc2022, v3.4-windowsservercore-ltsc2022, 3.4-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chaource-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git

--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.4.1-windowsservercore-ltsc2022, 3.4.1-windowsservercore-ltsc2022, v3.4-windowsservercore-ltsc2022, 3.4-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chaource-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.4.3-windowsservercore-ltsc2022, 3.4.3-windowsservercore-ltsc2022, v3.4-windowsservercore-ltsc2022, 3.4-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chaource-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
+GitCommit: a767e027745831be4213f86d020b9f6e56a9e59f
 Directory: v3.4/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.4.1-nanoserver-ltsc2022, 3.4.1-nanoserver-ltsc2022, v3.4-nanoserver-ltsc2022, 3.4-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chaource-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.4.3-nanoserver-ltsc2022, 3.4.3-nanoserver-ltsc2022, v3.4-nanoserver-ltsc2022, 3.4-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chaource-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
+GitCommit: a767e027745831be4213f86d020b9f6e56a9e59f
 Directory: v3.4/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.4.1, 3.4.1, v3.4, 3.4, v3, 3, chaource, latest
+Tags: v3.4.3, 3.4.3, v3.4, 3.4, v3, 3, chaource, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 19c7156de69c027a199d78d77efc7285d9cca13e
+GitCommit: a767e027745831be4213f86d020b9f6e56a9e59f
 Directory: v3.4/alpine
 
 Tags: v2.11.26-windowsservercore-ltsc2022, 2.11.26-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.26](https://github.com/traefik/traefik/releases/tag/v2.11.26) , [v3.4.3](https://github.com/traefik/traefik/releases/tag/v3.4.3), and  [v3.5.0-rc1](https://github.com/traefik/traefik/releases/tag/v3.5.0-rc1).

/cc @nmengin @mmatur @kevinpollet