### PR TITLE
Update bash

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -1,19 +1,19 @@
-# this file is generated via https://github.com/tianon/docker-bash/blob/ecfdac4d4bb13e377eb75b258371c52e13253be5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/tianon/docker-bash/blob/59788c3224d1c11f14518f6c860ce6bccaf21d54/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: devel-20250616, devel, devel-20250616-alpine3.22, devel-alpine3.22
+Tags: devel-20250627, devel, devel-20250627-alpine3.22, devel-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 80b590f06d5f8da2c8d36549d7b760e7a2c988a7
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: devel
 
-Tags: 5.3-rc2, 5.3-rc, rc, 5.3-rc2-alpine3.22, 5.3-rc-alpine3.22, rc-alpine3.22
+Tags: 5.3.0, 5.3, 5, latest, 5.3.0-alpine3.22, 5.3-alpine3.22, 5-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8c645d094186ccdca78c724ed020a27588b253b
-Directory: 5.3-rc
+GitCommit: 59788c3224d1c11f14518f6c860ce6bccaf21d54
+Directory: 5.3
 
-Tags: 5.2.37, 5.2, 5, latest, 5.2.37-alpine3.22, 5.2-alpine3.22, 5-alpine3.22, alpine3.22
+Tags: 5.2.37, 5.2, 5.2.37-alpine3.22, 5.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 9fc164bd1a8e4bfe16c517623ce935dc821bbb08
 Directory: 5.2
@@ -30,40 +30,40 @@ Directory: 5.0
 
 Tags: 4.4.23, 4.4, 4, 4.4.23-alpine3.22, 4.4-alpine3.22, 4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7deed0d5c668469ae5eaf56e2a6c925f9a6a48d0
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 4.4
 
 Tags: 4.3.48, 4.3, 4.3.48-alpine3.22, 4.3-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3cc929583554a6797eeedf1143461fb6934d41c
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 4.3
 
 Tags: 4.2.53, 4.2, 4.2.53-alpine3.22, 4.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 84117f18511a843e2587b998901b9e8f84863141
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 4.2
 
 Tags: 4.1.17, 4.1, 4.1.17-alpine3.22, 4.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 454c634ceb497bb3dd70cceffc18219af82094fc
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 4.1
 
 Tags: 4.0.44, 4.0, 4.0.44-alpine3.22, 4.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cf3478db7e68c12b2bf73225cb86d33d9067b01d
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 4.0
 
 Tags: 3.2.57, 3.2, 3, 3.2.57-alpine3.22, 3.2-alpine3.22, 3-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8d2e78e9fb10d94ab82f2c96ed5453116b60b266
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 3.2
 
 Tags: 3.1.23, 3.1, 3.1.23-alpine3.22, 3.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b88b446dde99f282604a9d4feee4ee4328012fb
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 3.1
 
 Tags: 3.0.22, 3.0, 3.0.22-alpine3.22, 3.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aa72817e8ccfc175d51acc2bcadae64684e06879
+GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/tianon/docker-bash/commit/3443fb2: Merge pull request https://github.com/tianon/docker-bash/pull/49 from self-five/savannah-timeout
- https://github.com/tianon/docker-bash/commit/099d611: Fall back to my mirrors when fetching from savannah.gnu.org fails
- https://github.com/tianon/docker-bash/commit/ade9ca5: Update devel to 20250627
- https://github.com/tianon/docker-bash/commit/ea92b19: Merge pull request https://github.com/tianon/docker-bash/pull/48 from self-five/5.3-ga
- https://github.com/tianon/docker-bash/commit/59788c3: Update to 5.3.0 (GA)