### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -7,20 +7,20 @@ GitRepo: https://github.com/docker-library/ghost.git
 
 Tags: 6.0.7, 6.0, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 07fb1d525e27f6ac95daf65eb00fc91f380e92c5
+GitCommit: 5d6813c52f8b6117d3bb694854ec3a92c0b23b56
 Directory: 6/debian
 
 Tags: 6.0.7-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 07fb1d525e27f6ac95daf65eb00fc91f380e92c5
+GitCommit: 5d6813c52f8b6117d3bb694854ec3a92c0b23b56
 Directory: 6/alpine
 
 Tags: 5.130.4, 5.130, 5
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 75d682ae014b696d78e0300a6bada92668ea479a
+GitCommit: 5d6813c52f8b6117d3bb694854ec3a92c0b23b56
 Directory: 5/debian
 
 Tags: 5.130.4-alpine, 5.130-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 75d682ae014b696d78e0300a6bada92668ea479a
+GitCommit: 5d6813c52f8b6117d3bb694854ec3a92c0b23b56
 Directory: 5/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/5d6813c: Update gosu to 1.18