### PR TITLE
Update bash

### DIFF
--- a/library/bash
+++ b/library/bash
@@ -3,9 +3,9 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon)
 GitRepo: https://github.com/tianon/docker-bash.git
 
-Tags: devel-20250918, devel, devel-20250918-alpine3.22, devel-alpine3.22
+Tags: devel-20251006, devel, devel-20251006-alpine3.22, devel-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4692ca63168aa1f5af2bea3e4c6857851e81f51c
+GitCommit: 33dd5c2ee28bf8f5a2429d538e2dbb3a00cd52a5
 Directory: devel
 
 Tags: 5.3.3, 5.3, 5, latest, 5.3.3-alpine3.22, 5.3-alpine3.22, 5-alpine3.22, alpine3.22
@@ -40,7 +40,7 @@ Directory: 4.3
 
 Tags: 4.2.53, 4.2, 4.2.53-alpine3.22, 4.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
+GitCommit: 8556e37dc74a044cfd6e8255acfd116a5bdb8588
 Directory: 4.2
 
 Tags: 4.1.17, 4.1, 4.1.17-alpine3.22, 4.1-alpine3.22
@@ -65,5 +65,5 @@ Directory: 3.1
 
 Tags: 3.0.22, 3.0, 3.0.22-alpine3.22, 3.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 099d6114cbdb9b016fb8c4beb653187df002f66f
+GitCommit: 5ffa8349006e790fe3534d0a6c3100fd6d725407
 Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/tianon/docker-bash/commit/33dd5c2: Update devel to 20251006, commit 25c6aa5b230167c6471898539c46dd2891d891a5
- https://github.com/tianon/docker-bash/commit/5ffa834: Update 3.0 to 3.0.22, baseline 3.0.16, patch 22
- https://github.com/tianon/docker-bash/commit/29a46dd: Update 3.0 to 3.0.16
- https://github.com/tianon/docker-bash/commit/8556e37: Update 4.2 to patch 53
- https://github.com/tianon/docker-bash/commit/8d6f883: Update 4.2