### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250609.0
+Tags: 2023, latest, 2023.7.20250623.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 4d953066c54d4022977eb64aa0b6bcd82e350f2f
+amd64-GitCommit: 1d30653467bce95f1e74ce047c186cf527122751
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: c261566026ff781e5efa379ecdd72d057abcefbd
+arm64v8-GitCommit: a81fad6c3cf53440ebc2f0cd04695e90e540612d
 
-Tags: 2, 2.0.20250610.0
+Tags: 2, 2.0.20250623.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 890e843557c587dec993e9be443d9220e663580b
+amd64-GitCommit: 1f08d8c203661dd3116b52c70b6a6067b22cc81a
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: bf0313fde8d73904f008a24d12f18d9d0d9a37c5
+arm64v8-GitCommit: 3988bfc773dc079afce6bdf9538b351d7ab11463
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- libxml2-2.9.1-6.amzn2.5.18
#### Packages addressing CVES:
- libxml2-2.9.1-6.amzn2.5.18
  - [CVE-2025-6021](https://alas.aws.amazon.com/cve/html/CVE-2025-6021.html)

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.7.20250623-0.amzn2023
- system-release-2023.7.20250623-0.amzn2023
- libxml2-2.10.4-1.amzn2023.0.11
- curl-minimal-8.11.1-4.amzn2023.0.1
- python3-3.9.23-1.amzn2023.0.1
- libcurl-minimal-8.11.1-4.amzn2023.0.1
- python3-libs-3.9.23-1.amzn2023.0.1
- libarchive-3.7.4-2.amzn2023.0.3
#### Packages addressing CVES:
- libxml2-2.10.4-1.amzn2023.0.11
  - [CVE-2025-6021](https://alas.aws.amazon.com/cve/html/CVE-2025-6021.html)
- curl-minimal-8.11.1-4.amzn2023.0.1, libcurl-minimal-8.11.1-4.amzn2023.0.1
  - [CVE-2024-9681](https://alas.aws.amazon.com/cve/html/CVE-2024-9681.html)
- python3-3.9.23-1.amzn2023.0.1, python3-libs-3.9.23-1.amzn2023.0.1
  - [CVE-2024-12718](https://alas.aws.amazon.com/cve/html/CVE-2024-12718.html)
  - [CVE-2025-4138](https://alas.aws.amazon.com/cve/html/CVE-2025-4138.html)
  - [CVE-2025-4330](https://alas.aws.amazon.com/cve/html/CVE-2025-4330.html)
  - [CVE-2025-4435](https://alas.aws.amazon.com/cve/html/CVE-2025-4435.html)
  - [CVE-2025-4517](https://alas.aws.amazon.com/cve/html/CVE-2025-4517.html)
- libarchive-3.7.4-2.amzn2023.0.3
  - [CVE-2025-5914](https://alas.aws.amazon.com/cve/html/CVE-2025-5914.html)