### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.0.9, 6.0, 6, latest
+Tags: 6.0.10, 6.0, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f2d920fb0f79d8ea79950da700178d3070812923
+GitCommit: 28bbafd7a89f343e65e27ab07e1857db96731d73
 Directory: 6/debian
 
-Tags: 6.0.9-alpine, 6.0-alpine, 6-alpine, alpine
+Tags: 6.0.10-alpine, 6.0-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f2d920fb0f79d8ea79950da700178d3070812923
+GitCommit: 28bbafd7a89f343e65e27ab07e1857db96731d73
 Directory: 6/alpine
 
 Tags: 5.130.5, 5.130, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/28bbafd: Update to 6.0.10, ghost-cli 1.28.3