### PR TITLE
Updated nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,44 +3,44 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.29.0, mainline, 1, 1.29, latest, 1.29.0-bookworm, mainline-bookworm, 1-bookworm, 1.29-bookworm, bookworm
+Tags: 1.29.1, mainline, 1, 1.29, latest, 1.29.1-bookworm, mainline-bookworm, 1-bookworm, 1.29-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b2faad22d5d15d966e46922033681639b2a6d6fa
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/debian
 
-Tags: 1.29.0-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.0-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.29-bookworm-perl, bookworm-perl
+Tags: 1.29.1-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.1-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.29-bookworm-perl, bookworm-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/debian-perl
 
-Tags: 1.29.0-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.0-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.29-bookworm-otel, bookworm-otel
+Tags: 1.29.1-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.1-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.29-bookworm-otel, bookworm-otel
 Architectures: amd64, arm64v8
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/debian-otel
 
-Tags: 1.29.0-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.0-alpine3.22, mainline-alpine3.22, 1-alpine3.22, 1.29-alpine3.22, alpine3.22
+Tags: 1.29.1-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.1-alpine3.22, mainline-alpine3.22, 1-alpine3.22, 1.29-alpine3.22, alpine3.22
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/alpine
 
-Tags: 1.29.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.0-alpine3.22-perl, mainline-alpine3.22-perl, 1-alpine3.22-perl, 1.29-alpine3.22-perl, alpine3.22-perl
+Tags: 1.29.1-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.1-alpine3.22-perl, mainline-alpine3.22-perl, 1-alpine3.22-perl, 1.29-alpine3.22-perl, alpine3.22-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/alpine-perl
 
-Tags: 1.29.0-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.0-alpine3.22-slim, mainline-alpine3.22-slim, 1-alpine3.22-slim, 1.29-alpine3.22-slim, alpine3.22-slim
+Tags: 1.29.1-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.1-alpine3.22-slim, mainline-alpine3.22-slim, 1-alpine3.22-slim, 1.29-alpine3.22-slim, alpine3.22-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/alpine-slim
 
-Tags: 1.29.0-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.0-alpine3.22-otel, mainline-alpine3.22-otel, 1-alpine3.22-otel, 1.29-alpine3.22-otel, alpine3.22-otel
+Tags: 1.29.1-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.1-alpine3.22-otel, mainline-alpine3.22-otel, 1-alpine3.22-otel, 1.29-alpine3.22-otel, alpine3.22-otel
 Architectures: amd64, arm64v8
-GitCommit: 7895505c41013f66d3841cd2613b436229c1fe0e
+GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
 Directory: mainline/alpine-otel
 
 Tags: 1.28.0, stable, 1.28, 1.28.0-bookworm, stable-bookworm, 1.28-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: b2faad22d5d15d966e46922033681639b2a6d6fa
+GitCommit: 9b549fdf936778810dbe95a4813899c60444ef1c
 Directory: stable/debian
 
 Tags: 1.28.0-perl, stable-perl, 1.28-perl, 1.28.0-bookworm-perl, stable-bookworm-perl, 1.28-bookworm-perl
@@ -65,7 +65,7 @@ Directory: stable/alpine-perl
 
 Tags: 1.28.0-alpine-slim, stable-alpine-slim, 1.28-alpine-slim, 1.28.0-alpine3.21-slim, stable-alpine3.21-slim, 1.28-alpine3.21-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 7f1d49f6f222f7e588a9066fd53a0ce43c3466a5
+GitCommit: 9b549fdf936778810dbe95a4813899c60444ef1c
 Directory: stable/alpine-slim
 
 Tags: 1.28.0-alpine-otel, stable-alpine-otel, 1.28-alpine-otel, 1.28.0-alpine3.21-otel, stable-alpine3.21-otel, 1.28-alpine3.21-otel


### PR DESCRIPTION
- mainline gets 1.29.1 and njs 0.9.1
- mainline and stable get minor fixes in entrypoints and dockerfiles