### PR TITLE
[SECURITY] Update Redis versions with July 2025 CVE fixes

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -19,42 +19,42 @@ Directory: alpine
 
 Tags: 8.0.3, 8.0, 8, 8.0.3-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b49d5c0cf4e96a277d4b4e98f61d10c792b37003
+GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
 GitFetch: refs/heads/release/8.0
 Directory: debian
 
 Tags: 8.0.3-alpine, 8.0-alpine, 8-alpine, 8.0.3-alpine3.21, 8.0-alpine3.21, 8-alpine3.21, alpine, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b49d5c0cf4e96a277d4b4e98f61d10c792b37003
+GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
 Tags: 7.4.5, 7.4, 7, 7.4.5-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7e0f53393290f7c1f35596117b67748efad16580
+GitCommit: 732a2608af90db97efa8ddd993fcbb63f5d2883b
 Directory: 7.4/debian
 
 Tags: 7.4.5-alpine, 7.4-alpine, 7-alpine, 7.4.5-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7e0f53393290f7c1f35596117b67748efad16580
+GitCommit: 732a2608af90db97efa8ddd993fcbb63f5d2883b
 Directory: 7.4/alpine
 
 Tags: 7.2.10, 7.2, 7.2.10-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a752e19782b9f8f80c7ef85e21cb47647954f09
+GitCommit: 732a2608af90db97efa8ddd993fcbb63f5d2883b
 Directory: 7.2/debian
 
 Tags: 7.2.10-alpine, 7.2-alpine, 7.2.10-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5a752e19782b9f8f80c7ef85e21cb47647954f09
+GitCommit: 732a2608af90db97efa8ddd993fcbb63f5d2883b
 Directory: 7.2/alpine
 
 Tags: 6.2.19, 6.2, 6, 6.2.19-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fa00bd2fff1533ad6e8483d9ce8868f383df2fbb
+GitCommit: 732a2608af90db97efa8ddd993fcbb63f5d2883b
 Directory: 6.2/debian
 
 Tags: 6.2.19-alpine, 6.2-alpine, 6-alpine, 6.2.19-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa00bd2fff1533ad6e8483d9ce8868f383df2fbb
+GitCommit: 732a2608af90db97efa8ddd993fcbb63f5d2883b
 Directory: 6.2/alpine

--- a/library/redis
+++ b/library/redis
@@ -17,44 +17,44 @@ GitCommit: c0091fa744e1437a972c5ee5c8062dc1894e6ab7
 GitFetch: refs/heads/release/8.2
 Directory: alpine
 
-Tags: 8.0.2, 8.0, 8, 8.0.2-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.0.3, 8.0, 8, 8.0.3-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5151eacdaf46f588f330c2e45fbed7fa0a7c192e
+GitCommit: b49d5c0cf4e96a277d4b4e98f61d10c792b37003
 GitFetch: refs/heads/release/8.0
 Directory: debian
 
-Tags: 8.0.2-alpine, 8.0-alpine, 8-alpine, 8.0.2-alpine3.21, 8.0-alpine3.21, 8-alpine3.21, alpine, alpine3.21
+Tags: 8.0.3-alpine, 8.0-alpine, 8-alpine, 8.0.3-alpine3.21, 8.0-alpine3.21, 8-alpine3.21, alpine, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5151eacdaf46f588f330c2e45fbed7fa0a7c192e
+GitCommit: b49d5c0cf4e96a277d4b4e98f61d10c792b37003
 GitFetch: refs/heads/release/8.0
 Directory: alpine
 
-Tags: 7.4.4, 7.4, 7, 7.4.4-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.5, 7.4, 7, 7.4.5-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
+GitCommit: 7e0f53393290f7c1f35596117b67748efad16580
 Directory: 7.4/debian
 
-Tags: 7.4.4-alpine, 7.4-alpine, 7-alpine, 7.4.4-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.5-alpine, 7.4-alpine, 7-alpine, 7.4.5-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
+GitCommit: 7e0f53393290f7c1f35596117b67748efad16580
 Directory: 7.4/alpine
 
-Tags: 7.2.9, 7.2, 7.2.9-bookworm, 7.2-bookworm
+Tags: 7.2.10, 7.2, 7.2.10-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
+GitCommit: 5a752e19782b9f8f80c7ef85e21cb47647954f09
 Directory: 7.2/debian
 
-Tags: 7.2.9-alpine, 7.2-alpine, 7.2.9-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.10-alpine, 7.2-alpine, 7.2.10-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7eaf5cd7042aee7a3f9049d91e48c647e2422de5
+GitCommit: 5a752e19782b9f8f80c7ef85e21cb47647954f09
 Directory: 7.2/alpine
 
-Tags: 6.2.18, 6.2, 6, 6.2.18-bookworm, 6.2-bookworm, 6-bookworm
+Tags: 6.2.19, 6.2, 6, 6.2.19-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 27cd071c3e9d903a19c79577ddb82fb322ef5ed6
+GitCommit: fa00bd2fff1533ad6e8483d9ce8868f383df2fbb
 Directory: 6.2/debian
 
-Tags: 6.2.18-alpine, 6.2-alpine, 6-alpine, 6.2.18-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
+Tags: 6.2.19-alpine, 6.2-alpine, 6-alpine, 6.2.19-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 27cd071c3e9d903a19c79577ddb82fb322ef5ed6
+GitCommit: fa00bd2fff1533ad6e8483d9ce8868f383df2fbb
 Directory: 6.2/alpine


### PR DESCRIPTION
Security updates for all non-milestone Redis versions:
- Redis 8.0.2 → 8.0.3 (CVE-2025-32023, CVE-2025-48367)
- Redis 7.4.4 → 7.4.5 (CVE-2025-32023, CVE-2025-48367)
- Redis 7.2.9 → 7.2.10 (CVE-2025-32023, CVE-2025-48367)
- Redis 6.2.18 → 6.2.19 (CVE-2025-32023, CVE-2025-48367)

CVE-2025-32023: Fix out-of-bounds write in HyperLogLog commands
CVE-2025-48367: Retry accepting other connections even if the accepted connection reports an error

NOTE that there is another PR that is open for an unrelated version:  https://github.com/docker-library/official-images/pull/19398