### PR TITLE
feat: Remove influxdb 1.10 from supported tags

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -36,18 +36,6 @@ Tags: 1.11-alpine, 1.11.8-alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/1.11/alpine
 
-Tags: 1.10-data, 1.10.8-data
-Directory: influxdb/1.10/data
-
-Tags: 1.10-data-alpine, 1.10.8-data-alpine
-Directory: influxdb/1.10/data/alpine
-
-Tags: 1.10-meta, 1.10.8-meta
-Directory: influxdb/1.10/meta
-
-Tags: 1.10-meta-alpine, 1.10.8-meta-alpine
-Directory: influxdb/1.10/meta/alpine
-
 Tags: 1.11-data, 1.11.8-data
 Directory: influxdb/1.11/data
 


### PR DESCRIPTION
After internal discussions we have decided to remove 1.10 from our supported dockerhub tags.