### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.0.0-alpha.1
+Tags: 6.0.0-alpha.2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 83ce6d8beb81974a32d4b1461406ab4a3e8be365
+GitCommit: e7b1033377c47e638d3875dc63468e814a655d08
 Directory: 6-rc/debian
 
-Tags: 6.0.0-alpha.1-alpine
+Tags: 6.0.0-alpha.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 83ce6d8beb81974a32d4b1461406ab4a3e8be365
+GitCommit: e7b1033377c47e638d3875dc63468e814a655d08
 Directory: 6-rc/alpine
 
-Tags: 5.130.1, 5.130, 5, latest
+Tags: 5.130.2, 5.130, 5, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 5dd89fdd04b1c93674e441732e877dbd3a90e558
+GitCommit: 9646b20a5604936a2ee5b703cfe4f2f8a30135a7
 Directory: 5/debian
 
-Tags: 5.130.1-alpine, 5.130-alpine, 5-alpine, alpine
+Tags: 5.130.2-alpine, 5.130-alpine, 5-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 5dd89fdd04b1c93674e441732e877dbd3a90e558
+GitCommit: 9646b20a5604936a2ee5b703cfe4f2f8a30135a7
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/e7b1033: Update to 6.0.0-alpha.2, ghost-cli 1.27.1
- https://github.com/docker-library/ghost/commit/9646b20: Update to 5.130.2, ghost-cli 1.27.1