### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 18beta2, 18beta2-trixie
+Tags: 18beta3, 18beta3-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 176bc3c3f06c7df2602331d65b779a6d08c56861
+GitCommit: 8d2eba60404809503b5a04c3e0c4ad7f0572b9bb
 Directory: 18/trixie
 
-Tags: 18beta2-bookworm
+Tags: 18beta3-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 889f9447cd2dfe21cccfbe9bb7945e3b037e02d8
+GitCommit: 8d2eba60404809503b5a04c3e0c4ad7f0572b9bb
 Directory: 18/bookworm
 
-Tags: 18beta2-alpine3.22, 18beta2-alpine
+Tags: 18beta3-alpine3.22, 18beta3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 889f9447cd2dfe21cccfbe9bb7945e3b037e02d8
+GitCommit: 8d2eba60404809503b5a04c3e0c4ad7f0572b9bb
 Directory: 18/alpine3.22
 
-Tags: 18beta2-alpine3.21
+Tags: 18beta3-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 889f9447cd2dfe21cccfbe9bb7945e3b037e02d8
+GitCommit: 8d2eba60404809503b5a04c3e0c4ad7f0572b9bb
 Directory: 18/alpine3.21
 
-Tags: 17.5, 17, latest, 17.5-trixie, 17-trixie, trixie
+Tags: 17.6, 17, latest, 17.6-trixie, 17-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 176bc3c3f06c7df2602331d65b779a6d08c56861
+GitCommit: e34fc9d23c4eab656e9037701d71962c9b46a2e7
 Directory: 17/trixie
 
-Tags: 17.5-bookworm, 17-bookworm, bookworm
+Tags: 17.6-bookworm, 17-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: e34fc9d23c4eab656e9037701d71962c9b46a2e7
 Directory: 17/bookworm
 
-Tags: 17.5-alpine3.22, 17-alpine3.22, alpine3.22, 17.5-alpine, 17-alpine, alpine
+Tags: 17.6-alpine3.22, 17-alpine3.22, alpine3.22, 17.6-alpine, 17-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: e34fc9d23c4eab656e9037701d71962c9b46a2e7
 Directory: 17/alpine3.22
 
-Tags: 17.5-alpine3.21, 17-alpine3.21, alpine3.21
+Tags: 17.6-alpine3.21, 17-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: e34fc9d23c4eab656e9037701d71962c9b46a2e7
 Directory: 17/alpine3.21
 
-Tags: 16.9, 16, 16.9-trixie, 16-trixie
+Tags: 16.10, 16, 16.10-trixie, 16-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 176bc3c3f06c7df2602331d65b779a6d08c56861
+GitCommit: 1cb68aee8fbbd39106c8a8eb41f45721941d11a8
 Directory: 16/trixie
 
-Tags: 16.9-bookworm, 16-bookworm
+Tags: 16.10-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 1cb68aee8fbbd39106c8a8eb41f45721941d11a8
 Directory: 16/bookworm
 
-Tags: 16.9-alpine3.22, 16-alpine3.22, 16.9-alpine, 16-alpine
+Tags: 16.10-alpine3.22, 16-alpine3.22, 16.10-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 1cb68aee8fbbd39106c8a8eb41f45721941d11a8
 Directory: 16/alpine3.22
 
-Tags: 16.9-alpine3.21, 16-alpine3.21
+Tags: 16.10-alpine3.21, 16-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 1cb68aee8fbbd39106c8a8eb41f45721941d11a8
 Directory: 16/alpine3.21
 
-Tags: 15.13, 15, 15.13-trixie, 15-trixie
+Tags: 15.14, 15, 15.14-trixie, 15-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 176bc3c3f06c7df2602331d65b779a6d08c56861
+GitCommit: b8ab4185a3d61f301db60806a4cf8ae479ac507e
 Directory: 15/trixie
 
-Tags: 15.13-bookworm, 15-bookworm
+Tags: 15.14-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: b8ab4185a3d61f301db60806a4cf8ae479ac507e
 Directory: 15/bookworm
 
-Tags: 15.13-alpine3.22, 15-alpine3.22, 15.13-alpine, 15-alpine
+Tags: 15.14-alpine3.22, 15-alpine3.22, 15.14-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: b8ab4185a3d61f301db60806a4cf8ae479ac507e
 Directory: 15/alpine3.22
 
-Tags: 15.13-alpine3.21, 15-alpine3.21
+Tags: 15.14-alpine3.21, 15-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: b8ab4185a3d61f301db60806a4cf8ae479ac507e
 Directory: 15/alpine3.21
 
-Tags: 14.18, 14, 14.18-trixie, 14-trixie
+Tags: 14.19, 14, 14.19-trixie, 14-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 176bc3c3f06c7df2602331d65b779a6d08c56861
+GitCommit: 836ebeb884c0e4c7d4f674a2fc19bf47fcd63c96
 Directory: 14/trixie
 
-Tags: 14.18-bookworm, 14-bookworm
+Tags: 14.19-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 836ebeb884c0e4c7d4f674a2fc19bf47fcd63c96
 Directory: 14/bookworm
 
-Tags: 14.18-alpine3.22, 14-alpine3.22, 14.18-alpine, 14-alpine
+Tags: 14.19-alpine3.22, 14-alpine3.22, 14.19-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 836ebeb884c0e4c7d4f674a2fc19bf47fcd63c96
 Directory: 14/alpine3.22
 
-Tags: 14.18-alpine3.21, 14-alpine3.21
+Tags: 14.19-alpine3.21, 14-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 836ebeb884c0e4c7d4f674a2fc19bf47fcd63c96
 Directory: 14/alpine3.21
 
-Tags: 13.21, 13, 13.21-trixie, 13-trixie
+Tags: 13.22, 13, 13.22-trixie, 13-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 176bc3c3f06c7df2602331d65b779a6d08c56861
+GitCommit: 1984f1787ad448db351da121bfe8708769d0f8a7
 Directory: 13/trixie
 
-Tags: 13.21-bookworm, 13-bookworm
+Tags: 13.22-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 1984f1787ad448db351da121bfe8708769d0f8a7
 Directory: 13/bookworm
 
-Tags: 13.21-alpine3.22, 13-alpine3.22, 13.21-alpine, 13-alpine
+Tags: 13.22-alpine3.22, 13-alpine3.22, 13.22-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 1984f1787ad448db351da121bfe8708769d0f8a7
 Directory: 13/alpine3.22
 
-Tags: 13.21-alpine3.21, 13-alpine3.21
+Tags: 13.22-alpine3.21, 13-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2c6fe8daca9d2ccc143afe6b1cdbc1eb80379d3f
+GitCommit: 1984f1787ad448db351da121bfe8708769d0f8a7
 Directory: 13/alpine3.21


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/8d2eba6: Update 18 to 18beta3, trixie 18\~beta3-1.pgdg130+1, bookworm 18~beta3-1.pgdg120+1
- https://github.com/docker-library/postgres/commit/e34fc9d: Update 17 to 17.6, trixie 17.6-1.pgdg13+1, bookworm 17.6-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/1cb68ae: Update 16 to 16.10, trixie 16.10-1.pgdg13+1, bookworm 16.10-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/b8ab418: Update 15 to 15.14, trixie 15.14-1.pgdg13+1, bookworm 15.14-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/836ebeb: Update 14 to 14.19, trixie 14.19-1.pgdg13+1, bookworm 14.19-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/1984f17: Update 13 to 13.22, trixie 13.22-1.pgdg13+1, bookworm 13.22-1.pgdg12+1