### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-9877"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 48cc251d441898c3f05fa3048ac2ad4c276ee2d7
+amd64-GitCommit: 5b33f7c43239403a22d823bc3ff2195ff1691fed
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c05043ab273ec4439190ca3f4b00d454590ff8c9
+arm64v8-GitCommit: 6ba0a813df5b6316cdaf952864aab34d7fc81557
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5702, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-9877.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
