### PR TITLE
Updated nginx debian images to pick up key fixes.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -5,7 +5,7 @@ GitRepo: https://github.com/nginx/docker-nginx.git
 
 Tags: 1.29.0, mainline, 1, 1.29, latest, 1.29.0-bookworm, mainline-bookworm, 1-bookworm, 1.29-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: b2faad22d5d15d966e46922033681639b2a6d6fa
 Directory: mainline/debian
 
 Tags: 1.29.0-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.0-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.29-bookworm-perl, bookworm-perl
@@ -40,7 +40,7 @@ Directory: mainline/alpine-otel
 
 Tags: 1.28.0, stable, 1.28, 1.28.0-bookworm, stable-bookworm, 1.28-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
+GitCommit: b2faad22d5d15d966e46922033681639b2a6d6fa
 Directory: stable/debian
 
 Tags: 1.28.0-perl, stable-perl, 1.28-perl, 1.28.0-bookworm-perl, stable-bookworm-perl, 1.28-bookworm-perl


### PR DESCRIPTION
We've introduced two new keys back in 2024 to be able to migrate off the older key.  Last week we actually started using one of the newer keys to sign the packages and metadata, however a bug in the key export logic, meant that only the first key was exported to the keyring, breaking the Dockerfile build.

With
https://github.com/nginx/docker-nginx/commit/0b49b8b12fd214b633114ac16d2dfd65d45ff160 now merged, let's update the references to the fixed base Dockerfiles.