### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-12450"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2f923af01654bf1418554dbe9635bb5ed4ba365a
+amd64-GitCommit: 680780efaa80d590309b635d2d5852ad05d34a82
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: bd45b774807f071c64d3fceba8cb528c51a6aa5c
+arm64v8-GitCommit: 5be53d74e379f4a5fbed9f0936cdb6b0e5d1ad5b
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-7425, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-12450.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
