### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -94,21 +94,6 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 60dc5f9555c521de086b2f5770514faf69ee2cc4
 Directory: ubuntu/noble
 
-Tags: oracular-curl, 24.10-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: f24f02bc0fda57d7f0e30b205df4a38114712b0a
-Directory: ubuntu/oracular/curl
-
-Tags: oracular-scm, 24.10-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: f24f02bc0fda57d7f0e30b205df4a38114712b0a
-Directory: ubuntu/oracular/scm
-
-Tags: oracular, 24.10
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: f24f02bc0fda57d7f0e30b205df4a38114712b0a
-Directory: ubuntu/oracular
-
 Tags: plucky-curl, 25.04-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0


### PR DESCRIPTION
- https://github.com/docker-library/official-images/pull/19469

Changes:

- https://github.com/docker-library/buildpack-deps/commit/b235331: Remove EOL Ubuntu Oracular (24.10)