### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev6, 3.3-dev, 3.3-dev6-trixie, 3.3-dev-trixie
+Tags: 3.3-dev7, 3.3-dev, 3.3-dev7-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: 8f63da4a118ce01253d4a1bc4a88a897989e8ee6
 Directory: 3.3
 
-Tags: 3.3-dev6-alpine, 3.3-dev-alpine, 3.3-dev6-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev7-alpine, 3.3-dev-alpine, 3.3-dev7-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 65c563d1acf447e3db0f03f531302fdd1a39c738
+GitCommit: 8f63da4a118ce01253d4a1bc4a88a897989e8ee6
 Directory: 3.3/alpine
 
 Tags: 3.2.4, 3.2, latest, lts, 3.2.4-trixie, 3.2-trixie, trixie, lts-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/8f63da4: Update 3.3 to 3.3-dev7