### PR TITLE
feat!: drop support for building SATOSA images on platforms other than linux/amd64 and linux/arm64

### DIFF
--- a/library/satosa
+++ b/library/satosa
@@ -1,4 +1,4 @@
-# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/912d6d6e4effb5c5a5b3555c716e04b3a5cc0e9d/generate-stackbrew-library.sh
+# This file is generated via https://github.com/IdentityPython/satosa-docker/blob/07ce67c693fbacb188e3d70c700e072e947b1564/generate-stackbrew-library.sh
 
 Maintainers: Matthew X. Economou <xenophon+idpy@irtnog.org> (@xenophonf)
 GitRepo: https://github.com/IdentityPython/satosa-docker.git
@@ -6,11 +6,11 @@ GitFetch: refs/heads/main
 
 Tags: 8.5.1-bookworm, 8.5-bookworm, 8-bookworm, bookworm
 SharedTags: 8.5.1, 8.5, 8, latest
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
+Architectures: amd64, arm64v8
+GitCommit: 8420c19d43d36f132e015a981df54f30dc54980f
 Directory: 8.5/bookworm
 
 Tags: 8.5.1-alpine3.22, 8.5-alpine3.22, 8-alpine3.22, alpine3.22, 8.5.1-alpine, 8.5-alpine, 8-alpine, alpine
-Architectures: amd64, arm64v8, ppc64le, riscv64
-GitCommit: dd0928a83ef54c8bed05691325f026d155e58dd3
+Architectures: amd64, arm64v8
+GitCommit: 8420c19d43d36f132e015a981df54f30dc54980f
 Directory: 8.5/alpine3.22


### PR DESCRIPTION
I am unable to determine why [cryptography](https://cryptography.io/) won't build on other platforms.

Closes IdentityPython/satosa-docker#15.