### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,62 +6,62 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.8.1-php8.1-apache, 6.8-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.8.1-php8.1, 6.8-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.1/apache
 
 Tags: 6.8.1-php8.1-fpm, 6.8-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.1/fpm
 
 Tags: 6.8.1-php8.1-fpm-alpine, 6.8-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.1/fpm-alpine
 
 Tags: 6.8.1-apache, 6.8-apache, 6-apache, apache, 6.8.1, 6.8, 6, latest, 6.8.1-php8.2-apache, 6.8-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.8.1-php8.2, 6.8-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.2/apache
 
 Tags: 6.8.1-fpm, 6.8-fpm, 6-fpm, fpm, 6.8.1-php8.2-fpm, 6.8-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.2/fpm
 
 Tags: 6.8.1-fpm-alpine, 6.8-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.8.1-php8.2-fpm-alpine, 6.8-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.2/fpm-alpine
 
 Tags: 6.8.1-php8.3-apache, 6.8-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.8.1-php8.3, 6.8-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.3/apache
 
 Tags: 6.8.1-php8.3-fpm, 6.8-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.3/fpm
 
 Tags: 6.8.1-php8.3-fpm-alpine, 6.8-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.3/fpm-alpine
 
 Tags: 6.8.1-php8.4-apache, 6.8-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.8.1-php8.4, 6.8-php8.4, 6-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.4/apache
 
 Tags: 6.8.1-php8.4-fpm, 6.8-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.4/fpm
 
 Tags: 6.8.1-php8.4-fpm-alpine, 6.8-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8721d7271bf763d999285985277d61e78c584aa
+GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
 Directory: latest/php8.4/fpm-alpine
 
 Tags: cli-2.12.0-php8.1, cli-2.12-php8.1, cli-2-php8.1, cli-php8.1


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/97b58bf: Merge pull request https://github.com/docker-library/wordpress/pull/971 from infosiftr/docker-ensure-installed
- https://github.com/docker-library/wordpress/commit/447d7d6: Add `docker-ensure-installed.sh` as an explicit entrypoint/symlink