### PR TITLE
[nats] Release v2.11.8

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 3ec49f76b02935f5c32ced5497f74e55d61e6d08
+GitCommit: a8cccfe32e277ef2b3ceec385b959349d8aca46d
 GitFetch: refs/heads/main
 
-Tags: 2.11.7-alpine3.22, 2.11-alpine3.22, 2-alpine3.22, alpine3.22, 2.11.7-alpine, 2.11-alpine, 2-alpine, alpine
+Tags: 2.11.8-alpine3.22, 2.11-alpine3.22, 2-alpine3.22, alpine3.22, 2.11.8-alpine, 2.11-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/alpine3.22
 
-Tags: 2.11.7-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.7-linux, 2.11-linux, 2-linux, linux
-SharedTags: 2.11.7, 2.11, 2, latest
+Tags: 2.11.8-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.8-linux, 2.11-linux, 2-linux, linux
+SharedTags: 2.11.8, 2.11, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.7-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.11.7-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.11.8-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.11.8-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.11.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.7-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.11.7-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.7, 2.11, 2, latest
+Tags: 2.11.8-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.11.8-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.8, 2.11, 2, latest
 Architectures: windows-amd64
 Directory: 2.11.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Details available at https://github.com/nats-io/nats-server/releases/tag/v2.11.8.