### PR TITLE
Odoo: update 16.0-18.0 to release 20250819

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: e35962374be54c7797b1f28bf7a2e046f145fd82
+GitCommit: 0461e8225b4aee856cc74d893c89cb4e3c6d43f1
 
-Tags: 18.0-20250807, 18.0, 18, latest
+Tags: 18.0-20250819, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250807, 17.0, 17
+Tags: 17.0-20250819, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250807, 16.0, 16
+Tags: 16.0-20250819, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks