### PR TITLE
archlinux: Release 20250629.0.373469

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250622.0.370030
-GitCommit: 70aed63144eeef75586bec5419a9dcb99f294c43
-GitFetch: refs/tags/v20250622.0.370030
+Tags: latest, base, base-20250629.0.373469
+GitCommit: 6dc57a996ed660aa8f9b7c085572a238dc05cc8e
+GitFetch: refs/tags/v20250629.0.373469
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250622.0.370030
-GitCommit: 70aed63144eeef75586bec5419a9dcb99f294c43
-GitFetch: refs/tags/v20250622.0.370030
+Tags: base-devel, base-devel-20250629.0.373469
+GitCommit: 6dc57a996ed660aa8f9b7c085572a238dc05cc8e
+GitFetch: refs/tags/v20250629.0.373469
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250622.0.370030
-GitCommit: 70aed63144eeef75586bec5419a9dcb99f294c43
-GitFetch: refs/tags/v20250622.0.370030
+Tags: multilib-devel, multilib-devel-20250629.0.373469
+GitCommit: 6dc57a996ed660aa8f9b7c085572a238dc05cc8e
+GitFetch: refs/tags/v20250629.0.373469
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks