### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-16823"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b598dbcf38e3c1f75ba8807ab5e8099c8f8bb01a
+amd64-GitCommit: 775d28963fab701f956994defdf245e59251fba3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 334b173a74181ecf17ca5fa57dd5452582e130c5
+arm64v8-GitCommit: 15beb262568ec072a023f0f4f9e0e5eed2b0f819
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-26465, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-16823.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
