### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 26-ea-11-jdk-oraclelinux9, 26-ea-11-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-11-jdk-oracle, 26-ea-11-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
-SharedTags: 26-ea-11-jdk, 26-ea-11, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-12-jdk-oraclelinux9, 26-ea-12-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-12-jdk-oracle, 26-ea-12-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
+SharedTags: 26-ea-12-jdk, 26-ea-12, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: amd64, arm64v8
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/oraclelinux9
 
-Tags: 26-ea-11-jdk-oraclelinux8, 26-ea-11-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
+Tags: 26-ea-12-jdk-oraclelinux8, 26-ea-12-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/oraclelinux8
 
-Tags: 26-ea-11-jdk-trixie, 26-ea-11-trixie, 26-ea-jdk-trixie, 26-ea-trixie, 26-jdk-trixie, 26-trixie
+Tags: 26-ea-12-jdk-trixie, 26-ea-12-trixie, 26-ea-jdk-trixie, 26-ea-trixie, 26-jdk-trixie, 26-trixie
 Architectures: amd64, arm64v8
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/trixie
 
-Tags: 26-ea-11-jdk-slim-trixie, 26-ea-11-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-jdk-slim-trixie, 26-slim-trixie, 26-ea-11-jdk-slim, 26-ea-11-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
+Tags: 26-ea-12-jdk-slim-trixie, 26-ea-12-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-jdk-slim-trixie, 26-slim-trixie, 26-ea-12-jdk-slim, 26-ea-12-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
 Architectures: amd64, arm64v8
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/slim-trixie
 
-Tags: 26-ea-11-jdk-bookworm, 26-ea-11-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
+Tags: 26-ea-12-jdk-bookworm, 26-ea-12-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/bookworm
 
-Tags: 26-ea-11-jdk-slim-bookworm, 26-ea-11-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm
+Tags: 26-ea-12-jdk-slim-bookworm, 26-ea-12-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/slim-bookworm
 
-Tags: 26-ea-11-jdk-windowsservercore-ltsc2025, 26-ea-11-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
-SharedTags: 26-ea-11-jdk-windowsservercore, 26-ea-11-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-11-jdk, 26-ea-11, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-12-jdk-windowsservercore-ltsc2025, 26-ea-12-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
+SharedTags: 26-ea-12-jdk-windowsservercore, 26-ea-12-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-12-jdk, 26-ea-12, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-11-jdk-windowsservercore-ltsc2022, 26-ea-11-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
-SharedTags: 26-ea-11-jdk-windowsservercore, 26-ea-11-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-11-jdk, 26-ea-11, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-12-jdk-windowsservercore-ltsc2022, 26-ea-12-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
+SharedTags: 26-ea-12-jdk-windowsservercore, 26-ea-12-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-12-jdk, 26-ea-12, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-11-jdk-nanoserver-ltsc2025, 26-ea-11-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
-SharedTags: 26-ea-11-jdk-nanoserver, 26-ea-11-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-12-jdk-nanoserver-ltsc2025, 26-ea-12-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
+SharedTags: 26-ea-12-jdk-nanoserver, 26-ea-12-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-11-jdk-nanoserver-ltsc2022, 26-ea-11-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
-SharedTags: 26-ea-11-jdk-nanoserver, 26-ea-11-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-12-jdk-nanoserver-ltsc2022, 26-ea-12-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
+SharedTags: 26-ea-12-jdk-nanoserver, 26-ea-12-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: 1b99f7d31a3315819afc6730b3eb350a0b078a25
+GitCommit: b37a81c3623cc7607bd4728486dca656ae0f0a1c
 Directory: 26/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/b37a81c: Update 26 to 26-ea+12