### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,22 +5,22 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 4.2.0-beta.3, 4.2-rc
+Tags: 4.2.0-beta.4, 4.2-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 32e64e501148ddd350f89047589da9c175238262
+GitCommit: 8de40987d186b08c73a6d6edb40d825c01fca590
 Directory: 4.2-rc/ubuntu
 
-Tags: 4.2.0-beta.3-management, 4.2-rc-management
+Tags: 4.2.0-beta.4-management, 4.2-rc-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: aaf82bfff4fd5ee6c98ec4ce7815e7e580066892
 Directory: 4.2-rc/ubuntu/management
 
-Tags: 4.2.0-beta.3-alpine, 4.2-rc-alpine
+Tags: 4.2.0-beta.4-alpine, 4.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 32e64e501148ddd350f89047589da9c175238262
+GitCommit: 8de40987d186b08c73a6d6edb40d825c01fca590
 Directory: 4.2-rc/alpine
 
-Tags: 4.2.0-beta.3-management-alpine, 4.2-rc-management-alpine
+Tags: 4.2.0-beta.4-management-alpine, 4.2-rc-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: aaf82bfff4fd5ee6c98ec4ce7815e7e580066892
 Directory: 4.2-rc/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/8de4098: Update 4.2-rc to 4.2.0-beta.4