### PR TITLE
Releasing neo4j 2025.08.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -4,25 +4,25 @@ Maintainers: Jenny Owen <jenny.owen@neo4j.com> (@jennyowen),
              Nedeljko Cvejic <nedeljko.cvejic@neo4j.com> (@nedeljko-cvejic)
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
-Tags: 2025.07.1-community-bullseye, 2025.07-community-bullseye, 2025-community-bullseye, 2025.07.1-community, 2025.07-community, 2025-community, 2025.07.1-bullseye, 2025.07-bullseye, 2025-bullseye, 2025.07.1, 2025.07, 2025, community-bullseye, community, bullseye, latest
+Tags: 2025.08.0-community-bullseye, 2025.08-community-bullseye, 2025-community-bullseye, 2025.08.0-community, 2025.08-community, 2025-community, 2025.08.0-bullseye, 2025.08-bullseye, 2025-bullseye, 2025.08.0, 2025.08, 2025, community-bullseye, community, bullseye, latest
 Architectures: amd64, arm64v8
-GitCommit: b9617865dd142ab65f5d8199a670f4e63b56fdc8
-Directory: 2025.07.1/bullseye/community
+GitCommit: 2f82a0e5580ff8b044d4835a79fb384e90f77e4f
+Directory: 2025.08.0/bullseye/community
 
-Tags: 2025.07.1-enterprise-bullseye, 2025.07-enterprise-bullseye, 2025-enterprise-bullseye, 2025.07.1-enterprise, 2025.07-enterprise, 2025-enterprise, enterprise-bullseye, enterprise
+Tags: 2025.08.0-enterprise-bullseye, 2025.08-enterprise-bullseye, 2025-enterprise-bullseye, 2025.08.0-enterprise, 2025.08-enterprise, 2025-enterprise, enterprise-bullseye, enterprise
 Architectures: amd64, arm64v8
-GitCommit: b9617865dd142ab65f5d8199a670f4e63b56fdc8
-Directory: 2025.07.1/bullseye/enterprise
+GitCommit: 2f82a0e5580ff8b044d4835a79fb384e90f77e4f
+Directory: 2025.08.0/bullseye/enterprise
 
-Tags: 2025.07.1-community-ubi9, 2025.07-community-ubi9, 2025-community-ubi9, 2025.07.1-ubi9, 2025.07-ubi9, 2025-ubi9, community-ubi9, ubi9
+Tags: 2025.08.0-community-ubi9, 2025.08-community-ubi9, 2025-community-ubi9, 2025.08.0-ubi9, 2025.08-ubi9, 2025-ubi9, community-ubi9, ubi9
 Architectures: amd64, arm64v8
-GitCommit: b9617865dd142ab65f5d8199a670f4e63b56fdc8
-Directory: 2025.07.1/ubi9/community
+GitCommit: 2f82a0e5580ff8b044d4835a79fb384e90f77e4f
+Directory: 2025.08.0/ubi9/community
 
-Tags: 2025.07.1-enterprise-ubi9, 2025.07-enterprise-ubi9, 2025-enterprise-ubi9, enterprise-ubi9
+Tags: 2025.08.0-enterprise-ubi9, 2025.08-enterprise-ubi9, 2025-enterprise-ubi9, enterprise-ubi9
 Architectures: amd64, arm64v8
-GitCommit: b9617865dd142ab65f5d8199a670f4e63b56fdc8
-Directory: 2025.07.1/ubi9/enterprise
+GitCommit: 2f82a0e5580ff8b044d4835a79fb384e90f77e4f
+Directory: 2025.08.0/ubi9/enterprise
 
 
 

--- a/library/neo4j
+++ b/library/neo4j
@@ -48,12 +48,12 @@ Directory: 5.26.11/ubi9/enterprise
 
 
 
-Tags: 4.4.44, 4.4.44-community, 4.4, 4.4-community
+Tags: 4.4.45, 4.4.45-community, 4.4, 4.4-community
 Architectures: amd64, arm64v8
-GitCommit: a0fc315f717639f19237bffd1ef1b9b4ecab4182
-Directory: 4.4.44/bullseye/community
+GitCommit: ad97122c1c0883832851bf30d1cddc51ee5bafb3
+Directory: 4.4.45/bullseye/community
 
-Tags: 4.4.44-enterprise, 4.4-enterprise
+Tags: 4.4.45-enterprise, 4.4-enterprise
 Architectures: amd64, arm64v8
-GitCommit: a0fc315f717639f19237bffd1ef1b9b4ecab4182
-Directory: 4.4.44/bullseye/enterprise
+GitCommit: ad97122c1c0883832851bf30d1cddc51ee5bafb3
+Directory: 4.4.45/bullseye/enterprise


### PR DESCRIPTION
Here is our new calver release, named 2025.08.0.
Thanks!