### PR TITLE
chore: remove influxdb 1.10 from supported tags

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -48,18 +48,6 @@ Directory: influxdb/1.11/meta
 Tags: 1.11-meta-alpine, 1.11.9-meta-alpine
 Directory: influxdb/1.11/meta/alpine
 
-Tags: 1.10-data, 1.10.9-data
-Directory: influxdb/1.10/data
-
-Tags: 1.10-data-alpine, 1.10.9-data-alpine
-Directory: influxdb/1.10/data/alpine
-
-Tags: 1.10-meta, 1.10.9-meta
-Directory: influxdb/1.10/meta
-
-Tags: 1.10-meta-alpine, 1.10.9-meta-alpine
-Directory: influxdb/1.10/meta/alpine
-
 Tags: 2, 2.7, 2.7.12, latest
 Architectures: amd64, arm64v8
 Directory: influxdb/2.7


### PR DESCRIPTION
EOL InfluxDB 1.10 and remove from the supported tags (again). https://github.com/docker-library/official-images/pull/19918 was unfortunately merged before we did our final 1.10 release (1.10.9), so https://github.com/docker-library/official-images/pull/19952 was created to temporarily add back the 1.10 tags to the list of supported tags in order to get 1.10.9 images built and into Docker Hub. Now that they are published, remove the 1.10 tags again.