### PR TITLE
Update irssi

### DIFF
--- a/library/irssi
+++ b/library/irssi
@@ -4,9 +4,9 @@ Maintainers: Jessie Frazelle <acidburn@google.com> (@jessfraz),
              Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/jessfraz/irssi.git
 
-Tags: 1.4.5, 1.4, 1, latest, 1.4.5-bookworm, 1.4-bookworm, 1-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b8ea417aaa1a29a6003756627d748450a5bf6abe
+Tags: 1.4.5, 1.4, 1, latest, 1.4.5-trixie, 1.4-trixie, 1-trixie, trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 071b281a8011fb7ac5c5d6b6928e13fee8ab719c
 Directory: debian
 
 Tags: 1.4.5-alpine, 1.4-alpine, 1-alpine, alpine, 1.4.5-alpine3.22, 1.4-alpine3.22, 1-alpine3.22, alpine3.22


### PR DESCRIPTION
Changes:

- https://github.com/jessfraz/irssi/commit/071b281: Update to Debian Trixie (https://github.com/jessfraz/irssi/pull/37)
- https://github.com/jessfraz/irssi/commit/ebbb2e3: Remove scheduled GHA runs (hopefully helps GitHub keep us enabled?)