### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2025-10407"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4b8879ec20f8a00a9304d0dcc494a11bea93f5dc
+amd64-GitCommit: 294d682bff4740ce534309f766bf0f6736bf7be6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cde1a732aeabaad056f70040037e02bdc4ffbc1d
+arm64v8-GitCommit: 1ca940d0aaa06cccf3bb1c6917adda069c8a11ad
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-47273, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-10407.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
