### PR TITLE
Update clojure to remove git from lein variants

### DIFF
--- a/library/clojure
+++ b/library/clojure
@@ -2,7 +2,7 @@ Maintainers: Paul Lam <paul@quantisan.com> (@Quantisan),
              Wes Morgan <wes@wesmorgan.me> (@cap10morgan)
 Architectures: riscv64, arm64v8, ppc64le, amd64, s390x
 GitRepo: https://github.com/Quantisan/docker-clojure.git
-GitCommit: 31ec9d8356409b27b68fb1dde7016f09d6776c89
+GitCommit: 65ac72665e7d872a3adeb476f04ae9c759298a22
 
 
 Tags: latest


### PR DESCRIPTION
As requested by the community: https://github.com/Quantisan/docker-clojure/issues/258