### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.0.3, 6.0, 6, latest
+Tags: 6.0.4, 6.0, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 44adbd73a5aab86d7b650c8e4baff2eaa4bda1ee
+GitCommit: 93e6f0b2a07742f7e023ddf20115eab0099e7cd1
 Directory: 6/debian
 
-Tags: 6.0.3-alpine, 6.0-alpine, 6-alpine, alpine
+Tags: 6.0.4-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 44adbd73a5aab86d7b650c8e4baff2eaa4bda1ee
+GitCommit: 93e6f0b2a07742f7e023ddf20115eab0099e7cd1
 Directory: 6/alpine
 
 Tags: 5.130.4, 5.130, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/93e6f0b: Update to 6.0.4, ghost-cli 1.28.3