### PR TITLE
Update Jetty to 12.0.24

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -7,379 +7,379 @@ GitRepo: https://github.com/eclipse/jetty.docker.git
 Tags: 9.4.57-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.57-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre8-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre8, 9.4-jre8, 9-jre8, 9.4.57-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre8
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.57-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre21, 9.4-jre21, 9-jre21, 9.4.57-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.57-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre17, 9.4-jre17, 9-jre17, 9.4.57-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.57-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jre11, 9.4-jre11, 9-jre11, 9.4.57-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk8, 9.4-jdk8, 9-jdk8, 9.4.57-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.57-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57, 9.4, 9, 9.4.57-jdk21, 9.4-jdk21, 9-jdk21, 9.4.57-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.57-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.57-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk17, 9.4-jdk17, 9-jdk17, 9.4.57-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.57-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk11, 9.4-jdk11, 9-jdk11, 9.4.57-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.24-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jre21, 12.0-jre21, 12-jre21, 12.0.24-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.24-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jre17, 12.0-jre17, 12-jre17, 12.0.24-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk24-alpine, 12.0-jdk24-alpine, 12-jdk24-alpine, 12.0.24-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin, 12-jdk24-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk24-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk24, 12.0-jdk24, 12-jdk24, 12.0.24-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin, 12-jdk24-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk24
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.24-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24, 12.0, 12, 12.0.24-jdk21, 12.0-jdk21, 12-jdk21, 12.0.24-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.24-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.24-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk17, 12.0-jdk17, 12-jdk17, 12.0.24-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.25-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jre21, 11.0-jre21, 11-jre21, 11.0.25-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.25-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jre17, 11.0-jre17, 11-jre17, 11.0.25-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.25-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jre11, 11.0-jre11, 11-jre11, 11.0.25-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.25-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25, 11.0, 11, 11.0.25-jdk21, 11.0-jdk21, 11-jdk21, 11.0.25-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.25-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.25-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk17, 11.0-jdk17, 11-jdk17, 11.0.25-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.25-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk11, 11.0-jdk11, 11-jdk11, 11.0.25-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.25-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jre21, 10.0-jre21, 10-jre21, 10.0.25-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.25-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jre17, 10.0-jre17, 10-jre17, 10.0.25-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.25-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jre11, 10.0-jre11, 10-jre11, 10.0.25-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.25-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25, 10.0, 10, 10.0.25-jdk21, 10.0-jdk21, 10-jdk21, 10.0.25-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.25-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.25-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk17, 10.0-jdk17, 10-jdk17, 10.0.25-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.25-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk11, 10.0-jdk11, 10-jdk11, 10.0.25-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.57-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 9.4.57-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk24-al2023
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-al2023
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.24-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-al2023
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 12.0.24-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.25-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 11.0.25-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.25-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
 
 Tags: 10.0.25-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
+GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0

--- a/library/jetty
+++ b/library/jetty
@@ -7,379 +7,379 @@ GitRepo: https://github.com/eclipse/jetty.docker.git
 Tags: 9.4.57-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.57-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre8-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre8, 9.4-jre8, 9-jre8, 9.4.57-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre8
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.57-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre21-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre21, 9.4-jre21, 9-jre21, 9.4.57-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre21
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.57-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre17-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre17, 9.4-jre17, 9-jre17, 9.4.57-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre17
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.57-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jre11-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jre11, 9.4-jre11, 9-jre11, 9.4.57-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jre11
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk8, 9.4-jdk8, 9-jdk8, 9.4.57-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk8
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.57-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk21-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57, 9.4, 9, 9.4.57-jdk21, 9.4-jdk21, 9-jdk21, 9.4.57-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.57-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk21
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.57-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk17, 9.4-jdk17, 9-jdk17, 9.4.57-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk17
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.57-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk11, 9.4-jdk11, 9-jdk11, 9.4.57-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
-Tags: 12.0.23-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.23-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.24-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.24-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jre21, 12.0-jre21, 12-jre21, 12.0.23-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.24-jre21, 12.0-jre21, 12-jre21, 12.0.24-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.23-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.24-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.24-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jre17, 12.0-jre17, 12-jre17, 12.0.23-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.24-jre17, 12.0-jre17, 12-jre17, 12.0.24-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk24-alpine, 12.0-jdk24-alpine, 12-jdk24-alpine, 12.0.23-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin, 12-jdk24-alpine-eclipse-temurin
+Tags: 12.0.24-jdk24-alpine, 12.0-jdk24-alpine, 12-jdk24-alpine, 12.0.24-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin, 12-jdk24-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk24-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk24, 12.0-jdk24, 12-jdk24, 12.0.23-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin, 12-jdk24-eclipse-temurin
+Tags: 12.0.24-jdk24, 12.0-jdk24, 12-jdk24, 12.0.24-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin, 12-jdk24-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk24
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.23-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.24-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.24-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23, 12.0, 12, 12.0.23-jdk21, 12.0-jdk21, 12-jdk21, 12.0.23-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.23-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.24, 12.0, 12, 12.0.24-jdk21, 12.0-jdk21, 12-jdk21, 12.0.24-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.24-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.23-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.24-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.24-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk17, 12.0-jdk17, 12-jdk17, 12.0.23-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.24-jdk17, 12.0-jdk17, 12-jdk17, 12.0.24-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
 Tags: 11.0.25-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.25-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jre21, 11.0-jre21, 11-jre21, 11.0.25-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.25-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jre17, 11.0-jre17, 11-jre17, 11.0.25-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.25-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jre11, 11.0-jre11, 11-jre11, 11.0.25-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.25-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25, 11.0, 11, 11.0.25-jdk21, 11.0-jdk21, 11-jdk21, 11.0.25-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.25-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.25-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk17, 11.0-jdk17, 11-jdk17, 11.0.25-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.25-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk11, 11.0-jdk11, 11-jdk11, 11.0.25-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.25-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jre21, 10.0-jre21, 10-jre21, 10.0.25-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.25-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jre17, 10.0-jre17, 10-jre17, 10.0.25-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.25-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jre11, 10.0-jre11, 10-jre11, 10.0.25-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.25-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25, 10.0, 10, 10.0.25-jdk21, 10.0-jdk21, 10-jdk21, 10.0.25-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.25-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.25-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk17, 10.0-jdk17, 10-jdk17, 10.0.25-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.25-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk11, 10.0-jdk11, 10-jdk11, 10.0.25-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: 34d907c9ea97a79faefe7d80e5a24f32b53a4f13
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk8
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.57-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk21
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk17
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 9.4.57-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
-GitCommit: 446d2207a126e7afe059328bc3641731d2cbd74e
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
-Tags: 12.0.23-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
+Tags: 12.0.24-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk24-al2023
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.24-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
+Tags: 12.0.24-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-al2023
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.23-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.24-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.24-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.24-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
+Tags: 12.0.24-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-al2023
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
-Tags: 12.0.23-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.24-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: af303c2b44ec3211b77f3a28fe6a4fbbfdac3f2a
+GitCommit: a0df629db6a02cca5c1b2223871c5dc0013c1fbd
 
 Tags: 11.0.25-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.25-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 11.0.25-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.25-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5
 
 Tags: 10.0.25-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: 354499910a5a61631cea6a8679f2d11f054c2ecb
+GitCommit: f8a99f51b870795d0d3af92d3a7e48dfb0e56bc5


### PR DESCRIPTION
- Update Jetty Version to `12.0.24`
- Changes to regenerate the `jetty.start` file after the Jetty version is updated (see https://github.com/jetty/jetty.docker/pull/262).