### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -6,22 +6,17 @@ GitRepo: https://github.com/docker-library/redmine.git
 
 Tags: 6.1.0, 6.1, 6, latest, 6.1.0-trixie, 6.1-trixie, 6-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 83dc5187580910a8f5b9578d6fe453db2d6f4811
+GitCommit: 782887eb82bfea15a4a6ea05569b81b323dd25cc
 Directory: 6.1/trixie
-
-Tags: 6.1.0-bookworm, 6.1-bookworm, 6-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 83dc5187580910a8f5b9578d6fe453db2d6f4811
-Directory: 6.1/bookworm
 
 Tags: 6.1.0-alpine3.22, 6.1-alpine3.22, 6-alpine3.22, alpine3.22, 6.1.0-alpine, 6.1-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 83dc5187580910a8f5b9578d6fe453db2d6f4811
+GitCommit: 782887eb82bfea15a4a6ea05569b81b323dd25cc
 Directory: 6.1/alpine3.22
 
 Tags: 6.1.0-alpine3.21, 6.1-alpine3.21, 6-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 83dc5187580910a8f5b9578d6fe453db2d6f4811
+GitCommit: 782887eb82bfea15a4a6ea05569b81b323dd25cc
 Directory: 6.1/alpine3.21
 
 Tags: 6.0.7, 6.0, 6.0.7-trixie, 6.0-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/2eaa84c: Merge pull request https://github.com/docker-library/redmine/pull/393 from infosiftr/i386
- https://github.com/docker-library/redmine/commit/4257a57: Remove bookworm from 6.1
- https://github.com/docker-library/redmine/commit/782887e: Add `rust` and `libclang` to dependencies installed during build to fix i386 builds (and hopefully others)
- https://github.com/docker-library/redmine/commit/eb3e633: Enable CI for i386 so we can catch non-amd64-non-arm64 failures sooner