### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev2, 3.3-dev, 3.3-dev2-bookworm, 3.3-dev-bookworm
+Tags: 3.3-dev3, 3.3-dev, 3.3-dev3-bookworm, 3.3-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b6f17fd781acb5ce7522ba6d5d2b03a34d210e5b
+GitCommit: bd1886e3b1856044dd77d309199afcd065df9d08
 Directory: 3.3
 
-Tags: 3.3-dev2-alpine, 3.3-dev-alpine, 3.3-dev2-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev3-alpine, 3.3-dev-alpine, 3.3-dev3-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b6f17fd781acb5ce7522ba6d5d2b03a34d210e5b
+GitCommit: bd1886e3b1856044dd77d309199afcd065df9d08
 Directory: 3.3/alpine
 
 Tags: 3.2.3, 3.2, latest, lts, 3.2.3-bookworm, 3.2-bookworm, bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bd1886e: Update 3.3 to 3.3-dev3