### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.0.2, 6.0, 6, latest
+Tags: 6.0.3, 6.0, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 367a5c44e346cb2fa71bf2a47f0e2b6d753c6b0c
+GitCommit: 44adbd73a5aab86d7b650c8e4baff2eaa4bda1ee
 Directory: 6/debian
 
-Tags: 6.0.2-alpine, 6.0-alpine, 6-alpine, alpine
+Tags: 6.0.3-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 367a5c44e346cb2fa71bf2a47f0e2b6d753c6b0c
+GitCommit: 44adbd73a5aab86d7b650c8e4baff2eaa4bda1ee
 Directory: 6/alpine
 
-Tags: 5.130.3, 5.130, 5
+Tags: 5.130.4, 5.130, 5
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 521da5fea8b4cccffdb40ad78205b96e8342b98d
+GitCommit: 75d682ae014b696d78e0300a6bada92668ea479a
 Directory: 5/debian
 
-Tags: 5.130.3-alpine, 5.130-alpine, 5-alpine
+Tags: 5.130.4-alpine, 5.130-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 521da5fea8b4cccffdb40ad78205b96e8342b98d
+GitCommit: 75d682ae014b696d78e0300a6bada92668ea479a
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/44adbd7: Update to 6.0.3, ghost-cli 1.28.3
- https://github.com/docker-library/ghost/commit/75d682a: Update to 5.130.4, ghost-cli 1.28.3