### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.4, 5.0, 5, latest, 5.0.4-jammy, 5.0-jammy, 5-jammy, jammy
+Tags: 5.0.5, 5.0, 5, latest, 5.0.5-jammy, 5.0-jammy, 5-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 0f32c04c976068ddf4b094044bd333ca46d42887
+GitCommit: da543c94df2e77fbbc83023c3259527aec45ec12
 Directory: 5.0
 
 Tags: 4.1.9, 4.1, 4, 4.1.9-jammy, 4.1-jammy, 4-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/da543c9: Update 5.0 to 5.0.5