### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/a4188abc0265aa1486fe38bb5a4ac457180b8ccd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/2237b8ab43ce6b33ea5dbcf4c446c3fbdcea90cb/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
@@ -7,20 +7,20 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 6.0.0, 6.0, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2237b8ab43ce6b33ea5dbcf4c446c3fbdcea90cb
+GitCommit: bb570dc7994c9827f7984aed03335fb9da8e1869
 Directory: 6/debian
 
 Tags: 6.0.0-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 2237b8ab43ce6b33ea5dbcf4c446c3fbdcea90cb
+GitCommit: bb570dc7994c9827f7984aed03335fb9da8e1869
 Directory: 6/alpine
 
 Tags: 5.130.3, 5.130, 5
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: ce47e6e3c1e58d76d5a9d7fa56042306a7767977
+GitCommit: 521da5fea8b4cccffdb40ad78205b96e8342b98d
 Directory: 5/debian
 
 Tags: 5.130.3-alpine, 5.130-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: ce47e6e3c1e58d76d5a9d7fa56042306a7767977
+GitCommit: 521da5fea8b4cccffdb40ad78205b96e8342b98d
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/bb570dc: Update to 6.0.0, ghost-cli 1.28.3
- https://github.com/docker-library/ghost/commit/521da5f: Update to 5.130.3, ghost-cli 1.28.3

https://github.com/TryGhost/Ghost-CLI/releases/tag/v1.28.3:
> fix(backup): fix backup command with ghost v6 by acburdine in https://github.com/TryGhost/Ghost-CLI/pull/1974