### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -4,6 +4,76 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
+Tags: 8.5.0alpha1-cli-bookworm, 8.5-rc-cli-bookworm, 8.5.0alpha1-bookworm, 8.5-rc-bookworm, 8.5.0alpha1-cli, 8.5-rc-cli, 8.5.0alpha1, 8.5-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bookworm/cli
+
+Tags: 8.5.0alpha1-apache-bookworm, 8.5-rc-apache-bookworm, 8.5.0alpha1-apache, 8.5-rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bookworm/apache
+
+Tags: 8.5.0alpha1-fpm-bookworm, 8.5-rc-fpm-bookworm, 8.5.0alpha1-fpm, 8.5-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bookworm/fpm
+
+Tags: 8.5.0alpha1-zts-bookworm, 8.5-rc-zts-bookworm, 8.5.0alpha1-zts, 8.5-rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bookworm/zts
+
+Tags: 8.5.0alpha1-cli-bullseye, 8.5-rc-cli-bullseye, 8.5.0alpha1-bullseye, 8.5-rc-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bullseye/cli
+
+Tags: 8.5.0alpha1-apache-bullseye, 8.5-rc-apache-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bullseye/apache
+
+Tags: 8.5.0alpha1-fpm-bullseye, 8.5-rc-fpm-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bullseye/fpm
+
+Tags: 8.5.0alpha1-zts-bullseye, 8.5-rc-zts-bullseye
+Architectures: amd64, arm32v7, arm64v8, i386
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/bullseye/zts
+
+Tags: 8.5.0alpha1-cli-alpine3.22, 8.5-rc-cli-alpine3.22, 8.5.0alpha1-alpine3.22, 8.5-rc-alpine3.22, 8.5.0alpha1-cli-alpine, 8.5-rc-cli-alpine, 8.5.0alpha1-alpine, 8.5-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/alpine3.22/cli
+
+Tags: 8.5.0alpha1-fpm-alpine3.22, 8.5-rc-fpm-alpine3.22, 8.5.0alpha1-fpm-alpine, 8.5-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/alpine3.22/fpm
+
+Tags: 8.5.0alpha1-zts-alpine3.22, 8.5-rc-zts-alpine3.22, 8.5.0alpha1-zts-alpine, 8.5-rc-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/alpine3.22/zts
+
+Tags: 8.5.0alpha1-cli-alpine3.21, 8.5-rc-cli-alpine3.21, 8.5.0alpha1-alpine3.21, 8.5-rc-alpine3.21
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/alpine3.21/cli
+
+Tags: 8.5.0alpha1-fpm-alpine3.21, 8.5-rc-fpm-alpine3.21
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/alpine3.21/fpm
+
+Tags: 8.5.0alpha1-zts-alpine3.21, 8.5-rc-zts-alpine3.21
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 5edcb5b2d79196de6d80bc10a0a0518199dbd46d
+Directory: 8.5-rc/alpine3.21/zts
+
 Tags: 8.4.10-cli-bookworm, 8.4-cli-bookworm, 8-cli-bookworm, cli-bookworm, 8.4.10-bookworm, 8.4-bookworm, 8-bookworm, bookworm, 8.4.10-cli, 8.4-cli, 8-cli, cli, 8.4.10, 8.4, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 6e025fb18826b21b5aa340f9cb35f82d31f58f16


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/adcc38eb: Merge pull request https://github.com/docker-library/php/pull/1589 from jnoordsij/add-php8.5-rc
- https://github.com/docker-library/php/commit/5edcb5b2: Add PHP 8.5-rc variant
- https://github.com/docker-library/php/commit/6fb46669: Enable OPCache for 8.5 pending upstream changes
- https://github.com/docker-library/php/commit/105bb3e5: Update in preparation for first PHP 8.5 alpha release
- https://github.com/docker-library/php/commit/c071029e: Update API url for obtaining RC releases
- https://github.com/docker-library/php/commit/82bac8f9: Cleanup some (now) unused code/conditions