### PR TITLE
SonarQube latest editions set to 2025.3

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,24 +4,24 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2025.4.0-developer, 2025.4-developer, developer
+Tags: 2025.3.1-developer, 2025.3-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
 GitFetch: refs/heads/master
 
-Tags: 2025.4.0-enterprise, 2025.4-enterprise, enterprise
+Tags: 2025.3.1-enterprise, 2025.3-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
 GitFetch: refs/heads/master
 
-Tags: 2025.4.0-datacenter-app, 2025.4-datacenter-app, datacenter-app
+Tags: 2025.3.1-datacenter-app, 2025.3-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
 GitFetch: refs/heads/master
 
-Tags: 2025.4.0-datacenter-search, 2025.4-datacenter-search, datacenter-search
+Tags: 2025.3.1-datacenter-search, 2025.3-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
 GitFetch: refs/heads/master
 
 Tags: 2025.1.3-developer, 2025.1-developer, 2025-lta-developer


### PR DESCRIPTION
Dear team,

We are aware of a licensing issue with SonarQube Server 2025.4, which was released yesterday. So we are proposing this PR to make sure that the latest edition tags (e.g., developer, enterprise, datacenter-app, datacenter-search) point to 2025.3.1 and that those are listed as the supported versions on the page.

Could you please treat it with urgency? Thanks for your help!