### PR TITLE
[oraclelinux] Updating 8 for ELSA-2025-10027

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5b33f7c43239403a22d823bc3ff2195ff1691fed
+amd64-GitCommit: 4e9d8c307845ea0a1ae91cf3e3324269137ed213
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6ba0a813df5b6316cdaf952864aab34d7fc81557
+arm64v8-GitCommit: 4612712a764e05dbe8c00941fe88ee320c4b6fd0
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6020

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-10027.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
