### PR TITLE
archlinux: Release 20250824.0.410029

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250817.0.405639
-GitCommit: 5f7a18761cc5a8e2469416aca9e41a9e87bcb038
-GitFetch: refs/tags/v20250817.0.405639
+Tags: latest, base, base-20250824.0.410029
+GitCommit: bdad294c7e0bafdc01f6bbd01c0e79c046369093
+GitFetch: refs/tags/v20250824.0.410029
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250817.0.405639
-GitCommit: 5f7a18761cc5a8e2469416aca9e41a9e87bcb038
-GitFetch: refs/tags/v20250817.0.405639
+Tags: base-devel, base-devel-20250824.0.410029
+GitCommit: bdad294c7e0bafdc01f6bbd01c0e79c046369093
+GitFetch: refs/tags/v20250824.0.410029
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250817.0.405639
-GitCommit: 5f7a18761cc5a8e2469416aca9e41a9e87bcb038
-GitFetch: refs/tags/v20250817.0.405639
+Tags: multilib-devel, multilib-devel-20250824.0.410029
+GitCommit: bdad294c7e0bafdc01f6bbd01c0e79c046369093
+GitFetch: refs/tags/v20250824.0.410029
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks