### PR TITLE
Update JRuby top JDK to 25

### DIFF
--- a/library/jruby
+++ b/library/jruby
@@ -3,7 +3,7 @@ Maintainers: JRuby Admin <admin@jruby.org> (@jruby),
              Thomas E Enebo <tom.enebo@gmail.com> (@enebo)
 GitRepo: https://github.com/jruby/docker-jruby.git
 GitFetch: refs/heads/master
-GitCommit: 73b84171f2eefb713ff4c4420a9cd46b19f7df42
+GitCommit: a8ffc83b6e262b7171f26a07284053dc3de9af6b
 
 Tags: latest, 10, 10.0, 10.0.2, 10.0-jre, 10.0-jre21, 10.0.2-jre, 10.0.2-jre21, 10.0.2.0, 10.0.2.0-jre, 10.0.2.0-jre21
 Architectures: amd64, arm64v8
@@ -13,13 +13,13 @@ Tags: 10-jdk, 10-jdk21, 10.0-jdk, 10.0-jdk21, 10.0.2-jdk, 10.0.2-jdk21, 10.0.2.0
 Architectures: amd64, arm64v8
 Directory: 10.0/jdk21
 
-Tags: 10.0-jre24, 10.0.2-jre24, 10.0.2.0-jre24
+Tags: 10.0-jre25, 10.0.2-jre25, 10.0.2.0-jre25
 Architectures: amd64, arm64v8
-Directory: 10.0/jre24
+Directory: 10.0/jre25
 
-Tags: 10.0-jdk24, 10.0.2-jdk24, 10.0.2.0-jdk24
+Tags: 10.0-jdk25, 10.0.2-jdk25, 10.0.2.0-jdk25
 Architectures: amd64, arm64v8
-Directory: 10.0/jdk24
+Directory: 10.0/jdk25
 
 Tags: 9, 9.4, 9.4.14, 9.4-jre, 9.4-jre8, 9.4.14-jre, 9.4.14-jre8, 9.4.14.0, 9.4.14.0-jre, 9.4.14.0-jre8
 Architectures: amd64, arm64v8
@@ -52,6 +52,14 @@ Directory: 9.4/jdk21
 Tags: 9.4-jre21, 9.4.14-jre21, 9.4.14.0-jre21
 Architectures: amd64, arm64v8
 Directory: 9.4/jre21
+
+Tags: 9.4-jdk25, 9.4.14-jdk25, 9.4.14.0-jdk25
+Architectures: amd64, arm64v8
+Directory: 9.4/jdk25
+
+Tags: 9.4-jre25, 9.4.14-jre25, 9.4.14.0-jre25
+Architectures: amd64, arm64v8
+Directory: 9.4/jre25
 
 Tags: 9.3, 9.3.15, 9.3-jre, 9.3-jre8, 9.3.15-jre, 9.3.15-jre8, 9.3.15.0, 9.3.15.0-jre, 9.3.15.0-jre8
 Architectures: amd64, arm64v8
@@ -93,13 +101,13 @@ Tags: 10.0-dev-jdk21
 Architectures: amd64, arm64v8
 Directory: 10.0-dev/jdk21
 
-Tags: 10.0-dev-jre24
+Tags: 10.0-dev-jre25
 Architectures: amd64, arm64v8
-Directory: 10.0-dev/jre24
+Directory: 10.0-dev/jre25
 
-Tags: 10.0-dev-jdk24
+Tags: 10.0-dev-jdk25
 Architectures: amd64, arm64v8
-Directory: 10.0-dev/jdk24
+Directory: 10.0-dev/jdk25
 
 Tags: 9.4-dev-jre8
 Architectures: amd64, arm64v8
@@ -132,4 +140,12 @@ Directory: 9.4-dev/jdk21
 Tags: 9.4-dev-jre21
 Architectures: amd64, arm64v8
 Directory: 9.4-dev/jre21
+
+Tags: 9.4-dev-jdk25
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jdk25
+
+Tags: 9.4-dev-jre25
+Architectures: amd64, arm64v8
+Directory: 9.4-dev/jre25
 


### PR DESCRIPTION
* 9.4 gains JDK 25 and JRE 25 images
* 10 moves the JDK and JRE 24 images to JDK and JRE 25