### PR TITLE
release sonarqube 2025.5.0 2025.4.3 2025.1.4

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,72 +4,67 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2025.4.2-developer, 2025.4-developer, developer
+Tags: 2025.5.0-developer, 2025.5-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
+GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
 GitFetch: refs/heads/master
 
-Tags: 2025.4.2-enterprise, 2025.4-enterprise, enterprise
+Tags: 2025.5.0-enterprise, 2025.5-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
+GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
 GitFetch: refs/heads/master
 
-Tags: 2025.4.2-datacenter-app, 2025.4-datacenter-app, datacenter-app
+Tags: 2025.5.0-datacenter-app, 2025.5-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
+GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
 GitFetch: refs/heads/master
 
-Tags: 2025.4.2-datacenter-search, 2025.4-datacenter-search, datacenter-search
+Tags: 2025.5.0-datacenter-search, 2025.5-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
+GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
 GitFetch: refs/heads/master
 
-Tags: 2025.1.3-developer, 2025.1-developer, 2025-lta-developer
+Tags: 2025.4.3-developer, 2025.4-developer
 Directory: commercial-editions/developer
-GitCommit: 2a5b137d0669b87f7dfe6c295a5078d7d7c1aaaf
-GitFetch: refs/heads/release/2025.1
+GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.1.3-enterprise, 2025.1-enterprise, 2025-lta-enterprise
+Tags: 2025.4.3-enterprise, 2025.4-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 2a5b137d0669b87f7dfe6c295a5078d7d7c1aaaf
-GitFetch: refs/heads/release/2025.1
+GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.1.3-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app
+Tags: 2025.4.3-datacenter-app, 2025.4-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 2a5b137d0669b87f7dfe6c295a5078d7d7c1aaaf
+GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitFetch: refs/heads/release/2025.4
+
+Tags: 2025.4.3-datacenter-search, 2025.4-datacenter-search
+Directory: commercial-editions/datacenter/search
+GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitFetch: refs/heads/release/2025.4
+
+Tags: 2025.1.4-developer, 2025.1-developer, 2025-lta-developer
+Directory: commercial-editions/developer
+GitCommit: 175609a6b668d26878ea8d063d66677247272f38
 GitFetch: refs/heads/release/2025.1
 
-Tags: 2025.1.3-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search
+Tags: 2025.1.4-enterprise, 2025.1-enterprise, 2025-lta-enterprise
+Directory: commercial-editions/enterprise
+GitCommit: 175609a6b668d26878ea8d063d66677247272f38
+GitFetch: refs/heads/release/2025.1
+
+Tags: 2025.1.4-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app
+Directory: commercial-editions/datacenter/app
+GitCommit: 175609a6b668d26878ea8d063d66677247272f38
+GitFetch: refs/heads/release/2025.1
+
+Tags: 2025.1.4-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 2a5b137d0669b87f7dfe6c295a5078d7d7c1aaaf
+GitCommit: 175609a6b668d26878ea8d063d66677247272f38
 GitFetch: refs/heads/release/2025.1
 
 Tags: 25.9.0.112764-community, community, latest
 Directory: community-build
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
-GitFetch: refs/heads/master
-
-Tags: 9.9.8-community, 9.9-community, 9-community, lts, lts-community
-Directory: 9/community
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
-GitFetch: refs/heads/master
-
-Tags: 9.9.8-developer, 9.9-developer, 9-developer, lts-developer
-Directory: 9/developer
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
-GitFetch: refs/heads/master
-
-Tags: 9.9.9-enterprise, 9.9-enterprise, 9-enterprise, lts-enterprise
-Directory: 9/enterprise
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
-GitFetch: refs/heads/master
-
-Tags: 9.9.9-datacenter-app, 9.9-datacenter-app, 9-datacenter-app, lts-datacenter-app
-Directory: 9/datacenter/app
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
-GitFetch: refs/heads/master
-
-Tags: 9.9.9-datacenter-search, 9.9-datacenter-search, 9-datacenter-search, lts-datacenter-search
-Directory: 9/datacenter/search
-GitCommit: 7d0a5314a4c301f1bd3ce713ad5f0d0e212883cf
+GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
 GitFetch: refs/heads/master


### PR DESCRIPTION
Hello everyone, we are introduce an extended support for 2025.4 version.

Hence we now have : latest from master, 2025.4 and 2025.1 as active version here.