### PR TITLE
Update Monica and remove mips64le tag

### DIFF
--- a/library/monica
+++ b/library/monica
@@ -1,34 +1,34 @@
-# This file is generated via https://github.com/monicahq/docker/blob/8c3bcc8d3ab01315ca762c995338083d71c5611e/generate-stackbrew-library.sh
+# This file is generated via https://github.com/monicahq/docker/blob/7ffc74385e243e2dac4d7013a3240c0ae1229f05/generate-stackbrew-library.sh
 Maintainers: Alexis Saettler <alexis@saettler.org> (@asbiin)
 GitRepo: https://github.com/monicahq/docker.git
 GitFetch: refs/heads/main
 
 Tags: 4.1.2-apache, 4.1-apache, 4-apache, apache, 4.1.2, 4.1, 4, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 4/apache
-GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
+GitCommit: 7ffc74385e243e2dac4d7013a3240c0ae1229f05
 
 Tags: 4.1.2-fpm-alpine, 4.1-fpm-alpine, 4-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 4/fpm-alpine
-GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
+GitCommit: 7ffc74385e243e2dac4d7013a3240c0ae1229f05
 
 Tags: 4.1.2-fpm, 4.1-fpm, 4-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 4/fpm
-GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
+GitCommit: 7ffc74385e243e2dac4d7013a3240c0ae1229f05
 
 Tags: 5.0.0-beta.5-apache, 5.0.0-beta-apache, 5.0-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 5/apache
-GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
+GitCommit: 7ffc74385e243e2dac4d7013a3240c0ae1229f05
 
 Tags: 5.0.0-beta.5-fpm-alpine, 5.0.0-beta-fpm-alpine, 5.0-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 5/fpm-alpine
-GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
+GitCommit: 7ffc74385e243e2dac4d7013a3240c0ae1229f05
 
 Tags: 5.0.0-beta.5-fpm, 5.0.0-beta-fpm, 5.0-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: 5/fpm
-GitCommit: 8c3bcc8d3ab01315ca762c995338083d71c5611e
+GitCommit: 7ffc74385e243e2dac4d7013a3240c0ae1229f05


### PR DESCRIPTION
Update Monica to remove `mips64le` tag.
See https://github.com/docker-library/official-images/pull/19660#issuecomment-3198610715