### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.8.20250808.1
+Tags: 2023, latest, 2023.8.20250818.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 94f86e7a853963227c332a030c651668c70850b9
+amd64-GitCommit: 749d179d33ea914415e7c369f39f6329a01852d0
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 69e020a7ded8ab2e4135561bac2368b56f63c451
+arm64v8-GitCommit: e06d6ee6322fdd67340c6b87bd400fd975ae76e9
 
-Tags: 2, 2.0.20250808.1
+Tags: 2, 2.0.20250818.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0a084d30ee45ac3299f958e7b37088a12f87b250
+amd64-GitCommit: 768f7e30b46c745fc4ec82b0f8362ecd7cded497
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 476fdaf0c9007b9803956c52bfc128b66bbce539
+arm64v8-GitCommit: 9a9a6f3a73a18c09b6cd8897bcb1e89870e100bf
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- sqlite-3.7.17-8.amzn2.1.3
- python-libs-2.7.18-1.amzn2.0.14
- python-2.7.18-1.amzn2.0.14

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.8.20250818-0.amzn2023
- system-release-2023.8.20250818-0.amzn2023
- python3-3.9.23-1.amzn2023.0.3
- sqlite-libs-3.40.0-1.amzn2023.0.6
- libcap-2.73-1.amzn2023.0.3
- python3-libs-3.9.23-1.amzn2023.0.3