### PR TITLE
archlinux: Release 20250706.0.377547

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250629.0.373469
-GitCommit: 6dc57a996ed660aa8f9b7c085572a238dc05cc8e
-GitFetch: refs/tags/v20250629.0.373469
+Tags: latest, base, base-20250706.0.377547
+GitCommit: 586fd52db83f6e3715f36ed5fd1783725c5ad3ca
+GitFetch: refs/tags/v20250706.0.377547
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250629.0.373469
-GitCommit: 6dc57a996ed660aa8f9b7c085572a238dc05cc8e
-GitFetch: refs/tags/v20250629.0.373469
+Tags: base-devel, base-devel-20250706.0.377547
+GitCommit: 586fd52db83f6e3715f36ed5fd1783725c5ad3ca
+GitFetch: refs/tags/v20250706.0.377547
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250629.0.373469
-GitCommit: 6dc57a996ed660aa8f9b7c085572a238dc05cc8e
-GitFetch: refs/tags/v20250629.0.373469
+Tags: multilib-devel, multilib-devel-20250706.0.377547
+GitCommit: 586fd52db83f6e3715f36ed5fd1783725c5ad3ca
+GitFetch: refs/tags/v20250706.0.377547
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks