### PR TITLE
Update varnish

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,33 +1,33 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/fb0aadb7c3eb09473d2e636db882929a108dd7ec/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/047117647276c4e83847b69899ce81283a2a4270/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 7.7.2, 7, 7.7, latest
+Tags: fresh, 7.7.3, 7, 7.7, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/debian
-GitCommit: fb0aadb7c3eb09473d2e636db882929a108dd7ec
+GitCommit: 2c2b9d92008b7623bd837cbb542ae02061d9a598
 GitFetch: refs/heads/main
 
-Tags: fresh-alpine, 7.7.2-alpine, 7-alpine, 7.7-alpine, alpine
+Tags: fresh-alpine, 7.7.3-alpine, 7-alpine, 7.7-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: fresh/alpine
-GitCommit: 8088573d7968abf4d69905cb76dd64b603f0d0f0
+GitCommit: 047117647276c4e83847b69899ce81283a2a4270
 GitFetch: refs/heads/main
 
-Tags: old, 7.6.4, 7.6
+Tags: old, 7.6.5, 7.6
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/debian
-GitCommit: fb0aadb7c3eb09473d2e636db882929a108dd7ec
+GitCommit: 2c2b9d92008b7623bd837cbb542ae02061d9a598
 GitFetch: refs/heads/main
 
-Tags: old-alpine, 7.6.4-alpine, 7.6-alpine
+Tags: old-alpine, 7.6.5-alpine, 7.6-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: old/alpine
-GitCommit: 8088573d7968abf4d69905cb76dd64b603f0d0f0
+GitCommit: 047117647276c4e83847b69899ce81283a2a4270
 GitFetch: refs/heads/main
 
-Tags: stable, 6.0.15, 6.0
+Tags: stable, 6.0.16, 6.0
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
 Directory: stable/debian
-GitCommit: 7489d188a63e4b649b3d57ff9fe50acea1de4c7f
+GitCommit: 2c2b9d92008b7623bd837cbb542ae02061d9a598
 GitFetch: refs/heads/main


### PR DESCRIPTION
7.7.3, 7.6.5 and 6.0.16, following [VSV00017](https://varnish-cache.org/security/VSV00017.html#vsv00017)