### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,62 +1,57 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/e73a53925b99eaf1bba6d0db5a882e611755fff8/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/0e32792ddbf9f32bdc4af4f1de754d4c650b97b0/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: e73a53925b99eaf1bba6d0db5a882e611755fff8
+GitCommit: 0e32792ddbf9f32bdc4af4f1de754d4c650b97b0
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c9d396b13758b9ef013ff0ebc31b15e246ced4d2
+amd64-GitCommit: 3fe52725c149a6966493eefe94d32a2704b6b7bf
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 731a682974d050920dff0cf9547d41ad1f898ba4
+arm32v5-GitCommit: 87672af361381fe3a46f9ee735c2972ef57a0715
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: e4b2bcae91a912bf7509d15b4360df5847fb638f
+arm32v6-GitCommit: 248607b93b215b4e7c8c6b3cd141f23de2e740ac
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: f51cc9054cc8eb2996a5b48bf4364997c0c3ab93
+arm32v7-GitCommit: 5f7f7ef50c73b07d9822c08b5ba0d7fb98b7b43a
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ef09fbe6f4c562e34bb67a0ba372702018eaccd4
+arm64v8-GitCommit: ab49e875ac9a27b182e49d70672530d6ec71d5d7
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 07b656d2484ca0788433469dbfce9da6c55658b2
-# https://github.com/docker-library/busybox/tree/dist-mips64le
-mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 8985b768384fd6f3ed696734e7e4db34b031ee2f
+i386-GitCommit: a3bd0b33cc571a394668621670d67886da930223
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 3bbb15b7efd6d99a73690516b4499b6642f97ef5
+ppc64le-GitCommit: fe3c277a9485182093b8b471d428ce9c9574a056
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 0aa8d9691f136754b8dab5af01429b32dfa36490
+riscv64-GitCommit: 57a6af974cdd6e8859cb2c76927765872426c39b
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 221f9e80b411fcfea795ca453cb5d2f9ef24aeee
+s390x-GitCommit: 53c1b0b8d9fff46e5ada0e5816fb5fd0281ef246
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 amd64-Directory: latest/glibc/amd64
 arm32v5-Directory: latest/glibc/arm32v5
 arm32v7-Directory: latest/glibc/arm32v7
 arm64v8-Directory: latest/glibc/arm64v8
 i386-Directory: latest/glibc/i386
-mips64le-Directory: latest/glibc/mips64le
 ppc64le-Directory: latest/glibc/ppc64le
 riscv64-Directory: latest/glibc/riscv64
 s390x-Directory: latest/glibc/s390x
 
 Tags: 1.37.0-uclibc, 1.37-uclibc, 1-uclibc, unstable-uclibc, uclibc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 amd64-Directory: latest/uclibc/amd64
 arm32v5-Directory: latest/uclibc/arm32v5
 arm32v7-Directory: latest/uclibc/arm32v7
 arm64v8-Directory: latest/uclibc/arm64v8
 i386-Directory: latest/uclibc/i386
-mips64le-Directory: latest/uclibc/mips64le
 
 Tags: 1.37.0-musl, 1.37-musl, 1-musl, unstable-musl, musl
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
@@ -70,38 +65,35 @@ riscv64-Directory: latest/musl/riscv64
 s390x-Directory: latest/musl/s390x
 
 Tags: 1.37.0, 1.37, 1, unstable, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x, arm32v6, riscv64
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x, arm32v6, riscv64
 amd64-Directory: latest/glibc/amd64
 arm32v5-Directory: latest/glibc/arm32v5
 arm32v7-Directory: latest/glibc/arm32v7
 arm64v8-Directory: latest/glibc/arm64v8
 i386-Directory: latest/glibc/i386
-mips64le-Directory: latest/glibc/mips64le
 ppc64le-Directory: latest/glibc/ppc64le
 s390x-Directory: latest/glibc/s390x
 arm32v6-Directory: latest/musl/arm32v6
 riscv64-Directory: latest/musl/riscv64
 
 Tags: 1.36.1-glibc, 1.36-glibc, stable-glibc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 amd64-Directory: latest-1/glibc/amd64
 arm32v5-Directory: latest-1/glibc/arm32v5
 arm32v7-Directory: latest-1/glibc/arm32v7
 arm64v8-Directory: latest-1/glibc/arm64v8
 i386-Directory: latest-1/glibc/i386
-mips64le-Directory: latest-1/glibc/mips64le
 ppc64le-Directory: latest-1/glibc/ppc64le
 riscv64-Directory: latest-1/glibc/riscv64
 s390x-Directory: latest-1/glibc/s390x
 
 Tags: 1.36.1-uclibc, 1.36-uclibc, stable-uclibc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386
 amd64-Directory: latest-1/uclibc/amd64
 arm32v5-Directory: latest-1/uclibc/arm32v5
 arm32v7-Directory: latest-1/uclibc/arm32v7
 arm64v8-Directory: latest-1/uclibc/arm64v8
 i386-Directory: latest-1/uclibc/i386
-mips64le-Directory: latest-1/uclibc/mips64le
 
 Tags: 1.36.1-musl, 1.36-musl, stable-musl
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
@@ -115,13 +107,12 @@ riscv64-Directory: latest-1/musl/riscv64
 s390x-Directory: latest-1/musl/s390x
 
 Tags: 1.36.1, 1.36, stable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x, arm32v6, riscv64
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x, arm32v6, riscv64
 amd64-Directory: latest-1/glibc/amd64
 arm32v5-Directory: latest-1/glibc/arm32v5
 arm32v7-Directory: latest-1/glibc/arm32v7
 arm64v8-Directory: latest-1/glibc/arm64v8
 i386-Directory: latest-1/glibc/i386
-mips64le-Directory: latest-1/glibc/mips64le
 ppc64le-Directory: latest-1/glibc/ppc64le
 s390x-Directory: latest-1/glibc/s390x
 arm32v6-Directory: latest-1/musl/arm32v6


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/30746a4: Merge pull request https://github.com/docker-library/busybox/pull/228 from infosiftr/mips64le
- https://github.com/docker-library/busybox/commit/9682eb9: Drop support for mips64le
- https://github.com/docker-library/busybox/commit/1c7a8da: Merge pull request https://github.com/docker-library/busybox/pull/227 from infosiftr/buildroot-2025.05.1
- https://github.com/docker-library/busybox/commit/7d95034: Update buildroot to 2025.05.1
- https://github.com/docker-library/busybox/commit/246d420: Merge pull request https://github.com/docker-library/busybox/pull/226 from infosiftr/trixie
- https://github.com/docker-library/busybox/commit/e0ffe6a: Update to Debian Trixie
- https://github.com/docker-library/busybox/commit/e226b0e: Merge pull request https://github.com/docker-library/busybox/pull/225 from infosiftr/buildroot-2025.05