### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,120 +4,120 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 26-ea-9-jdk-oraclelinux9, 26-ea-9-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-9-jdk-oracle, 26-ea-9-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
-SharedTags: 26-ea-9-jdk, 26-ea-9, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-10-jdk-oraclelinux9, 26-ea-10-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-10-jdk-oracle, 26-ea-10-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
+SharedTags: 26-ea-10-jdk, 26-ea-10, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: amd64, arm64v8
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/oraclelinux9
 
-Tags: 26-ea-9-jdk-oraclelinux8, 26-ea-9-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
+Tags: 26-ea-10-jdk-oraclelinux8, 26-ea-10-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/oraclelinux8
 
-Tags: 26-ea-9-jdk-bookworm, 26-ea-9-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
+Tags: 26-ea-10-jdk-bookworm, 26-ea-10-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/bookworm
 
-Tags: 26-ea-9-jdk-slim-bookworm, 26-ea-9-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm, 26-ea-9-jdk-slim, 26-ea-9-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
+Tags: 26-ea-10-jdk-slim-bookworm, 26-ea-10-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm, 26-ea-10-jdk-slim, 26-ea-10-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
 Architectures: amd64, arm64v8
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/slim-bookworm
 
-Tags: 26-ea-9-jdk-bullseye, 26-ea-9-bullseye, 26-ea-jdk-bullseye, 26-ea-bullseye, 26-jdk-bullseye, 26-bullseye
+Tags: 26-ea-10-jdk-bullseye, 26-ea-10-bullseye, 26-ea-jdk-bullseye, 26-ea-bullseye, 26-jdk-bullseye, 26-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/bullseye
 
-Tags: 26-ea-9-jdk-slim-bullseye, 26-ea-9-slim-bullseye, 26-ea-jdk-slim-bullseye, 26-ea-slim-bullseye, 26-jdk-slim-bullseye, 26-slim-bullseye
+Tags: 26-ea-10-jdk-slim-bullseye, 26-ea-10-slim-bullseye, 26-ea-jdk-slim-bullseye, 26-ea-slim-bullseye, 26-jdk-slim-bullseye, 26-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/slim-bullseye
 
-Tags: 26-ea-9-jdk-windowsservercore-ltsc2025, 26-ea-9-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
-SharedTags: 26-ea-9-jdk-windowsservercore, 26-ea-9-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-9-jdk, 26-ea-9, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-10-jdk-windowsservercore-ltsc2025, 26-ea-10-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
+SharedTags: 26-ea-10-jdk-windowsservercore, 26-ea-10-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-10-jdk, 26-ea-10, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-9-jdk-windowsservercore-ltsc2022, 26-ea-9-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
-SharedTags: 26-ea-9-jdk-windowsservercore, 26-ea-9-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-9-jdk, 26-ea-9, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-10-jdk-windowsservercore-ltsc2022, 26-ea-10-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
+SharedTags: 26-ea-10-jdk-windowsservercore, 26-ea-10-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-10-jdk, 26-ea-10, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-9-jdk-nanoserver-ltsc2025, 26-ea-9-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
-SharedTags: 26-ea-9-jdk-nanoserver, 26-ea-9-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-10-jdk-nanoserver-ltsc2025, 26-ea-10-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
+SharedTags: 26-ea-10-jdk-nanoserver, 26-ea-10-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-9-jdk-nanoserver-ltsc2022, 26-ea-9-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
-SharedTags: 26-ea-9-jdk-nanoserver, 26-ea-9-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-10-jdk-nanoserver-ltsc2022, 26-ea-10-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
+SharedTags: 26-ea-10-jdk-nanoserver, 26-ea-10-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: 47927ef10288acd6fff133a6b3c6b705011a79bc
+GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
 Directory: 26/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 25-ea-34-jdk-oraclelinux9, 25-ea-34-oraclelinux9, 25-ea-jdk-oraclelinux9, 25-ea-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-ea-34-jdk-oracle, 25-ea-34-oracle, 25-ea-jdk-oracle, 25-ea-oracle, 25-jdk-oracle, 25-oracle
-SharedTags: 25-ea-34-jdk, 25-ea-34, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-rc-jdk-oraclelinux9, 25-rc-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-rc-jdk-oracle, 25-rc-oracle, 25-jdk-oracle, 25-oracle
+SharedTags: 25-rc-jdk, 25-rc, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/oraclelinux9
 
-Tags: 25-ea-34-jdk-oraclelinux8, 25-ea-34-oraclelinux8, 25-ea-jdk-oraclelinux8, 25-ea-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
+Tags: 25-rc-jdk-oraclelinux8, 25-rc-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/oraclelinux8
 
-Tags: 25-ea-34-jdk-bookworm, 25-ea-34-bookworm, 25-ea-jdk-bookworm, 25-ea-bookworm, 25-jdk-bookworm, 25-bookworm
+Tags: 25-rc-jdk-bookworm, 25-rc-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/bookworm
 
-Tags: 25-ea-34-jdk-slim-bookworm, 25-ea-34-slim-bookworm, 25-ea-jdk-slim-bookworm, 25-ea-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-ea-34-jdk-slim, 25-ea-34-slim, 25-ea-jdk-slim, 25-ea-slim, 25-jdk-slim, 25-slim
+Tags: 25-rc-jdk-slim-bookworm, 25-rc-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm, 25-rc-jdk-slim, 25-rc-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/slim-bookworm
 
-Tags: 25-ea-34-jdk-bullseye, 25-ea-34-bullseye, 25-ea-jdk-bullseye, 25-ea-bullseye, 25-jdk-bullseye, 25-bullseye
+Tags: 25-rc-jdk-bullseye, 25-rc-bullseye, 25-jdk-bullseye, 25-bullseye
 Architectures: amd64, arm64v8
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/bullseye
 
-Tags: 25-ea-34-jdk-slim-bullseye, 25-ea-34-slim-bullseye, 25-ea-jdk-slim-bullseye, 25-ea-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
+Tags: 25-rc-jdk-slim-bullseye, 25-rc-slim-bullseye, 25-jdk-slim-bullseye, 25-slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/slim-bullseye
 
-Tags: 25-ea-34-jdk-windowsservercore-ltsc2025, 25-ea-34-windowsservercore-ltsc2025, 25-ea-jdk-windowsservercore-ltsc2025, 25-ea-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
-SharedTags: 25-ea-34-jdk-windowsservercore, 25-ea-34-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-34-jdk, 25-ea-34, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-rc-jdk-windowsservercore-ltsc2025, 25-rc-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
+SharedTags: 25-rc-jdk-windowsservercore, 25-rc-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-rc-jdk, 25-rc, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 25-ea-34-jdk-windowsservercore-ltsc2022, 25-ea-34-windowsservercore-ltsc2022, 25-ea-jdk-windowsservercore-ltsc2022, 25-ea-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
-SharedTags: 25-ea-34-jdk-windowsservercore, 25-ea-34-windowsservercore, 25-ea-jdk-windowsservercore, 25-ea-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-ea-34-jdk, 25-ea-34, 25-ea-jdk, 25-ea, 25-jdk, 25
+Tags: 25-rc-jdk-windowsservercore-ltsc2022, 25-rc-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
+SharedTags: 25-rc-jdk-windowsservercore, 25-rc-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-rc-jdk, 25-rc, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 25-ea-34-jdk-nanoserver-ltsc2025, 25-ea-34-nanoserver-ltsc2025, 25-ea-jdk-nanoserver-ltsc2025, 25-ea-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
-SharedTags: 25-ea-34-jdk-nanoserver, 25-ea-34-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-rc-jdk-nanoserver-ltsc2025, 25-rc-nanoserver-ltsc2025, 25-jdk-nanoserver-ltsc2025, 25-nanoserver-ltsc2025
+SharedTags: 25-rc-jdk-nanoserver, 25-rc-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 25-ea-34-jdk-nanoserver-ltsc2022, 25-ea-34-nanoserver-ltsc2022, 25-ea-jdk-nanoserver-ltsc2022, 25-ea-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
-SharedTags: 25-ea-34-jdk-nanoserver, 25-ea-34-nanoserver, 25-ea-jdk-nanoserver, 25-ea-nanoserver, 25-jdk-nanoserver, 25-nanoserver
+Tags: 25-rc-jdk-nanoserver-ltsc2022, 25-rc-nanoserver-ltsc2022, 25-jdk-nanoserver-ltsc2022, 25-nanoserver-ltsc2022
+SharedTags: 25-rc-jdk-nanoserver, 25-rc-nanoserver, 25-jdk-nanoserver, 25-nanoserver
 Architectures: windows-amd64
-GitCommit: cf3ebd20b3c77e5671cf93933140c8f7573fba5f
+GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
 Directory: 25/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/e6ea477: Update 26 to 26-ea+10
- https://github.com/docker-library/openjdk/commit/0ef4c9f: Update 25 to 25
- https://github.com/docker-library/openjdk/commit/55c0cc6: Update Alpine versions (3.22 + 3.21)