### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.0.6, 6.0, 6, latest
+Tags: 6.0.7, 6.0, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 6290e8d21bdd45e71987936e4914ee3d3e15b9b2
+GitCommit: 07fb1d525e27f6ac95daf65eb00fc91f380e92c5
 Directory: 6/debian
 
-Tags: 6.0.6-alpine, 6.0-alpine, 6-alpine, alpine
+Tags: 6.0.7-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 6290e8d21bdd45e71987936e4914ee3d3e15b9b2
+GitCommit: 07fb1d525e27f6ac95daf65eb00fc91f380e92c5
 Directory: 6/alpine
 
 Tags: 5.130.4, 5.130, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/07fb1d5: Update to 6.0.7, ghost-cli 1.28.3