### PR TITLE
Bring back NeuroDebian images for recent releases

### DIFF
--- a/library/neurodebian
+++ b/library/neurodebian
@@ -1,6 +1,6 @@
 Maintainers: Yaroslav Halchenko <debian@onerussian.com> (@yarikoptic)
 GitRepo: https://github.com/neurodebian/dockerfiles.git
-GitCommit: 2b928e45821cfe101eaccf18e597794b575b9174
+GitCommit: 763e5953e63f2e0f46d2304dfd6c2f051ca378ca
 
 Tags: jammy, nd22.04
 Architectures: amd64, arm64v8


### PR DESCRIPTION
I finally got time to attend to this to "completion".  I tried to affect only recent releases so that older ones still use older DSA1024 key, and newer ones the new RSA4096 one.

refs:
- https://github.com/neurodebian/dockerfiles/issues/18
- https://github.com/neurodebian/neurodebian/issues/97