### PR TITLE
archlinux: Release 20250817.0.405639

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250810.0.398652
-GitCommit: e8bde646cc506d354b218400f8a8dfa8253b1b9a
-GitFetch: refs/tags/v20250810.0.398652
+Tags: latest, base, base-20250817.0.405639
+GitCommit: 5f7a18761cc5a8e2469416aca9e41a9e87bcb038
+GitFetch: refs/tags/v20250817.0.405639
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250810.0.398652
-GitCommit: e8bde646cc506d354b218400f8a8dfa8253b1b9a
-GitFetch: refs/tags/v20250810.0.398652
+Tags: base-devel, base-devel-20250817.0.405639
+GitCommit: 5f7a18761cc5a8e2469416aca9e41a9e87bcb038
+GitFetch: refs/tags/v20250817.0.405639
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250810.0.398652
-GitCommit: e8bde646cc506d354b218400f8a8dfa8253b1b9a
-GitFetch: refs/tags/v20250810.0.398652
+Tags: multilib-devel, multilib-devel-20250817.0.405639
+GitCommit: 5f7a18761cc5a8e2469416aca9e41a9e87bcb038
+GitFetch: refs/tags/v20250817.0.405639
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks