### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4c74fa19391cdc46521acb0dcb7c9e61dbf4db3e
 Directory: 3.3/alpine
 
-Tags: 3.2.4, 3.2, latest, lts, 3.2.4-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.5, 3.2, latest, lts, 3.2.5-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ef134ca68778a0e16bd235fd6a902b682148b3ea
+GitCommit: e9703bec7c7ba6ef31d7d152604d1f6b7135f861
 Directory: 3.2
 
-Tags: 3.2.4-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.4-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.5-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.5-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ef134ca68778a0e16bd235fd6a902b682148b3ea
+GitCommit: e9703bec7c7ba6ef31d7d152604d1f6b7135f861
 Directory: 3.2/alpine
 
 Tags: 3.1.8, 3.1, 3.1.8-trixie, 3.1-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e9703be: Update 3.2 to 3.2.5