### PR TITLE
Release SonarQube Server 2025.4.2 and Community Build 25.8

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,24 +4,24 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2025.4.1-developer, 2025.4-developer, developer
+Tags: 2025.4.2-developer, 2025.4-developer, developer
 Directory: commercial-editions/developer
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
-Tags: 2025.4.1-enterprise, 2025.4-enterprise, enterprise
+Tags: 2025.4.2-enterprise, 2025.4-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
-Tags: 2025.4.1-datacenter-app, 2025.4-datacenter-app, datacenter-app
+Tags: 2025.4.2-datacenter-app, 2025.4-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
-Tags: 2025.4.1-datacenter-search, 2025.4-datacenter-search, datacenter-search
+Tags: 2025.4.2-datacenter-search, 2025.4-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
 Tags: 2025.1.3-developer, 2025.1-developer, 2025-lta-developer
@@ -44,32 +44,32 @@ Directory: commercial-editions/datacenter/search
 GitCommit: 2a5b137d0669b87f7dfe6c295a5078d7d7c1aaaf
 GitFetch: refs/heads/release/2025.1
 
-Tags: 25.7.0.110598-community, community, latest
+Tags: 25.8.0.112029-community, community, latest
 Directory: community-build
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
 Tags: 9.9.8-community, 9.9-community, 9-community, lts, lts-community
 Directory: 9/community
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
 Tags: 9.9.8-developer, 9.9-developer, 9-developer, lts-developer
 Directory: 9/developer
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
 Tags: 9.9.9-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
 Directory: 9/enterprise
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
 Tags: 9.9.9-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
 Directory: 9/datacenter/app
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master
 
 Tags: 9.9.9-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
 Directory: 9/datacenter/search
-GitCommit: dd566423d641b8fc06cf65229bc2cb1c5fe913f9
+GitCommit: d0232e04203b6d79306b2e5c403c6b41d4d65741
 GitFetch: refs/heads/master


### PR DESCRIPTION
Dear team,

we would like to release our new SonarQube Server 2025.4.2 and Community Build 25.8 docker images.

Thanks for your help!