### PR TITLE
Update neo4j 5.26.11

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -26,25 +26,25 @@ Directory: 2025.07.1/ubi9/enterprise
 
 
 
-Tags: 5.26.10-community-bullseye, 5.26-community-bullseye, 5-community-bullseye, 5.26.10-community, 5.26-community, 5-community, 5.26.10-bullseye, 5.26-bullseye, 5-bullseye, 5.26.10, 5.26, 5
+Tags: 5.26.11-community-bullseye, 5.26-community-bullseye, 5-community-bullseye, 5.26.11-community, 5.26-community, 5-community, 5.26.11-bullseye, 5.26-bullseye, 5-bullseye, 5.26.11, 5.26, 5
 Architectures: amd64, arm64v8
-GitCommit: 26ed3b6bcf5b8141ec4641a6822688142d3e7f80
-Directory: 5.26.10/bullseye/community
+GitCommit: 235ccdb26ebbae0520ee5dd157b6055b34b88661
+Directory: 5.26.11/bullseye/community
 
-Tags: 5.26.10-enterprise-bullseye, 5.26-enterprise-bullseye, 5-enterprise-bullseye, 5.26.10-enterprise, 5.26-enterprise, 5-enterprise
+Tags: 5.26.11-enterprise-bullseye, 5.26-enterprise-bullseye, 5-enterprise-bullseye, 5.26.11-enterprise, 5.26-enterprise, 5-enterprise
 Architectures: amd64, arm64v8
-GitCommit: 26ed3b6bcf5b8141ec4641a6822688142d3e7f80
-Directory: 5.26.10/bullseye/enterprise
+GitCommit: 235ccdb26ebbae0520ee5dd157b6055b34b88661
+Directory: 5.26.11/bullseye/enterprise
 
-Tags: 5.26.10-community-ubi9, 5.26-community-ubi9, 5-community-ubi9, 5.26.10-ubi9, 5.26-ubi9, 5-ubi9
+Tags: 5.26.11-community-ubi9, 5.26-community-ubi9, 5-community-ubi9, 5.26.11-ubi9, 5.26-ubi9, 5-ubi9
 Architectures: amd64, arm64v8
-GitCommit: 26ed3b6bcf5b8141ec4641a6822688142d3e7f80
-Directory: 5.26.10/ubi9/community
+GitCommit: 235ccdb26ebbae0520ee5dd157b6055b34b88661
+Directory: 5.26.11/ubi9/community
 
-Tags: 5.26.10-enterprise-ubi9, 5.26-enterprise-ubi9, 5-enterprise-ubi9
+Tags: 5.26.11-enterprise-ubi9, 5.26-enterprise-ubi9, 5-enterprise-ubi9
 Architectures: amd64, arm64v8
-GitCommit: 26ed3b6bcf5b8141ec4641a6822688142d3e7f80
-Directory: 5.26.10/ubi9/enterprise
+GitCommit: 235ccdb26ebbae0520ee5dd157b6055b34b88661
+Directory: 5.26.11/ubi9/enterprise
 
 
 


### PR DESCRIPTION
Hi there,
Here is the new release for our 5.26 image, named 5.26.11. 