### PR TITLE
archlinux: Release 20250914.0.420821

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250907.0.417472
-GitCommit: 0839d1f828eda0827f1174e222caf0c785dbb2c6
-GitFetch: refs/tags/v20250907.0.417472
+Tags: latest, base, base-20250914.0.420821
+GitCommit: c2ce6ada2ff5025a64770a0697cbc55da0ae9042
+GitFetch: refs/tags/v20250914.0.420821
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250907.0.417472
-GitCommit: 0839d1f828eda0827f1174e222caf0c785dbb2c6
-GitFetch: refs/tags/v20250907.0.417472
+Tags: base-devel, base-devel-20250914.0.420821
+GitCommit: c2ce6ada2ff5025a64770a0697cbc55da0ae9042
+GitFetch: refs/tags/v20250914.0.420821
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250907.0.417472
-GitCommit: 0839d1f828eda0827f1174e222caf0c785dbb2c6
-GitFetch: refs/tags/v20250907.0.417472
+Tags: multilib-devel, multilib-devel-20250914.0.420821
+GitCommit: c2ce6ada2ff5025a64770a0697cbc55da0ae9042
+GitFetch: refs/tags/v20250914.0.420821
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks