### PR TITLE
gitsha bump for Neo4j 2025.09.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -6,22 +6,22 @@ GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
 Tags: 2025.09.0-community-bullseye, 2025.09-community-bullseye, 2025-community-bullseye, 2025.09.0-community, 2025.09-community, 2025-community, 2025.09.0-bullseye, 2025.09-bullseye, 2025-bullseye, 2025.09.0, 2025.09, 2025, community-bullseye, community, bullseye, latest
 Architectures: amd64, arm64v8
-GitCommit: 31cca81e274ab0d5785a97d72b712ef563ab5b2d
+GitCommit: 439722772cf16662310df3e1d8f898272454f85a
 Directory: 2025.09.0/bullseye/community
 
 Tags: 2025.09.0-enterprise-bullseye, 2025.09-enterprise-bullseye, 2025-enterprise-bullseye, 2025.09.0-enterprise, 2025.09-enterprise, 2025-enterprise, enterprise-bullseye, enterprise
 Architectures: amd64, arm64v8
-GitCommit: 31cca81e274ab0d5785a97d72b712ef563ab5b2d
+GitCommit: 439722772cf16662310df3e1d8f898272454f85a
 Directory: 2025.09.0/bullseye/enterprise
 
 Tags: 2025.09.0-community-ubi9, 2025.09-community-ubi9, 2025-community-ubi9, 2025.09.0-ubi9, 2025.09-ubi9, 2025-ubi9, community-ubi9, ubi9
 Architectures: amd64, arm64v8
-GitCommit: 31cca81e274ab0d5785a97d72b712ef563ab5b2d
+GitCommit: 439722772cf16662310df3e1d8f898272454f85a
 Directory: 2025.09.0/ubi9/community
 
 Tags: 2025.09.0-enterprise-ubi9, 2025.09-enterprise-ubi9, 2025-enterprise-ubi9, enterprise-ubi9
 Architectures: amd64, arm64v8
-GitCommit: 31cca81e274ab0d5785a97d72b712ef563ab5b2d
+GitCommit: 439722772cf16662310df3e1d8f898272454f85a
 Directory: 2025.09.0/ubi9/enterprise
 
 


### PR DESCRIPTION
There was a minor a problem with the https://dist.neo4j.org/neo4j-community-2025.09.0-unix.tar.gz and https://dist.neo4j.org/neo4j-enterprise-2025.09.0-unix.tar.gz tars, so we had to re-upload a new version with a fix. 

The neo4j download URI remains the same, but the SHA is different, so the docker image source needs an update otherwise it will fail the next time a rebuild is scheduled. Hope that's ok!