### PR TITLE
SapMachine Updates

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,167 +1,147 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Arno Zeller <sapmachine@sap.com> (@ArnoZeller)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: latest, jdk-ubuntu, 24, 24-jdk-ubuntu, 24.0.1, 24.0.1-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, 24-ubuntu-noble, 24-ubuntu-24.04, 24.0.1-ubuntu-noble, 24.0.1-ubuntu-24.04, 24-jdk-ubuntu-noble, 24-jdk-ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 24.0.1-jdk-ubuntu-noble, 24.0.1-jdk-ubuntu-24.04
+Tags: latest, ubuntu, jdk, jdk-ubuntu, 24, 24-ubuntu, 24.0.1, 24.0.1-ubuntu, 24-jdk, 24-jdk-ubuntu, 24.0.1-jdk, 24.0.1-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 24-ubuntu-noble, 24-ubuntu-24.04, 24-jdk-ubuntu-noble, 24-jdk-ubuntu-24.04, 24.0.1-ubuntu-noble, 24.0.1-ubuntu-24.04, 24.0.1-jdk-ubuntu-noble, 24.0.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/24_04/jdk
 
-Tags: jdk-headless-ubuntu, 24-jdk-headless-ubuntu, 24.0.1-jdk-headless-ubuntu, 24-jdk-headless-ubuntu-noble, 24-jdk-headless-ubuntu-24.04, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 24.0.1-jdk-headless-ubuntu-noble, 24.0.1-jdk-headless-ubuntu-24.04
+Tags: jdk-headless, jdk-headless-ubuntu, 24-jdk-headless, 24-jdk-headless-ubuntu, 24.0.1-jdk-headless, 24.0.1-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 24-jdk-headless-ubuntu-noble, 24-jdk-headless-ubuntu-24.04, 24.0.1-jdk-headless-ubuntu-noble, 24.0.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/24_04/jdk-headless
 
-Tags: jre-ubuntu, 24-jre-ubuntu, 24.0.1-jre-ubuntu, 24-jre-ubuntu-noble, 24-jre-ubuntu-24.04, jre-ubuntu-noble, jre-ubuntu-24.04, 24.0.1-jre-ubuntu-noble, 24.0.1-jre-ubuntu-24.04
+Tags: jre, jre-ubuntu, 24-jre, 24-jre-ubuntu, 24.0.1-jre, 24.0.1-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 24-jre-ubuntu-noble, 24-jre-ubuntu-24.04, 24.0.1-jre-ubuntu-noble, 24.0.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/24_04/jre
 
-Tags: jre-headless-ubuntu, 24-jre-headless-ubuntu, 24.0.1-jre-headless-ubuntu, 24-jre-headless-ubuntu-noble, 24-jre-headless-ubuntu-24.04, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 24.0.1-jre-headless-ubuntu-noble, 24.0.1-jre-headless-ubuntu-24.04
+Tags: jre-headless, jre-headless-ubuntu, 24-jre-headless, 24-jre-headless-ubuntu, 24.0.1-jre-headless, 24.0.1-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 24-jre-headless-ubuntu-noble, 24-jre-headless-ubuntu-24.04, 24.0.1-jre-headless-ubuntu-noble, 24.0.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/24_04/jre-headless
 
-Tags: ubuntu-jammy, ubuntu-22.04, 24-ubuntu-jammy, 24-ubuntu-22.04, 24.0.1-ubuntu-jammy, 24.0.1-ubuntu-22.04, 24-jdk-ubuntu-jammy, 24-jdk-ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 24.0.1-jdk-ubuntu-jammy, 24.0.1-jdk-ubuntu-22.04
+Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 24-ubuntu-jammy, 24-ubuntu-22.04, 24-jdk-ubuntu-jammy, 24-jdk-ubuntu-22.04, 24.0.1-ubuntu-jammy, 24.0.1-ubuntu-22.04, 24.0.1-jdk-ubuntu-jammy, 24.0.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/22_04/jdk
 
-Tags: 24-jdk-headless-ubuntu-jammy, 24-jdk-headless-ubuntu-22.04, jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 24.0.1-jdk-headless-ubuntu-jammy, 24.0.1-jdk-headless-ubuntu-22.04
+Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 24-jdk-headless-ubuntu-jammy, 24-jdk-headless-ubuntu-22.04, 24.0.1-jdk-headless-ubuntu-jammy, 24.0.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/22_04/jdk-headless
 
-Tags: 24-jre-ubuntu-jammy, 24-jre-ubuntu-22.04, jre-ubuntu-jammy, jre-ubuntu-22.04, 24.0.1-jre-ubuntu-jammy, 24.0.1-jre-ubuntu-22.04
+Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 24-jre-ubuntu-jammy, 24-jre-ubuntu-22.04, 24.0.1-jre-ubuntu-jammy, 24.0.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/22_04/jre
 
-Tags: 24-jre-headless-ubuntu-jammy, 24-jre-headless-ubuntu-22.04, jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 24.0.1-jre-headless-ubuntu-jammy, 24.0.1-jre-headless-ubuntu-22.04
+Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 24-jre-headless-ubuntu-jammy, 24-jre-headless-ubuntu-22.04, 24.0.1-jre-headless-ubuntu-jammy, 24.0.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/ubuntu/22_04/jre-headless
 
-Tags: ubuntu-focal, ubuntu-20.04, 24-ubuntu-focal, 24-ubuntu-20.04, 24.0.1-ubuntu-focal, 24.0.1-ubuntu-20.04, 24-jdk-ubuntu-focal, 24-jdk-ubuntu-20.04, jdk-ubuntu-focal, jdk-ubuntu-20.04, 24.0.1-jdk-ubuntu-focal, 24.0.1-jdk-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
-Directory: dockerfiles/24/ubuntu/20_04/jdk
+Tags: alpine, jdk-alpine, 24-alpine, 24.0.1-alpine, 24-jdk-alpine, 24.0.1-jdk-alpine, alpine-3.22, jdk-alpine-3.22, 24-alpine-3.22, 24-jdk-alpine-3.22, 24.0.1-alpine-3.22, 24.0.1-jdk-alpine-3.22
+Architectures: amd64
+GitCommit: 8540b4a7636cfd29507fb6853f8f5d6331f62d24
+Directory: dockerfiles/24/alpine/3_22/jdk
 
-Tags: 24-jdk-headless-ubuntu-focal, 24-jdk-headless-ubuntu-20.04, jdk-headless-ubuntu-focal, jdk-headless-ubuntu-20.04, 24.0.1-jdk-headless-ubuntu-focal, 24.0.1-jdk-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
-Directory: dockerfiles/24/ubuntu/20_04/jdk-headless
+Tags: jre-alpine, 24-jre-alpine, 24.0.1-jre-alpine, jre-alpine-3.22, 24-jre-alpine-3.22, 24.0.1-jre-alpine-3.22
+Architectures: amd64
+GitCommit: 8540b4a7636cfd29507fb6853f8f5d6331f62d24
+Directory: dockerfiles/24/alpine/3_22/jre
 
-Tags: 24-jre-ubuntu-focal, 24-jre-ubuntu-20.04, jre-ubuntu-focal, jre-ubuntu-20.04, 24.0.1-jre-ubuntu-focal, 24.0.1-jre-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
-Directory: dockerfiles/24/ubuntu/20_04/jre
-
-Tags: 24-jre-headless-ubuntu-focal, 24-jre-headless-ubuntu-20.04, jre-headless-ubuntu-focal, jre-headless-ubuntu-20.04, 24.0.1-jre-headless-ubuntu-focal, 24.0.1-jre-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
-Directory: dockerfiles/24/ubuntu/20_04/jre-headless
-
-Tags: jdk-alpine, 24-jdk-alpine, 24.0.1-jdk-alpine, alpine-3.21, 24-alpine-3.21, 24.0.1-alpine-3.21, 24-jdk-alpine-3.21, jdk-alpine-3.21, 24.0.1-jdk-alpine-3.21
+Tags: alpine-3.21, jdk-alpine-3.21, 24-alpine-3.21, 24-jdk-alpine-3.21, 24.0.1-alpine-3.21, 24.0.1-jdk-alpine-3.21
 Architectures: amd64
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/alpine/3_21/jdk
 
-Tags: jre-alpine, 24-jre-alpine, 24.0.1-jre-alpine, 24-jre-alpine-3.21, jre-alpine-3.21, 24.0.1-jre-alpine-3.21
+Tags: jre-alpine-3.21, 24-jre-alpine-3.21, 24.0.1-jre-alpine-3.21
 Architectures: amd64
 GitCommit: f812009dd9d683d710e00f3e9c6978c23c4da797
 Directory: dockerfiles/24/alpine/3_21/jre
 
-Tags: 21, lts, 21-jdk-ubuntu, lts-jdk-ubuntu, 21.0.7, 21.0.7-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, lts-ubuntu-noble, lts-ubuntu-24.04, 21.0.7-ubuntu-noble, 21.0.7-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 21.0.7-jdk-ubuntu-noble, 21.0.7-jdk-ubuntu-24.04
+Tags: lts, lts-ubuntu, 21, 21-ubuntu, 21.0.7, 21.0.7-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.7-jdk, 21.0.7-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.7-ubuntu-noble, 21.0.7-ubuntu-24.04, 21.0.7-jdk-ubuntu-noble, 21.0.7-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/24_04/jdk
 
-Tags: 21-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, 21.0.7-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 21.0.7-jdk-headless-ubuntu-noble, 21.0.7-jdk-headless-ubuntu-24.04
+Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.7-jdk-headless, 21.0.7-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.7-jdk-headless-ubuntu-noble, 21.0.7-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
-Tags: 21-jre-ubuntu, lts-jre-ubuntu, 21.0.7-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 21.0.7-jre-ubuntu-noble, 21.0.7-jre-ubuntu-24.04
+Tags: 21-jre, 21-jre-ubuntu, 21.0.7-jre, 21.0.7-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.7-jre-ubuntu-noble, 21.0.7-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/24_04/jre
 
-Tags: 21-jre-headless-ubuntu, lts-jre-headless-ubuntu, 21.0.7-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 21.0.7-jre-headless-ubuntu-noble, 21.0.7-jre-headless-ubuntu-24.04
+Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.7-jre-headless, 21.0.7-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.7-jre-headless-ubuntu-noble, 21.0.7-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
-Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, lts-ubuntu-jammy, lts-ubuntu-22.04, 21.0.7-ubuntu-jammy, 21.0.7-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 21.0.7-jdk-ubuntu-jammy, 21.0.7-jdk-ubuntu-22.04
+Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.7-ubuntu-jammy, 21.0.7-ubuntu-22.04, 21.0.7-jdk-ubuntu-jammy, 21.0.7-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/22_04/jdk
 
-Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 21.0.7-jdk-headless-ubuntu-jammy, 21.0.7-jdk-headless-ubuntu-22.04
+Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.7-jdk-headless-ubuntu-jammy, 21.0.7-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
 
-Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 21.0.7-jre-ubuntu-jammy, 21.0.7-jre-ubuntu-22.04
+Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.7-jre-ubuntu-jammy, 21.0.7-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/22_04/jre
 
-Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 21.0.7-jre-headless-ubuntu-jammy, 21.0.7-jre-headless-ubuntu-22.04
+Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.7-jre-headless-ubuntu-jammy, 21.0.7-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
-Tags: 21-ubuntu-focal, 21-ubuntu-20.04, lts-ubuntu-focal, lts-ubuntu-20.04, 21.0.7-ubuntu-focal, 21.0.7-ubuntu-20.04, 21-jdk-ubuntu-focal, 21-jdk-ubuntu-20.04, lts-jdk-ubuntu-focal, lts-jdk-ubuntu-20.04, 21.0.7-jdk-ubuntu-focal, 21.0.7-jdk-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
-Directory: dockerfiles/21/ubuntu/20_04/jdk
+Tags: lts-alpine, 21-alpine, 21.0.7-alpine, lts-jdk-alpine, 21-jdk-alpine, 21.0.7-jdk-alpine, lts-alpine-3.22, lts-jdk-alpine-3.22, 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.7-alpine-3.22, 21.0.7-jdk-alpine-3.22
+Architectures: amd64
+GitCommit: f6b5f88e98cac94b30cfaa2321cfde070fd32208
+Directory: dockerfiles/21/alpine/3_22/jdk
 
-Tags: 21-jdk-headless-ubuntu-focal, 21-jdk-headless-ubuntu-20.04, lts-jdk-headless-ubuntu-focal, lts-jdk-headless-ubuntu-20.04, 21.0.7-jdk-headless-ubuntu-focal, 21.0.7-jdk-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
-Directory: dockerfiles/21/ubuntu/20_04/jdk-headless
+Tags: lts-jre-alpine, 21-jre-alpine, 21.0.7-jre-alpine, lts-jre-alpine-3.22, 21-jre-alpine-3.22, 21.0.7-jre-alpine-3.22
+Architectures: amd64
+GitCommit: f6b5f88e98cac94b30cfaa2321cfde070fd32208
+Directory: dockerfiles/21/alpine/3_22/jre
 
-Tags: 21-jre-ubuntu-focal, 21-jre-ubuntu-20.04, lts-jre-ubuntu-focal, lts-jre-ubuntu-20.04, 21.0.7-jre-ubuntu-focal, 21.0.7-jre-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
-Directory: dockerfiles/21/ubuntu/20_04/jre
-
-Tags: 21-jre-headless-ubuntu-focal, 21-jre-headless-ubuntu-20.04, lts-jre-headless-ubuntu-focal, lts-jre-headless-ubuntu-20.04, 21.0.7-jre-headless-ubuntu-focal, 21.0.7-jre-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
-Directory: dockerfiles/21/ubuntu/20_04/jre-headless
-
-Tags: 21-jdk-alpine, lts-jdk-alpine, 21.0.7-jdk-alpine, 21-alpine-3.21, lts-alpine-3.21, 21.0.7-alpine-3.21, 21-jdk-alpine-3.21, lts-jdk-alpine-3.21, 21.0.7-jdk-alpine-3.21
+Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.7-alpine-3.21, 21.0.7-jdk-alpine-3.21
 Architectures: amd64
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/alpine/3_21/jdk
 
-Tags: 21-jre-alpine, lts-jre-alpine, 21.0.7-jre-alpine, 21-jre-alpine-3.21, lts-jre-alpine-3.21, 21.0.7-jre-alpine-3.21
+Tags: lts-jre-alpine-3.21, 21-jre-alpine-3.21, 21.0.7-jre-alpine-3.21
 Architectures: amd64
 GitCommit: 54b17adefafcdd1f5929dd7681d8b98ab4d86e4c
 Directory: dockerfiles/21/alpine/3_21/jre
 
-Tags: 17, 17-jdk-ubuntu, 17.0.15, 17.0.15-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17.0.15-ubuntu-noble, 17.0.15-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.15-jdk-ubuntu-noble, 17.0.15-jdk-ubuntu-24.04
+Tags: 17, 17-ubuntu, 17.0.15, 17.0.15-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.15-jdk, 17.0.15-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.15-ubuntu-noble, 17.0.15-ubuntu-24.04, 17.0.15-jdk-ubuntu-noble, 17.0.15-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/ubuntu/24_04/jdk
 
-Tags: 17-jdk-headless-ubuntu, 17.0.15-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.15-jdk-headless-ubuntu-noble, 17.0.15-jdk-headless-ubuntu-24.04
+Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.15-jdk-headless, 17.0.15-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.15-jdk-headless-ubuntu-noble, 17.0.15-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
-Tags: 17-jre-ubuntu, 17.0.15-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.15-jre-ubuntu-noble, 17.0.15-jre-ubuntu-24.04
+Tags: 17-jre, 17-jre-ubuntu, 17.0.15-jre, 17.0.15-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.15-jre-ubuntu-noble, 17.0.15-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/ubuntu/24_04/jre
 
-Tags: 17-jre-headless-ubuntu, 17.0.15-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.15-jre-headless-ubuntu-noble, 17.0.15-jre-headless-ubuntu-24.04
+Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.15-jre-headless, 17.0.15-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.15-jre-headless-ubuntu-noble, 17.0.15-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
-Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17.0.15-ubuntu-jammy, 17.0.15-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.15-jdk-ubuntu-jammy, 17.0.15-jdk-ubuntu-22.04
+Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.15-ubuntu-jammy, 17.0.15-ubuntu-22.04, 17.0.15-jdk-ubuntu-jammy, 17.0.15-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/ubuntu/22_04/jdk
@@ -181,57 +161,47 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
-Tags: 17-ubuntu-focal, 17-ubuntu-20.04, 17.0.15-ubuntu-focal, 17.0.15-ubuntu-20.04, 17-jdk-ubuntu-focal, 17-jdk-ubuntu-20.04, 17.0.15-jdk-ubuntu-focal, 17.0.15-jdk-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
-Directory: dockerfiles/17/ubuntu/20_04/jdk
+Tags: 17-alpine, 17.0.15-alpine, 17-jdk-alpine, 17.0.15-jdk-alpine, 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.15-alpine-3.22, 17.0.15-jdk-alpine-3.22
+Architectures: amd64
+GitCommit: 7363a6d1e47c9f6371c1fb5b2dcc8525396e5d2f
+Directory: dockerfiles/17/alpine/3_22/jdk
 
-Tags: 17-jdk-headless-ubuntu-focal, 17-jdk-headless-ubuntu-20.04, 17.0.15-jdk-headless-ubuntu-focal, 17.0.15-jdk-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
-Directory: dockerfiles/17/ubuntu/20_04/jdk-headless
+Tags: 17-jre-alpine, 17.0.15-jre-alpine, 17-jre-alpine-3.22, 17.0.15-jre-alpine-3.22
+Architectures: amd64
+GitCommit: 7363a6d1e47c9f6371c1fb5b2dcc8525396e5d2f
+Directory: dockerfiles/17/alpine/3_22/jre
 
-Tags: 17-jre-ubuntu-focal, 17-jre-ubuntu-20.04, 17.0.15-jre-ubuntu-focal, 17.0.15-jre-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
-Directory: dockerfiles/17/ubuntu/20_04/jre
-
-Tags: 17-jre-headless-ubuntu-focal, 17-jre-headless-ubuntu-20.04, 17.0.15-jre-headless-ubuntu-focal, 17.0.15-jre-headless-ubuntu-20.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
-Directory: dockerfiles/17/ubuntu/20_04/jre-headless
-
-Tags: 17-jdk-alpine, 17.0.15-jdk-alpine, 17-alpine-3.21, 17.0.15-alpine-3.21, 17-jdk-alpine-3.21, 17.0.15-jdk-alpine-3.21
+Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.15-alpine-3.21, 17.0.15-jdk-alpine-3.21
 Architectures: amd64
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/alpine/3_21/jdk
 
-Tags: 17-jre-alpine, 17.0.15-jre-alpine, 17-jre-alpine-3.21, 17.0.15-jre-alpine-3.21
+Tags: 17-jre-alpine-3.21, 17.0.15-jre-alpine-3.21
 Architectures: amd64
 GitCommit: eda1e4d07cb6b70feef4d6192bcf09593bafc3dd
 Directory: dockerfiles/17/alpine/3_21/jre
 
-Tags: 11, 11-jdk-ubuntu, 11.0.27, 11.0.27-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11.0.27-ubuntu-noble, 11.0.27-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.27-jdk-ubuntu-noble, 11.0.27-jdk-ubuntu-24.04
+Tags: 11, 11-ubuntu, 11.0.27, 11.0.27-ubuntu, 11-jdk, 11-jdk-ubuntu, 11.0.27-jdk, 11.0.27-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.27-ubuntu-noble, 11.0.27-ubuntu-24.04, 11.0.27-jdk-ubuntu-noble, 11.0.27-jdk-ubuntu-24.04
 Architectures: amd64
 GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
 Directory: dockerfiles/11/ubuntu/24_04/jdk
 
-Tags: 11-jdk-headless-ubuntu, 11.0.27-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.27-jdk-headless-ubuntu-noble, 11.0.27-jdk-headless-ubuntu-24.04
+Tags: 11-jdk-headless, 11-jdk-headless-ubuntu, 11.0.27-jdk-headless, 11.0.27-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.27-jdk-headless-ubuntu-noble, 11.0.27-jdk-headless-ubuntu-24.04
 Architectures: amd64
 GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
 Directory: dockerfiles/11/ubuntu/24_04/jdk-headless
 
-Tags: 11-jre-ubuntu, 11.0.27-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.27-jre-ubuntu-noble, 11.0.27-jre-ubuntu-24.04
+Tags: 11-jre, 11-jre-ubuntu, 11.0.27-jre, 11.0.27-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.27-jre-ubuntu-noble, 11.0.27-jre-ubuntu-24.04
 Architectures: amd64
 GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
 Directory: dockerfiles/11/ubuntu/24_04/jre
 
-Tags: 11-jre-headless-ubuntu, 11.0.27-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.27-jre-headless-ubuntu-noble, 11.0.27-jre-headless-ubuntu-24.04
+Tags: 11-jre-headless, 11-jre-headless-ubuntu, 11.0.27-jre-headless, 11.0.27-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.27-jre-headless-ubuntu-noble, 11.0.27-jre-headless-ubuntu-24.04
 Architectures: amd64
 GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
 Directory: dockerfiles/11/ubuntu/24_04/jre-headless
 
-Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11.0.27-ubuntu-jammy, 11.0.27-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.27-jdk-ubuntu-jammy, 11.0.27-jdk-ubuntu-22.04
+Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.27-ubuntu-jammy, 11.0.27-ubuntu-22.04, 11.0.27-jdk-ubuntu-jammy, 11.0.27-jdk-ubuntu-22.04
 Architectures: amd64
 GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
 Directory: dockerfiles/11/ubuntu/22_04/jdk
@@ -250,23 +220,3 @@ Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.27-jre-he
 Architectures: amd64
 GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
 Directory: dockerfiles/11/ubuntu/22_04/jre-headless
-
-Tags: 11-ubuntu-focal, 11-ubuntu-20.04, 11.0.27-ubuntu-focal, 11.0.27-ubuntu-20.04, 11-jdk-ubuntu-focal, 11-jdk-ubuntu-20.04, 11.0.27-jdk-ubuntu-focal, 11.0.27-jdk-ubuntu-20.04
-Architectures: amd64
-GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
-Directory: dockerfiles/11/ubuntu/20_04/jdk
-
-Tags: 11-jdk-headless-ubuntu-focal, 11-jdk-headless-ubuntu-20.04, 11.0.27-jdk-headless-ubuntu-focal, 11.0.27-jdk-headless-ubuntu-20.04
-Architectures: amd64
-GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
-Directory: dockerfiles/11/ubuntu/20_04/jdk-headless
-
-Tags: 11-jre-ubuntu-focal, 11-jre-ubuntu-20.04, 11.0.27-jre-ubuntu-focal, 11.0.27-jre-ubuntu-20.04
-Architectures: amd64
-GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
-Directory: dockerfiles/11/ubuntu/20_04/jre
-
-Tags: 11-jre-headless-ubuntu-focal, 11-jre-headless-ubuntu-20.04, 11.0.27-jre-headless-ubuntu-focal, 11.0.27-jre-headless-ubuntu-20.04
-Architectures: amd64
-GitCommit: b56fec3b73cca3045d10f608837dcc1d690123db
-Directory: dockerfiles/11/ubuntu/20_04/jre-headless


### PR DESCRIPTION
Drop Ubuntu 20.04
Add Alpine 3.22
Some fixes for tags

This is also our follow up for #19167
