### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,120 +4,120 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 26-ea-7-jdk-oraclelinux9, 26-ea-7-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-7-jdk-oracle, 26-ea-7-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
-SharedTags: 26-ea-7-jdk, 26-ea-7, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-8-jdk-oraclelinux9, 26-ea-8-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-8-jdk-oracle, 26-ea-8-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
+SharedTags: 26-ea-8-jdk, 26-ea-8, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: amd64, arm64v8
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/oraclelinux9
 
-Tags: 26-ea-7-jdk-oraclelinux8, 26-ea-7-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
+Tags: 26-ea-8-jdk-oraclelinux8, 26-ea-8-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/oraclelinux8
 
-Tags: 26-ea-7-jdk-bookworm, 26-ea-7-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
+Tags: 26-ea-8-jdk-bookworm, 26-ea-8-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/bookworm
 
-Tags: 26-ea-7-jdk-slim-bookworm, 26-ea-7-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm, 26-ea-7-jdk-slim, 26-ea-7-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
+Tags: 26-ea-8-jdk-slim-bookworm, 26-ea-8-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm, 26-ea-8-jdk-slim, 26-ea-8-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
 Architectures: amd64, arm64v8
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/slim-bookworm
 
-Tags: 26-ea-7-jdk-bullseye, 26-ea-7-bullseye, 26-ea-jdk-bullseye, 26-ea-bullseye, 26-jdk-bullseye, 26-bullseye
+Tags: 26-ea-8-jdk-bullseye, 26-ea-8-bullseye, 26-ea-jdk-bullseye, 26-ea-bullseye, 26-jdk-bullseye, 26-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/bullseye
 
-Tags: 26-ea-7-jdk-slim-bullseye, 26-ea-7-slim-bullseye, 26-ea-jdk-slim-bullseye, 26-ea-slim-bullseye, 26-jdk-slim-bullseye, 26-slim-bullseye
+Tags: 26-ea-8-jdk-slim-bullseye, 26-ea-8-slim-bullseye, 26-ea-jdk-slim-bullseye, 26-ea-slim-bullseye, 26-jdk-slim-bullseye, 26-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/slim-bullseye
 
-Tags: 26-ea-7-jdk-windowsservercore-ltsc2025, 26-ea-7-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
-SharedTags: 26-ea-7-jdk-windowsservercore, 26-ea-7-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-7-jdk, 26-ea-7, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-8-jdk-windowsservercore-ltsc2025, 26-ea-8-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
+SharedTags: 26-ea-8-jdk-windowsservercore, 26-ea-8-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-8-jdk, 26-ea-8, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-7-jdk-windowsservercore-ltsc2022, 26-ea-7-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
-SharedTags: 26-ea-7-jdk-windowsservercore, 26-ea-7-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-7-jdk, 26-ea-7, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-8-jdk-windowsservercore-ltsc2022, 26-ea-8-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
+SharedTags: 26-ea-8-jdk-windowsservercore, 26-ea-8-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-8-jdk, 26-ea-8, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-7-jdk-nanoserver-ltsc2025, 26-ea-7-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
-SharedTags: 26-ea-7-jdk-nanoserver, 26-ea-7-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-8-jdk-nanoserver-ltsc2025, 26-ea-8-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
+SharedTags: 26-ea-8-jdk-nanoserver, 26-ea-8-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-7-jdk-nanoserver-ltsc2022, 26-ea-7-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
-SharedTags: 26-ea-7-jdk-nanoserver, 26-ea-7-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-8-jdk-nanoserver-ltsc2022, 26-ea-8-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
+SharedTags: 26-ea-8-jdk-nanoserver, 26-ea-8-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: 82d170e645026220d32f1ae5a1ad99c2fc26189e
+GitCommit: cab7b939233281f9f432bf89494dd1dca9a3b81c
 Directory: 26/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 25-ea-32-jdk-oraclelinux9, 25-ea-32-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-32-jdk-oracle, 25-ea-32-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-32-jdk, 25-ea-32, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-33-jdk-oraclelinux9, 25-ea-33-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-33-jdk-oracle, 25-ea-33-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-ea-33-jdk, 25-ea-33, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-32-jdk-oraclelinux8, 25-ea-32-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-ea-33-jdk-oraclelinux8, 25-ea-33-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-32-jdk-bookworm, 25-ea-32-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-ea-33-jdk-bookworm, 25-ea-33-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-32-jdk-slim-bookworm, 25-ea-32-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-32-jdk-slim, 25-ea-32-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-ea-33-jdk-slim-bookworm, 25-ea-33-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-33-jdk-slim, 25-ea-33-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-32-jdk-bullseye, 25-ea-32-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-ea-33-jdk-bullseye, 25-ea-33-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-32-jdk-slim-bullseye, 25-ea-32-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-ea-33-jdk-slim-bullseye, 25-ea-33-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-32-jdk-windowsservercore-ltsc2025, 25-ea-32-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
-SharedTags: 25-ea-32-jdk-windowsservercore, 25-ea-32-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-32-jdk, 25-ea-32, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-33-jdk-windowsservercore-ltsc2025, 25-ea-33-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-ea-33-jdk-windowsservercore, 25-ea-33-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-33-jdk, 25-ea-33, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 25-ea-32-jdk-windowsservercore-ltsc2022, 25-ea-32-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-32-jdk-windowsservercore, 25-ea-32-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-32-jdk, 25-ea-32, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-ea-33-jdk-windowsservercore-ltsc2022, 25-ea-33-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-ea-33-jdk-windowsservercore, 25-ea-33-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-33-jdk, 25-ea-33, 25-ea-jdk, 25-ea, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-32-jdk-nanoserver-ltsc2025, 25-ea-32-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
-SharedTags: 25-ea-32-jdk-nanoserver, 25-ea-32-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-33-jdk-nanoserver-ltsc2025, 25-ea-33-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-ea-33-jdk-nanoserver, 25-ea-33-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 25-ea-32-jdk-nanoserver-ltsc2022, 25-ea-32-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
-SharedTags: 25-ea-32-jdk-nanoserver, 25-ea-32-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-ea-33-jdk-nanoserver-ltsc2022, 25-ea-33-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-ea-33-jdk-nanoserver, 25-ea-33-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: 08ca8d42f8cad03c076aad1ad3ed1557074be316
+GitCommit: 3943cfb049b3547e497655ebcf93650b912b31d1
 Directory: 25/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/cab7b93: Update 26 to 26-ea+8
- https://github.com/docker-library/openjdk/commit/3943cfb: Update 25 to 25-ea+33