### PR TITLE
"[oraclelinux] Updating 10 for ELSA-2025-14984"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b20ed0327b3c0ec59da250f978fa76d37379cd83
+amd64-GitCommit: d357fef6b2db2125c23debd3f32930acf21924c2
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f9a4ec3004d9bd65dfceb69f2c818d68af5369ef
+arm64v8-GitCommit: e49ce307d68443f836bb812c323002995d7c6222
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-8194, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-14984.html

Signed-off-by: Mark Will <mark.will@oracle.com>
