### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2025-7512 ELSA-2025-9421 ELSA-2025-9418 ELSA-2025-7510 ELSA-2025-9420 ELSA-2025-10630 ELSA-2025-9940 ELSA-2025-7517  ELSA-2025-7524

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 294d682bff4740ce534309f766bf0f6736bf7be6
+amd64-GitCommit: d66749be81ce303cf6c5cb09a36f60aa0d63b671
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1ca940d0aaa06cccf3bb1c6917adda069c8a11ad
+arm64v8-GitCommit: 3ed3cec468a85a641d53b3654058e715c3ee905b
 
 Tags: 9
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-8176, CVE-2025-47268, CVE-2025-3576, CVE-2024-57970, CVE-2025-25724, CVE-2025-49794, CVE-2025-49795, CVE-2025-49796, CVE-2025-6021, CVE-2025-47273, CVE-2025-3277, CVE-2025-31115, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-7512.html
https://linux.oracle.com/errata/ELSA-2025-9421.html
https://linux.oracle.com/errata/ELSA-2025-9418.html
https://linux.oracle.com/errata/ELSA-2025-7510.html
https://linux.oracle.com/errata/ELSA-2025-9420.html
https://linux.oracle.com/errata/ELSA-2025-10630.html
https://linux.oracle.com/errata/ELSA-2025-9940.html
https://linux.oracle.com/errata/ELSA-2025-7517.html
https://linux.oracle.com/errata/ELSA-2025-7524.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
