### PR TITLE
chore(rust): Update Rust version to 1.90.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,52 +1,52 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/4a8b913f00f3a52547c2c6e9487e0b5d5aecabbf/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/3aad80112be66bf796c202713029d7ba93dff7fa/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.89-bullseye, 1.89.0-bullseye, bullseye
+Tags: 1-bullseye, 1.90-bullseye, 1.90.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.89-slim-bullseye, 1.89.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.90-slim-bullseye, 1.90.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.89-bookworm, 1.89.0-bookworm, bookworm
+Tags: 1-bookworm, 1.90-bookworm, 1.90.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.89-slim-bookworm, 1.89.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.90-slim-bookworm, 1.90.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.89-trixie, 1.89.0-trixie, trixie, 1, 1.89, 1.89.0, latest
+Tags: 1-trixie, 1.90-trixie, 1.90.0-trixie, trixie, 1, 1.90, 1.90.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 4a8b913f00f3a52547c2c6e9487e0b5d5aecabbf
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.89-slim-trixie, 1.89.0-slim-trixie, slim-trixie, 1-slim, 1.89-slim, 1.89.0-slim, slim
+Tags: 1-slim-trixie, 1.90-slim-trixie, 1.90.0-slim-trixie, slim-trixie, 1-slim, 1.90-slim, 1.90.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 4a8b913f00f3a52547c2c6e9487e0b5d5aecabbf
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.20, 1.89-alpine3.20, 1.89.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.90-alpine3.20, 1.90.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.89-alpine3.21, 1.89.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.90-alpine3.21, 1.90.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.89-alpine3.22, 1.89.0-alpine3.22, alpine3.22, 1-alpine, 1.89-alpine, 1.89.0-alpine, alpine
+Tags: 1-alpine3.22, 1.90-alpine3.22, 1.90.0-alpine3.22, alpine3.22, 1-alpine, 1.90-alpine, 1.90.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 97d440079ab3d6dc6895557f7a2a13c7280c5521
+GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
 Directory: stable/alpine3.22
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.90.0
https://blog.rust-lang.org/2025/09/18/Rust-1.90.0/