### PR TITLE
Use the new YAML anchors support to DRY up our bashbrew version

### DIFF
--- a/.github/workflows/.bashbrew/action.yml
+++ b/.github/workflows/.bashbrew/action.yml
@@ -8,11 +8,14 @@ runs:
   using: 'composite'
   steps:
 
-    # these two version numbers are intentionally as close together as I could possibly get them because no matter what I tried, GitHub will not allow me to DRY them (can't have any useful variables in `uses:` and can't even have YAML references to steal it in `env:` or something)
-    - shell: 'bash -Eeuo pipefail -x {0}'
-      run:    echo BASHBREW_VERSION=v0.1.13 >> "$GITHUB_ENV"
-    - uses: docker-library/bashbrew@v0.1.13
+    - uses: &bb docker-library/bashbrew@v0.1.13
       if: inputs.build == 'host'
+
+    - shell: 'bash -Eeuo pipefail -x {0}'
+      env:
+        BB: *bb
+      run: |
+        echo "BASHBREW_VERSION=${BB##*@}" >> "$GITHUB_ENV"
 
     - run: docker build --pull --tag oisupport/bashbrew:base "https://github.com/docker-library/bashbrew.git#$BASHBREW_VERSION"
       shell: 'bash -Eeuo pipefail -x {0}'


### PR DESCRIPTION
This still isn't *ideal* because I'd rather have `uses:` be the dynamic value embedding a variable of bashbrew version, but parsing the version out of *that* value isn't horrible so if this works, I'll try to be satisfied.

https://github.blog/changelog/2025-09-18-actions-yaml-anchors-and-non-public-workflow-templates/