### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250623.1
+Tags: 2023, latest, 2023.8.20250715.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 1d30653467bce95f1e74ce047c186cf527122751
+amd64-GitCommit: 12e432807ac744a5cf1da9f5a0ac5fd0bfad2a94
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: a81fad6c3cf53440ebc2f0cd04695e90e540612d
+arm64v8-GitCommit: 2e3920bd4904e8c6203193a800065fb9b8ca818a
 
-Tags: 2, 2.0.20250623.0
+Tags: 2, 2.0.20250707.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 1f08d8c203661dd3116b52c70b6a6067b22cc81a
+amd64-GitCommit: ff7c7277e66ddb9671b1d2f52a9dd03e12da17ad
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 3988bfc773dc079afce6bdf9538b351d7ab11463
+arm64v8-GitCommit: 430c00bfbceb577b29e177caff97e7d64baeeceb
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- python-libs-2.7.18-1.amzn2.0.13
- python-2.7.18-1.amzn2.0.13

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.8.20250715-0.amzn2023
- system-release-2023.8.20250715-0.amzn2023
- ca-certificates-2025.2.76-1.0.amzn2023.0.2
- python3-pip-wheel-21.3.1-2.amzn2023.0.12
- glib2-2.82.2-766.amzn2023