### PR TITLE
Update release tags for Percona Server MongoDB

### DIFF
--- a/library/percona
+++ b/library/percona
@@ -12,21 +12,17 @@ GitCommit: 9cd781adb27010da39faab5daca25c1e72db0af4
 Directory: percona-server-8.0
 File: Dockerfile-dockerhub
 
-#
-# disabled due to build failures
-# https://github.com/docker-library/official-images/pull/18900#issuecomment-2971658372
-#
-#Tags: psmdb-8.0.4, psmdb-8.0
-#GitCommit: 01836bbd1b62ad6ee28226986b2d7fff660523b6
-#Directory: percona-server-mongodb-8.0
-#File: Dockerfile-dockerhub
-#
-#Tags: psmdb-7.0.16, psmdb-7.0
-#GitCommit: 01836bbd1b62ad6ee28226986b2d7fff660523b6
-#Directory: percona-server-mongodb-7.0
-#File: Dockerfile-dockerhub
+Tags: psmdb-8.0.8, psmdb-8.0
+GitCommit: 00f5c9f0a32e4e4efbc589153f3b5412098572b9
+Directory: percona-server-mongodb-8.0
+File: Dockerfile-dockerhub
 
-Tags: psmdb-6.0.21, psmdb-6.0
-GitCommit: 01836bbd1b62ad6ee28226986b2d7fff660523b6
+Tags: psmdb-7.0.18, psmdb-7.0
+GitCommit: 00f5c9f0a32e4e4efbc589153f3b5412098572b9
+Directory: percona-server-mongodb-7.0
+File: Dockerfile-dockerhub
+
+Tags: psmdb-6.0.24, psmdb-6.0
+GitCommit: 00f5c9f0a32e4e4efbc589153f3b5412098572b9
 Directory: percona-server-mongodb-6.0
 File: Dockerfile-dockerhub


### PR DESCRIPTION
Removed commands which caused build failures - https://github.com/docker-library/official-images/pull/18900#issuecomment-2971658372