### PR TITLE
[varnish] debian - fresh and old moved to trixie

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,11 +1,11 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/22149a31ff7ca2f96d624175ee06419b42eafaa9/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/fb0aadb7c3eb09473d2e636db882929a108dd7ec/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 7.7.2, 7, 7.7, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: 22149a31ff7ca2f96d624175ee06419b42eafaa9
+GitCommit: fb0aadb7c3eb09473d2e636db882929a108dd7ec
 GitFetch: refs/heads/main
 
 Tags: fresh-alpine, 7.7.2-alpine, 7-alpine, 7.7-alpine, alpine
@@ -17,7 +17,7 @@ GitFetch: refs/heads/main
 Tags: old, 7.6.4, 7.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: 22149a31ff7ca2f96d624175ee06419b42eafaa9
+GitCommit: fb0aadb7c3eb09473d2e636db882929a108dd7ec
 GitFetch: refs/heads/main
 
 Tags: old-alpine, 7.6.4-alpine, 7.6-alpine


### PR DESCRIPTION
fresh and old debian images now based on trixie.
stable stays on bookworm due to legacy build constraints.