### PR TITLE
"[oraclelinux] Updating 10and 10-slim for ELSA-2025-16115"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ceaac006871c6de92428452d9279dbe09bb9de26
+amd64-GitCommit: b598dbcf38e3c1f75ba8807ab5e8099c8f8bb01a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 986f0034efc0eff43ac535eab8a3c3b8792e226a
+arm64v8-GitCommit: 334b173a74181ecf17ca5fa57dd5452582e130c5
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-32988, CVE-2025-32989, CVE-2025-32990, CVE-2025-6395, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-16115.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
