### PR TITLE
"[oraclelinux] Updating 10and 10-slim for ELSA-2025-11933
ELSA-2025-11933"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e22bf43372eb565676eee202cf8fb033924cc541
+amd64-GitCommit: 443ff4e5fc210c89d03bffe7d655634159bc9b3e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7c0a6bfdf2fd18d13fd192513e7ab008ae3f290c
+arm64v8-GitCommit: 7e1840b80d8e0eda305c0d2e8c8655eebbc6dd9d
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for , CVE-2025-6965, none, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-11933.html
https://linux.oracle.com/errata/ELSA-2025-11933.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
