### PR TITLE
"[oraclelinux] Updating 10and 10-slim for ELSA-2025-13240 ELSA-2025-13429"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1b992f72c3fa21d995ec8e02ad96738613a1456b
+amd64-GitCommit: 84e7de0a91a548c336ae3e8b1e37dd432ba58ba7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b0975d462bcbcf3e1b5b9d0fa23e9dbd1af79039
+arm64v8-GitCommit: e9fbf6fde9b711f78fcd14dbb4c15e6783ef961f
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-8058, CVE-2025-32414, CVE-2025-32415, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-13240.html
https://linux.oracle.com/errata/ELSA-2025-13429.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
