### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-14557 ELSA-2025-14560"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d9d0a86768453a503dbf103d9e6485c456acffd3
+amd64-GitCommit: fec6de9e14b525e3738f9b622d4f6f5093c2b123
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5b7684b8b5dc6ba158d00ae4bb78631cc578b2bb
+arm64v8-GitCommit: f1620f0ec65d70b12481e59aa79719f155606a3d
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6020, CVE-2025-8194, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-14557.html
https://linux.oracle.com/errata/ELSA-2025-14560.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
