### PR TITLE
Bump Traefik to v3.5.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.5.2-windowsservercore-ltsc2022, 3.5.2-windowsservercore-ltsc2022, v3.5-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.5.3-windowsservercore-ltsc2022, 3.5.3-windowsservercore-ltsc2022, v3.5-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f9585618309c08b77540c0207590df9986be9733
+GitCommit: d670ca0784dab782d512d5a38ad1cf164b2cdb4a
 Directory: v3.5/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.5.2-nanoserver-ltsc2022, 3.5.2-nanoserver-ltsc2022, v3.5-nanoserver-ltsc2022, 3.5-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.5.3-nanoserver-ltsc2022, 3.5.3-nanoserver-ltsc2022, v3.5-nanoserver-ltsc2022, 3.5-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f9585618309c08b77540c0207590df9986be9733
+GitCommit: d670ca0784dab782d512d5a38ad1cf164b2cdb4a
 Directory: v3.5/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.5.2, 3.5.2, v3.5, 3.5, v3, 3, chabichou, latest
+Tags: v3.5.3, 3.5.3, v3.5, 3.5, v3, 3, chabichou, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f9585618309c08b77540c0207590df9986be9733
+GitCommit: d670ca0784dab782d512d5a38ad1cf164b2cdb4a
 Directory: v3.5/alpine
 
 Tags: v2.11.29-windowsservercore-ltsc2022, 2.11.29-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.5.3](https://github.com/traefik/traefik/releases/tag/v3.5.3).

/cc @mmatur @kevinpollet

Cheers
