### PR TITLE
add @jungm as tomee maintainer

### DIFF
--- a/library/tomee
+++ b/library/tomee
@@ -1,4 +1,4 @@
-Maintainers: Alex Soto <asotobu@gmail.com> (@lordofthejars), Otavio Santana <otaviojava@apache.org> (@otaviojava), Jonathan Gallimore <jgallimore@apache.org> (@jgallimore), Rod Jenkins <rodj@rodandmichelle.com> (@scriptmonkey)
+Maintainers: Alex Soto <asotobu@gmail.com> (@lordofthejars), Otavio Santana <otaviojava@apache.org> (@otaviojava), Jonathan Gallimore <jgallimore@apache.org> (@jgallimore), Rod Jenkins <rodj@rodandmichelle.com> (@scriptmonkey), Markus Jung <jungm@apache.org> (@jungm)
 GitRepo: https://github.com/tomitribe/docker-tomee.git
 GitCommit: a413d6e6c081efad3874eecea6b93dd0a174ad92
 Architectures: amd64, arm64v8


### PR DESCRIPTION
I'm on the Apache TomEE PMC (see https://projects.apache.org/committee.html?tomee) and also have commit access to tomitribe/docker-tomee, so it would IMO only make sense to add myself as a maintainer for this image