### PR TITLE
Mediawiki 1.39.15 / 1.43.5 / 1.44.2

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,38 +3,38 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: 8d5915f6b11612e3eed4f7e00ddc8288e4c5e267
+GitCommit: 22e0f2939d36bfc61d1572e4e1a2afd66d84e6f5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version
-Tags: 1.44.0, 1.44, latest, stable
+Tags: 1.44.2, 1.44, latest, stable
 Directory: 1.44/apache
 
-Tags: 1.44.0-fpm, 1.44-fpm, stable-fpm
+Tags: 1.44.2-fpm, 1.44-fpm, stable-fpm
 Directory: 1.44/fpm
 
-Tags: 1.44.0-fpm-alpine, 1.44-fpm-alpine, stable-fpm-alpine
+Tags: 1.44.2-fpm-alpine, 1.44-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.44/fpm-alpine
 
 # current lts version
-Tags: 1.43.3, 1.43, lts
+Tags: 1.43.5, 1.43, lts
 Directory: 1.43/apache
 
-Tags: 1.43.3-fpm, 1.43-fpm, lts-fpm
+Tags: 1.43.5-fpm, 1.43-fpm, lts-fpm
 Directory: 1.43/fpm
 
-Tags: 1.43.3-fpm-alpine, 1.43-fpm-alpine, lts-fpm-alpine
+Tags: 1.43.5-fpm-alpine, 1.43-fpm-alpine, lts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.43/fpm-alpine
 
 # current legacy lts version
-Tags: 1.39.13, 1.39
+Tags: 1.39.15, 1.39
 Directory: 1.39/apache
 
-Tags: 1.39.13-fpm, 1.39-fpm
+Tags: 1.39.15-fpm, 1.39-fpm
 Directory: 1.39/fpm
 
-Tags: 1.39.13-fpm-alpine, 1.39-fpm-alpine
+Tags: 1.39.15-fpm-alpine, 1.39-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.39/fpm-alpine


### PR DESCRIPTION
See https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/TF4S5Y2324UIW3GOBPBWD2MSUSROG5GH/ for the mailing list announcement.

Related to https://github.com/wikimedia/mediawiki-docker/pull/161

Link: https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/TF4S5Y2324UIW3GOBPBWD2MSUSROG5GH/