### PR TITLE
eclipse-temurin: add ubi10-minimal and removed deprecated ubuntu focal images

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -17,11 +17,6 @@ Architectures: amd64
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8u452-b09-jdk-focal, 8-jdk-focal, 8-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
-Directory: 8/jdk/ubuntu/focal
-
 Tags: 8u452-b09-jdk-jammy, 8-jdk-jammy, 8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
@@ -84,11 +79,6 @@ Tags: 8u452-b09-jre-alpine-3.21, 8-jre-alpine-3.21, 8u452-b09-jre-alpine, 8-jre-
 Architectures: amd64
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
 Directory: 8/jre/alpine/3.21
-
-Tags: 8u452-b09-jre-focal, 8-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
-Directory: 8/jre/ubuntu/focal
 
 Tags: 8u452-b09-jre-jammy, 8-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
@@ -155,11 +145,6 @@ Architectures: amd64
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
 Directory: 11/jdk/alpine/3.21
 
-Tags: 11.0.27_6-jdk-focal, 11-jdk-focal, 11-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 11/jdk/ubuntu/focal
-
 Tags: 11.0.27_6-jdk-jammy, 11-jdk-jammy, 11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
@@ -222,11 +207,6 @@ Tags: 11.0.27_6-jre-alpine-3.21, 11-jre-alpine-3.21, 11.0.27_6-jre-alpine, 11-jr
 Architectures: amd64
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
 Directory: 11/jre/alpine/3.21
-
-Tags: 11.0.27_6-jre-focal, 11-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 11/jre/ubuntu/focal
 
 Tags: 11.0.27_6-jre-jammy, 11-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
@@ -293,11 +273,6 @@ Architectures: amd64
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
 Directory: 17/jdk/alpine/3.21
 
-Tags: 17.0.15_6-jdk-focal, 17-jdk-focal, 17-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 17/jdk/ubuntu/focal
-
 Tags: 17.0.15_6-jdk-jammy, 17-jdk-jammy, 17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
@@ -360,11 +335,6 @@ Tags: 17.0.15_6-jre-alpine-3.21, 17-jre-alpine-3.21, 17.0.15_6-jre-alpine, 17-jr
 Architectures: amd64
 GitCommit: 69517080a51c4f0de4d7a7f7d40f3e4a65603acb
 Directory: 17/jre/alpine/3.21
-
-Tags: 17.0.15_6-jre-focal, 17-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 17/jre/ubuntu/focal
 
 Tags: 17.0.15_6-jre-jammy, 17-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x


### PR DESCRIPTION
Adding ubi10-minimal images for eclipse-temurin -

The external-pins for the the new base images have been added:
https://github.com/docker-library/official-images/pull/19235
And the Dockerfiles for all versions have been merged:
https://github.com/adoptium/containers/pull/770

Removing deprecated ubuntu focal images in https://github.com/adoptium/containers/pull/772