### PR TITLE
arangodb 3.12.5 (with BTS-1877 fix)

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -4,5 +4,5 @@ GitFetch: refs/heads/official
 
 Tags: 3.12, 3.12.5, latest
 Architectures: amd64, arm64v8
-GitCommit: 4b0e7ca61aaaa24cf0d65d1ff96ed6068bcf5e9a
+GitCommit: fc9ce3eff9804b5232c97894c603266eae12a592
 Directory: alpine/3.12.5


### PR DESCRIPTION
Updated ArangoDB 3.12 to 3.12.5 with BTS-1877 fix.