### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.8.20250715.0
+Tags: 2023, latest, 2023.8.20250808.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 12e432807ac744a5cf1da9f5a0ac5fd0bfad2a94
+amd64-GitCommit: 94f86e7a853963227c332a030c651668c70850b9
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2e3920bd4904e8c6203193a800065fb9b8ca818a
+arm64v8-GitCommit: 69e020a7ded8ab2e4135561bac2368b56f63c451
 
-Tags: 2, 2.0.20250707.0
+Tags: 2, 2.0.20250808.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: ff7c7277e66ddb9671b1d2f52a9dd03e12da17ad
+amd64-GitCommit: 0a084d30ee45ac3299f958e7b37088a12f87b250
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 430c00bfbceb577b29e177caff97e7d64baeeceb
+arm64v8-GitCommit: 476fdaf0c9007b9803956c52bfc128b66bbce539
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
#### Packages addressing CVES:

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.8.20250808-0.amzn2023
- system-release-2023.8.20250808-0.amzn2023
#### Packages addressing CVES: