### PR TITLE
Updating to the Latest Release of Backdrop 1.32.0

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.31.0, 1.31, 1, 1.31.0-apache, 1.31-apache, 1-apache, apache, latest
+Tags: 1.32.0, 1.32, 1, 1.32.0-apache, 1.32-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 82f5f08f12c2e861cde61b7b4dac8ebd76f3ee1f
+GitCommit: c7b2ec4e51f6cd53fce2d04198130959b67cd0ec
 Directory: 1/apache
 
-Tags: 1.31.0-fpm, 1.31-fpm, 1-fpm, fpm
+Tags: 1.32.0-fpm, 1.32-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 82f5f08f12c2e861cde61b7b4dac8ebd76f3ee1f
+GitCommit: c7b2ec4e51f6cd53fce2d04198130959b67cd0ec
 Directory: 1/fpm


### PR DESCRIPTION
Update Backdrop CMS to 1.32.0
    
Here's the latest release of Backdrop:
https://github.com/backdrop/backdrop/releases/tag/1.32.0
    
Here's the latest commit to backdrop-docker repo
https://github.com/backdrop-ops/backdrop-docker/commits/master