### PR TITLE
[varnish][security] upgrade varnish

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,28 +1,33 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/ed86c8d78292bb13fe129ba5dcccfd8d11ed1481/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/25ddb659ae85cd3784712e7228a88e8d7a9cb37f/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 7.7.1, 7, 7.7, latest
+Tags: fresh, 7.7.2, 7, 7.7, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: ed86c8d78292bb13fe129ba5dcccfd8d11ed1481
+GitCommit: 7489d188a63e4b649b3d57ff9fe50acea1de4c7f
+GitFetch: refs/heads/main
 
-Tags: fresh-alpine, 7.7.1-alpine, 7-alpine, 7.7-alpine, alpine
+Tags: fresh-alpine, 7.7.2-alpine, 7-alpine, 7.7-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: ed86c8d78292bb13fe129ba5dcccfd8d11ed1481
+GitCommit: 8088573d7968abf4d69905cb76dd64b603f0d0f0
+GitFetch: refs/heads/main
 
-Tags: old, 7.6.3, 7.6
+Tags: old, 7.6.4, 7.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: ea97ed35f2b0eb438ccd6a9250c36567686bfb4a
+GitCommit: 7489d188a63e4b649b3d57ff9fe50acea1de4c7f
+GitFetch: refs/heads/main
 
-Tags: old-alpine, 7.6.3-alpine, 7.6-alpine
+Tags: old-alpine, 7.6.4-alpine, 7.6-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/alpine
-GitCommit: ea97ed35f2b0eb438ccd6a9250c36567686bfb4a
+GitCommit: 8088573d7968abf4d69905cb76dd64b603f0d0f0
+GitFetch: refs/heads/main
 
-Tags: stable, 6.0.14, 6.0
+Tags: stable, 6.0.15, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/debian
-GitCommit: ea97ed35f2b0eb438ccd6a9250c36567686bfb4a
+GitCommit: 7489d188a63e4b649b3d57ff9fe50acea1de4c7f
+GitFetch: refs/heads/main


### PR DESCRIPTION
Predominently because of https://varnish-cache.org/security/VSV00017.html#vsv00017 Also upgrade Alpine/Debian versions and don't install `varnish-dev` on `debian` images.

#fixes https://github.com/varnish/docker-varnish/issues/85