### PR TITLE
Redis release 8.2.0

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -3,27 +3,28 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Alexander Dobrzhansky <alexander.dobrzhansky@redis.com> (@adobrzhansky),
              Max Berkman <max.berkman@redis.com> (@maxb-io),
              Dagan Sandler <dagan.sandler@redis.com> (@dagansandler)
+             Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.2-rc1, 8.2-rc1-bookworm
+Tags: 8.2.0, 8.2, 8, 8.2.0-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: dc9ceb8661ea4bfc660d73d6889533e0ae8fb3f3
+GitCommit: e19e964037c9a47962beaf727fa623c7fe1bed6b
 GitFetch: refs/heads/release/8.2
 Directory: debian
 
-Tags: 8.2-rc1-alpine, 8.2-rc1-alpine3.22
+Tags: 8.2.0-alpine, 8.2-alpine, 8-alpine, 8.2.0-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dc9ceb8661ea4bfc660d73d6889533e0ae8fb3f3
+GitCommit: e19e964037c9a47962beaf727fa623c7fe1bed6b
 GitFetch: refs/heads/release/8.2
 Directory: alpine
 
-Tags: 8.0.3, 8.0, 8, 8.0.3-bookworm, 8.0-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.0.3, 8.0, 8.0.3-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
 GitFetch: refs/heads/release/8.0
 Directory: debian
 
-Tags: 8.0.3-alpine, 8.0-alpine, 8-alpine, 8.0.3-alpine3.21, 8.0-alpine3.21, 8-alpine3.21, alpine, alpine3.21
+Tags: 8.0.3-alpine, 8.0-alpine, 8.0.3-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 101262a8cf05b98137d88bc17e77db90c24cc783
 GitFetch: refs/heads/release/8.0


### PR DESCRIPTION
This is 8.2.0 release of redis.

@adamiBs or @adobrzhansky please approve that the release and changes in maintainers list are accepted since I'm not there yet.