### PR TITLE
Gradle: Transfer the `gradle` image to Gradle

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -1,5 +1,7 @@
-Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
-GitRepo: https://github.com/keeganwitt/docker-gradle.git
+Maintainers: Louis Jacomet <louis@gradle.com> (@ljacomet),
+             Christoph Obexer <cobexer@gradle.com> (@cobexer),
+             Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
+GitRepo: https://github.com/gradle/docker-gradle.git
 
 
 # Gradle 9.x


### PR DESCRIPTION
Moving the repository and adding official maintainers from Gradle.