### PR TITLE
Odoo: update 17.0-19.0 to release 20250930

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 9404592737f4a58dade648ba2c9c35de1feb2fb4
+GitCommit: 529a49c8b7da4201fc461434f9ec8ad170ef3202
 
-Tags: 19.0-20250918, 19.0, 19, latest
+Tags: 19.0-20250930, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20250918, 18.0, 18
+Tags: 18.0-20250930, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20250918, 17.0, 17
+Tags: 17.0-20250930, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks