### PR TITLE
Update mainline nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -1,41 +1,41 @@
-# this file is generated via https://github.com/nginx/docker-nginx/blob/c3dcb125c9534ed5e76ebba48171b26411b8e478/generate-stackbrew-library.sh
+# this file is generated via https://github.com/nginx/docker-nginx/blob/b75b089789daa4ce5510d6cb246147cb1eb8922d/generate-stackbrew-library.sh
 
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.29.1, mainline, 1, 1.29, latest, 1.29.1-bookworm, mainline-bookworm, 1-bookworm, 1.29-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+Tags: 1.29.2, mainline, 1, 1.29, latest, 1.29.2-trixie, mainline-trixie, 1-trixie, 1.29-trixie, trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/debian
 
-Tags: 1.29.1-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.1-bookworm-perl, mainline-bookworm-perl, 1-bookworm-perl, 1.29-bookworm-perl, bookworm-perl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+Tags: 1.29.2-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.2-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.29-trixie-perl, trixie-perl
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/debian-perl
 
-Tags: 1.29.1-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.1-bookworm-otel, mainline-bookworm-otel, 1-bookworm-otel, 1.29-bookworm-otel, bookworm-otel
+Tags: 1.29.2-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.2-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.29-trixie-otel, trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/debian-otel
 
-Tags: 1.29.1-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.1-alpine3.22, mainline-alpine3.22, 1-alpine3.22, 1.29-alpine3.22, alpine3.22
+Tags: 1.29.2-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.2-alpine3.22, mainline-alpine3.22, 1-alpine3.22, 1.29-alpine3.22, alpine3.22
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/alpine
 
-Tags: 1.29.1-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.1-alpine3.22-perl, mainline-alpine3.22-perl, 1-alpine3.22-perl, 1.29-alpine3.22-perl, alpine3.22-perl
+Tags: 1.29.2-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.2-alpine3.22-perl, mainline-alpine3.22-perl, 1-alpine3.22-perl, 1.29-alpine3.22-perl, alpine3.22-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/alpine-perl
 
-Tags: 1.29.1-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.1-alpine3.22-slim, mainline-alpine3.22-slim, 1-alpine3.22-slim, 1.29-alpine3.22-slim, alpine3.22-slim
+Tags: 1.29.2-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.2-alpine3.22-slim, mainline-alpine3.22-slim, 1-alpine3.22-slim, 1.29-alpine3.22-slim, alpine3.22-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/alpine-slim
 
-Tags: 1.29.1-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.1-alpine3.22-otel, mainline-alpine3.22-otel, 1-alpine3.22-otel, 1.29-alpine3.22-otel, alpine3.22-otel
+Tags: 1.29.2-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.2-alpine3.22-otel, mainline-alpine3.22-otel, 1-alpine3.22-otel, 1.29-alpine3.22-otel, alpine3.22-otel
 Architectures: amd64, arm64v8
-GitCommit: 5a4ad48c733b365d69a4d1c9946a9d8480469c7f
+GitCommit: c3785f2653008f9354c3d29a54d8c5459c53fa60
 Directory: mainline/alpine-otel
 
 Tags: 1.28.0, stable, 1.28, 1.28.0-bookworm, stable-bookworm, 1.28-bookworm


### PR DESCRIPTION
With this bump, mainline image is now:
- based on Debian 13 "trixie", adding riscv64 and removing mips64le
- ships nginx 1.29.2
- ships njs 0.9.3