### PR TITLE
alpine: bump 3.22.2, 3.21.5, 3.20.8, 3.19.9

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.22.1, 3.22, 3, latest
+Tags: 3.22.2, 3.22, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.22
-GitCommit: 01dd5fbd09e25f6c040627eedf18bbfccfa9ad6e
+GitCommit: 4dc13cbc7caffe03c98aa99f28e27c2fb6f7e74d
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -27,10 +27,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.21.4, 3.21
+Tags: 3.21.5, 3.21
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.21
-GitCommit: dd258ea6660042cdf5aef42ef7745640ce27bf8e
+GitCommit: 2c30d5daeebb5090b1b6363a9e97dd88bf08a642
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -40,10 +40,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.20.7, 3.20
+Tags: 3.20.8, 3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.20
-GitCommit: 62f727c549aafddfe09929209215e68eb222f0b2
+GitCommit: f5ce8f036ef8a57481ae6f3f1cf7f2300cff8d29
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -53,10 +53,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.19.8, 3.19
+Tags: 3.19.9, 3.19
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64
 GitFetch: refs/heads/v3.19
-GitCommit: f2420d7551c86c2cd3fab04159b57b9bcc533647
+GitCommit: ee939d52345248420cf62d4606ccc7152bc5a107
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
- CVE-2025-9230
- CVE-2025-9231
- CVE-2025-9232