### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -4,61 +4,61 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
 
-Tags: 26-ea-15-jdk-oraclelinux9, 26-ea-15-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-15-jdk-oracle, 26-ea-15-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
-SharedTags: 26-ea-15-jdk, 26-ea-15, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-16-jdk-oraclelinux9, 26-ea-16-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-jdk-oraclelinux9, 26-oraclelinux9, 26-ea-16-jdk-oracle, 26-ea-16-oracle, 26-ea-jdk-oracle, 26-ea-oracle, 26-jdk-oracle, 26-oracle
+SharedTags: 26-ea-16-jdk, 26-ea-16, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: amd64, arm64v8
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/oraclelinux9
 
-Tags: 26-ea-15-jdk-oraclelinux8, 26-ea-15-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
+Tags: 26-ea-16-jdk-oraclelinux8, 26-ea-16-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8, 26-jdk-oraclelinux8, 26-oraclelinux8
 Architectures: amd64, arm64v8
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/oraclelinux8
 
-Tags: 26-ea-15-jdk-trixie, 26-ea-15-trixie, 26-ea-jdk-trixie, 26-ea-trixie, 26-jdk-trixie, 26-trixie
+Tags: 26-ea-16-jdk-trixie, 26-ea-16-trixie, 26-ea-jdk-trixie, 26-ea-trixie, 26-jdk-trixie, 26-trixie
 Architectures: amd64, arm64v8
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/trixie
 
-Tags: 26-ea-15-jdk-slim-trixie, 26-ea-15-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-jdk-slim-trixie, 26-slim-trixie, 26-ea-15-jdk-slim, 26-ea-15-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
+Tags: 26-ea-16-jdk-slim-trixie, 26-ea-16-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-jdk-slim-trixie, 26-slim-trixie, 26-ea-16-jdk-slim, 26-ea-16-slim, 26-ea-jdk-slim, 26-ea-slim, 26-jdk-slim, 26-slim
 Architectures: amd64, arm64v8
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/slim-trixie
 
-Tags: 26-ea-15-jdk-bookworm, 26-ea-15-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
+Tags: 26-ea-16-jdk-bookworm, 26-ea-16-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm, 26-jdk-bookworm, 26-bookworm
 Architectures: amd64, arm64v8
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/bookworm
 
-Tags: 26-ea-15-jdk-slim-bookworm, 26-ea-15-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm
+Tags: 26-ea-16-jdk-slim-bookworm, 26-ea-16-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm, 26-jdk-slim-bookworm, 26-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/slim-bookworm
 
-Tags: 26-ea-15-jdk-windowsservercore-ltsc2025, 26-ea-15-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
-SharedTags: 26-ea-15-jdk-windowsservercore, 26-ea-15-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-15-jdk, 26-ea-15, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-16-jdk-windowsservercore-ltsc2025, 26-ea-16-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025, 26-jdk-windowsservercore-ltsc2025, 26-windowsservercore-ltsc2025
+SharedTags: 26-ea-16-jdk-windowsservercore, 26-ea-16-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-16-jdk, 26-ea-16, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-15-jdk-windowsservercore-ltsc2022, 26-ea-15-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
-SharedTags: 26-ea-15-jdk-windowsservercore, 26-ea-15-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-15-jdk, 26-ea-15, 26-ea-jdk, 26-ea, 26-jdk, 26
+Tags: 26-ea-16-jdk-windowsservercore-ltsc2022, 26-ea-16-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022, 26-jdk-windowsservercore-ltsc2022, 26-windowsservercore-ltsc2022
+SharedTags: 26-ea-16-jdk-windowsservercore, 26-ea-16-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-jdk-windowsservercore, 26-windowsservercore, 26-ea-16-jdk, 26-ea-16, 26-ea-jdk, 26-ea, 26-jdk, 26
 Architectures: windows-amd64
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-15-jdk-nanoserver-ltsc2025, 26-ea-15-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
-SharedTags: 26-ea-15-jdk-nanoserver, 26-ea-15-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-16-jdk-nanoserver-ltsc2025, 26-ea-16-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025, 26-jdk-nanoserver-ltsc2025, 26-nanoserver-ltsc2025
+SharedTags: 26-ea-16-jdk-nanoserver, 26-ea-16-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-15-jdk-nanoserver-ltsc2022, 26-ea-15-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
-SharedTags: 26-ea-15-jdk-nanoserver, 26-ea-15-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
+Tags: 26-ea-16-jdk-nanoserver-ltsc2022, 26-ea-16-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022, 26-jdk-nanoserver-ltsc2022, 26-nanoserver-ltsc2022
+SharedTags: 26-ea-16-jdk-nanoserver, 26-ea-16-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver, 26-jdk-nanoserver, 26-nanoserver
 Architectures: windows-amd64
-GitCommit: d2503db56c29492e4cd034ad0abd93101063d6f8
+GitCommit: 93829cab56868eec605f6eda309de2c7a8de30c5
 Directory: 26/jdk/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/93829ca: Update 26 to 26-ea+16