### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/1db0b83844caab1b3ea845dfebce83c9cd737278/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/e73a53925b99eaf1bba6d0db5a882e611755fff8/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 1db0b83844caab1b3ea845dfebce83c9cd737278
+GitCommit: e73a53925b99eaf1bba6d0db5a882e611755fff8
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f2a6730c23406abf8e00bbada490547224b4a9b6
+amd64-GitCommit: c9d396b13758b9ef013ff0ebc31b15e246ced4d2
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: a03ad9aa05f149b1b2967f5b8bb74b245e12dc2c
+arm32v5-GitCommit: 731a682974d050920dff0cf9547d41ad1f898ba4
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 46a4d93f3ab42ec5612c70ef9ccca4e58ec3090d
+arm32v6-GitCommit: e4b2bcae91a912bf7509d15b4360df5847fb638f
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 0b3c5ddb57a0880cb90d48f8e3aee22683f8aa82
+arm32v7-GitCommit: f51cc9054cc8eb2996a5b48bf4364997c0c3ab93
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f2bef30838ec9b2ca8a5eaa95c6f1e0901b1646d
+arm64v8-GitCommit: ef09fbe6f4c562e34bb67a0ba372702018eaccd4
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 13e1e8e27c7c9b0ff51f63407c7bea13d728c372
+i386-GitCommit: 07b656d2484ca0788433469dbfce9da6c55658b2
 # https://github.com/docker-library/busybox/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: b1dd0660c3c1ab84b15e926741a5ce8399b4b51e
+mips64le-GitCommit: 8985b768384fd6f3ed696734e7e4db34b031ee2f
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 185cc27c8afb93973df954e9a8e23d7bf515c467
+ppc64le-GitCommit: 3bbb15b7efd6d99a73690516b4499b6642f97ef5
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 7927d211681ecaaafcdacb326fd655ad430b6a63
+riscv64-GitCommit: 0aa8d9691f136754b8dab5af01429b32dfa36490
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 288b6bf064a55945cd5ace670f1807558b62af87
+s390x-GitCommit: 221f9e80b411fcfea795ca453cb5d2f9ef24aeee
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/e73a539: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/973bd0d: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/646eeca: Update metadata for i386
- https://github.com/docker-library/busybox/commit/8331a43: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/f5a6d45: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/19a38d3: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/a795aba: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/1db0b83: Update metadata for mips64le
- https://github.com/docker-library/busybox/commit/9b5c0d4: Update metadata for i386
- https://github.com/docker-library/busybox/commit/aa37b54: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/5303a70: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/bb435a1: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/e226b0e: Merge pull request https://github.com/docker-library/busybox/pull/225 from infosiftr/buildroot-2025.05
- https://github.com/docker-library/busybox/commit/dee52aa: Update metadata for amd64