### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -35,17 +35,17 @@ GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: debian/bullseye
 
 Tags: forky-curl, testing-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 6fbd1fd6aa17031b10f11a97c31b9da1ac09db76
 Directory: debian/forky/curl
 
 Tags: forky-scm, testing-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 6fbd1fd6aa17031b10f11a97c31b9da1ac09db76
 Directory: debian/forky/scm
 
 Tags: forky, testing
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 6fbd1fd6aa17031b10f11a97c31b9da1ac09db76
 Directory: debian/forky
 


### PR DESCRIPTION
https://github.com/docker-library/official-images/pull/19823

> (In short, no more `arm32v5` for `testing`/`forky`, and possibly eventually removed from `unstable` as well.)