### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,49 +4,49 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 6.0.0-alpha2, 6.0, 6.0.alpha, 6.0.0-alpha, 6.0.0-alpha2-apache, 6.0-apache, 6.0.alpha-apache, 6.0.0-alpha-apache, 6.0.0-alpha2-php8.3, 6.0-php8.3, 6.0.alpha-php8.3, 6.0.0-alpha-php8.3, 6.0.0-alpha2-php8.3-apache, 6.0-php8.3-apache, 6.0.alpha-php8.3-apache, 6.0.0-alpha-php8.3-apache
+Tags: 6.0.0-alpha3, 6.0, 6.0.alpha, 6.0.0-alpha, 6.0.0-alpha3-apache, 6.0-apache, 6.0.alpha-apache, 6.0.0-alpha-apache, 6.0.0-alpha3-php8.3, 6.0-php8.3, 6.0.alpha-php8.3, 6.0.0-alpha-php8.3, 6.0.0-alpha3-php8.3-apache, 6.0-php8.3-apache, 6.0.alpha-php8.3-apache, 6.0.0-alpha-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 6.0.alpha/php8.3/apache
 
-Tags: 6.0.0-alpha2-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.alpha-php8.3-fpm-alpine, 6.0.0-alpha-php8.3-fpm-alpine
+Tags: 6.0.0-alpha3-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.alpha-php8.3-fpm-alpine, 6.0.0-alpha-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 6.0.alpha/php8.3/fpm-alpine
 
-Tags: 6.0.0-alpha2-php8.3-fpm, 6.0-php8.3-fpm, 6.0.alpha-php8.3-fpm, 6.0.0-alpha-php8.3-fpm
+Tags: 6.0.0-alpha3-php8.3-fpm, 6.0-php8.3-fpm, 6.0.alpha-php8.3-fpm, 6.0.0-alpha-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 6.0.alpha/php8.3/fpm
 
-Tags: 5.4.0-alpha2-php8.2-apache, 5.4-php8.2-apache, 5.4.alpha-php8.2-apache, 5.4.0-alpha-php8.2-apache
+Tags: 5.4.0-alpha3-php8.2-apache, 5.4-php8.2-apache, 5.4.alpha-php8.2-apache, 5.4.0-alpha-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 5.4.alpha/php8.2/apache
 
-Tags: 5.4.0-alpha2-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.alpha-php8.2-fpm-alpine, 5.4.0-alpha-php8.2-fpm-alpine
+Tags: 5.4.0-alpha3-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.alpha-php8.2-fpm-alpine, 5.4.0-alpha-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 5.4.alpha/php8.2/fpm-alpine
 
-Tags: 5.4.0-alpha2-php8.2-fpm, 5.4-php8.2-fpm, 5.4.alpha-php8.2-fpm, 5.4.0-alpha-php8.2-fpm
+Tags: 5.4.0-alpha3-php8.2-fpm, 5.4-php8.2-fpm, 5.4.alpha-php8.2-fpm, 5.4.0-alpha-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 5.4.alpha/php8.2/fpm
 
-Tags: 5.4.0-alpha2, 5.4, 5.4.alpha, 5.4.0-alpha, 5.4.0-alpha2-apache, 5.4-apache, 5.4.alpha-apache, 5.4.0-alpha-apache, 5.4.0-alpha2-php8.3, 5.4-php8.3, 5.4.alpha-php8.3, 5.4.0-alpha-php8.3, 5.4.0-alpha2-php8.3-apache, 5.4-php8.3-apache, 5.4.alpha-php8.3-apache, 5.4.0-alpha-php8.3-apache
+Tags: 5.4.0-alpha3, 5.4, 5.4.alpha, 5.4.0-alpha, 5.4.0-alpha3-apache, 5.4-apache, 5.4.alpha-apache, 5.4.0-alpha-apache, 5.4.0-alpha3-php8.3, 5.4-php8.3, 5.4.alpha-php8.3, 5.4.0-alpha-php8.3, 5.4.0-alpha3-php8.3-apache, 5.4-php8.3-apache, 5.4.alpha-php8.3-apache, 5.4.0-alpha-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 5.4.alpha/php8.3/apache
 
-Tags: 5.4.0-alpha2-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.alpha-php8.3-fpm-alpine, 5.4.0-alpha-php8.3-fpm-alpine
+Tags: 5.4.0-alpha3-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.alpha-php8.3-fpm-alpine, 5.4.0-alpha-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 5.4.alpha/php8.3/fpm-alpine
 
-Tags: 5.4.0-alpha2-php8.3-fpm, 5.4-php8.3-fpm, 5.4.alpha-php8.3-fpm, 5.4.0-alpha-php8.3-fpm
+Tags: 5.4.0-alpha3-php8.3-fpm, 5.4-php8.3-fpm, 5.4.alpha-php8.3-fpm, 5.4.0-alpha-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 950c6dac45e3f56b4699e9cfbe4305274c430438
+GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
 Directory: 5.4.alpha/php8.3/fpm
 
 Tags: 5.3.2-php8.1-apache, 5.3-php8.1-apache, 5-php8.1-apache, php8.1-apache


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@f293626: Update Joomla 5.4.0-alpha2 to 5.4.0-alpha3 and 6.0.0-alpha2 to 6.0.0-alpha3