### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.25.1-trixie, 1.25-trixie, 1-trixie, trixie
-SharedTags: 1.25.1, 1.25, 1, latest
+Tags: 1.25.2-trixie, 1.25-trixie, 1-trixie, trixie
+SharedTags: 1.25.2, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/trixie
 
-Tags: 1.25.1-bookworm, 1.25-bookworm, 1-bookworm, bookworm
+Tags: 1.25.2-bookworm, 1.25-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/bookworm
 
-Tags: 1.25.1-alpine3.22, 1.25-alpine3.22, 1-alpine3.22, alpine3.22, 1.25.1-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.2-alpine3.22, 1.25-alpine3.22, 1-alpine3.22, alpine3.22, 1.25.2-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/alpine3.22
 
-Tags: 1.25.1-alpine3.21, 1.25-alpine3.21, 1-alpine3.21, alpine3.21
+Tags: 1.25.2-alpine3.21, 1.25-alpine3.21, 1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/alpine3.21
 
-Tags: 1.25.1-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 1.25.1-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.1, 1.25, 1, latest
+Tags: 1.25.2-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.25.2-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.2, 1.25, 1, latest
 Architectures: windows-amd64
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.25.1-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.25.1-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.1, 1.25, 1, latest
+Tags: 1.25.2-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.25.2-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.2, 1.25, 1, latest
 Architectures: windows-amd64
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.25.1-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 1.25.1-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.25.2-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 1.25.2-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.25.1-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.25.1-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.25.2-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.25.2-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: be5c27da377afdeebf0c5747560bedd7f96ccb1c
+GitCommit: 65a36abba8dba306c230eaa5fa2d822e62febbe0
 Directory: 1.25/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.24.7-trixie, 1.24-trixie
-SharedTags: 1.24.7, 1.24
+Tags: 1.24.8-trixie, 1.24-trixie
+SharedTags: 1.24.8, 1.24
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/trixie
 
-Tags: 1.24.7-bookworm, 1.24-bookworm
+Tags: 1.24.8-bookworm, 1.24-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/bookworm
 
-Tags: 1.24.7-alpine3.22, 1.24-alpine3.22, 1.24.7-alpine, 1.24-alpine
+Tags: 1.24.8-alpine3.22, 1.24-alpine3.22, 1.24.8-alpine, 1.24-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/alpine3.22
 
-Tags: 1.24.7-alpine3.21, 1.24-alpine3.21
+Tags: 1.24.8-alpine3.21, 1.24-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/alpine3.21
 
-Tags: 1.24.7-windowsservercore-ltsc2025, 1.24-windowsservercore-ltsc2025
-SharedTags: 1.24.7-windowsservercore, 1.24-windowsservercore, 1.24.7, 1.24
+Tags: 1.24.8-windowsservercore-ltsc2025, 1.24-windowsservercore-ltsc2025
+SharedTags: 1.24.8-windowsservercore, 1.24-windowsservercore, 1.24.8, 1.24
 Architectures: windows-amd64
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.24.7-windowsservercore-ltsc2022, 1.24-windowsservercore-ltsc2022
-SharedTags: 1.24.7-windowsservercore, 1.24-windowsservercore, 1.24.7, 1.24
+Tags: 1.24.8-windowsservercore-ltsc2022, 1.24-windowsservercore-ltsc2022
+SharedTags: 1.24.8-windowsservercore, 1.24-windowsservercore, 1.24.8, 1.24
 Architectures: windows-amd64
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.24.7-nanoserver-ltsc2025, 1.24-nanoserver-ltsc2025
-SharedTags: 1.24.7-nanoserver, 1.24-nanoserver
+Tags: 1.24.8-nanoserver-ltsc2025, 1.24-nanoserver-ltsc2025
+SharedTags: 1.24.8-nanoserver, 1.24-nanoserver
 Architectures: windows-amd64
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.24.7-nanoserver-ltsc2022, 1.24-nanoserver-ltsc2022
-SharedTags: 1.24.7-nanoserver, 1.24-nanoserver
+Tags: 1.24.8-nanoserver-ltsc2022, 1.24-nanoserver-ltsc2022
+SharedTags: 1.24.8-nanoserver, 1.24-nanoserver
 Architectures: windows-amd64
-GitCommit: 266d88a19c1eec1e84266bef042ba832e32cf149
+GitCommit: 1538c1993363659087125a7f2a18f5136ba12de2
 Directory: 1.24/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/65a36ab: Update 1.25 to 1.25.2
- https://github.com/docker-library/golang/commit/1538c19: Update 1.24 to 1.24.8