### PR TITLE
archlinux: Release 20250720.0.386825

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250713.0.382768
-GitCommit: 811a79c1883f789130d4ac520de03c2bb9ab40fa
-GitFetch: refs/tags/v20250713.0.382768
+Tags: latest, base, base-20250720.0.386825
+GitCommit: ecd024d596772f1a52efc4ad8ff54577cbefca9e
+GitFetch: refs/tags/v20250720.0.386825
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250713.0.382768
-GitCommit: 811a79c1883f789130d4ac520de03c2bb9ab40fa
-GitFetch: refs/tags/v20250713.0.382768
+Tags: base-devel, base-devel-20250720.0.386825
+GitCommit: ecd024d596772f1a52efc4ad8ff54577cbefca9e
+GitFetch: refs/tags/v20250720.0.386825
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250713.0.382768
-GitCommit: 811a79c1883f789130d4ac520de03c2bb9ab40fa
-GitFetch: refs/tags/v20250713.0.382768
+Tags: multilib-devel, multilib-devel-20250720.0.386825
+GitCommit: ecd024d596772f1a52efc4ad8ff54577cbefca9e
+GitFetch: refs/tags/v20250720.0.386825
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks