### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -16,14 +16,14 @@ GitCommit: 516237cdb5e0991abc0c6dcbbc7a66cc6444d3a3
 Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.42, 8.0, 8.0.42-oraclelinux9, 8.0-oraclelinux9, 8.0.42-oracle, 8.0-oracle
+Tags: 8.0.43, 8.0, 8.0.43-oraclelinux9, 8.0-oraclelinux9, 8.0.43-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 94583e54d3bc02af523af720fdd58f8215287da9
+GitCommit: 4ea634473f3ca9b1dcd476236e6d617258e2d63b
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.42-bookworm, 8.0-bookworm, 8.0.42-debian, 8.0-debian
+Tags: 8.0.43-bookworm, 8.0-bookworm, 8.0.43-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 94583e54d3bc02af523af720fdd58f8215287da9
+GitCommit: 4ea634473f3ca9b1dcd476236e6d617258e2d63b
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/4ea6344: Update 8.0 to 8.0.43, debian 8.0.43-1debian12, oracle 8.0.43-1.el9, mysql-shell 8.0.43-1.el9