### PR TITLE
archlinux: Release 20250928.0.426921

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250921.0.423275
-GitCommit: bbd87e8bcfb68bdee826aa3ccd5dd907e35dbc69
-GitFetch: refs/tags/v20250921.0.423275
+Tags: latest, base, base-20250928.0.426921
+GitCommit: 90eb341f00a3bb9401fe599087757c60920c8485
+GitFetch: refs/tags/v20250928.0.426921
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250921.0.423275
-GitCommit: bbd87e8bcfb68bdee826aa3ccd5dd907e35dbc69
-GitFetch: refs/tags/v20250921.0.423275
+Tags: base-devel, base-devel-20250928.0.426921
+GitCommit: 90eb341f00a3bb9401fe599087757c60920c8485
+GitFetch: refs/tags/v20250928.0.426921
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250921.0.423275
-GitCommit: bbd87e8bcfb68bdee826aa3ccd5dd907e35dbc69
-GitFetch: refs/tags/v20250921.0.423275
+Tags: multilib-devel, multilib-devel-20250928.0.426921
+GitCommit: 90eb341f00a3bb9401fe599087757c60920c8485
+GitFetch: refs/tags/v20250928.0.426921
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks