### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-16116"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d357fef6b2db2125c23debd3f32930acf21924c2
+amd64-GitCommit: ceaac006871c6de92428452d9279dbe09bb9de26
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e49ce307d68443f836bb812c323002995d7c6222
+arm64v8-GitCommit: 986f0034efc0eff43ac535eab8a3c3b8792e226a
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-32988, CVE-2025-32989, CVE-2025-32990, CVE-2025-6395, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-16116.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
