### PR TITLE
Remove `opcache` from `php-ext-install`

### DIFF
--- a/test/tests/php-ext-install/container.sh
+++ b/test/tests/php-ext-install/container.sh
@@ -5,7 +5,4 @@ docker-php-ext-install pdo_mysql 2>&1
 php -d display_errors=stderr -r 'exit(extension_loaded("pdo_mysql") ? 0 : 1);'
 grep -q '^extension=' /usr/local/etc/php/conf.d/*pdo_mysql*.ini
 
-# opcache is pre-built by default at least as far back as PHP 5.5
-docker-php-ext-enable opcache 2>&1
-php -d display_errors=stderr -r 'exit(extension_loaded("Zend OPcache") ? 0 : 1);'
-grep -q '^zend_extension=' /usr/local/etc/php/conf.d/*opcache*.ini
+# TODO now that opcache is built-in (8.5+), we could use a new zend_extension to test that they're loaded correctly too 🙈


### PR DESCRIPTION
In 8.5, `opcache` is now built-in (and since pretty recently, it's been enabled-by-default in the PHP images too).

See also:
- https://github.com/docker-library/php/pull/1587
- https://github.com/docker-library/php/pull/1604