### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2025-15099 ELSA-2025-15019"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fec6de9e14b525e3738f9b622d4f6f5093c2b123
+amd64-GitCommit: b20ed0327b3c0ec59da250f978fa76d37379cd83
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f1620f0ec65d70b12481e59aa79719f155606a3d
+arm64v8-GitCommit: f9a4ec3004d9bd65dfceb69f2c818d68af5369ef
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6020, CVE-2025-8941, CVE-2025-8194, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-15099.html
https://linux.oracle.com/errata/ELSA-2025-15019.html

Signed-off-by: Mark Will <mark.will@oracle.com>
