### PR TITLE
eclipse-temurin: add ubi10-minimal

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -39,6 +39,11 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 8/jdk/ubi/ubi9-minimal
 
+Tags: 8u432-b06-jdk-ubi10-minimal, 8-jdk-ubi10-minimal, 8-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 8/jdk/ubi/ubi10-minimal
+
 Tags: 8u432-b06-jdk-windowsservercore-ltsc2025, 8-jdk-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025
 SharedTags: 8u432-b06-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u432-b06-jdk, 8-jdk, 8
 Architectures: windows-amd64
@@ -118,6 +123,11 @@ Tags: 8u432-b06-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 8/jre/ubi/ubi9-minimal
+
+Tags: 8u432-b06-jre-ubi10-minimal, 8-jre-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 8/jre/ubi/ubi10-minimal
 
 Tags: 8u432-b06-jre-windowsservercore-ltsc2025, 8-jre-windowsservercore-ltsc2025
 SharedTags: 8u432-b06-jre-windowsservercore, 8-jre-windowsservercore, 8u432-b06-jre, 8-jre
@@ -201,6 +211,11 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 11/jdk/ubi/ubi9-minimal
 
+Tags: 11.0.25_9-jdk-ubi10-minimal, 11-jdk-ubi10-minimal, 11-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 11/jdk/ubi/ubi10-minimal
+
 Tags: 11.0.25_9-jdk-windowsservercore-ltsc2025, 11-jdk-windowsservercore-ltsc2025, 11-windowsservercore-ltsc2025
 SharedTags: 11.0.25_9-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.25_9-jdk, 11-jdk, 11
 Architectures: windows-amd64
@@ -280,6 +295,11 @@ Tags: 11.0.25_9-jre-ubi9-minimal, 11-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 11/jre/ubi/ubi9-minimal
+
+Tags: 11.0.25_9-jre-ubi10-minimal, 11-jre-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 11/jre/ubi/ubi10-minimal
 
 Tags: 11.0.25_9-jre-windowsservercore-ltsc2025, 11-jre-windowsservercore-ltsc2025
 SharedTags: 11.0.25_9-jre-windowsservercore, 11-jre-windowsservercore, 11.0.25_9-jre, 11-jre
@@ -363,6 +383,11 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 17/jdk/ubi/ubi9-minimal
 
+Tags: 17.0.13_11-jdk-ubi10-minimal, 17-jdk-ubi10-minimal, 17-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 17/jdk/ubi/ubi10-minimal
+
 Tags: 17.0.13_11-jdk-windowsservercore-ltsc2025, 17-jdk-windowsservercore-ltsc2025, 17-windowsservercore-ltsc2025
 SharedTags: 17.0.13_11-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.13_11-jdk, 17-jdk, 17
 Architectures: windows-amd64
@@ -443,6 +468,11 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 17/jre/ubi/ubi9-minimal
 
+Tags: 17.0.13_11-jre-ubi10-minimal, 17-jre-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 17/jre/ubi/ubi10-minimal
+
 Tags: 17.0.13_11-jre-windowsservercore-ltsc2025, 17-jre-windowsservercore-ltsc2025
 SharedTags: 17.0.13_11-jre-windowsservercore, 17-jre-windowsservercore, 17.0.13_11-jre, 17-jre
 Architectures: windows-amd64
@@ -520,6 +550,11 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 21/jdk/ubi/ubi9-minimal
 
+Tags: 21.0.5_11-jdk-ubi10-minimal, 21-jdk-ubi10-minimal, 21-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 21/jdk/ubi/ubi10-minimal
+
 Tags: 21.0.5_11-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
 SharedTags: 21.0.5_11-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.5_11-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
@@ -595,6 +630,11 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 21/jre/ubi/ubi9-minimal
 
+Tags: 21.0.5_11-jre-ubi10-minimal, 21-jre-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 21/jre/ubi/ubi10-minimal
+
 Tags: 21.0.5_11-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
 SharedTags: 21.0.5_11-jre-windowsservercore, 21-jre-windowsservercore, 21.0.5_11-jre, 21-jre
 Architectures: windows-amd64
@@ -667,6 +707,11 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 23/jdk/ubi/ubi9-minimal
 
+Tags: 23.0.1_11-jdk-ubi10-minimal, 23-jdk-ubi10-minimal, 23-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 23/jdk/ubi/ubi10-minimal
+
 Tags: 23.0.1_11-jdk-windowsservercore-ltsc2025, 23-jdk-windowsservercore-ltsc2025, 23-windowsservercore-ltsc2025
 SharedTags: 23.0.1_11-jdk-windowsservercore, 23-jdk-windowsservercore, 23-windowsservercore, 23.0.1_11-jdk, 23-jdk, 23
 Architectures: windows-amd64
@@ -736,6 +781,11 @@ Tags: 23.0.1_11-jre-ubi9-minimal, 23-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
 Directory: 23/jre/ubi/ubi9-minimal
+
+Tags: 23.0.1_11-jre-ubi10-minimal, 23-jre-ubi10-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 223947cdea5cc88bdeecb26e600e215bc785b1cc
+Directory: 23/jre/ubi/ubi10-minimal
 
 Tags: 23.0.1_11-jre-windowsservercore-ltsc2025, 23-jre-windowsservercore-ltsc2025
 SharedTags: 23.0.1_11-jre-windowsservercore, 23-jre-windowsservercore, 23.0.1_11-jre, 23-jre


### PR DESCRIPTION
Adding ubi10-minimal images for eclipse-temurin -

The external-pins for the the new base images have been added:
https://github.com/docker-library/official-images/pull/19235

And the Dockerfiles for all versions have been merged:
https://github.com/adoptium/containers/pull/770

