### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,122 +4,92 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 6.0.0-alpha3, 6.0, 6.0.alpha, 6.0.0-alpha, 6.0.0-alpha3-apache, 6.0-apache, 6.0.alpha-apache, 6.0.0-alpha-apache, 6.0.0-alpha3-php8.3, 6.0-php8.3, 6.0.alpha-php8.3, 6.0.0-alpha-php8.3, 6.0.0-alpha3-php8.3-apache, 6.0-php8.3-apache, 6.0.alpha-php8.3-apache, 6.0.0-alpha-php8.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 6.0.alpha/php8.3/apache
+Tags: 6.0.0-beta1, 6.0, 6.0.beta, 6.0.0-beta, 6.0.0-beta1-apache, 6.0-apache, 6.0.beta-apache, 6.0.0-beta-apache, 6.0.0-beta1-php8.3, 6.0-php8.3, 6.0.beta-php8.3, 6.0.0-beta-php8.3, 6.0.0-beta1-php8.3-apache, 6.0-php8.3-apache, 6.0.beta-php8.3-apache, 6.0.0-beta-php8.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 6.0.beta/php8.3/apache
 
-Tags: 6.0.0-alpha3-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.alpha-php8.3-fpm-alpine, 6.0.0-alpha-php8.3-fpm-alpine
+Tags: 6.0.0-beta1-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.beta-php8.3-fpm-alpine, 6.0.0-beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 6.0.alpha/php8.3/fpm-alpine
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 6.0.beta/php8.3/fpm-alpine
 
-Tags: 6.0.0-alpha3-php8.3-fpm, 6.0-php8.3-fpm, 6.0.alpha-php8.3-fpm, 6.0.0-alpha-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 6.0.alpha/php8.3/fpm
+Tags: 6.0.0-beta1-php8.3-fpm, 6.0-php8.3-fpm, 6.0.beta-php8.3-fpm, 6.0.0-beta-php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 6.0.beta/php8.3/fpm
 
-Tags: 5.4.0-alpha3-php8.2-apache, 5.4-php8.2-apache, 5.4.alpha-php8.2-apache, 5.4.0-alpha-php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 5.4.alpha/php8.2/apache
+Tags: 5.4.0-beta1-php8.2-apache, 5.4-php8.2-apache, 5.4.beta-php8.2-apache, 5.4.0-beta-php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 5.4.beta/php8.2/apache
 
-Tags: 5.4.0-alpha3-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.alpha-php8.2-fpm-alpine, 5.4.0-alpha-php8.2-fpm-alpine
+Tags: 5.4.0-beta1-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.beta-php8.2-fpm-alpine, 5.4.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 5.4.alpha/php8.2/fpm-alpine
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 5.4.beta/php8.2/fpm-alpine
 
-Tags: 5.4.0-alpha3-php8.2-fpm, 5.4-php8.2-fpm, 5.4.alpha-php8.2-fpm, 5.4.0-alpha-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 5.4.alpha/php8.2/fpm
+Tags: 5.4.0-beta1-php8.2-fpm, 5.4-php8.2-fpm, 5.4.beta-php8.2-fpm, 5.4.0-beta-php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 5.4.beta/php8.2/fpm
 
-Tags: 5.4.0-alpha3, 5.4, 5.4.alpha, 5.4.0-alpha, 5.4.0-alpha3-apache, 5.4-apache, 5.4.alpha-apache, 5.4.0-alpha-apache, 5.4.0-alpha3-php8.3, 5.4-php8.3, 5.4.alpha-php8.3, 5.4.0-alpha-php8.3, 5.4.0-alpha3-php8.3-apache, 5.4-php8.3-apache, 5.4.alpha-php8.3-apache, 5.4.0-alpha-php8.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 5.4.alpha/php8.3/apache
+Tags: 5.4.0-beta1, 5.4, 5.4.beta, 5.4.0-beta, 5.4.0-beta1-apache, 5.4-apache, 5.4.beta-apache, 5.4.0-beta-apache, 5.4.0-beta1-php8.3, 5.4-php8.3, 5.4.beta-php8.3, 5.4.0-beta-php8.3, 5.4.0-beta1-php8.3-apache, 5.4-php8.3-apache, 5.4.beta-php8.3-apache, 5.4.0-beta-php8.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 5.4.beta/php8.3/apache
 
-Tags: 5.4.0-alpha3-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.alpha-php8.3-fpm-alpine, 5.4.0-alpha-php8.3-fpm-alpine
+Tags: 5.4.0-beta1-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.beta-php8.3-fpm-alpine, 5.4.0-beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 5.4.alpha/php8.3/fpm-alpine
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 5.4.beta/php8.3/fpm-alpine
 
-Tags: 5.4.0-alpha3-php8.3-fpm, 5.4-php8.3-fpm, 5.4.alpha-php8.3-fpm, 5.4.0-alpha-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f2936260e5f398854939c429f5468f2d5b43df8d
-Directory: 5.4.alpha/php8.3/fpm
+Tags: 5.4.0-beta1-php8.3-fpm, 5.4-php8.3-fpm, 5.4.beta-php8.3-fpm, 5.4.0-beta-php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+Directory: 5.4.beta/php8.3/fpm
 
-Tags: 5.3.2-php8.1-apache, 5.3-php8.1-apache, 5-php8.1-apache, php8.1-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+Tags: 5.3.3-php8.1-apache, 5.3-php8.1-apache, 5-php8.1-apache, php8.1-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.1/apache
 
-Tags: 5.3.2-php8.1-fpm-alpine, 5.3-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
+Tags: 5.3.3-php8.1-fpm-alpine, 5.3-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.1/fpm-alpine
 
-Tags: 5.3.2-php8.1-fpm, 5.3-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+Tags: 5.3.3-php8.1-fpm, 5.3-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.1/fpm
 
-Tags: 5.3.2-php8.2-apache, 5.3-php8.2-apache, 5-php8.2-apache, php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+Tags: 5.3.3-php8.2-apache, 5.3-php8.2-apache, 5-php8.2-apache, php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.2/apache
 
-Tags: 5.3.2-php8.2-fpm-alpine, 5.3-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 5.3.3-php8.2-fpm-alpine, 5.3-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.2/fpm-alpine
 
-Tags: 5.3.2-php8.2-fpm, 5.3-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+Tags: 5.3.3-php8.2-fpm, 5.3-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.2/fpm
 
-Tags: 5.3.2, 5.3, 5, latest, 5.3.2-apache, 5.3-apache, 5-apache, apache, 5.3.2-php8.3, 5.3-php8.3, 5-php8.3, php8.3, 5.3.2-php8.3-apache, 5.3-php8.3-apache, 5-php8.3-apache, php8.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+Tags: 5.3.3, 5.3, 5, latest, 5.3.3-apache, 5.3-apache, 5-apache, apache, 5.3.3-php8.3, 5.3-php8.3, 5-php8.3, php8.3, 5.3.3-php8.3-apache, 5.3-php8.3-apache, 5-php8.3-apache, php8.3-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.3/apache
 
-Tags: 5.3.2-php8.3-fpm-alpine, 5.3-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 5.3.3-php8.3-fpm-alpine, 5.3-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.3/fpm-alpine
 
-Tags: 5.3.2-php8.3-fpm, 5.3-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 029a7a61c78666ccf23b6cee64b8c79fbc537248
+Tags: 5.3.3-php8.3-fpm, 5.3-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
 Directory: 5.3/php8.3/fpm
-
-Tags: 4.4.13-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5
-Directory: 4.4/php8.1/apache
-
-Tags: 4.4.13-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5
-Directory: 4.4/php8.1/fpm-alpine
-
-Tags: 4.4.13-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5
-Directory: 4.4/php8.1/fpm
-
-Tags: 4.4.13, 4.4, 4, 4.4.13-apache, 4.4-apache, 4-apache, 4.4.13-php8.2, 4.4-php8.2, 4-php8.2, 4.4.13-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5
-Directory: 4.4/php8.2/apache
-
-Tags: 4.4.13-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5
-Directory: 4.4/php8.2/fpm-alpine
-
-Tags: 4.4.13-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b32f0a2ba4ad99f15c0acd26b2f862c038ff3f5
-Directory: 4.4/php8.2/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@6fec384: Update to imagick-3.8.0
- joomla-docker/docker-joomla@34c4e71: Update Joomla 5.3.2 to 5.3.3
- joomla-docker/docker-joomla@95ebefe: Remove Joomla 6.0.0-alpha and add 6.0.0-beta and Joomla 5.4.0-alpha and add 5.4.0-beta
- joomla-docker/docker-joomla@8b1a7ca: Remove Joomla 4.4 build