### PR TITLE
Odoo: Add Odoo 19.0

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5229f719d751ea7f375f48b8ba8483894d04ab63
+GitCommit: 9404592737f4a58dade648ba2c9c35de1feb2fb4
 
-Tags: 18.0-20250909, 18.0, 18, latest
+Tags: 19.0-20250918, 19.0, 19, latest
+Architectures: amd64, arm64v8, ppc64le
+Directory: 19.0
+
+Tags: 18.0-20250918, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250909, 17.0, 17
-Architectures: amd64, arm64v8, ppc64le
-Directory: 17.0
-
-Tags: 16.0-20250909, 16.0, 16
+Tags: 17.0-20250918, 17.0, 17
 Architectures: amd64, arm64v8
-Directory: 16.0
+Directory: 17.0
 


### PR DESCRIPTION
Hello,

This PR 

- adds Odoo latest version 19.0
- removes Odoo 16.0
- updates 17.0-18.0 to release 20250918

Thanks