### PR TITLE
feat!: version bump to SATOSA v8.5.1

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -14,14 +14,3 @@ Tags: 8.5.1-alpine3.22, 8.5-alpine3.22, 8-alpine3.22, alpine3.22, 8.5.1-alpine, 
 Architectures: amd64, arm64v8, ppc64le, riscv64
 GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
 Directory: 8.5/alpine3.22
-
-Tags: 8.4.0-bookworm, 8.4-bookworm
-SharedTags: 8.4.0, 8.4
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
-Directory: 8.4/bookworm
-
-Tags: 8.4.0-alpine3.22, 8.4-alpine3.22, 8.4.0-alpine, 8.4-alpine
-Architectures: amd64, arm64v8, ppc64le, riscv64
-GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
-Directory: 8.4/alpine3.22

--- a/library/satosa
+++ b/library/satosa
@@ -1,16 +1,27 @@
-# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/9c8b9a9f2fd6d095944637f658f2d2dccf68259b/generate-stackbrew-library.sh
+# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/912d6d6e4effb5c5a5b3555c716e04b3a5cc0e9d/generate-stackbrew-library.sh
 
-Maintainers: Matthew X. Economou <economoum@niaid.nih.gov> (@niheconomoum)
+Maintainers: Matthew X. Economou <xenophon+idpy@irtnog.org> (@xenophonf)
 GitRepo: https://github.com/IdentityPython/satosa-docker.git
 GitFetch: refs/heads/main
 
-Tags: 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, bookworm
-SharedTags: 8.4.0, 8.4, 8, latest
-Architectures: amd64, arm64v8
-GitCommit: 69038a84d541717d66420f3ad8ec7c9da22c91b4
+Tags: 8.5.1-bookworm, 8.5-bookworm, 8-bookworm, bookworm
+SharedTags: 8.5.1, 8.5, 8, latest
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
+Directory: 8.5/bookworm
+
+Tags: 8.5.1-alpine3.22, 8.5-alpine3.22, 8-alpine3.22, alpine3.22, 8.5.1-alpine, 8.5-alpine, 8-alpine, alpine
+Architectures: amd64, arm64v8, ppc64le, riscv64
+GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
+Directory: 8.5/alpine3.22
+
+Tags: 8.4.0-bookworm, 8.4-bookworm
+SharedTags: 8.4.0, 8.4
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
 Directory: 8.4/bookworm
 
-Tags: 8.4.0-alpine3.19, 8.4-alpine3.19, 8-alpine3.19, alpine3.19, 8.4.0-alpine, 8.4-alpine, 8-alpine, alpine
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 74a847396f1190ec26679fc3bf09ffcc42d2e999
-Directory: 8.4/alpine3.19
+Tags: 8.4.0-alpine3.22, 8.4-alpine3.22, 8.4.0-alpine, 8.4-alpine
+Architectures: amd64, arm64v8, ppc64le, riscv64
+GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
+Directory: 8.4/alpine3.22


### PR DESCRIPTION
This includes fixes for IdentityPython/satosa-docker#10 and IdentityPython/satosa-docker#12 as well as base image updates.  Please note that the new maintainer is the same person.  However, the work is now community-sponsored.

BREAKING CHANGE: This drops support for 32-bit architectures; cf. IdentityPython/satosa-docker#11.