### PR TITLE
Bump Traefik to v2.11.28 and v3.4.5 and v3.5.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.5.0-rc2-windowsservercore-ltsc2022, 3.5.0-rc2-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022
+Tags: v3.5.0-windowsservercore-ltsc2022, 3.5.0-windowsservercore-ltsc2022, v3.5-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c73fc0b54ac57e7e65351bc379e87feed19763a2
+GitCommit: 10c579a8e3c43ef2a7d438aed4911091967b9fbc
 Directory: v3.5/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.5.0-rc2-nanoserver-ltsc2022, 3.5.0-rc2-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022
+Tags: v3.5.0-nanoserver-ltsc2022, 3.5.0-nanoserver-ltsc2022, v3.5-nanoserver-ltsc2022, 3.5-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c73fc0b54ac57e7e65351bc379e87feed19763a2
+GitCommit: 10c579a8e3c43ef2a7d438aed4911091967b9fbc
 Directory: v3.5/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.5.0-rc2, 3.5.0-rc2, chabichou
+Tags: v3.5.0, 3.5.0, v3.5, 3.5, v3, 3, chabichou, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c73fc0b54ac57e7e65351bc379e87feed19763a2
+GitCommit: 10c579a8e3c43ef2a7d438aed4911091967b9fbc
 Directory: v3.5/alpine
 
 Tags: v3.4.5-windowsservercore-ltsc2022, 3.4.5-windowsservercore-ltsc2022, v3.4-windowsservercore-ltsc2022, 3.4-windowsservercore-ltsc2022, chaource-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.28](https://github.com/traefik/traefik/releases/tag/v2.11.28), [v3.4.5](https://github.com/traefik/traefik/releases/tag/v3.4.5), and [v3.5.0](https://github.com/traefik/traefik/releases/tag/v3.5.0).

/cc @nmengin @mmatur @rtribotte

Cheers