### PR TITLE
Odoo: update 16.0-18.0 to release 20250909

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 0461e8225b4aee856cc74d893c89cb4e3c6d43f1
+GitCommit: 5229f719d751ea7f375f48b8ba8483894d04ab63
 
-Tags: 18.0-20250819, 18.0, 18, latest
+Tags: 18.0-20250909, 18.0, 18, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250819, 17.0, 17
+Tags: 17.0-20250909, 17.0, 17
 Architectures: amd64, arm64v8, ppc64le
 Directory: 17.0
 
-Tags: 16.0-20250819, 16.0, 16
+Tags: 16.0-20250909, 16.0, 16
 Architectures: amd64, arm64v8
 Directory: 16.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks