### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-11035 ELSA-2025-11036"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a03519ff983042313f97695d63c9b724faf5faa8
+amd64-GitCommit: bd0c560512c432254deef4f91c4eb4a9928b2801
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 04ba4886b91964f27df842567cde5a5d677a99d3
+arm64v8-GitCommit: 73b70db70148443e94cc0f11552c6d9280f0bda1
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2019-17543, CVE-2025-47273, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-11035.html
https://linux.oracle.com/errata/ELSA-2025-11036.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
