### PR TITLE
disable gazebo classic as focal is EOL

### DIFF
--- a/library/gazebo
+++ b/library/gazebo
@@ -1,19 +1,2 @@
 Maintainers: Tully Foote <tfoote+buildfarm@osrfoundation.org> (@tfoote)
 GitRepo: https://github.com/osrf/docker_images.git
-
-################################################################################
-# Release: 11
-
-########################################
-# Distro: ubuntu:focal
-
-Tags: gzserver11, gzserver11-focal
-Architectures: amd64
-GitCommit: f7bb3258d4814deec1eca7e46cbb8d7f4b054431
-Directory: gazebo/11/ubuntu/focal/gzserver11
-
-Tags: libgazebo11, libgazebo11-focal, latest
-Architectures: amd64
-GitCommit: f7bb3258d4814deec1eca7e46cbb8d7f4b054431
-Directory: gazebo/11/ubuntu/focal/libgazebo11
-


### PR DESCRIPTION
This disable builds for Gazebo 11 that is based on Ubuntu Focal

New gazebo images will be released in the future so the library will be updated https://github.com/gazebo-release/gz-sim8-release/issues/8