### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b6f17fd781acb5ce7522ba6d5d2b03a34d210e5b
 Directory: 3.3/alpine
 
-Tags: 3.2.1, 3.2, latest, lts, 3.2.1-bookworm, 3.2-bookworm, bookworm, lts-bookworm
+Tags: 3.2.2, 3.2, latest, lts, 3.2.2-bookworm, 3.2-bookworm, bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: e57bdf9982a76d5391e3f40eec41ae0c6c477ae0
+GitCommit: d29240a8f2a0b5f4eead7098f7fc4952654c5e21
 Directory: 3.2
 
-Tags: 3.2.1-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.1-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.2-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.2-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e57bdf9982a76d5391e3f40eec41ae0c6c477ae0
+GitCommit: d29240a8f2a0b5f4eead7098f7fc4952654c5e21
 Directory: 3.2/alpine
 
 Tags: 3.1.8, 3.1, 3.1.8-bookworm, 3.1-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/d29240a: Update 3.2 to 3.2.2