### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-13428"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 680780efaa80d590309b635d2d5852ad05d34a82
+amd64-GitCommit: 1b992f72c3fa21d995ec8e02ad96738613a1456b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5be53d74e379f4a5fbed9f0936cdb6b0e5d1ad5b
+arm64v8-GitCommit: b0975d462bcbcf3e1b5b9d0fa23e9dbd1af79039
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-32414, CVE-2025-32415, CVE-2025-8058. CVE-2022-29458

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-13428.html
https://linux.oracle.com/errata/ELSA-2025-12980.html
https://linux.oracle.com/errata/ELSA-2025-13203.html
https://linux.oracle.com/errata/ELSA-2025-12748.html
https://linux.oracle.com/errata/ELSA-2025-12876.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
