### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-10128"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4e9d8c307845ea0a1ae91cf3e3324269137ed213
+amd64-GitCommit: 4b8879ec20f8a00a9304d0dcc494a11bea93f5dc
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4612712a764e05dbe8c00941fe88ee320c4b6fd0
+arm64v8-GitCommit: cde1a732aeabaad056f70040037e02bdc4ffbc1d
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-12718, CVE-2025-4138, CVE-2025-4330, CVE-2025-4435, CVE-2025-4517, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-10128.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
