### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,49 +4,49 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 6.0.0-beta1, 6.0, 6.0.beta, 6.0.0-beta, 6.0.0-beta1-apache, 6.0-apache, 6.0.beta-apache, 6.0.0-beta-apache, 6.0.0-beta1-php8.3, 6.0-php8.3, 6.0.beta-php8.3, 6.0.0-beta-php8.3, 6.0.0-beta1-php8.3-apache, 6.0-php8.3-apache, 6.0.beta-php8.3-apache, 6.0.0-beta-php8.3-apache
+Tags: 6.0.0-beta2, 6.0, 6.0.beta, 6.0.0-beta, 6.0.0-beta2-apache, 6.0-apache, 6.0.beta-apache, 6.0.0-beta-apache, 6.0.0-beta2-php8.3, 6.0-php8.3, 6.0.beta-php8.3, 6.0.0-beta-php8.3, 6.0.0-beta2-php8.3-apache, 6.0-php8.3-apache, 6.0.beta-php8.3-apache, 6.0.0-beta-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 6.0.beta/php8.3/apache
 
-Tags: 6.0.0-beta1-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.beta-php8.3-fpm-alpine, 6.0.0-beta-php8.3-fpm-alpine
+Tags: 6.0.0-beta2-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.beta-php8.3-fpm-alpine, 6.0.0-beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 6.0.beta/php8.3/fpm-alpine
 
-Tags: 6.0.0-beta1-php8.3-fpm, 6.0-php8.3-fpm, 6.0.beta-php8.3-fpm, 6.0.0-beta-php8.3-fpm
+Tags: 6.0.0-beta2-php8.3-fpm, 6.0-php8.3-fpm, 6.0.beta-php8.3-fpm, 6.0.0-beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 6.0.beta/php8.3/fpm
 
-Tags: 5.4.0-beta1-php8.2-apache, 5.4-php8.2-apache, 5.4.beta-php8.2-apache, 5.4.0-beta-php8.2-apache
+Tags: 5.4.0-beta2-php8.2-apache, 5.4-php8.2-apache, 5.4.beta-php8.2-apache, 5.4.0-beta-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 5.4.beta/php8.2/apache
 
-Tags: 5.4.0-beta1-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.beta-php8.2-fpm-alpine, 5.4.0-beta-php8.2-fpm-alpine
+Tags: 5.4.0-beta2-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.beta-php8.2-fpm-alpine, 5.4.0-beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 5.4.beta/php8.2/fpm-alpine
 
-Tags: 5.4.0-beta1-php8.2-fpm, 5.4-php8.2-fpm, 5.4.beta-php8.2-fpm, 5.4.0-beta-php8.2-fpm
+Tags: 5.4.0-beta2-php8.2-fpm, 5.4-php8.2-fpm, 5.4.beta-php8.2-fpm, 5.4.0-beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 5.4.beta/php8.2/fpm
 
-Tags: 5.4.0-beta1, 5.4, 5.4.beta, 5.4.0-beta, 5.4.0-beta1-apache, 5.4-apache, 5.4.beta-apache, 5.4.0-beta-apache, 5.4.0-beta1-php8.3, 5.4-php8.3, 5.4.beta-php8.3, 5.4.0-beta-php8.3, 5.4.0-beta1-php8.3-apache, 5.4-php8.3-apache, 5.4.beta-php8.3-apache, 5.4.0-beta-php8.3-apache
+Tags: 5.4.0-beta2, 5.4, 5.4.beta, 5.4.0-beta, 5.4.0-beta2-apache, 5.4-apache, 5.4.beta-apache, 5.4.0-beta-apache, 5.4.0-beta2-php8.3, 5.4-php8.3, 5.4.beta-php8.3, 5.4.0-beta-php8.3, 5.4.0-beta2-php8.3-apache, 5.4-php8.3-apache, 5.4.beta-php8.3-apache, 5.4.0-beta-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 5.4.beta/php8.3/apache
 
-Tags: 5.4.0-beta1-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.beta-php8.3-fpm-alpine, 5.4.0-beta-php8.3-fpm-alpine
+Tags: 5.4.0-beta2-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.beta-php8.3-fpm-alpine, 5.4.0-beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 5.4.beta/php8.3/fpm-alpine
 
-Tags: 5.4.0-beta1-php8.3-fpm, 5.4-php8.3-fpm, 5.4.beta-php8.3-fpm, 5.4.0-beta-php8.3-fpm
+Tags: 5.4.0-beta2-php8.3-fpm, 5.4-php8.3-fpm, 5.4.beta-php8.3-fpm, 5.4.0-beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fec384fc4c6079b429ca7dbb5799e45cab66220
+GitCommit: bcd2a5e3ad4f979e1e39149bf94e986f63fce1ac
 Directory: 5.4.beta/php8.3/fpm
 
 Tags: 5.3.3-php8.1-apache, 5.3-php8.1-apache, 5-php8.1-apache, php8.1-apache


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@bcd2a5e: Update Joomla 5.4.0-beta1 to 5.4.0-beta2 and 6.0.0-beta1 to 6.0.0-beta2