### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 65c563d1acf447e3db0f03f531302fdd1a39c738
 Directory: 3.3/alpine
 
-Tags: 3.2.3, 3.2, latest, lts, 3.2.3-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.4, 3.2, latest, lts, 3.2.4-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: ef134ca68778a0e16bd235fd6a902b682148b3ea
 Directory: 3.2
 
-Tags: 3.2.3-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.3-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.4-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.4-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3b6ff7d6c6c2562948c4e91e6f592e176eab5e0f
+GitCommit: ef134ca68778a0e16bd235fd6a902b682148b3ea
 Directory: 3.2/alpine
 
 Tags: 3.1.8, 3.1, 3.1.8-trixie, 3.1-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ef134ca: Update 3.2 to 3.2.4