### PR TITLE
caddy: v2.10.2 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,52 +1,52 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/b4226f27405e98d9330ca807a80807d5d523ebba/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/5572371a83e48fd0368a4917d0fc48e44ef30582/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
-Tags: 2.10.0-alpine, 2.10-alpine, 2-alpine, alpine
-SharedTags: 2.10.0, 2.10, 2, latest
+Tags: 2.10.2-alpine, 2.10-alpine, 2-alpine, alpine
+SharedTags: 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/alpine
-GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
+GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.10.0-builder-alpine, 2.10-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.10.0-builder, 2.10-builder, 2-builder, builder
+Tags: 2.10.2-builder-alpine, 2.10-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/builder
-GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
+GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.10.0-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.10.0-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.0, 2.10, 2, latest
+Tags: 2.10.2-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.10.2-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows/ltsc2022
-GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
+GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.10.0-windowsservercore-ltsc2025, 2.10-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 2.10.0-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.0, 2.10, 2, latest
+Tags: 2.10.2-windowsservercore-ltsc2025, 2.10-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 2.10.2-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows/ltsc2025
-GitCommit: b4226f27405e98d9330ca807a80807d5d523ebba
+GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 2.10.0-builder-windowsservercore-ltsc2022, 2.10-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.10.0-builder, 2.10-builder, 2-builder, builder
+Tags: 2.10.2-builder-windowsservercore-ltsc2022, 2.10-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-builder/ltsc2022
-GitCommit: aa3e73e0731fbca665be75edef9fbb60d3169278
+GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.10.0-builder-windowsservercore-ltsc2025, 2.10-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
-SharedTags: 2.10.0-builder, 2.10-builder, 2-builder, builder
+Tags: 2.10.2-builder-windowsservercore-ltsc2025, 2.10-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
+SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-builder/ltsc2025
-GitCommit: b4226f27405e98d9330ca807a80807d5d523ebba
+GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.10.1

https://github.com/caddyserver/caddy/releases/tag/v2.10.2

https://github.com/caddyserver/caddy-docker/pull/415