### PR TITLE
archlinux: Release 20251005.0.430597

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20250928.0.426921
-GitCommit: 90eb341f00a3bb9401fe599087757c60920c8485
-GitFetch: refs/tags/v20250928.0.426921
+Tags: latest, base, base-20251005.0.430597
+GitCommit: bab15f2a96c4dab1c0e0bbc6620900f5ba79d171
+GitFetch: refs/tags/v20251005.0.430597
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20250928.0.426921
-GitCommit: 90eb341f00a3bb9401fe599087757c60920c8485
-GitFetch: refs/tags/v20250928.0.426921
+Tags: base-devel, base-devel-20251005.0.430597
+GitCommit: bab15f2a96c4dab1c0e0bbc6620900f5ba79d171
+GitFetch: refs/tags/v20251005.0.430597
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20250928.0.426921
-GitCommit: 90eb341f00a3bb9401fe599087757c60920c8485
-GitFetch: refs/tags/v20250928.0.426921
+Tags: multilib-devel, multilib-devel-20251005.0.430597
+GitCommit: bab15f2a96c4dab1c0e0bbc6620900f5ba79d171
+GitFetch: refs/tags/v20251005.0.430597
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks