### PR TITLE
Bump Traefik to v3.5.1 and v2.11.29

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,22 +20,22 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 263eee8e2738fe8cbbbc05b5188903b7868b898c
 Directory: v3.5/alpine
 
-Tags: v2.11.28-windowsservercore-ltsc2022, 2.11.28-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.29-windowsservercore-ltsc2022, 2.11.29-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6056d5aff8500ad756a785ac6dec09e3907e4298
+GitCommit: ad4563c38375d0cc39f9016241b69518398a5b2b
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.28-nanoserver-ltsc2022, 2.11.28-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.29-nanoserver-ltsc2022, 2.11.29-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6056d5aff8500ad756a785ac6dec09e3907e4298
+GitCommit: ad4563c38375d0cc39f9016241b69518398a5b2b
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.28, 2.11.28, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.29, 2.11.29, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6056d5aff8500ad756a785ac6dec09e3907e4298
+GitCommit: ad4563c38375d0cc39f9016241b69518398a5b2b
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.5.1](https://github.com/traefik/traefik/releases/tag/v3.5.1) and to [v2.11.29](https://github.com/traefik/traefik/releases/tag/v2.11.29).

/cc @mmatur @kevinpollet

Cheers
