### PR TITLE
Update phpMyAdmin image Architectures

### DIFF
--- a/library/phpmyadmin
+++ b/library/phpmyadmin
@@ -1,19 +1,19 @@
-# This file is generated via https://github.com/phpmyadmin/docker/blob/272944cc5a10f7740acacbe2a35c2c1f6d9a98c7/generate-stackbrew-library.sh
+# This file is generated via https://github.com/phpmyadmin/docker/blob/0c64340e5d8cbae534b84c4820e0f38d28f44081/generate-stackbrew-library.sh
 Maintainers: Isaac Bennetch <bennetch@gmail.com> (@ibennetch),
              William Desportes <williamdes@wdes.fr> (@williamdes)
 GitRepo: https://github.com/phpmyadmin/docker.git
 
 Tags: 5.2.2-apache, 5.2-apache, 5-apache, apache, 5.2.2, 5.2, 5, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 188a0e35423fb615db47e6a0a8209fe7288eb2ed
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 24c2f1f855bfa93c9c2640261f601620bf312f17
 Directory: apache
 
 Tags: 5.2.2-fpm, 5.2-fpm, 5-fpm, fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 188a0e35423fb615db47e6a0a8209fe7288eb2ed
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 24c2f1f855bfa93c9c2640261f601620bf312f17
 Directory: fpm
 
 Tags: 5.2.2-fpm-alpine, 5.2-fpm-alpine, 5-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 216be795f7a1a60c2c27ff5d00b5c8476771e1d1
+GitCommit: 24c2f1f855bfa93c9c2640261f601620bf312f17
 Directory: fpm-alpine


### PR DESCRIPTION
Ref: https://github.com/docker-library/official-images/pull/19660#issuecomment-3198610715

And updates `ENV` statements syntax: https://github.com/phpmyadmin/docker/commit/24c2f1f855bfa93c9c2640261f601620bf312f17