### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -5,16 +5,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2025-08-08
-Tags: 15.2.0, 15.2, 15, latest, 15.2.0-bookworm, 15.2-bookworm, 15-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 339fcb5f09293ecdb47d6ae0b36b12509f0080e3
+Tags: 15.2.0, 15.2, 15, latest, 15.2.0-trixie, 15.2-trixie, 15-trixie, trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 915af5ccbb6b09575e244f280c26925e77172039
 Directory: 15
 # Docker EOL: 2027-02-08
 
 # Last Modified: 2025-05-23
-Tags: 14.3.0, 14.3, 14, 14.3.0-bookworm, 14.3-bookworm, 14-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d262936418fbf062bb25907d5126a178578ab58b
+Tags: 14.3.0, 14.3, 14, 14.3.0-trixie, 14.3-trixie, 14-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: 280306a58a2ff0c21a95ed8abe882ac483d03c8b
 Directory: 14
 # Docker EOL: 2026-11-23
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/915af5c: Update 15 to debian trixie
- https://github.com/docker-library/gcc/commit/280306a: Update 14 to debian trixie