### PR TITLE
chore: Bump to Rust version 1.88.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,41 +1,42 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/311332e026a7a603ccb2e7d8f9eb0117615f49df/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/9ba2805c3642783b50436e140f5eaa9ecf173054/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
-             Scott Schafer <schaferjscott@gmail.com> (@Muscraft)
+             Scott Schafer <schaferjscott@gmail.com> (@Muscraft),
+             Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.87-bullseye, 1.87.0-bullseye, bullseye
+Tags: 1-bullseye, 1.88-bullseye, 1.88.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.87-slim-bullseye, 1.87.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.88-slim-bullseye, 1.88.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.87-bookworm, 1.87.0-bookworm, bookworm, 1, 1.87, 1.87.0, latest
+Tags: 1-bookworm, 1.88-bookworm, 1.88.0-bookworm, bookworm, 1, 1.88, 1.88.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.87-slim-bookworm, 1.87.0-slim-bookworm, slim-bookworm, 1-slim, 1.87-slim, 1.87.0-slim, slim
+Tags: 1-slim-bookworm, 1.88-slim-bookworm, 1.88.0-slim-bookworm, slim-bookworm, 1-slim, 1.88-slim, 1.88.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/bookworm/slim
 
-Tags: 1-alpine3.20, 1.87-alpine3.20, 1.87.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.88-alpine3.20, 1.88.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8
-GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.87-alpine3.21, 1.87.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.88-alpine3.21, 1.88.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8
-GitCommit: dfb10b7de9b61ced7cd6eb3907815cadbc6f16c3
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.87-alpine3.22, 1.87.0-alpine3.22, alpine3.22, 1-alpine, 1.87-alpine, 1.87.0-alpine, alpine
+Tags: 1-alpine3.22, 1.88-alpine3.22, 1.88.0-alpine3.22, alpine3.22, 1-alpine, 1.88-alpine, 1.88.0-alpine, alpine
 Architectures: amd64, arm64v8
-GitCommit: 311332e026a7a603ccb2e7d8f9eb0117615f49df
+GitCommit: 9ba2805c3642783b50436e140f5eaa9ecf173054
 Directory: stable/alpine3.22
 


### PR DESCRIPTION
https://blog.rust-lang.org/2025/06/26/Rust-1.88.0/
https://github.com/rust-lang/rust/releases/tag/1.88.0