### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/wordpress/blob/9e96b4488a3289a74cee97dae955dfe03aece0ad/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/wordpress/blob/c8b214cc10dae78c4a7c9e1d98ee104e0f027441/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -19,32 +19,32 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.1/fpm-alpine
 
-Tags: 6.8.2-apache, 6.8-apache, 6-apache, apache, 6.8.2, 6.8, 6, latest, 6.8.2-php8.2-apache, 6.8-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.8.2-php8.2, 6.8-php8.2, 6-php8.2, php8.2
+Tags: 6.8.2-php8.2-apache, 6.8-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.8.2-php8.2, 6.8-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.2/apache
 
-Tags: 6.8.2-fpm, 6.8-fpm, 6-fpm, fpm, 6.8.2-php8.2-fpm, 6.8-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.8.2-php8.2-fpm, 6.8-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.2/fpm
 
-Tags: 6.8.2-fpm-alpine, 6.8-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.8.2-php8.2-fpm-alpine, 6.8-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.8.2-php8.2-fpm-alpine, 6.8-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.8.2-php8.3-apache, 6.8-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.8.2-php8.3, 6.8-php8.3, 6-php8.3, php8.3
+Tags: 6.8.2-apache, 6.8-apache, 6-apache, apache, 6.8.2, 6.8, 6, latest, 6.8.2-php8.3-apache, 6.8-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.8.2-php8.3, 6.8-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.3/apache
 
-Tags: 6.8.2-php8.3-fpm, 6.8-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.8.2-fpm, 6.8-fpm, 6-fpm, fpm, 6.8.2-php8.3-fpm, 6.8-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.3/fpm
 
-Tags: 6.8.2-php8.3-fpm-alpine, 6.8-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.8.2-fpm-alpine, 6.8-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.8.2-php8.3-fpm-alpine, 6.8-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: cb4dee629a6dbc942cb218f3d8516e71eb13b27e
 Directory: latest/php8.3/fpm-alpine
@@ -69,12 +69,12 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.1/alpine
 
-Tags: cli-2.12.0, cli-2.12, cli-2, cli, cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
+Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.2/alpine
 
-Tags: cli-2.12.0-php8.3, cli-2.12-php8.3, cli-2-php8.3, cli-php8.3
+Tags: cli-2.12.0, cli-2.12, cli-2, cli, cli-2.12.0-php8.3, cli-2.12-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
 Directory: cli/php8.3/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/7a04048: Merge pull request https://github.com/docker-library/wordpress/pull/981 from infosiftr/php8.3
- https://github.com/docker-library/wordpress/commit/c8b214c: Update default PHP to 8.3