### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,107 +4,107 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 26-ea-10-jdk-oraclelinux9, 26-ea-10-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-10-jdk-oracle, 26-ea-10-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
-SharedTags: 26-ea-10-jdk, 26-ea-10, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-11-jdk-oraclelinux9, 26-ea-11-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-11-jdk-oracle, 26-ea-11-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
+SharedTags: 26-ea-11-jdk, 26-ea-11, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: amd64, arm64v8
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/oraclelinux9
 
-Tags: 26-ea-10-jdk-oraclelinux8, 26-ea-10-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
+Tags: 26-ea-11-jdk-oraclelinux8, 26-ea-11-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/oraclelinux8
 
-Tags: 26-ea-10-jdk-trixie, 26-ea-10-trixie, 26-ea-jdk-trixie, 26-ea-trixie, 26-jdk-trixie, 26-trixie
+Tags: 26-ea-11-jdk-trixie, 26-ea-11-trixie, 26-ea-jdk-trixie, 26-ea-trixie, 26-jdk-trixie, 26-trixie
 Architectures: amd64, arm64v8
-GitCommit: 9fa18d4c199ab09c81ea596289a02fdcf0e684b1
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/trixie
 
-Tags: 26-ea-10-jdk-slim-trixie, 26-ea-10-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-jdk-slim-trixie, 26-slim-trixie, 26-ea-10-jdk-slim, 26-ea-10-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
+Tags: 26-ea-11-jdk-slim-trixie, 26-ea-11-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-jdk-slim-trixie, 26-slim-trixie, 26-ea-11-jdk-slim, 26-ea-11-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
 Architectures: amd64, arm64v8
-GitCommit: 9fa18d4c199ab09c81ea596289a02fdcf0e684b1
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/slim-trixie
 
-Tags: 26-ea-10-jdk-bookworm, 26-ea-10-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
+Tags: 26-ea-11-jdk-bookworm, 26-ea-11-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
 Architectures: amd64, arm64v8
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/bookworm
 
-Tags: 26-ea-10-jdk-slim-bookworm, 26-ea-10-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm
+Tags: 26-ea-11-jdk-slim-bookworm, 26-ea-11-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/slim-bookworm
 
-Tags: 26-ea-10-jdk-windowsservercore-ltsc2025, 26-ea-10-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
-SharedTags: 26-ea-10-jdk-windowsservercore, 26-ea-10-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-10-jdk, 26-ea-10, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-11-jdk-windowsservercore-ltsc2025, 26-ea-11-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
+SharedTags: 26-ea-11-jdk-windowsservercore, 26-ea-11-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-11-jdk, 26-ea-11, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-10-jdk-windowsservercore-ltsc2022, 26-ea-10-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
-SharedTags: 26-ea-10-jdk-windowsservercore, 26-ea-10-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-10-jdk, 26-ea-10, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-11-jdk-windowsservercore-ltsc2022, 26-ea-11-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
+SharedTags: 26-ea-11-jdk-windowsservercore, 26-ea-11-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-11-jdk, 26-ea-11, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-10-jdk-nanoserver-ltsc2025, 26-ea-10-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
-SharedTags: 26-ea-10-jdk-nanoserver, 26-ea-10-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-11-jdk-nanoserver-ltsc2025, 26-ea-11-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
+SharedTags: 26-ea-11-jdk-nanoserver, 26-ea-11-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-10-jdk-nanoserver-ltsc2022, 26-ea-10-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
-SharedTags: 26-ea-10-jdk-nanoserver, 26-ea-10-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-11-jdk-nanoserver-ltsc2022, 26-ea-11-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
+SharedTags: 26-ea-11-jdk-nanoserver, 26-ea-11-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: e6ea4775388030187e24406f191f932fb707f7bd
+GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
 Directory: 26/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 Tags: 25-rc-jdk-oraclelinux9, 25-rc-oraclelinux9, 25-jdk-oraclelinux9, 25-oraclelinux9, 25-rc-jdk-oracle, 25-rc-oracle, 25-jdk-oracle, 25-oracle
 SharedTags: 25-rc-jdk, 25-rc, 25-jdk, 25
 Architectures: amd64, arm64v8
-GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/oraclelinux9
 
 Tags: 25-rc-jdk-oraclelinux8, 25-rc-oraclelinux8, 25-jdk-oraclelinux8, 25-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/oraclelinux8
 
 Tags: 25-rc-jdk-trixie, 25-rc-trixie, 25-jdk-trixie, 25-trixie
 Architectures: amd64, arm64v8
-GitCommit: 9fa18d4c199ab09c81ea596289a02fdcf0e684b1
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/trixie
 
 Tags: 25-rc-jdk-slim-trixie, 25-rc-slim-trixie, 25-jdk-slim-trixie, 25-slim-trixie, 25-rc-jdk-slim, 25-rc-slim, 25-jdk-slim, 25-slim
 Architectures: amd64, arm64v8
-GitCommit: 9fa18d4c199ab09c81ea596289a02fdcf0e684b1
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/slim-trixie
 
 Tags: 25-rc-jdk-bookworm, 25-rc-bookworm, 25-jdk-bookworm, 25-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/bookworm
 
 Tags: 25-rc-jdk-slim-bookworm, 25-rc-slim-bookworm, 25-jdk-slim-bookworm, 25-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/slim-bookworm
 
 Tags: 25-rc-jdk-windowsservercore-ltsc2025, 25-rc-windowsservercore-ltsc2025, 25-jdk-windowsservercore-ltsc2025, 25-windowsservercore-ltsc2025
 SharedTags: 25-rc-jdk-windowsservercore, 25-rc-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-rc-jdk, 25-rc, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
 Tags: 25-rc-jdk-windowsservercore-ltsc2022, 25-rc-windowsservercore-ltsc2022, 25-jdk-windowsservercore-ltsc2022, 25-windowsservercore-ltsc2022
 SharedTags: 25-rc-jdk-windowsservercore, 25-rc-windowsservercore, 25-jdk-windowsservercore, 25-windowsservercore, 25-rc-jdk, 25-rc, 25-jdk, 25
 Architectures: windows-amd64
-GitCommit: 0ef4c9faaa4fc9072be73522f4bbd5298a098505
+GitCommit: 86aa1e4688f5a8a814aa56a023223847f9a907f3
 Directory: 25/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/1b99f7d: Update 26 to 26-ea+11
- https://github.com/docker-library/openjdk/commit/86aa1e4: Update 25