### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.2.0-beta.4, 4.2-rc
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 8de40987d186b08c73a6d6edb40d825c01fca590
+GitCommit: e963688c182bf362170635dc550e16e4d7b002b8
 Directory: 4.2-rc/ubuntu
 
 Tags: 4.2.0-beta.4-management, 4.2-rc-management
@@ -17,7 +17,7 @@ Directory: 4.2-rc/ubuntu/management
 
 Tags: 4.2.0-beta.4-alpine, 4.2-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8de40987d186b08c73a6d6edb40d825c01fca590
+GitCommit: e963688c182bf362170635dc550e16e4d7b002b8
 Directory: 4.2-rc/alpine
 
 Tags: 4.2.0-beta.4-management-alpine, 4.2-rc-management-alpine
@@ -27,7 +27,7 @@ Directory: 4.2-rc/alpine/management
 
 Tags: 4.1.4, 4.1, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 795da0e715c8c6c5cfef7a08d7917fd43f425bc4
+GitCommit: afa514ae410f3f21127291c2a827c7ed8deda515
 Directory: 4.1/ubuntu
 
 Tags: 4.1.4-management, 4.1-management, 4-management, management
@@ -37,7 +37,7 @@ Directory: 4.1/ubuntu/management
 
 Tags: 4.1.4-alpine, 4.1-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 795da0e715c8c6c5cfef7a08d7917fd43f425bc4
+GitCommit: afa514ae410f3f21127291c2a827c7ed8deda515
 Directory: 4.1/alpine
 
 Tags: 4.1.4-management-alpine, 4.1-management-alpine, 4-management-alpine, management-alpine
@@ -47,7 +47,7 @@ Directory: 4.1/alpine/management
 
 Tags: 4.0.9, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 3b417e35b15f8e491b0ab4dcded09dd13366b50c
+GitCommit: 472c590ec4dddf4494c8ed6576d6d78588e3cd35
 Directory: 4.0/ubuntu
 
 Tags: 4.0.9-management, 4.0-management
@@ -57,7 +57,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.9-alpine, 4.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3b417e35b15f8e491b0ab4dcded09dd13366b50c
+GitCommit: 472c590ec4dddf4494c8ed6576d6d78588e3cd35
 Directory: 4.0/alpine
 
 Tags: 4.0.9-management-alpine, 4.0-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e963688: Update 4.2-rc to openssl 3.3.5
- https://github.com/docker-library/rabbitmq/commit/afa514a: Update 4.1 to openssl 3.3.5
- https://github.com/docker-library/rabbitmq/commit/472c590: Update 4.0 to openssl 3.3.5