### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.8.20250908.0
+Tags: 2023, latest, 2023.8.20250915.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 31bea68f5849c5dd4d4d26a069c2c8cbe55e7c8c
+amd64-GitCommit: 517030564458f4df68cfc6fc11b044c06498bed9
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: fe961d3f21ed034fe29765cf59cdf2415e13a5f8
+arm64v8-GitCommit: e0077a4a03b5e75433604061e25acbd421d969d4
 
-Tags: 2, 2.0.20250902.3
+Tags: 2, 2.0.20250915.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 81757e0aa88c134de580b4e8847288e0ab819b77
+amd64-GitCommit: 257eeb1b8d2e285c625853acfc2405e2e8fdb33c
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 595a1c3983040407f8318c4771971c97ac6bd7c7
+arm64v8-GitCommit: 98fdc690d0be56f1a2260a5deb5114c85c98a8f7
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.8.20250915-0.amzn2023
- system-release-2023.8.20250915-0.amzn2023
- glibc-minimal-langpack-2.34-231.amzn2023.0.1
- glibc-2.34-231.amzn2023.0.1
- glibc-common-2.34-231.amzn2023.0.1