### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b6f17fd781acb5ce7522ba6d5d2b03a34d210e5b
 Directory: 3.3/alpine
 
-Tags: 3.2.2, 3.2, latest, lts, 3.2.2-bookworm, 3.2-bookworm, bookworm, lts-bookworm
+Tags: 3.2.3, 3.2, latest, lts, 3.2.3-bookworm, 3.2-bookworm, bookworm, lts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d29240a8f2a0b5f4eead7098f7fc4952654c5e21
+GitCommit: 3b6ff7d6c6c2562948c4e91e6f592e176eab5e0f
 Directory: 3.2
 
-Tags: 3.2.2-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.2-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.3-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.3-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d29240a8f2a0b5f4eead7098f7fc4952654c5e21
+GitCommit: 3b6ff7d6c6c2562948c4e91e6f592e176eab5e0f
 Directory: 3.2/alpine
 
 Tags: 3.1.8, 3.1, 3.1.8-bookworm, 3.1-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3b6ff7d: Update 3.2 to 3.2.3