### PR TITLE
Odoo: update 16.0-18.0 to release 20250725

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: fc0fbafb02e82e1d17bcf22d10466d6c6fb55a7b
+GitCommit: aa4008ad317c2e442c75ff3540cc95373f44aec8
 
-Tags: 18.0-20250710, 18.0, 18, latest
+Tags: 18.0-20250725, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250710, 17.0, 17
+Tags: 17.0-20250725, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250710, 16.0, 16
+Tags: 16.0-20250725, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks