### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -1,45 +1,45 @@
-# this file is generated via https://github.com/docker-library/postgres/blob/a37e929682e8de45a3304a5bf9d63210c2e0a680/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/postgres/blob/304578a4b447792df66768a25a54e2247b117e74/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 18rc1, 18rc1-trixie
+Tags: 18.0, 18, latest, 18.0-trixie, 18-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
+GitCommit: 22ca5c8d8e4b37bece4d38dbce1a060583b5308a
 Directory: 18/trixie
 
-Tags: 18rc1-bookworm
+Tags: 18.0-bookworm, 18-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
+GitCommit: 22ca5c8d8e4b37bece4d38dbce1a060583b5308a
 Directory: 18/bookworm
 
-Tags: 18rc1-alpine3.22, 18rc1-alpine
+Tags: 18.0-alpine3.22, 18-alpine3.22, alpine3.22, 18.0-alpine, 18-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
+GitCommit: 22ca5c8d8e4b37bece4d38dbce1a060583b5308a
 Directory: 18/alpine3.22
 
-Tags: 18rc1-alpine3.21
+Tags: 18.0-alpine3.21, 18-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
+GitCommit: 22ca5c8d8e4b37bece4d38dbce1a060583b5308a
 Directory: 18/alpine3.21
 
-Tags: 17.6, 17, latest, 17.6-trixie, 17-trixie, trixie
+Tags: 17.6, 17, 17.6-trixie, 17-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
+GitCommit: 87e6f65859a53d10c5170a587def1bfc882d3830
 Directory: 17/trixie
 
-Tags: 17.6-bookworm, 17-bookworm, bookworm
+Tags: 17.6-bookworm, 17-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
+GitCommit: 87e6f65859a53d10c5170a587def1bfc882d3830
 Directory: 17/bookworm
 
-Tags: 17.6-alpine3.22, 17-alpine3.22, alpine3.22, 17.6-alpine, 17-alpine, alpine
+Tags: 17.6-alpine3.22, 17-alpine3.22, 17.6-alpine, 17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
 Directory: 17/alpine3.22
 
-Tags: 17.6-alpine3.21, 17-alpine3.21, alpine3.21
+Tags: 17.6-alpine3.21, 17-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a2433755c76d294477c85945d68944f8cdb7cf4b
 Directory: 17/alpine3.21


### PR DESCRIPTION
# Important Note

This (18+) includes https://github.com/docker-library/postgres/pull/1259, which **changes the default value of `PGDATA`** to `/var/lib/postgresql/MAJOR/docker` (in the case of this version in specific, `/var/lib/postgresql/18/docker`), and the volume to `/var/lib/postgresql`.

---

Changes:

- https://github.com/docker-library/postgres/commit/304578a: Update latest to 18
- https://github.com/docker-library/postgres/commit/22ca5c8: Update 18 to 18.0, trixie 18.0-1.pgdg13+3, bookworm 18.0-1.pgdg12+3
- https://github.com/docker-library/postgres/commit/87e6f65: Update 17 to trixie 17.6-2.pgdg13+1, bookworm 17.6-2.pgdg12+1