### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,72 +4,72 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev8, 3.3-dev, 3.3-dev8-trixie, 3.3-dev-trixie
+Tags: 3.3-dev9, 3.3-dev, 3.3-dev9-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4c74fa19391cdc46521acb0dcb7c9e61dbf4db3e
+GitCommit: 4cd7a3775e0995919e129289cfa2e314e37fb15e
 Directory: 3.3
 
-Tags: 3.3-dev8-alpine, 3.3-dev-alpine, 3.3-dev8-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev9-alpine, 3.3-dev-alpine, 3.3-dev9-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4c74fa19391cdc46521acb0dcb7c9e61dbf4db3e
+GitCommit: 4cd7a3775e0995919e129289cfa2e314e37fb15e
 Directory: 3.3/alpine
 
-Tags: 3.2.5, 3.2, latest, lts, 3.2.5-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.6, 3.2, latest, lts, 3.2.6-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9703bec7c7ba6ef31d7d152604d1f6b7135f861
+GitCommit: 04b2168ff76f90727c02f01cb719f655e768f6fd
 Directory: 3.2
 
-Tags: 3.2.5-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.5-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.6-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.6-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9703bec7c7ba6ef31d7d152604d1f6b7135f861
+GitCommit: 04b2168ff76f90727c02f01cb719f655e768f6fd
 Directory: 3.2/alpine
 
-Tags: 3.1.8, 3.1, 3.1.8-trixie, 3.1-trixie
+Tags: 3.1.9, 3.1, 3.1.9-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: 0d89f493da93a6e40d26926929cf12bf95fbec5b
 Directory: 3.1
 
-Tags: 3.1.8-alpine, 3.1-alpine, 3.1.8-alpine3.22, 3.1-alpine3.22
+Tags: 3.1.9-alpine, 3.1-alpine, 3.1.9-alpine3.22, 3.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d9460179b64eac94bd181a488a74d8e6df7bdbf5
+GitCommit: 0d89f493da93a6e40d26926929cf12bf95fbec5b
 Directory: 3.1/alpine
 
-Tags: 3.0.11, 3.0, 3.0.11-trixie, 3.0-trixie
+Tags: 3.0.12, 3.0, 3.0.12-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: 0390f3e72676323955e3a7d230393c7b5478f0b0
 Directory: 3.0
 
-Tags: 3.0.11-alpine, 3.0-alpine, 3.0.11-alpine3.22, 3.0-alpine3.22
+Tags: 3.0.12-alpine, 3.0-alpine, 3.0.12-alpine3.22, 3.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6fa540dd7d9d82634605e727a8e1c726a23d8b0d
+GitCommit: 0390f3e72676323955e3a7d230393c7b5478f0b0
 Directory: 3.0/alpine
 
-Tags: 2.8.15, 2.8, 2.8.15-trixie, 2.8-trixie
+Tags: 2.8.16, 2.8, 2.8.16-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: 97dd996d667932ef9359dcb8f2b3242eb54b253e
 Directory: 2.8
 
-Tags: 2.8.15-alpine, 2.8-alpine, 2.8.15-alpine3.22, 2.8-alpine3.22
+Tags: 2.8.16-alpine, 2.8-alpine, 2.8.16-alpine3.22, 2.8-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: 97dd996d667932ef9359dcb8f2b3242eb54b253e
 Directory: 2.8/alpine
 
-Tags: 2.6.22, 2.6, 2.6.22-trixie, 2.6-trixie
+Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: 926111706a0ffd8b815e1edfd317aae52d06d083
 Directory: 2.6
 
-Tags: 2.6.22-alpine, 2.6-alpine, 2.6.22-alpine3.22, 2.6-alpine3.22
+Tags: 2.6.23-alpine, 2.6-alpine, 2.6.23-alpine3.22, 2.6-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: 926111706a0ffd8b815e1edfd317aae52d06d083
 Directory: 2.6/alpine
 
-Tags: 2.4.29, 2.4, 2.4.29-trixie, 2.4-trixie
+Tags: 2.4.30, 2.4, 2.4.30-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ff3f8bcd0304645bd56e5c6118fa8989f8bba00
+GitCommit: c55eb01d1a1866a421e20e21bace391080fc58ba
 Directory: 2.4
 
-Tags: 2.4.29-alpine, 2.4-alpine, 2.4.29-alpine3.22, 2.4-alpine3.22
+Tags: 2.4.30-alpine, 2.4-alpine, 2.4.30-alpine3.22, 2.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3117d2496500d354bb79eff90b6ba247fb456276
+GitCommit: c55eb01d1a1866a421e20e21bace391080fc58ba
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/04b2168: Update 3.2 to 3.2.6
- https://github.com/docker-library/haproxy/commit/97dd996: Update 2.8 to 2.8.16
- https://github.com/docker-library/haproxy/commit/c55eb01: Update 2.4 to 2.4.30
- https://github.com/docker-library/haproxy/commit/4cd7a37: Update 3.3 to 3.3-dev9
- https://github.com/docker-library/haproxy/commit/0d89f49: Update 3.1 to 3.1.9
- https://github.com/docker-library/haproxy/commit/0390f3e: Update 3.0 to 3.0.12
- https://github.com/docker-library/haproxy/commit/9261117: Update 2.6 to 2.6.23