### PR TITLE
Update Jetty versions to 10.0.26 & 11.0.26, and introduce new images for 12.1.0

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -79,6 +79,26 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
+Tags: 12.1.0-jdk21-alpine, 12.1-jdk21-alpine, 12.1.0-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.1/jdk21-alpine
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
+Tags: 12.1.0, 12.1, 12.1.0-jdk21, 12.1-jdk21, 12.1.0-eclipse-temurin, 12.1-eclipse-temurin, 12.1.0-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.1/jdk21
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
+Tags: 12.1.0-jdk17-alpine, 12.1-jdk17-alpine, 12.1.0-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.1/jdk17-alpine
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
+Tags: 12.1.0-jdk17, 12.1-jdk17, 12.1.0-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.1/jdk17
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
 Tags: 12.0.25-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.25-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
@@ -129,125 +149,125 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 11.0.25-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.25-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
+Tags: 11.0.26-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.26-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jre21, 11.0-jre21, 11-jre21, 11.0.25-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
+Tags: 11.0.26-jre21, 11.0-jre21, 11-jre21, 11.0.26-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre21
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.25-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
+Tags: 11.0.26-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.26-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jre17, 11.0-jre17, 11-jre17, 11.0.25-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
+Tags: 11.0.26-jre17, 11.0-jre17, 11-jre17, 11.0.26-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre17
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.25-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
+Tags: 11.0.26-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.26-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jre11, 11.0-jre11, 11-jre11, 11.0.25-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
+Tags: 11.0.26-jre11, 11.0-jre11, 11-jre11, 11.0.26-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jre11
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.25-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
+Tags: 11.0.26-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.26-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25, 11.0, 11, 11.0.25-jdk21, 11.0-jdk21, 11-jdk21, 11.0.25-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.25-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
+Tags: 11.0.26, 11.0, 11, 11.0.26-jdk21, 11.0-jdk21, 11-jdk21, 11.0.26-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.26-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk21
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.25-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
+Tags: 11.0.26-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.26-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk17, 11.0-jdk17, 11-jdk17, 11.0.25-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
+Tags: 11.0.26-jdk17, 11.0-jdk17, 11-jdk17, 11.0.26-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk17
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.25-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
+Tags: 11.0.26-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.26-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk11, 11.0-jdk11, 11-jdk11, 11.0.25-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
+Tags: 11.0.26-jdk11, 11.0-jdk11, 11-jdk11, 11.0.26-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/11.0/jdk11
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.25-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
+Tags: 10.0.26-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.26-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jre21, 10.0-jre21, 10-jre21, 10.0.25-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
+Tags: 10.0.26-jre21, 10.0-jre21, 10-jre21, 10.0.26-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre21
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.25-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
+Tags: 10.0.26-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.26-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jre17, 10.0-jre17, 10-jre17, 10.0.25-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
+Tags: 10.0.26-jre17, 10.0-jre17, 10-jre17, 10.0.26-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre17
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.25-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
+Tags: 10.0.26-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.26-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jre11, 10.0-jre11, 10-jre11, 10.0.25-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
+Tags: 10.0.26-jre11, 10.0-jre11, 10-jre11, 10.0.26-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jre11
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.25-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
+Tags: 10.0.26-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.26-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25, 10.0, 10, 10.0.25-jdk21, 10.0-jdk21, 10-jdk21, 10.0.25-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.25-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
+Tags: 10.0.26, 10.0, 10, 10.0.26-jdk21, 10.0-jdk21, 10-jdk21, 10.0.26-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.26-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk21
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.25-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
+Tags: 10.0.26-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.26-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk17, 10.0-jdk17, 10-jdk17, 10.0.25-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
+Tags: 10.0.26-jdk17, 10.0-jdk17, 10-jdk17, 10.0.26-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk17
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.25-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
+Tags: 10.0.26-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.26-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk11, 10.0-jdk11, 10-jdk11, 10.0.25-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
+Tags: 10.0.26-jdk11, 10.0-jdk11, 10-jdk11, 10.0.26-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/10.0/jdk11
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
 Tags: 9.4.58-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
 Architectures: amd64, arm64v8
@@ -289,6 +309,26 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
+Tags: 12.1.0-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.1/jdk21-alpine
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
+Tags: 12.1.0-amazoncorretto, 12.1-amazoncorretto, 12.1.0-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.1/jdk21
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
+Tags: 12.1.0-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.1/jdk17-alpine
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
+Tags: 12.1.0-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.1/jdk17
+GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
+
 Tags: 12.0.25-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk24-al2023
@@ -324,62 +364,62 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 11.0.25-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
+Tags: 11.0.26-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.25-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
+Tags: 11.0.26-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.26-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk21
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
+Tags: 11.0.26-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
+Tags: 11.0.26-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk17
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
+Tags: 11.0.26-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 11.0.25-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
+Tags: 11.0.26-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/11.0/jdk11
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
+Tags: 10.0.26-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.25-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
+Tags: 10.0.26-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.26-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk21
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
+Tags: 10.0.26-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
+Tags: 10.0.26-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk17
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
+Tags: 10.0.26-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
 
-Tags: 10.0.25-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
+Tags: 10.0.26-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/10.0/jdk11
-GitCommit: 68752e005359f51f5ba72091fb4daf006db482e0
+GitCommit: 5a8d565c6959453cf11c2906059be01adc848004

--- a/library/jetty
+++ b/library/jetty
@@ -79,72 +79,72 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.1.0-jdk21-alpine, 12.1-jdk21-alpine, 12.1.0-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin
+Tags: 12.1.0-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.0-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk21-alpine
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.1.0, 12.1, 12.1.0-jdk21, 12.1-jdk21, 12.1.0-eclipse-temurin, 12.1-eclipse-temurin, 12.1.0-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin
+Tags: 12.1.0, 12.1, 12, 12.1.0-jdk21, 12.1-jdk21, 12-jdk21, 12.1.0-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.0-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk21
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.1.0-jdk17-alpine, 12.1-jdk17-alpine, 12.1.0-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin
+Tags: 12.1.0-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.0-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk17-alpine
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.1.0-jdk17, 12.1-jdk17, 12.1.0-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin
+Tags: 12.1.0-jdk17, 12.1-jdk17, 12-jdk17, 12.1.0-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk17
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.0.25-jre21-alpine, 12.0-jre21-alpine, 12-jre21-alpine, 12.0.25-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin, 12-jre21-alpine-eclipse-temurin
+Tags: 12.0.25-jre21-alpine, 12.0-jre21-alpine, 12.0.25-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jre21, 12.0-jre21, 12-jre21, 12.0.25-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin, 12-jre21-eclipse-temurin
+Tags: 12.0.25-jre21, 12.0-jre21, 12.0.25-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jre17-alpine, 12.0-jre17-alpine, 12-jre17-alpine, 12.0.25-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin, 12-jre17-alpine-eclipse-temurin
+Tags: 12.0.25-jre17-alpine, 12.0-jre17-alpine, 12.0.25-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jre17, 12.0-jre17, 12-jre17, 12.0.25-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin, 12-jre17-eclipse-temurin
+Tags: 12.0.25-jre17, 12.0-jre17, 12.0.25-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk24-alpine, 12.0-jdk24-alpine, 12-jdk24-alpine, 12.0.25-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin, 12-jdk24-alpine-eclipse-temurin
+Tags: 12.0.25-jdk24-alpine, 12.0-jdk24-alpine, 12.0.25-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk24-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk24, 12.0-jdk24, 12-jdk24, 12.0.25-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin, 12-jdk24-eclipse-temurin
+Tags: 12.0.25-jdk24, 12.0-jdk24, 12.0.25-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk24
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk21-alpine, 12.0-jdk21-alpine, 12-jdk21-alpine, 12.0.25-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.0.25-jdk21-alpine, 12.0-jdk21-alpine, 12.0.25-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25, 12.0, 12, 12.0.25-jdk21, 12.0-jdk21, 12-jdk21, 12.0.25-eclipse-temurin, 12.0-eclipse-temurin, 12-eclipse-temurin, 12.0.25-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.0.25, 12.0, 12.0.25-jdk21, 12.0-jdk21, 12.0.25-eclipse-temurin, 12.0-eclipse-temurin, 12.0.25-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk17-alpine, 12.0-jdk17-alpine, 12-jdk17-alpine, 12.0.25-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.0.25-jdk17-alpine, 12.0-jdk17-alpine, 12.0.25-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk17, 12.0-jdk17, 12-jdk17, 12.0.25-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.0.25-jdk17, 12.0-jdk17, 12.0.25-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
@@ -309,57 +309,57 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.1.0-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto
+Tags: 12.1.0-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21-alpine
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.1.0-amazoncorretto, 12.1-amazoncorretto, 12.1.0-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto
+Tags: 12.1.0-amazoncorretto, 12.1-amazoncorretto, 12-amazoncorretto, 12.1.0-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.1.0-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto
+Tags: 12.1.0-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17-alpine
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.1.0-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto
+Tags: 12.1.0-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17
 GitCommit: 36c91c23fef339df187fbf73e56a0376688dbc32
 
-Tags: 12.0.25-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto, 12-jdk24-al2023-amazoncorretto
+Tags: 12.0.25-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk24-al2023
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.0.25-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
+Tags: 12.0.25-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-al2023
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-amazoncorretto, 12.0-amazoncorretto, 12-amazoncorretto, 12.0.25-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.0.25-amazoncorretto, 12.0-amazoncorretto, 12.0.25-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.0.25-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
+Tags: 12.0.25-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-al2023
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.0.25-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.0.25-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7


### PR DESCRIPTION
- `10.0.25` -> `10.0.26`
- `11.0.25` -> `11.0.26`
- Added new images for `12.1.0`