### PR TITLE
[SECURITY] Update redis to 6.2.20, 7.2.11,7.4.6, 8.04 and 8.2.2

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -8,25 +8,25 @@ GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.2.2, 8.2, 8, 8.2.2-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
+GitCommit: c5846c13383c8b284897ff171e0c946868ed4c8c
 GitFetch: refs/tags/v8.2.2
 Directory: debian
 
 Tags: 8.2.2-alpine, 8.2-alpine, 8-alpine, 8.2.2-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f76d8a1cc979be6202aed93efddd2a0ebbfa0209
+GitCommit: c5846c13383c8b284897ff171e0c946868ed4c8c
 GitFetch: refs/tags/v8.2.2
 Directory: alpine
 
 Tags: 8.0.4, 8.0, 8.0.4-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c0125f5be8786d556a9d3edd70f51974fe045c1a
+GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
 GitFetch: refs/tags/v8.0.4
 Directory: debian
 
 Tags: 8.0.4-alpine, 8.0-alpine, 8.0.4-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c0125f5be8786d556a9d3edd70f51974fe045c1a
+GitCommit: 2277e5ead99f0caacbd90e0d04693adb27ebfaa6
 GitFetch: refs/tags/v8.0.4
 Directory: alpine
 


### PR DESCRIPTION
Update redis versions

6.2.19 -> 6.2.20
7.2.10 -> 7.2.11
7.4.5 -> 7.4.6
8.0.3 -> 8.0.4
8.2.1 -> 8.2.2

These updates are related to following CVEs:

1.  (CVE-2025-49844) A Lua script may lead to remote code execution
2.  (CVE-2025-46817) A Lua script may lead to integer overflow and potential RCE
3.  (CVE-2025-46818) A Lua script can be executed in the context of another user
4.  (CVE-2025-46819) LUA out-of-bound read