### PR TITLE
Revert `dist-clean` for ruby-native-ext test

### DIFF
--- a/test/tests/ruby-native-extension/run.sh
+++ b/test/tests/ruby-native-extension/run.sh
@@ -24,7 +24,7 @@ if ! docker run --rm --entrypoint sh "$image" -c 'command -v gcc' > /dev/null; t
 				RUN set -eux; \
 					apt-get update; \
 					apt-get install -y --no-install-recommends gcc make libc6-dev; \
-					apt-get dist-clean
+					rm -rf /var/lib/apt/lists/*
 			EOD
 			;;
 	esac


### PR DESCRIPTION
This test is run on diverse Debian bases so doesn't always have `apt-get dist-clean`

Reverts part of https://github.com/docker-library/official-images/pull/19984
Related to failures on https://github.com/docker-library/official-images/pull/20003

Fixed:
```console
$ ./test/run.sh -t ruby-native-extension jruby:9
testing jruby:9
        'ruby-native-extension' [1/1]...passed
```

Broken:
```console
./test/run.sh -t ruby-native-extension jruby:9
testing jruby:9
        'ruby-native-extension' [1/1]...
[...]
+ apt-get dist-clean
E: Invalid operation dist-clean
The command '/bin/sh -c set -eux;                                       apt-get update;                                apt-get install -y --no-install-recommends gcc make libc6-dev;                                   apt-get dist-clean' returned a non-zero code: 100
failed
```