### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-12010"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4280bdc8be2559d47436ec020eb980d3b17601d7
+amd64-GitCommit: e22bf43372eb565676eee202cf8fb033924cc541
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a051a546119b36c7d825713eadcaeaba5c618dcf
+arm64v8-GitCommit: 7c0a6bfdf2fd18d13fd192513e7ab008ae3f290c
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6965, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-12010.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
