### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-11992"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 07b89e4dea7f6bb6f378df0ddf88df8e2c7db95f
+amd64-GitCommit: 4280bdc8be2559d47436ec020eb980d3b17601d7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7fb1d0dbcb7015034c622a5b90d3c6ae161a5f10
+arm64v8-GitCommit: a051a546119b36c7d825713eadcaeaba5c618dcf
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6965, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-11992.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
