### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-10698"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9af3781f4a6e91907dbda1fc34cbe5971c36729a
+amd64-GitCommit: a03519ff983042313f97695d63c9b724faf5faa8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6d4c96c789b2c9cc6cb1f7cb8c13fb46f74fe576
+arm64v8-GitCommit: 04ba4886b91964f27df842567cde5a5d677a99d3
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-49794, CVE-2025-49796, CVE-2025-6021, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-10698.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
