### PR TITLE
mediawiki: Upgrade to acpu 5.1.27

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,7 +3,7 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: cab2f393566610279ba8ed3288d25b72db90c735
+GitCommit: 8d5915f6b11612e3eed4f7e00ddc8288e4c5e267
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version


### PR DESCRIPTION
Related to https://github.com/wikimedia/mediawiki-docker/pull/158