### PR TITLE
kibana: bump tag to reflect image contents

### DIFF
--- a/library/kibana
+++ b/library/kibana
@@ -3,7 +3,7 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: kibana
 Builder: buildkit
 
-Tags: 7.17.28
+Tags: 7.17.29
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/7.17
 GitCommit: 28b876f2aaba7bc27d76a1acd55cbc8ada9b5dea


### PR DESCRIPTION
Fix the tag for `kibana` 7 series to reflect what it contains. The `kibana:7.17.28` image actually contains `7.17.29` and has since https://github.com/docker-library/official-images/pull/19558.

Dockerfile: https://github.com/elastic/dockerfiles/blob/28b876f2aaba7bc27d76a1acd55cbc8ada9b5dea/kibana/Dockerfile#L19

<details>
<summary>Relevant part of the Diff from #19558:</summary>

```diff
diff --git a/kibana_7.17.28/Dockerfile b/kibana_7.17.28/Dockerfile
index a254906..010782a 100644
--- a/kibana_7.17.28/Dockerfile
+++ b/kibana_7.17.28/Dockerfile
@@ -9,14 +9,14 @@
 # Build stage 0 `builder`:
 # Extract Kibana artifact
 ################################################################################
-FROM ubuntu:20.04 AS builder
+FROM ubuntu:24.04 AS builder
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y curl
 
 RUN cd /tmp && \
   curl --retry 8 -s -L \
     --output kibana.tar.gz \
-     https://artifacts.elastic.co/downloads/kibana/kibana-7.17.28-linux-$(arch).tar.gz && \
+     https://artifacts.elastic.co/downloads/kibana/kibana-7.17.29-linux-$(arch).tar.gz && \
   cd -
 
 
@@ -36,7 +36,7 @@ RUN chmod -R g=u /usr/share/kibana
 # Copy kibana from stage 0
 # Add entrypoint
 ################################################################################
-FROM ubuntu:20.04
+FROM ubuntu:24.04
 EXPOSE 5601
 
 RUN for iter in {1..10}; do \
@@ -99,30 +99,30 @@ RUN chmod g+ws /usr/share/kibana && \
 RUN find / -xdev -perm -4000 -exec chmod u-s {} +
 
 # Provide a non-root user to run the process.
-RUN groupadd --gid 1000 kibana && \
+RUN userdel -r ubuntu && groupadd --gid 1000 kibana && \
     useradd --uid 1000 --gid 1000 -G 0 \
       --home-dir /usr/share/kibana --no-create-home \
       kibana
 
-LABEL org.label-schema.build-date="2025-02-19T12:12:43.403Z" \
+LABEL org.label-schema.build-date="2025-06-18T11:10:23.947Z" \
   org.label-schema.license="Elastic License" \
   org.label-schema.name="Kibana" \
   org.label-schema.schema-version="1.0" \
   org.label-schema.url="https://www.elastic.co/products/kibana" \
   org.label-schema.usage="https://www.elastic.co/guide/en/kibana/reference/index.html" \
-  org.label-schema.vcs-ref="e13d3db4d0479be06aa5447d35797f750b8121f3" \
+  org.label-schema.vcs-ref="f6e2f2e44cc0a6a11435f1b6350f735e23bef4b4" \
   org.label-schema.vcs-url="https://github.com/elastic/kibana" \
   org.label-schema.vendor="Elastic" \
-  org.label-schema.version="7.17.28" \
-  org.opencontainers.image.created="2025-02-19T12:12:43.403Z" \
+  org.label-schema.version="7.17.29" \
+  org.opencontainers.image.created="2025-06-18T11:10:23.947Z" \
   org.opencontainers.image.documentation="https://www.elastic.co/guide/en/kibana/reference/index.html" \
   org.opencontainers.image.licenses="Elastic License" \
-  org.opencontainers.image.revision="e13d3db4d0479be06aa5447d35797f750b8121f3" \
+  org.opencontainers.image.revision="f6e2f2e44cc0a6a11435f1b6350f735e23bef4b4" \
   org.opencontainers.image.source="https://github.com/elastic/kibana" \
   org.opencontainers.image.title="Kibana" \
   org.opencontainers.image.url="https://www.elastic.co/products/kibana" \
   org.opencontainers.image.vendor="Elastic" \
-  org.opencontainers.image.version="7.17.28"
+  org.opencontainers.image.version="7.17.29"
 
 
 ENTRYPOINT ["/bin/tini", "--"]
```

</details>

Fixes https://github.com/docker-library/official-images/issues/20040