### PR TITLE
[nats] Release v2.12.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: b486da9a110f9bffb40d23ec80238acc8b022fdd
+GitCommit: 73e42c1d77ec6e1981a0128de878759f6c960bc2
 GitFetch: refs/heads/main
 
-Tags: 2.11.9-alpine3.22, 2.11-alpine3.22, 2-alpine3.22, alpine3.22, 2.11.9-alpine, 2.11-alpine, 2-alpine, alpine
+Tags: 2.12.0-alpine3.22, 2.12-alpine3.22, 2-alpine3.22, alpine3.22, 2.12.0-alpine, 2.12-alpine, 2-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
+Directory: 2.12.x/alpine3.22
+
+Tags: 2.12.0-scratch, 2.12-scratch, 2-scratch, scratch, 2.12.0-linux, 2.12-linux, 2-linux, linux
+SharedTags: 2.12.0, 2.12, 2, latest
+Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
+Directory: 2.12.x/scratch
+
+Tags: 2.12.0-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.12.0-windowsservercore, 2.12-windowsservercore, 2-windowsservercore, windowsservercore
+Architectures: windows-amd64
+Directory: 2.12.x/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.12.0-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.12.0-nanoserver, 2.12-nanoserver, 2-nanoserver, nanoserver, 2.12.0, 2.12, 2, latest
+Architectures: windows-amd64
+Directory: 2.12.x/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 2.11.9-alpine3.22, 2.11-alpine3.22, 2.11.9-alpine, 2.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/alpine3.22
 
-Tags: 2.11.9-scratch, 2.11-scratch, 2-scratch, scratch, 2.11.9-linux, 2.11-linux, 2-linux, linux
-SharedTags: 2.11.9, 2.11, 2, latest
+Tags: 2.11.9-scratch, 2.11-scratch, 2.11.9-linux, 2.11-linux
+SharedTags: 2.11.9, 2.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.9-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.11.9-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.11.9-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
+SharedTags: 2.11.9-windowsservercore, 2.11-windowsservercore
 Architectures: windows-amd64
 Directory: 2.11.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.9-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.11.9-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver, 2.11.9, 2.11, 2, latest
+Tags: 2.11.9-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
+SharedTags: 2.11.9-nanoserver, 2.11-nanoserver, 2.11.9, 2.11
 Architectures: windows-amd64
 Directory: 2.11.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
More information here: https://github.com/nats-io/nats-server/releases/tag/v2.12.0