### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -6,25 +6,25 @@ GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 5.0.5, 5.0, 5, latest, 5.0.5-jammy, 5.0-jammy, 5-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: da543c94df2e77fbbc83023c3259527aec45ec12
+GitCommit: e91994ea673c47d987bfc08c5eeee8d8fdc1ab82
 Directory: 5.0
 
 Tags: 4.1.10, 4.1, 4, 4.1.10-jammy, 4.1-jammy, 4-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: efc59fdd09c2ed4dcde420064eb0223898d77fb2
+GitCommit: e91994ea673c47d987bfc08c5eeee8d8fdc1ab82
 Directory: 4.1
 
 Tags: 4.0.18, 4.0, 4.0.18-jammy, 4.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: b4b0579f68b8dfbffb61a438c8aaad14fccf44c4
+GitCommit: e91994ea673c47d987bfc08c5eeee8d8fdc1ab82
 Directory: 4.0
 
 Tags: 3.11.19, 3.11, 3, 3.11.19-jammy, 3.11-jammy, 3-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
+GitCommit: e91994ea673c47d987bfc08c5eeee8d8fdc1ab82
 Directory: 3.11
 
 Tags: 3.0.32, 3.0, 3.0.32-jammy, 3.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4acdd8cbbc6f21083e9b8176452a2728fa08f2c7
+GitCommit: e91994ea673c47d987bfc08c5eeee8d8fdc1ab82
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/e91994e: Update gosu to 1.18