### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.8.1-php8.1-apache, 6.8-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.8.1-php8.1, 6.8-php8.1, 6-php8.1, php8.1
+Tags: 6.8.2-php8.1-apache, 6.8-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.8.2-php8.1, 6.8-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.1/apache
 
-Tags: 6.8.1-php8.1-fpm, 6.8-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
+Tags: 6.8.2-php8.1-fpm, 6.8-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.1/fpm
 
-Tags: 6.8.1-php8.1-fpm-alpine, 6.8-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 6.8.2-php8.1-fpm-alpine, 6.8-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.8.1-apache, 6.8-apache, 6-apache, apache, 6.8.1, 6.8, 6, latest, 6.8.1-php8.2-apache, 6.8-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.8.1-php8.2, 6.8-php8.2, 6-php8.2, php8.2
+Tags: 6.8.2-apache, 6.8-apache, 6-apache, apache, 6.8.2, 6.8, 6, latest, 6.8.2-php8.2-apache, 6.8-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.8.2-php8.2, 6.8-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.2/apache
 
-Tags: 6.8.1-fpm, 6.8-fpm, 6-fpm, fpm, 6.8.1-php8.2-fpm, 6.8-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.8.2-fpm, 6.8-fpm, 6-fpm, fpm, 6.8.2-php8.2-fpm, 6.8-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.2/fpm
 
-Tags: 6.8.1-fpm-alpine, 6.8-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.8.1-php8.2-fpm-alpine, 6.8-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.8.2-fpm-alpine, 6.8-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.8.2-php8.2-fpm-alpine, 6.8-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.8.1-php8.3-apache, 6.8-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.8.1-php8.3, 6.8-php8.3, 6-php8.3, php8.3
+Tags: 6.8.2-php8.3-apache, 6.8-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.8.2-php8.3, 6.8-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.3/apache
 
-Tags: 6.8.1-php8.3-fpm, 6.8-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.8.2-php8.3-fpm, 6.8-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.3/fpm
 
-Tags: 6.8.1-php8.3-fpm-alpine, 6.8-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.8.2-php8.3-fpm-alpine, 6.8-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.3/fpm-alpine
 
-Tags: 6.8.1-php8.4-apache, 6.8-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.8.1-php8.4, 6.8-php8.4, 6-php8.4, php8.4
+Tags: 6.8.2-php8.4-apache, 6.8-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.8.2-php8.4, 6.8-php8.4, 6-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.4/apache
 
-Tags: 6.8.1-php8.4-fpm, 6.8-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
+Tags: 6.8.2-php8.4-fpm, 6.8-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.4/fpm
 
-Tags: 6.8.1-php8.4-fpm-alpine, 6.8-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
+Tags: 6.8.2-php8.4-fpm-alpine, 6.8-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 447d7d60da6f91d656ac711dbab2a042e1b5b515
+GitCommit: 6b67cd46375883e2e25d218736ce936f93aca3b2
 Directory: latest/php8.4/fpm-alpine
 
 Tags: cli-2.12.0-php8.1, cli-2.12-php8.1, cli-2-php8.1, cli-php8.1
@@ -83,63 +83,3 @@ Tags: cli-2.12.0-php8.4, cli-2.12-php8.4, cli-2-php8.4, cli-php8.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.4/alpine
-
-Tags: beta-6.8.2-RC1-php8.1-apache, beta-6.8.2-php8.1-apache, beta-6.8-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.8.2-RC1-php8.1, beta-6.8.2-php8.1, beta-6.8-php8.1, beta-6-php8.1, beta-php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.1/apache
-
-Tags: beta-6.8.2-RC1-php8.1-fpm, beta-6.8.2-php8.1-fpm, beta-6.8-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.1/fpm
-
-Tags: beta-6.8.2-RC1-php8.1-fpm-alpine, beta-6.8.2-php8.1-fpm-alpine, beta-6.8-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.1/fpm-alpine
-
-Tags: beta-6.8.2-RC1-apache, beta-6.8.2-apache, beta-6.8-apache, beta-6-apache, beta-apache, beta-6.8.2-RC1, beta-6.8.2, beta-6.8, beta-6, beta, beta-6.8.2-RC1-php8.2-apache, beta-6.8.2-php8.2-apache, beta-6.8-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.8.2-RC1-php8.2, beta-6.8.2-php8.2, beta-6.8-php8.2, beta-6-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.2/apache
-
-Tags: beta-6.8.2-RC1-fpm, beta-6.8.2-fpm, beta-6.8-fpm, beta-6-fpm, beta-fpm, beta-6.8.2-RC1-php8.2-fpm, beta-6.8.2-php8.2-fpm, beta-6.8-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.2/fpm
-
-Tags: beta-6.8.2-RC1-fpm-alpine, beta-6.8.2-fpm-alpine, beta-6.8-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.8.2-RC1-php8.2-fpm-alpine, beta-6.8.2-php8.2-fpm-alpine, beta-6.8-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.2/fpm-alpine
-
-Tags: beta-6.8.2-RC1-php8.3-apache, beta-6.8.2-php8.3-apache, beta-6.8-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.8.2-RC1-php8.3, beta-6.8.2-php8.3, beta-6.8-php8.3, beta-6-php8.3, beta-php8.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.3/apache
-
-Tags: beta-6.8.2-RC1-php8.3-fpm, beta-6.8.2-php8.3-fpm, beta-6.8-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.3/fpm
-
-Tags: beta-6.8.2-RC1-php8.3-fpm-alpine, beta-6.8.2-php8.3-fpm-alpine, beta-6.8-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.3/fpm-alpine
-
-Tags: beta-6.8.2-RC1-php8.4-apache, beta-6.8.2-php8.4-apache, beta-6.8-php8.4-apache, beta-6-php8.4-apache, beta-php8.4-apache, beta-6.8.2-RC1-php8.4, beta-6.8.2-php8.4, beta-6.8-php8.4, beta-6-php8.4, beta-php8.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.4/apache
-
-Tags: beta-6.8.2-RC1-php8.4-fpm, beta-6.8.2-php8.4-fpm, beta-6.8-php8.4-fpm, beta-6-php8.4-fpm, beta-php8.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.4/fpm
-
-Tags: beta-6.8.2-RC1-php8.4-fpm-alpine, beta-6.8.2-php8.4-fpm-alpine, beta-6.8-php8.4-fpm-alpine, beta-6-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe46b5e252346246362c11299cb4763888056060
-Directory: beta/php8.4/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/6b67cd4: Update latest to 6.8.2
- https://github.com/docker-library/wordpress/commit/2aeae25: Update beta to 6.8.2