### PR TITLE
Add XWiki 17.4.2 as intermediate LTS version

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -18,17 +18,17 @@ Directory: 17/mariadb-tomcat
 GitCommit: 33e5c797b2cfa5527452b679bce856d79f4c4e29
 
 # Intermediate LTS
-Tags: 17.4, 17.4.2, 17.4-mysql-tomcat, 17.4.2-mysql-tomcat, lts-latest-mysql-tomcat, lts-latest-mysql, lts-latest
+Tags: 17.4, 17.4.2, 17.4-mysql-tomcat, 17.4.2-mysql-tomcat
 Architectures: amd64, arm64v8
 Directory: 17.4/mysql-tomcat
 GitCommit: 26aac747da65d11d2d238a91fc17c0f00c3f8807
 
-Tags: 17.4-postgres-tomcat, 17.4.2-postgres-tomcat, lts-latest-postgres-tomcat, lts-latest-postgres
+Tags: 17.4-postgres-tomcat, 17.4.2-postgres-tomcat
 Architectures: amd64, arm64v8
 Directory: 17.4/postgres-tomcat
 GitCommit: 26aac747da65d11d2d238a91fc17c0f00c3f8807
 
-Tags: 17.4-mariadb-tomcat, 17.4.2-mariadb-tomcat, lts-latest-mariadb-tomcat, lts-latest-mariadb
+Tags: 17.4-mariadb-tomcat, 17.4.2-mariadb-tomcat
 Architectures: amd64, arm64v8
 Directory: 17.4/mariadb-tomcat
 GitCommit: 26aac747da65d11d2d238a91fc17c0f00c3f8807

--- a/library/xwiki
+++ b/library/xwiki
@@ -17,6 +17,22 @@ Architectures: amd64, arm64v8
 Directory: 17/mariadb-tomcat
 GitCommit: 33e5c797b2cfa5527452b679bce856d79f4c4e29
 
+# Intermediate LTS
+Tags: 17.4, 17.4.2, 17.4-mysql-tomcat, 17.4.2-mysql-tomcat, lts-latest-mysql-tomcat, lts-latest-mysql, lts-latest
+Architectures: amd64, arm64v8
+Directory: 17.4/mysql-tomcat
+GitCommit: 26aac747da65d11d2d238a91fc17c0f00c3f8807
+
+Tags: 17.4-postgres-tomcat, 17.4.2-postgres-tomcat, lts-latest-postgres-tomcat, lts-latest-postgres
+Architectures: amd64, arm64v8
+Directory: 17.4/postgres-tomcat
+GitCommit: 26aac747da65d11d2d238a91fc17c0f00c3f8807
+
+Tags: 17.4-mariadb-tomcat, 17.4.2-mariadb-tomcat, lts-latest-mariadb-tomcat, lts-latest-mariadb
+Architectures: amd64, arm64v8
+Directory: 17.4/mariadb-tomcat
+GitCommit: 26aac747da65d11d2d238a91fc17c0f00c3f8807
+
 # LTS
 Tags: 16, 16.10, 16.10.9, 16-mysql-tomcat, 16.10-mysql-tomcat, 16.10.9-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64, arm64v8


### PR DESCRIPTION
XWiki is introducing a second, intermediate LTS version per year, the latest LTS version can be tracked with the `lts-latest` tags.