### PR TITLE
Make Kapacitor v1.8.0 the 'latest' version

### DIFF
--- a/library/kapacitor
+++ b/library/kapacitor
@@ -4,14 +4,14 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
 GitRepo: https://github.com/influxdata/influxdata-docker
 GitCommit: 98c1460c26ffb6d62d5cc659b1ead23c67437e5d
 
-Tags: 1.7, 1.7.7, latest
+Tags: 1.7, 1.7.7
 Architectures: amd64, arm64v8
 Directory: kapacitor/1.7
 
 Tags: 1.7-alpine, 1.7.7-alpine, alpine
 Directory: kapacitor/1.7/alpine
 
-Tags: 1.8, 1.8.0
+Tags: 1.8, 1.8.0, latest
 Architectures: amd64, arm64v8
 Directory: kapacitor/1.8
 


### PR DESCRIPTION
PR #19378 added Kapacitor v1.8.0 but kept `latest` at v1.7. This PR fixes this and moves the tag to the actual latest version.