### PR TITLE
fluentd: Update to v1.19.0

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -16,14 +16,8 @@ GitFetch: refs/heads/v1.16
 GitCommit: 505a1af75b4a4adb40d576df7b18cebab853264e
 Directory: v1.16/debian
 
-# Alpine images
-Tags: v1.18.0-1.0, v1.18-1, latest
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c3c82df3ec08a46ba346e53c4644cfc667dc703
-Directory: v1.18/alpine
-
 # Debian images
-Tags: v1.18.0-debian-1.0, v1.18-debian-1
+Tags: v1.19.0-debian-1.0, v1.19-debian-1, v1.19.0-1.0, v1.19-1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0c3c82df3ec08a46ba346e53c4644cfc667dc703
-Directory: v1.18/debian
+GitCommit: 42a0afa30b3821482bce1ba8e67266d745619724
+Directory: v1.19/debian


### PR DESCRIPTION
NOTE: Since v1.19.0, alpine will not shipped anymore, so alpine target was removed.