### PR TITLE
"[oraclelinux] Updating 10and 10-slim for ELSA-2025-10855 ELSA-2025-11066"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: de5c32f47e209c97bd4c18cc2e3b7ff53185ff1e
+amd64-GitCommit: 91d2f212cbb3feab675773c9dd4b4a773bc60858
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: be8a3d6591fca7b0baed3e1d41a764e802933ad3
+arm64v8-GitCommit: e03013f81b03556b3c12cdc48724e8def259e8c9
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-52533, CVE-2025-4373, CVE-2025-5702, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-10855.html
https://linux.oracle.com/errata/ELSA-2025-11066.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
