### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-11327"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 91d2f212cbb3feab675773c9dd4b4a773bc60858
+amd64-GitCommit: 07b89e4dea7f6bb6f378df0ddf88df8e2c7db95f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e03013f81b03556b3c12cdc48724e8def259e8c9
+arm64v8-GitCommit: 7fb1d0dbcb7015034c622a5b90d3c6ae161a5f10
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2024-34397, CVE-2024-52533, CVE-2025-4373, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-11327.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
