### PR TITLE
archlinux: Release 20250727.0.390543

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250720.0.386825
-GitCommit: ecd024d596772f1a52efc4ad8ff54577cbefca9e
-GitFetch: refs/tags/v20250720.0.386825
+Tags: latest, base, base-20250727.0.390543
+GitCommit: 5b795383cad1cb308b7a03894f8c98eb2ead6cb4
+GitFetch: refs/tags/v20250727.0.390543
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250720.0.386825
-GitCommit: ecd024d596772f1a52efc4ad8ff54577cbefca9e
-GitFetch: refs/tags/v20250720.0.386825
+Tags: base-devel, base-devel-20250727.0.390543
+GitCommit: 5b795383cad1cb308b7a03894f8c98eb2ead6cb4
+GitFetch: refs/tags/v20250727.0.390543
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250720.0.386825
-GitCommit: ecd024d596772f1a52efc4ad8ff54577cbefca9e
-GitFetch: refs/tags/v20250720.0.386825
+Tags: multilib-devel, multilib-devel-20250727.0.390543
+GitCommit: 5b795383cad1cb308b7a03894f8c98eb2ead6cb4
+GitFetch: refs/tags/v20250727.0.390543
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks