### PR TITLE
Release SonarQube Server 2025.4.1

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,24 +4,24 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2025.3.1-developer, 2025.3-developer, developer
+Tags: 2025.4.1-developer, 2025.4-developer, developer
 Directory: commercial-editions/developer
-GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
-Tags: 2025.3.1-enterprise, 2025.3-enterprise, enterprise
+Tags: 2025.4.1-enterprise, 2025.4-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
-Tags: 2025.3.1-datacenter-app, 2025.3-datacenter-app, datacenter-app
+Tags: 2025.4.1-datacenter-app, 2025.4-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
-Tags: 2025.3.1-datacenter-search, 2025.3-datacenter-search, datacenter-search
+Tags: 2025.4.1-datacenter-search, 2025.4-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: e29feb48414fb0f210d4d025158b7557eefe0092
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
 Tags: 2025.1.3-developer, 2025.1-developer, 2025-lta-developer
@@ -46,30 +46,30 @@ GitFetch: refs/heads/release/2025.1
 
 Tags: 25.7.0.110598-community, community, latest
 Directory: community-build
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
 Tags: 9.9.8-community, 9.9-community, 9-community, lts, lts-community
 Directory: 9/community
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
 Tags: 9.9.8-developer, 9.9-developer, 9-developer, lts-developer
 Directory: 9/developer
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
 Tags: 9.9.9-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
 Directory: 9/enterprise
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
 Tags: 9.9.9-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
 Directory: 9/datacenter/app
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master
 
 Tags: 9.9.9-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
 Directory: 9/datacenter/search
-GitCommit: 4c717b6de25b4882074a79d7f02447004df555cf
+GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
 GitFetch: refs/heads/master


### PR DESCRIPTION
Dear team,

we are ready to release SonarQube Server 2025.4.1 that fixes certain licensing issues that customers might experience.

Could you please review it and let the patch version reach our Docker users rapidly?

Thanks!