### PR TITLE
archlinux: Release 20250713.0.382768

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250706.0.377547
-GitCommit: 586fd52db83f6e3715f36ed5fd1783725c5ad3ca
-GitFetch: refs/tags/v20250706.0.377547
+Tags: latest, base, base-20250713.0.382768
+GitCommit: 811a79c1883f789130d4ac520de03c2bb9ab40fa
+GitFetch: refs/tags/v20250713.0.382768
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250706.0.377547
-GitCommit: 586fd52db83f6e3715f36ed5fd1783725c5ad3ca
-GitFetch: refs/tags/v20250706.0.377547
+Tags: base-devel, base-devel-20250713.0.382768
+GitCommit: 811a79c1883f789130d4ac520de03c2bb9ab40fa
+GitFetch: refs/tags/v20250713.0.382768
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250706.0.377547
-GitCommit: 586fd52db83f6e3715f36ed5fd1783725c5ad3ca
-GitFetch: refs/tags/v20250706.0.377547
+Tags: multilib-devel, multilib-devel-20250713.0.382768
+GitCommit: 811a79c1883f789130d4ac520de03c2bb9ab40fa
+GitFetch: refs/tags/v20250713.0.382768
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks