### PR TITLE
Update SapMachine dockerfiles

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -13,12 +13,12 @@ Directory: dockerfiles/24/ubuntu/24_04/jdk-headless
 
 Tags: jre, jre-ubuntu, 24-jre, 24-jre-ubuntu, 24.0.2-jre, 24.0.2-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 24-jre-ubuntu-noble, 24-jre-ubuntu-24.04, 24.0.2-jre-ubuntu-noble, 24.0.2-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/ubuntu/24_04/jre
 
 Tags: jre-headless, jre-headless-ubuntu, 24-jre-headless, 24-jre-headless-ubuntu, 24.0.2-jre-headless, 24.0.2-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 24-jre-headless-ubuntu-noble, 24-jre-headless-ubuntu-24.04, 24.0.2-jre-headless-ubuntu-noble, 24.0.2-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/ubuntu/24_04/jre-headless
 
 Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 24-ubuntu-jammy, 24-ubuntu-22.04, 24-jdk-ubuntu-jammy, 24-jdk-ubuntu-22.04, 24.0.2-ubuntu-jammy, 24.0.2-ubuntu-22.04, 24.0.2-jdk-ubuntu-jammy, 24.0.2-jdk-ubuntu-22.04
@@ -33,32 +33,32 @@ Directory: dockerfiles/24/ubuntu/22_04/jdk-headless
 
 Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 24-jre-ubuntu-jammy, 24-jre-ubuntu-22.04, 24.0.2-jre-ubuntu-jammy, 24.0.2-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/ubuntu/22_04/jre
 
 Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 24-jre-headless-ubuntu-jammy, 24-jre-headless-ubuntu-22.04, 24.0.2-jre-headless-ubuntu-jammy, 24.0.2-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/ubuntu/22_04/jre-headless
 
 Tags: alpine, jdk-alpine, 24-alpine, 24.0.2-alpine, 24-jdk-alpine, 24.0.2-jdk-alpine, alpine-3.22, jdk-alpine-3.22, 24-alpine-3.22, 24-jdk-alpine-3.22, 24.0.2-alpine-3.22, 24.0.2-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/alpine/3_22/jdk
 
 Tags: jre-alpine, 24-jre-alpine, 24.0.2-jre-alpine, jre-alpine-3.22, 24-jre-alpine-3.22, 24.0.2-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/alpine/3_22/jre
 
 Tags: alpine-3.21, jdk-alpine-3.21, 24-alpine-3.21, 24-jdk-alpine-3.21, 24.0.2-alpine-3.21, 24.0.2-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/alpine/3_21/jdk
 
 Tags: jre-alpine-3.21, 24-jre-alpine-3.21, 24.0.2-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 7c561e5b3845d2d64659cef30adf35abfe9b1407
+GitCommit: 051d757d530f478f382196a670e172a334c3f3cc
 Directory: dockerfiles/24/alpine/3_21/jre
 
 Tags: lts, lts-ubuntu, 21, 21-ubuntu, 21.0.8, 21.0.8-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.8-jdk, 21.0.8-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.8-ubuntu-noble, 21.0.8-ubuntu-24.04, 21.0.8-jdk-ubuntu-noble, 21.0.8-jdk-ubuntu-24.04
@@ -73,12 +73,12 @@ Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
 Tags: 21-jre, 21-jre-ubuntu, 21.0.8-jre, 21.0.8-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.8-jre-ubuntu-noble, 21.0.8-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/ubuntu/24_04/jre
 
 Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.8-jre-headless, 21.0.8-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.8-jre-headless-ubuntu-noble, 21.0.8-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
 Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.8-ubuntu-jammy, 21.0.8-ubuntu-22.04, 21.0.8-jdk-ubuntu-jammy, 21.0.8-jdk-ubuntu-22.04
@@ -93,32 +93,32 @@ Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
 
 Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.8-jre-ubuntu-jammy, 21.0.8-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/ubuntu/22_04/jre
 
 Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.8-jre-headless-ubuntu-jammy, 21.0.8-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
 Tags: lts-alpine, 21-alpine, 21.0.8-alpine, lts-jdk-alpine, 21-jdk-alpine, 21.0.8-jdk-alpine, lts-alpine-3.22, lts-jdk-alpine-3.22, 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.8-alpine-3.22, 21.0.8-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/alpine/3_22/jdk
 
 Tags: lts-jre-alpine, 21-jre-alpine, 21.0.8-jre-alpine, lts-jre-alpine-3.22, 21-jre-alpine-3.22, 21.0.8-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/alpine/3_22/jre
 
 Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.8-alpine-3.21, 21.0.8-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/alpine/3_21/jdk
 
 Tags: lts-jre-alpine-3.21, 21-jre-alpine-3.21, 21.0.8-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 91e51ca6dbafe13fd8779addc7bd182899f48c4d
+GitCommit: 989c1beedf97fc313bd38094ba546c58edd44f74
 Directory: dockerfiles/21/alpine/3_21/jre
 
 Tags: 17, 17-ubuntu, 17.0.16, 17.0.16-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.16-jdk, 17.0.16-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.16-ubuntu-noble, 17.0.16-ubuntu-24.04, 17.0.16-jdk-ubuntu-noble, 17.0.16-jdk-ubuntu-24.04
@@ -133,12 +133,12 @@ Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
 Tags: 17-jre, 17-jre-ubuntu, 17.0.16-jre, 17.0.16-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.16-jre-ubuntu-noble, 17.0.16-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/ubuntu/24_04/jre
 
 Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.16-jre-headless, 17.0.16-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.16-jre-headless-ubuntu-noble, 17.0.16-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
 Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.16-ubuntu-jammy, 17.0.16-ubuntu-22.04, 17.0.16-jdk-ubuntu-jammy, 17.0.16-jdk-ubuntu-22.04
@@ -153,32 +153,32 @@ Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
 
 Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.16-jre-ubuntu-jammy, 17.0.16-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/ubuntu/22_04/jre
 
 Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.16-jre-headless-ubuntu-jammy, 17.0.16-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
 Tags: 17-alpine, 17.0.16-alpine, 17-jdk-alpine, 17.0.16-jdk-alpine, 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.16-alpine-3.22, 17.0.16-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/alpine/3_22/jdk
 
 Tags: 17-jre-alpine, 17.0.16-jre-alpine, 17-jre-alpine-3.22, 17.0.16-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/alpine/3_22/jre
 
 Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.16-alpine-3.21, 17.0.16-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/alpine/3_21/jdk
 
 Tags: 17-jre-alpine-3.21, 17.0.16-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 81ccc83d83e0714d37e84c84ee487f390cb2d4ce
+GitCommit: 874b80982a0c001fd11cb6638e5fcb6fe4cfb21f
 Directory: dockerfiles/17/alpine/3_21/jre
 
 Tags: 11, 11-ubuntu, 11.0.28, 11.0.28-ubuntu, 11-jdk, 11-jdk-ubuntu, 11.0.28-jdk, 11.0.28-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.28-ubuntu-noble, 11.0.28-ubuntu-24.04, 11.0.28-jdk-ubuntu-noble, 11.0.28-jdk-ubuntu-24.04
@@ -193,12 +193,12 @@ Directory: dockerfiles/11/ubuntu/24_04/jdk-headless
 
 Tags: 11-jre, 11-jre-ubuntu, 11.0.28-jre, 11.0.28-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.28-jre-ubuntu-noble, 11.0.28-jre-ubuntu-24.04
 Architectures: amd64
-GitCommit: 8d84d8ee2e839d8f5f923978ff4446704318120f
+GitCommit: fe73fbcedcbaed0232d7276f2901aebe33e347fc
 Directory: dockerfiles/11/ubuntu/24_04/jre
 
 Tags: 11-jre-headless, 11-jre-headless-ubuntu, 11.0.28-jre-headless, 11.0.28-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.28-jre-headless-ubuntu-noble, 11.0.28-jre-headless-ubuntu-24.04
 Architectures: amd64
-GitCommit: 8d84d8ee2e839d8f5f923978ff4446704318120f
+GitCommit: fe73fbcedcbaed0232d7276f2901aebe33e347fc
 Directory: dockerfiles/11/ubuntu/24_04/jre-headless
 
 Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.28-ubuntu-jammy, 11.0.28-ubuntu-22.04, 11.0.28-jdk-ubuntu-jammy, 11.0.28-jdk-ubuntu-22.04
@@ -213,10 +213,10 @@ Directory: dockerfiles/11/ubuntu/22_04/jdk-headless
 
 Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.28-jre-ubuntu-jammy, 11.0.28-jre-ubuntu-22.04
 Architectures: amd64
-GitCommit: 8d84d8ee2e839d8f5f923978ff4446704318120f
+GitCommit: fe73fbcedcbaed0232d7276f2901aebe33e347fc
 Directory: dockerfiles/11/ubuntu/22_04/jre
 
 Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.28-jre-headless-ubuntu-jammy, 11.0.28-jre-headless-ubuntu-22.04
 Architectures: amd64
-GitCommit: 8d84d8ee2e839d8f5f923978ff4446704318120f
+GitCommit: fe73fbcedcbaed0232d7276f2901aebe33e347fc
 Directory: dockerfiles/11/ubuntu/22_04/jre-headless


### PR DESCRIPTION
This updates the source dockerfiles for SapMachine.

It basically contains two fixes:
1. Trigger build of alpine based images by inserting dependency to nss lib. This should remove the vulnerability.
2. Fix entry point for JRE images