### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev5, 3.3-dev, 3.3-dev5-bookworm, 3.3-dev-bookworm
+Tags: 3.3-dev6, 3.3-dev, 3.3-dev6-bookworm, 3.3-dev-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ad5441e37d329696c2022721a2575d3be5fd1d4
+GitCommit: 65c563d1acf447e3db0f03f531302fdd1a39c738
 Directory: 3.3
 
-Tags: 3.3-dev5-alpine, 3.3-dev-alpine, 3.3-dev5-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev6-alpine, 3.3-dev-alpine, 3.3-dev6-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ad5441e37d329696c2022721a2575d3be5fd1d4
+GitCommit: 65c563d1acf447e3db0f03f531302fdd1a39c738
 Directory: 3.3/alpine
 
 Tags: 3.2.3, 3.2, latest, lts, 3.2.3-bookworm, 3.2-bookworm, bookworm, lts-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/65c563d: Update 3.3 to 3.3-dev6