### PR TITLE
Update to Flink 2.1.0

### DIFF
--- a/library/flink
+++ b/library/flink
@@ -3,17 +3,32 @@
 Maintainers: The Apache Flink Project <dev@flink.apache.org> (@ApacheFlink)
 GitRepo: https://github.com/apache/flink-docker.git
 
-Tags: 2.0.0-scala_2.12-java21, 2.0-scala_2.12-java21, scala_2.12-java21, 2.0.0-java21, 2.0-java21, java21
+Tags: 2.1.0-scala_2.12-java21, 2.1-scala_2.12-java21, scala_2.12-java21, 2.1.0-java21, 2.1-java21, java21
+Architectures: amd64,arm64v8
+GitCommit: 398bafb626b7ee940cbd0d5026005d8d6f8d1786
+Directory: ./2.1/scala_2.12-java21-ubuntu
+
+Tags: 2.1.0-scala_2.12-java17, 2.1-scala_2.12-java17, scala_2.12-java17, 2.1.0-scala_2.12, 2.1-scala_2.12, scala_2.12, 2.1.0-java17, 2.1-java17, java17, 2.1.0, 2.1, latest
+Architectures: amd64,arm64v8
+GitCommit: 398bafb626b7ee940cbd0d5026005d8d6f8d1786
+Directory: ./2.1/scala_2.12-java17-ubuntu
+
+Tags: 2.1.0-scala_2.12-java11, 2.1-scala_2.12-java11, scala_2.12-java11, 2.1.0-java11, 2.1-java11, java11
+Architectures: amd64,arm64v8
+GitCommit: 398bafb626b7ee940cbd0d5026005d8d6f8d1786
+Directory: ./2.1/scala_2.12-java11-ubuntu
+
+Tags: 2.0.0-scala_2.12-java21, 2.0-scala_2.12-java21, 2.0.0-java21, 2.0-java21
 Architectures: amd64,arm64v8
 GitCommit: d32c85bcf93b430d56685b54ab5732a20e472e2e
 Directory: ./2.0/scala_2.12-java21-ubuntu
 
-Tags: 2.0.0-scala_2.12-java17, 2.0-scala_2.12-java17, scala_2.12-java17, 2.0.0-scala_2.12, 2.0-scala_2.12, scala_2.12, 2.0.0-java17, 2.0-java17, java17, 2.0.0, 2.0, latest
+Tags: 2.0.0-scala_2.12-java17, 2.0-scala_2.12-java17, 2.0.0-scala_2.12, 2.0-scala_2.12, 2.0.0-java17, 2.0-java17, 2.0.0, 2.0
 Architectures: amd64,arm64v8
 GitCommit: d32c85bcf93b430d56685b54ab5732a20e472e2e
 Directory: ./2.0/scala_2.12-java17-ubuntu
 
-Tags: 2.0.0-scala_2.12-java11, 2.0-scala_2.12-java11, scala_2.12-java11, 2.0.0-java11, 2.0-java11, java11
+Tags: 2.0.0-scala_2.12-java11, 2.0-scala_2.12-java11, 2.0.0-java11, 2.0-java11
 Architectures: amd64,arm64v8
 GitCommit: d32c85bcf93b430d56685b54ab5732a20e472e2e
 Directory: ./2.0/scala_2.12-java11-ubuntu
@@ -32,18 +47,3 @@ Tags: 1.20.2-scala_2.12-java11, 1.20-scala_2.12-java11, 1.20.2-scala_2.12, 1.20-
 Architectures: amd64,arm64v8
 GitCommit: 3679d8deb790720fa63d4682c1fc928c252e7d9f
 Directory: ./1.20/scala_2.12-java11-ubuntu
-
-Tags: 1.19.3-scala_2.12-java8, 1.19-scala_2.12-java8, 1.19.3-java8, 1.19-java8
-Architectures: amd64,arm64v8
-GitCommit: 3679d8deb790720fa63d4682c1fc928c252e7d9f
-Directory: ./1.19/scala_2.12-java8-ubuntu
-
-Tags: 1.19.3-scala_2.12-java17, 1.19-scala_2.12-java17, 1.19.3-java17, 1.19-java17
-Architectures: amd64,arm64v8
-GitCommit: 3679d8deb790720fa63d4682c1fc928c252e7d9f
-Directory: ./1.19/scala_2.12-java17-ubuntu
-
-Tags: 1.19.3-scala_2.12-java11, 1.19-scala_2.12-java11, 1.19.3-scala_2.12, 1.19-scala_2.12, 1.19.3-java11, 1.19-java11, 1.19.3, 1.19
-Architectures: amd64,arm64v8
-GitCommit: 3679d8deb790720fa63d4682c1fc928c252e7d9f
-Directory: ./1.19/scala_2.12-java11-ubuntu


### PR DESCRIPTION
This is the official release of Apache Flink 2.1.0:
- Add new released 2.1.0.
- Remove unsupported 1.19.3.