### PR TITLE
eclipse-temurin: July PSU updates

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,610 +7,681 @@ GitFetch: refs/heads/main
 Builder: buildkit
 
 #------------------------------v8 images---------------------------------
-Tags: 8u452-b09-jdk-alpine-3.20, 8-jdk-alpine-3.20, 8-alpine-3.20
+Tags: 8u462-b08-jdk-alpine-3.20, 8-jdk-alpine-3.20, 8-alpine-3.20
 Architectures: amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/alpine/3.20
 
-Tags: 8u452-b09-jdk-alpine-3.21, 8-jdk-alpine-3.21, 8-alpine-3.21, 8u452-b09-jdk-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u462-b08-jdk-alpine-3.21, 8-jdk-alpine-3.21, 8-alpine-3.21
 Architectures: amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8u452-b09-jdk-focal, 8-jdk-focal, 8-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
-Directory: 8/jdk/ubuntu/focal
+Tags: 8u462-b08-jdk-alpine-3.22, 8-jdk-alpine-3.22, 8-alpine-3.22, 8u462-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
+Architectures: amd64
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 8/jdk/alpine/3.22
 
-Tags: 8u452-b09-jdk-jammy, 8-jdk-jammy, 8-jammy
+Tags: 8u462-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/ubuntu/jammy
 
-Tags: 8u452-b09-jdk-noble, 8-jdk-noble, 8-noble
-SharedTags: 8u452-b09-jdk, 8-jdk, 8
+Tags: 8u462-b08-jdk-noble, 8-jdk-noble, 8-noble
+SharedTags: 8u462-b08-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/ubuntu/noble
 
-Tags: 8u452-b09-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Tags: 8u462-b08-jdk-ubi10-minimal, 8-jdk-ubi10-minimal, 8-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 8/jdk/ubi/ubi10-minimal
+
+Tags: 8u462-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/ubi/ubi9-minimal
 
-Tags: 8u452-b09-jdk-windowsservercore-ltsc2025, 8-jdk-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025
-SharedTags: 8u452-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u452-b09-jdk, 8-jdk, 8
+Tags: 8u462-b08-jdk-windowsservercore-ltsc2025, 8-jdk-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025
+SharedTags: 8u462-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u462-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8u452-b09-jdk-nanoserver-ltsc2025, 8-jdk-nanoserver-ltsc2025, 8-nanoserver-ltsc2025
-SharedTags: 8u452-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u462-b08-jdk-nanoserver-ltsc2025, 8-jdk-nanoserver-ltsc2025, 8-nanoserver-ltsc2025
+SharedTags: 8u462-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 8u452-b09-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u452-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u452-b09-jdk, 8-jdk, 8
+Tags: 8u462-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u462-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u462-b08-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u452-b09-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
-SharedTags: 8u452-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u462-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
+SharedTags: 8u462-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u452-b09-jre-alpine-3.20, 8-jre-alpine-3.20
+Tags: 8u462-b08-jre-alpine-3.20, 8-jre-alpine-3.20
 Architectures: amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/alpine/3.20
 
-Tags: 8u452-b09-jre-alpine-3.21, 8-jre-alpine-3.21, 8u452-b09-jre-alpine, 8-jre-alpine
+Tags: 8u462-b08-jre-alpine-3.21, 8-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/alpine/3.21
 
-Tags: 8u452-b09-jre-focal, 8-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
-Directory: 8/jre/ubuntu/focal
+Tags: 8u462-b08-jre-alpine-3.22, 8-jre-alpine-3.22, 8u462-b08-jre-alpine, 8-jre-alpine
+Architectures: amd64
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 8/jre/alpine/3.22
 
-Tags: 8u452-b09-jre-jammy, 8-jre-jammy
+Tags: 8u462-b08-jre-jammy, 8-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/ubuntu/jammy
 
-Tags: 8u452-b09-jre-noble, 8-jre-noble
-SharedTags: 8u452-b09-jre, 8-jre
+Tags: 8u462-b08-jre-noble, 8-jre-noble
+SharedTags: 8u462-b08-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/ubuntu/noble
 
-Tags: 8u452-b09-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Tags: 8u462-b08-jre-ubi10-minimal, 8-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 8/jre/ubi/ubi10-minimal
+
+Tags: 8u462-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/ubi/ubi9-minimal
 
-Tags: 8u452-b09-jre-windowsservercore-ltsc2025, 8-jre-windowsservercore-ltsc2025
-SharedTags: 8u452-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u452-b09-jre, 8-jre
+Tags: 8u462-b08-jre-windowsservercore-ltsc2025, 8-jre-windowsservercore-ltsc2025
+SharedTags: 8u462-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u462-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8u452-b09-jre-nanoserver-ltsc2025, 8-jre-nanoserver-ltsc2025
-SharedTags: 8u452-b09-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u462-b08-jre-nanoserver-ltsc2025, 8-jre-nanoserver-ltsc2025
+SharedTags: 8u462-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 8u452-b09-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u452-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u452-b09-jre, 8-jre
+Tags: 8u462-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u462-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u462-b08-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u452-b09-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
-SharedTags: 8u452-b09-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u462-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
+SharedTags: 8u462-b08-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 4890fb4638e68c037c00c4a28c7587e0b5c96fcf
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 
 #------------------------------v11 images---------------------------------
-Tags: 11.0.27_6-jdk-alpine-3.20, 11-jdk-alpine-3.20, 11-alpine-3.20
+Tags: 11.0.28_6-jdk-alpine-3.20, 11-jdk-alpine-3.20, 11-alpine-3.20
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/alpine/3.20
 
-Tags: 11.0.27_6-jdk-alpine-3.21, 11-jdk-alpine-3.21, 11-alpine-3.21, 11.0.27_6-jdk-alpine, 11-jdk-alpine, 11-alpine
+Tags: 11.0.28_6-jdk-alpine-3.21, 11-jdk-alpine-3.21, 11-alpine-3.21
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/alpine/3.21
 
-Tags: 11.0.27_6-jdk-focal, 11-jdk-focal, 11-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 11/jdk/ubuntu/focal
+Tags: 11.0.28_6-jdk-alpine-3.22, 11-jdk-alpine-3.22, 11-alpine-3.22, 11.0.28_6-jdk-alpine, 11-jdk-alpine, 11-alpine
+Architectures: amd64
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 11/jdk/alpine/3.22
 
-Tags: 11.0.27_6-jdk-jammy, 11-jdk-jammy, 11-jammy
+Tags: 11.0.28_6-jdk-jammy, 11-jdk-jammy, 11-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/ubuntu/jammy
 
-Tags: 11.0.27_6-jdk-noble, 11-jdk-noble, 11-noble
-SharedTags: 11.0.27_6-jdk, 11-jdk, 11
+Tags: 11.0.28_6-jdk-noble, 11-jdk-noble, 11-noble
+SharedTags: 11.0.28_6-jdk, 11-jdk, 11
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/ubuntu/noble
 
-Tags: 11.0.27_6-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Tags: 11.0.28_6-jdk-ubi10-minimal, 11-jdk-ubi10-minimal, 11-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 11/jdk/ubi/ubi10-minimal
+
+Tags: 11.0.28_6-jdk-ubi9-minimal, 11-jdk-ubi9-minimal, 11-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/ubi/ubi9-minimal
 
-Tags: 11.0.27_6-jdk-windowsservercore-ltsc2025, 11-jdk-windowsservercore-ltsc2025, 11-windowsservercore-ltsc2025
-SharedTags: 11.0.27_6-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.27_6-jdk, 11-jdk, 11
+Tags: 11.0.28_6-jdk-windowsservercore-ltsc2025, 11-jdk-windowsservercore-ltsc2025, 11-windowsservercore-ltsc2025
+SharedTags: 11.0.28_6-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.28_6-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 11.0.27_6-jdk-nanoserver-ltsc2025, 11-jdk-nanoserver-ltsc2025, 11-nanoserver-ltsc2025
-SharedTags: 11.0.27_6-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.28_6-jdk-nanoserver-ltsc2025, 11-jdk-nanoserver-ltsc2025, 11-nanoserver-ltsc2025
+SharedTags: 11.0.28_6-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 11.0.27_6-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
-SharedTags: 11.0.27_6-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.27_6-jdk, 11-jdk, 11
+Tags: 11.0.28_6-jdk-windowsservercore-ltsc2022, 11-jdk-windowsservercore-ltsc2022, 11-windowsservercore-ltsc2022
+SharedTags: 11.0.28_6-jdk-windowsservercore, 11-jdk-windowsservercore, 11-windowsservercore, 11.0.28_6-jdk, 11-jdk, 11
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.27_6-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
-SharedTags: 11.0.27_6-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
+Tags: 11.0.28_6-jdk-nanoserver-ltsc2022, 11-jdk-nanoserver-ltsc2022, 11-nanoserver-ltsc2022
+SharedTags: 11.0.28_6-jdk-nanoserver, 11-jdk-nanoserver, 11-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 11.0.27_6-jre-alpine-3.20, 11-jre-alpine-3.20
+Tags: 11.0.28_6-jre-alpine-3.20, 11-jre-alpine-3.20
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/alpine/3.20
 
-Tags: 11.0.27_6-jre-alpine-3.21, 11-jre-alpine-3.21, 11.0.27_6-jre-alpine, 11-jre-alpine
+Tags: 11.0.28_6-jre-alpine-3.21, 11-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/alpine/3.21
 
-Tags: 11.0.27_6-jre-focal, 11-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 11/jre/ubuntu/focal
+Tags: 11.0.28_6-jre-alpine-3.22, 11-jre-alpine-3.22, 11.0.28_6-jre-alpine, 11-jre-alpine
+Architectures: amd64
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 11/jre/alpine/3.22
 
-Tags: 11.0.27_6-jre-jammy, 11-jre-jammy
+Tags: 11.0.28_6-jre-jammy, 11-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/ubuntu/jammy
 
-Tags: 11.0.27_6-jre-noble, 11-jre-noble
-SharedTags: 11.0.27_6-jre, 11-jre
+Tags: 11.0.28_6-jre-noble, 11-jre-noble
+SharedTags: 11.0.28_6-jre, 11-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/ubuntu/noble
 
-Tags: 11.0.27_6-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Tags: 11.0.28_6-jre-ubi10-minimal, 11-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 11/jre/ubi/ubi10-minimal
+
+Tags: 11.0.28_6-jre-ubi9-minimal, 11-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/ubi/ubi9-minimal
 
-Tags: 11.0.27_6-jre-windowsservercore-ltsc2025, 11-jre-windowsservercore-ltsc2025
-SharedTags: 11.0.27_6-jre-windowsservercore, 11-jre-windowsservercore, 11.0.27_6-jre, 11-jre
+Tags: 11.0.28_6-jre-windowsservercore-ltsc2025, 11-jre-windowsservercore-ltsc2025
+SharedTags: 11.0.28_6-jre-windowsservercore, 11-jre-windowsservercore, 11.0.28_6-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 11.0.27_6-jre-nanoserver-ltsc2025, 11-jre-nanoserver-ltsc2025
-SharedTags: 11.0.27_6-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.28_6-jre-nanoserver-ltsc2025, 11-jre-nanoserver-ltsc2025
+SharedTags: 11.0.28_6-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 11.0.27_6-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
-SharedTags: 11.0.27_6-jre-windowsservercore, 11-jre-windowsservercore, 11.0.27_6-jre, 11-jre
+Tags: 11.0.28_6-jre-windowsservercore-ltsc2022, 11-jre-windowsservercore-ltsc2022
+SharedTags: 11.0.28_6-jre-windowsservercore, 11-jre-windowsservercore, 11.0.28_6-jre, 11-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 11.0.27_6-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
-SharedTags: 11.0.27_6-jre-nanoserver, 11-jre-nanoserver
+Tags: 11.0.28_6-jre-nanoserver-ltsc2022, 11-jre-nanoserver-ltsc2022
+SharedTags: 11.0.28_6-jre-nanoserver, 11-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 11/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.15_6-jdk-alpine-3.20, 17-jdk-alpine-3.20, 17-alpine-3.20
+Tags: 17.0.16_8-jdk-alpine-3.20, 17-jdk-alpine-3.20, 17-alpine-3.20
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/alpine/3.20
 
-Tags: 17.0.15_6-jdk-alpine-3.21, 17-jdk-alpine-3.21, 17-alpine-3.21, 17.0.15_6-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.16_8-jdk-alpine-3.21, 17-jdk-alpine-3.21, 17-alpine-3.21
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/alpine/3.21
 
-Tags: 17.0.15_6-jdk-focal, 17-jdk-focal, 17-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 17/jdk/ubuntu/focal
+Tags: 17.0.16_8-jdk-alpine-3.22, 17-jdk-alpine-3.22, 17-alpine-3.22, 17.0.16_8-jdk-alpine, 17-jdk-alpine, 17-alpine
+Architectures: amd64
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 17/jdk/alpine/3.22
 
-Tags: 17.0.15_6-jdk-jammy, 17-jdk-jammy, 17-jammy
+Tags: 17.0.16_8-jdk-jammy, 17-jdk-jammy, 17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.15_6-jdk-noble, 17-jdk-noble, 17-noble
-SharedTags: 17.0.15_6-jdk, 17-jdk, 17
+Tags: 17.0.16_8-jdk-noble, 17-jdk-noble, 17-noble
+SharedTags: 17.0.16_8-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/ubuntu/noble
 
-Tags: 17.0.15_6-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.16_8-jdk-ubi10-minimal, 17-jdk-ubi10-minimal, 17-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 17/jdk/ubi/ubi10-minimal
+
+Tags: 17.0.16_8-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.15_6-jdk-windowsservercore-ltsc2025, 17-jdk-windowsservercore-ltsc2025, 17-windowsservercore-ltsc2025
-SharedTags: 17.0.15_6-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.15_6-jdk, 17-jdk, 17
+Tags: 17.0.16_8-jdk-windowsservercore-ltsc2025, 17-jdk-windowsservercore-ltsc2025, 17-windowsservercore-ltsc2025
+SharedTags: 17.0.16_8-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.16_8-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 17.0.15_6-jdk-nanoserver-ltsc2025, 17-jdk-nanoserver-ltsc2025, 17-nanoserver-ltsc2025
-SharedTags: 17.0.15_6-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.16_8-jdk-nanoserver-ltsc2025, 17-jdk-nanoserver-ltsc2025, 17-nanoserver-ltsc2025
+SharedTags: 17.0.16_8-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 17.0.15_6-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.15_6-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.15_6-jdk, 17-jdk, 17
+Tags: 17.0.16_8-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.16_8-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.16_8-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.15_6-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.15_6-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.16_8-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.16_8-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.15_6-jre-alpine-3.20, 17-jre-alpine-3.20
+Tags: 17.0.16_8-jre-alpine-3.20, 17-jre-alpine-3.20
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/alpine/3.20
 
-Tags: 17.0.15_6-jre-alpine-3.21, 17-jre-alpine-3.21, 17.0.15_6-jre-alpine, 17-jre-alpine
+Tags: 17.0.16_8-jre-alpine-3.21, 17-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/alpine/3.21
 
-Tags: 17.0.15_6-jre-focal, 17-jre-focal
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
-Directory: 17/jre/ubuntu/focal
+Tags: 17.0.16_8-jre-alpine-3.22, 17-jre-alpine-3.22, 17.0.16_8-jre-alpine, 17-jre-alpine
+Architectures: amd64
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 17/jre/alpine/3.22
 
-Tags: 17.0.15_6-jre-jammy, 17-jre-jammy
+Tags: 17.0.16_8-jre-jammy, 17-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/ubuntu/jammy
 
-Tags: 17.0.15_6-jre-noble, 17-jre-noble
-SharedTags: 17.0.15_6-jre, 17-jre
+Tags: 17.0.16_8-jre-noble, 17-jre-noble
+SharedTags: 17.0.16_8-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/ubuntu/noble
 
-Tags: 17.0.15_6-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.16_8-jre-ubi10-minimal, 17-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 17/jre/ubi/ubi10-minimal
+
+Tags: 17.0.16_8-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.15_6-jre-windowsservercore-ltsc2025, 17-jre-windowsservercore-ltsc2025
-SharedTags: 17.0.15_6-jre-windowsservercore, 17-jre-windowsservercore, 17.0.15_6-jre, 17-jre
+Tags: 17.0.16_8-jre-windowsservercore-ltsc2025, 17-jre-windowsservercore-ltsc2025
+SharedTags: 17.0.16_8-jre-windowsservercore, 17-jre-windowsservercore, 17.0.16_8-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 17.0.15_6-jre-nanoserver-ltsc2025, 17-jre-nanoserver-ltsc2025
-SharedTags: 17.0.15_6-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.16_8-jre-nanoserver-ltsc2025, 17-jre-nanoserver-ltsc2025
+SharedTags: 17.0.16_8-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 17.0.15_6-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.15_6-jre-windowsservercore, 17-jre-windowsservercore, 17.0.15_6-jre, 17-jre
+Tags: 17.0.16_8-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.16_8-jre-windowsservercore, 17-jre-windowsservercore, 17.0.16_8-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.15_6-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.15_6-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.16_8-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.16_8-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 
 #------------------------------v21 images---------------------------------
-Tags: 21.0.7_6-jdk-alpine-3.20, 21-jdk-alpine-3.20, 21-alpine-3.20
+Tags: 21.0.8_9-jdk-alpine-3.20, 21-jdk-alpine-3.20, 21-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/alpine/3.20
 
-Tags: 21.0.7_6-jdk-alpine-3.21, 21-jdk-alpine-3.21, 21-alpine-3.21, 21.0.7_6-jdk-alpine, 21-jdk-alpine, 21-alpine
+Tags: 21.0.8_9-jdk-alpine-3.21, 21-jdk-alpine-3.21, 21-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/alpine/3.21
 
-Tags: 21.0.7_6-jdk-jammy, 21-jdk-jammy, 21-jammy
+Tags: 21.0.8_9-jdk-alpine-3.22, 21-jdk-alpine-3.22, 21-alpine-3.22, 21.0.8_9-jdk-alpine, 21-jdk-alpine, 21-alpine
+Architectures: amd64, arm64v8
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 21/jdk/alpine/3.22
+
+Tags: 21.0.8_9-jdk-jammy, 21-jdk-jammy, 21-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/ubuntu/jammy
 
-Tags: 21.0.7_6-jdk-noble, 21-jdk-noble, 21-noble
-SharedTags: 21.0.7_6-jdk, 21-jdk, 21, latest
+Tags: 21.0.8_9-jdk-noble, 21-jdk-noble, 21-noble
+SharedTags: 21.0.8_9-jdk, 21-jdk, 21, latest
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/ubuntu/noble
 
-Tags: 21.0.7_6-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Tags: 21.0.8_9-jdk-ubi10-minimal, 21-jdk-ubi10-minimal, 21-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 21/jdk/ubi/ubi10-minimal
+
+Tags: 21.0.8_9-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/ubi/ubi9-minimal
 
-Tags: 21.0.7_6-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
-SharedTags: 21.0.7_6-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.7_6-jdk, 21-jdk, 21, latest
+Tags: 21.0.8_9-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
+SharedTags: 21.0.8_9-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.8_9-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 21.0.7_6-jdk-nanoserver-ltsc2025, 21-jdk-nanoserver-ltsc2025, 21-nanoserver-ltsc2025
-SharedTags: 21.0.7_6-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.8_9-jdk-nanoserver-ltsc2025, 21-jdk-nanoserver-ltsc2025, 21-nanoserver-ltsc2025
+SharedTags: 21.0.8_9-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 21.0.7_6-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21.0.7_6-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.7_6-jdk, 21-jdk, 21, latest
+Tags: 21.0.8_9-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21.0.8_9-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.8_9-jdk, 21-jdk, 21, latest
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.7_6-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
-SharedTags: 21.0.7_6-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.8_9-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
+SharedTags: 21.0.8_9-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.7_6-jre-alpine-3.20, 21-jre-alpine-3.20
+Tags: 21.0.8_9-jre-alpine-3.20, 21-jre-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/alpine/3.20
 
-Tags: 21.0.7_6-jre-alpine-3.21, 21-jre-alpine-3.21, 21.0.7_6-jre-alpine, 21-jre-alpine
+Tags: 21.0.8_9-jre-alpine-3.21, 21-jre-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/alpine/3.21
 
-Tags: 21.0.7_6-jre-jammy, 21-jre-jammy
+Tags: 21.0.8_9-jre-alpine-3.22, 21-jre-alpine-3.22, 21.0.8_9-jre-alpine, 21-jre-alpine
+Architectures: amd64, arm64v8
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 21/jre/alpine/3.22
+
+Tags: 21.0.8_9-jre-jammy, 21-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/ubuntu/jammy
 
-Tags: 21.0.7_6-jre-noble, 21-jre-noble
-SharedTags: 21.0.7_6-jre, 21-jre
+Tags: 21.0.8_9-jre-noble, 21-jre-noble
+SharedTags: 21.0.8_9-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/ubuntu/noble
 
-Tags: 21.0.7_6-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Tags: 21.0.8_9-jre-ubi10-minimal, 21-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 21/jre/ubi/ubi10-minimal
+
+Tags: 21.0.8_9-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/ubi/ubi9-minimal
 
-Tags: 21.0.7_6-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
-SharedTags: 21.0.7_6-jre-windowsservercore, 21-jre-windowsservercore, 21.0.7_6-jre, 21-jre
+Tags: 21.0.8_9-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
+SharedTags: 21.0.8_9-jre-windowsservercore, 21-jre-windowsservercore, 21.0.8_9-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 21.0.7_6-jre-nanoserver-ltsc2025, 21-jre-nanoserver-ltsc2025
-SharedTags: 21.0.7_6-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.8_9-jre-nanoserver-ltsc2025, 21-jre-nanoserver-ltsc2025
+SharedTags: 21.0.8_9-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 21.0.7_6-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
-SharedTags: 21.0.7_6-jre-windowsservercore, 21-jre-windowsservercore, 21.0.7_6-jre, 21-jre
+Tags: 21.0.8_9-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
+SharedTags: 21.0.8_9-jre-windowsservercore, 21-jre-windowsservercore, 21.0.8_9-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.7_6-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
-SharedTags: 21.0.7_6-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.8_9-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
+SharedTags: 21.0.8_9-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 
 #------------------------------v24 images---------------------------------
-Tags: 24.0.1_9-jdk-alpine-3.20, 24-jdk-alpine-3.20, 24-alpine-3.20
+Tags: 24.0.2_12-jdk-alpine-3.20, 24-jdk-alpine-3.20, 24-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/alpine/3.20
 
-Tags: 24.0.1_9-jdk-alpine-3.21, 24-jdk-alpine-3.21, 24-alpine-3.21, 24.0.1_9-jdk-alpine, 24-jdk-alpine, 24-alpine
+Tags: 24.0.2_12-jdk-alpine-3.21, 24-jdk-alpine-3.21, 24-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/alpine/3.21
 
-Tags: 24.0.1_9-jdk-noble, 24-jdk-noble, 24-noble
-SharedTags: 24.0.1_9-jdk, 24-jdk, 24
+Tags: 24.0.2_12-jdk-alpine-3.22, 24-jdk-alpine-3.22, 24-alpine-3.22, 24.0.2_12-jdk-alpine, 24-jdk-alpine, 24-alpine
+Architectures: amd64, arm64v8
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 24/jdk/alpine/3.22
+
+Tags: 24.0.2_12-jdk-noble, 24-jdk-noble, 24-noble
+SharedTags: 24.0.2_12-jdk, 24-jdk, 24
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/ubuntu/noble
 
-Tags: 24.0.1_9-jdk-ubi9-minimal, 24-jdk-ubi9-minimal, 24-ubi9-minimal
+Tags: 24.0.2_12-jdk-ubi10-minimal, 24-jdk-ubi10-minimal, 24-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 24/jdk/ubi/ubi10-minimal
+
+Tags: 24.0.2_12-jdk-ubi9-minimal, 24-jdk-ubi9-minimal, 24-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/ubi/ubi9-minimal
 
-Tags: 24.0.1_9-jdk-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
-SharedTags: 24.0.1_9-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24.0.1_9-jdk, 24-jdk, 24
+Tags: 24.0.2_12-jdk-windowsservercore-ltsc2025, 24-jdk-windowsservercore-ltsc2025, 24-windowsservercore-ltsc2025
+SharedTags: 24.0.2_12-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24.0.2_12-jdk, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 24.0.1_9-jdk-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
-SharedTags: 24.0.1_9-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24.0.2_12-jdk-nanoserver-ltsc2025, 24-jdk-nanoserver-ltsc2025, 24-nanoserver-ltsc2025
+SharedTags: 24.0.2_12-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 24.0.1_9-jdk-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
-SharedTags: 24.0.1_9-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24.0.1_9-jdk, 24-jdk, 24
+Tags: 24.0.2_12-jdk-windowsservercore-ltsc2022, 24-jdk-windowsservercore-ltsc2022, 24-windowsservercore-ltsc2022
+SharedTags: 24.0.2_12-jdk-windowsservercore, 24-jdk-windowsservercore, 24-windowsservercore, 24.0.2_12-jdk, 24-jdk, 24
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24.0.1_9-jdk-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
-SharedTags: 24.0.1_9-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
+Tags: 24.0.2_12-jdk-nanoserver-ltsc2022, 24-jdk-nanoserver-ltsc2022, 24-nanoserver-ltsc2022
+SharedTags: 24.0.2_12-jdk-nanoserver, 24-jdk-nanoserver, 24-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 24.0.1_9-jre-alpine-3.20, 24-jre-alpine-3.20
+Tags: 24.0.2_12-jre-alpine-3.20, 24-jre-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/alpine/3.20
 
-Tags: 24.0.1_9-jre-alpine-3.21, 24-jre-alpine-3.21, 24.0.1_9-jre-alpine, 24-jre-alpine
+Tags: 24.0.2_12-jre-alpine-3.21, 24-jre-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/alpine/3.21
 
-Tags: 24.0.1_9-jre-noble, 24-jre-noble
-SharedTags: 24.0.1_9-jre, 24-jre
+Tags: 24.0.2_12-jre-alpine-3.22, 24-jre-alpine-3.22, 24.0.2_12-jre-alpine, 24-jre-alpine
+Architectures: amd64, arm64v8
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 24/jre/alpine/3.22
+
+Tags: 24.0.2_12-jre-noble, 24-jre-noble
+SharedTags: 24.0.2_12-jre, 24-jre
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/ubuntu/noble
 
-Tags: 24.0.1_9-jre-ubi9-minimal, 24-jre-ubi9-minimal
+Tags: 24.0.2_12-jre-ubi10-minimal, 24-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+Directory: 24/jre/ubi/ubi10-minimal
+
+Tags: 24.0.2_12-jre-ubi9-minimal, 24-jre-ubi9-minimal
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/ubi/ubi9-minimal
 
-Tags: 24.0.1_9-jre-windowsservercore-ltsc2025, 24-jre-windowsservercore-ltsc2025
-SharedTags: 24.0.1_9-jre-windowsservercore, 24-jre-windowsservercore, 24.0.1_9-jre, 24-jre
+Tags: 24.0.2_12-jre-windowsservercore-ltsc2025, 24-jre-windowsservercore-ltsc2025
+SharedTags: 24.0.2_12-jre-windowsservercore, 24-jre-windowsservercore, 24.0.2_12-jre, 24-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 24.0.1_9-jre-nanoserver-ltsc2025, 24-jre-nanoserver-ltsc2025
-SharedTags: 24.0.1_9-jre-nanoserver, 24-jre-nanoserver
+Tags: 24.0.2_12-jre-nanoserver-ltsc2025, 24-jre-nanoserver-ltsc2025
+SharedTags: 24.0.2_12-jre-nanoserver, 24-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 24.0.1_9-jre-windowsservercore-ltsc2022, 24-jre-windowsservercore-ltsc2022
-SharedTags: 24.0.1_9-jre-windowsservercore, 24-jre-windowsservercore, 24.0.1_9-jre, 24-jre
+Tags: 24.0.2_12-jre-windowsservercore-ltsc2022, 24-jre-windowsservercore-ltsc2022
+SharedTags: 24.0.2_12-jre-windowsservercore, 24-jre-windowsservercore, 24.0.2_12-jre, 24-jre
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 24.0.1_9-jre-nanoserver-ltsc2022, 24-jre-nanoserver-ltsc2022
-SharedTags: 24.0.1_9-jre-nanoserver, 24-jre-nanoserver
+Tags: 24.0.2_12-jre-nanoserver-ltsc2022, 24-jre-nanoserver-ltsc2022
+SharedTags: 24.0.2_12-jre-nanoserver, 24-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: 30d5f31fe4d1360da008ef3205ec3d5bf7e5b53d
+GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
 Directory: 24/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+


### PR DESCRIPTION
The full set of platforms which are included in our containers have now been released, so we need to get the images created and published to dockerhub for the new release.

@gdams A second pair of eyeballs on this as more than just a rubber stamp would be appreciated as we have a few changes of levels in here and the removal of focal/addition of alpine 3.22 makes this less trivial than it usually is.