### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-11140"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: bd0c560512c432254deef4f91c4eb4a9928b2801
+amd64-GitCommit: de5c32f47e209c97bd4c18cc2e3b7ff53185ff1e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 73b70db70148443e94cc0f11552c6d9280f0bda1
+arm64v8-GitCommit: be8a3d6591fca7b0baed3e1d41a764e802933ad3
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-52533, CVE-2025-4373, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-11140.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
