### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev6, 3.3-dev, 3.3-dev6-bookworm, 3.3-dev-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 65c563d1acf447e3db0f03f531302fdd1a39c738
+Tags: 3.3-dev6, 3.3-dev, 3.3-dev6-trixie, 3.3-dev-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 3.3
 
 Tags: 3.3-dev6-alpine, 3.3-dev-alpine, 3.3-dev6-alpine3.22, 3.3-dev-alpine3.22
@@ -14,9 +14,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 65c563d1acf447e3db0f03f531302fdd1a39c738
 Directory: 3.3/alpine
 
-Tags: 3.2.3, 3.2, latest, lts, 3.2.3-bookworm, 3.2-bookworm, bookworm, lts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3b6ff7d6c6c2562948c4e91e6f592e176eab5e0f
+Tags: 3.2.3, 3.2, latest, lts, 3.2.3-trixie, 3.2-trixie, trixie, lts-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 3.2
 
 Tags: 3.2.3-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.3-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
@@ -24,9 +24,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3b6ff7d6c6c2562948c4e91e6f592e176eab5e0f
 Directory: 3.2/alpine
 
-Tags: 3.1.8, 3.1, 3.1.8-bookworm, 3.1-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d9460179b64eac94bd181a488a74d8e6df7bdbf5
+Tags: 3.1.8, 3.1, 3.1.8-trixie, 3.1-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 3.1
 
 Tags: 3.1.8-alpine, 3.1-alpine, 3.1.8-alpine3.22, 3.1-alpine3.22
@@ -34,9 +34,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: d9460179b64eac94bd181a488a74d8e6df7bdbf5
 Directory: 3.1/alpine
 
-Tags: 3.0.11, 3.0, 3.0.11-bookworm, 3.0-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6fa540dd7d9d82634605e727a8e1c726a23d8b0d
+Tags: 3.0.11, 3.0, 3.0.11-trixie, 3.0-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 3.0
 
 Tags: 3.0.11-alpine, 3.0-alpine, 3.0.11-alpine3.22, 3.0-alpine3.22
@@ -44,9 +44,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 6fa540dd7d9d82634605e727a8e1c726a23d8b0d
 Directory: 3.0/alpine
 
-Tags: 2.8.15, 2.8, 2.8.15-bookworm, 2.8-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+Tags: 2.8.15, 2.8, 2.8.15-trixie, 2.8-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 2.8
 
 Tags: 2.8.15-alpine, 2.8-alpine, 2.8.15-alpine3.22, 2.8-alpine3.22
@@ -54,9 +54,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 2.8/alpine
 
-Tags: 2.6.22, 2.6, 2.6.22-bookworm, 2.6-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+Tags: 2.6.22, 2.6, 2.6.22-trixie, 2.6-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 2.6
 
 Tags: 2.6.22-alpine, 2.6-alpine, 2.6.22-alpine3.22, 2.6-alpine3.22
@@ -64,9 +64,9 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
 Directory: 2.6/alpine
 
-Tags: 2.4.29, 2.4, 2.4.29-bookworm, 2.4-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c153740fe581f5c43c6c5571acd00055e49e478d
+Tags: 2.4.29, 2.4, 2.4.29-trixie, 2.4-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
 Directory: 2.4
 
 Tags: 2.4.29-alpine, 2.4-alpine, 2.4.29-alpine3.22, 2.4-alpine3.22


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/22356f3: Merge pull request https://github.com/docker-library/haproxy/pull/249 from infosiftr/trixie
- https://github.com/docker-library/haproxy/commit/2ff3f8b: Update to Debian Trixie