### PR TITLE
Updated 2025.07-rc Debian images to Debian 13 (Trixie)

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -35,16 +35,16 @@ GitCommit: e56ad74382f7d3f3fcfb5942bb39d2e7d5b27343
 Directory: 2025.02-dev/fpm-alpine
 
 Tags: 2025.07-rc-apache, rc-apache, 2025.07-rc, rc
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a78ba574557f23b522d0379c3af05bddfb57b4fc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: fe4374468345b2ddaedbb075f80b2b810e3ef6af
 Directory: 2025.07-rc/apache
 
 Tags: 2025.07-rc-fpm, rc-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a78ba574557f23b522d0379c3af05bddfb57b4fc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: fe4374468345b2ddaedbb075f80b2b810e3ef6af
 Directory: 2025.07-rc/fpm
 
 Tags: 2025.07-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a78ba574557f23b522d0379c3af05bddfb57b4fc
+GitCommit: fe4374468345b2ddaedbb075f80b2b810e3ef6af
 Directory: 2025.07-rc/fpm-alpine


### PR DESCRIPTION
Updated 2025.07-rc Debian images to Debian 13 (Trixie)