### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/a842bfea737b1127a922a27d768df7e382f740af/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/58af1a21e095e94e24b02350d0dbbc3d7f0a62ba/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -6,14 +6,14 @@ GitRepo: https://github.com/docker-library/gcc.git
 
 # Last Modified: 2025-08-08
 Tags: 15.2.0, 15.2, 15, latest, 15.2.0-trixie, 15.2-trixie, 15-trixie, trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 915af5ccbb6b09575e244f280c26925e77172039
 Directory: 15
 # Docker EOL: 2027-02-08
 
 # Last Modified: 2025-05-23
 Tags: 14.3.0, 14.3, 14, 14.3.0-trixie, 14.3-trixie, 14-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 280306a58a2ff0c21a95ed8abe882ac483d03c8b
 Directory: 14
 # Docker EOL: 2026-11-23


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/58af1a2: Remove support for riscv64 (builds too slowly, so builds never finish)
- https://github.com/docker-library/gcc/commit/c9d547e: Pin 12 & 13 to bookworm (trixie has gcc 14, thus ABI breakage abounds for older versions)