### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,9 +25,9 @@ GitCommit: 118c07a8e6467baababb4634b6cfde14a67c24b0
 Directory: 13
 # Docker EOL: 2026-12-05
 
-# Last Modified: 2024-06-20
-Tags: 12.4.0, 12.4, 12, 12.4.0-bookworm, 12.4-bookworm, 12-bookworm
+# Last Modified: 2025-07-11
+Tags: 12.5.0, 12.5, 12, 12.5.0-bookworm, 12.5-bookworm, 12-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b5055bcc1551a7e271af315158e1c260c212409c
+GitCommit: 7070981b23d22d3ca790f87bff26f13f3614dd4c
 Directory: 12
-# Docker EOL: 2025-12-20
+# Docker EOL: 2027-01-11


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/7070981: Update 12 to 12.5.0