### PR TITLE
Update Debian (esp. for 13.1, 12.12)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -7,34 +7,34 @@ GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
 GitCommit: 7935fc7dd049cb343df42037c152f570069d274f
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: abafad7e06a0b9b4d694544168ea5d73c5f3b3a0
+amd64-GitCommit: 875d8cd35082521d449942a5fc0769ea216a1b87
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 922fcd185d679f4746a5c19edadd83f4e2645994
+arm32v5-GitCommit: 86d8fff614d8dfa8d1a40ccec375a2bdf1181760
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 2c372cdba888c303bdae9b8ff333f3efff906f4d
+arm32v7-GitCommit: ab01951075b83da00a545fde031841d23577ced4
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1645447bf7fe5b9b2ff4303b9297b7e30d6e2e4f
+arm64v8-GitCommit: 2dfb94bd326fba1c1463b5d7e32cc56d1312f3f9
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 2658ec3a0e2e8c92e1c4fe6bbc646e14eabcb74d
+i386-GitCommit: fa82d0c45894b27f77c510b12e9f798670cc3512
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-mips64le
 mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 7d6b56071f6e0aa6fd002b5da57834ee1d14fa93
+mips64le-GitCommit: 5cec53d14e925faf0d26e3e71eb5b70104a9572f
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 4bc37747be83ace401d8bd9a15ad21c187b3b197
+ppc64le-GitCommit: ed5dd4ef1b4e8c8fe4bddd461f12911b1ef764af
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: a040e0113fd188e7a04d108cf0d4f00aa2af49f8
+riscv64-GitCommit: 8b103a8463d7f66830a046809026c3f0b464c1bc
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 25a7f5460e97647be5b7011633a5a44bf0c87059
+s390x-GitCommit: 6b81e138b2d049444f0eb0e14089f079ccb25873
 
-# bookworm -- Debian 12.11 Released 17 May 2025
-Tags: bookworm, bookworm-20250811, 12.11, 12
+# bookworm -- Debian 12.12 Released 06 September 2025
+Tags: bookworm, bookworm-20250908, 12.12, 12
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Builder: oci-import
 Directory: bookworm/oci
@@ -44,62 +44,62 @@ Tags: bookworm-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: bookworm/backports
 
-Tags: bookworm-slim, bookworm-20250811-slim, 12.11-slim, 12-slim
+Tags: bookworm-slim, bookworm-20250908-slim, 12.12-slim, 12-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Builder: oci-import
 Directory: bookworm/slim/oci
 File: index.json
 
 # bullseye -- Debian 11.11 Released 31 August 2024
-Tags: bullseye, bullseye-20250811, 11.11, 11
+Tags: bullseye, bullseye-20250908, 11.11, 11
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: bullseye/oci
 File: index.json
 
-Tags: bullseye-slim, bullseye-20250811-slim, 11.11-slim, 11-slim
+Tags: bullseye-slim, bullseye-20250908-slim, 11.11-slim, 11-slim
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: bullseye/slim/oci
 File: index.json
 
 # experimental -- Experimental packages - not released; use at your own risk.
-Tags: experimental, experimental-20250811
+Tags: experimental, experimental-20250908
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 Directory: experimental
 
 # forky -- Debian x.y Testing distribution - Not Released
-Tags: forky, forky-20250811
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Tags: forky, forky-20250908
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: forky/oci
 File: index.json
 
 Tags: forky-backports
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: forky/backports
 
-Tags: forky-slim, forky-20250811-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Tags: forky-slim, forky-20250908-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: forky/slim/oci
 File: index.json
 
 # oldoldstable -- Debian 11.11 Released 31 August 2024
-Tags: oldoldstable, oldoldstable-20250811
+Tags: oldoldstable, oldoldstable-20250908
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: oldoldstable/oci
 File: index.json
 
-Tags: oldoldstable-slim, oldoldstable-20250811-slim
+Tags: oldoldstable-slim, oldoldstable-20250908-slim
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: oldoldstable/slim/oci
 File: index.json
 
-# oldstable -- Debian 12.11 Released 17 May 2025
-Tags: oldstable, oldstable-20250811
+# oldstable -- Debian 12.12 Released 06 September 2025
+Tags: oldstable, oldstable-20250908
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Builder: oci-import
 Directory: oldstable/oci
@@ -109,32 +109,32 @@ Tags: oldstable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Directory: oldstable/backports
 
-Tags: oldstable-slim, oldstable-20250811-slim
+Tags: oldstable-slim, oldstable-20250908-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 Builder: oci-import
 Directory: oldstable/slim/oci
 File: index.json
 
 # rc-buggy -- Experimental packages - not released; use at your own risk.
-Tags: rc-buggy, rc-buggy-20250811
+Tags: rc-buggy, rc-buggy-20250908
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 Directory: rc-buggy
 
 # sid -- Debian x.y Unstable - Not Released
-Tags: sid, sid-20250811
+Tags: sid, sid-20250908
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: sid/oci
 File: index.json
 
-Tags: sid-slim, sid-20250811-slim
+Tags: sid-slim, sid-20250908-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: sid/slim/oci
 File: index.json
 
-# stable -- Debian 13.0 Released 09 August 2025
-Tags: stable, stable-20250811
+# stable -- Debian 13.1 Released 06 September 2025
+Tags: stable, stable-20250908
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: stable/oci
@@ -144,31 +144,31 @@ Tags: stable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: stable/backports
 
-Tags: stable-slim, stable-20250811-slim
+Tags: stable-slim, stable-20250908-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: stable/slim/oci
 File: index.json
 
 # testing -- Debian x.y Testing distribution - Not Released
-Tags: testing, testing-20250811
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Tags: testing, testing-20250908
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: testing/oci
 File: index.json
 
 Tags: testing-backports
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: testing/backports
 
-Tags: testing-slim, testing-20250811-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Tags: testing-slim, testing-20250908-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: testing/slim/oci
 File: index.json
 
-# trixie -- Debian 13.0 Released 09 August 2025
-Tags: trixie, trixie-20250811, 13.0, 13, latest
+# trixie -- Debian 13.1 Released 06 September 2025
+Tags: trixie, trixie-20250908, 13.1, 13, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: trixie/oci
@@ -178,20 +178,20 @@ Tags: trixie-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: trixie/backports
 
-Tags: trixie-slim, trixie-20250811-slim, 13.0-slim, 13-slim
+Tags: trixie-slim, trixie-20250908-slim, 13.1-slim, 13-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: trixie/slim/oci
 File: index.json
 
 # unstable -- Debian x.y Unstable - Not Released
-Tags: unstable, unstable-20250811
+Tags: unstable, unstable-20250908
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: unstable/oci
 File: index.json
 
-Tags: unstable-slim, unstable-20250811-slim
+Tags: unstable-slim, unstable-20250908-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: unstable/slim/oci


### PR DESCRIPTION
https://lists.debian.org/debian-devel-announce/2025/09/msg00001.html

> armel removal from forky
> ------------------------
> 
> The armel architecture has now been removed from the forky suite. This
> port supported very old ARM systems without hardware floating-point,
> such as early plug computers and NAS devices.
> 
> As development effort increasingly focuses on newer ARM hardware (armhf
> and arm64), armel is no longer part of forky.

(In short, no more `arm32v5` for `testing`/`forky`, and possibly eventually removed from `unstable` as well.)