### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,12 +5,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 5.127.2, 5.127, 5, latest
+Tags: 5.128.0, 5.128, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: e69077bccf7d6a25858805a6077320986dbae9f9
+GitCommit: 4ab56b390e45ba4be016b95c7e671dae96450ac1
 Directory: 5/debian
 
-Tags: 5.127.2-alpine, 5.127-alpine, 5-alpine, alpine
+Tags: 5.128.0-alpine, 5.128-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: e69077bccf7d6a25858805a6077320986dbae9f9
+GitCommit: 4ab56b390e45ba4be016b95c7e671dae96450ac1
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/4ab56b3: Update to 5.128.0, ghost-cli 1.27.0