### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.1.1, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 7e462c35dba545cf20d78a0ac3d18ba27c2e847e
+GitCommit: 9eafde89a61aa032cf9a47cd1e58951444210ff5
 Directory: 4.1/ubuntu
 
 Tags: 4.1.1-management, 4.1-management, 4-management, management
@@ -17,7 +17,7 @@ Directory: 4.1/ubuntu/management
 
 Tags: 4.1.1-alpine, 4.1-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7e462c35dba545cf20d78a0ac3d18ba27c2e847e
+GitCommit: 9eafde89a61aa032cf9a47cd1e58951444210ff5
 Directory: 4.1/alpine
 
 Tags: 4.1.1-management-alpine, 4.1-management-alpine, 4-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 4.1/alpine/management
 
 Tags: 4.0.9, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 9fe5ffd717216db809fe0207c0b7266d231fa3a0
+GitCommit: 87e124e1c98f38cda70af592b5c994c36cb7847c
 Directory: 4.0/ubuntu
 
 Tags: 4.0.9-management, 4.0-management
@@ -37,7 +37,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.9-alpine, 4.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9fe5ffd717216db809fe0207c0b7266d231fa3a0
+GitCommit: 87e124e1c98f38cda70af592b5c994c36cb7847c
 Directory: 4.0/alpine
 
 Tags: 4.0.9-management-alpine, 4.0-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/9eafde8: Update 4.1 to openssl 3.3.4
- https://github.com/docker-library/rabbitmq/commit/87e124e: Update 4.0 to openssl 3.3.4