### PR TITLE
Update KrakenD to v2.11.1

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -1,9 +1,11 @@
 Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
-             Daniel López <dlopez@krakend.io> (@kpacha)
+             Daniel López <dlopez@krakend.io> (@kpacha),
+             Jorge Tarrero <jorge.tarrero@krakend.io> (@thedae),
+             David Hontecillas <david.hontecillas@krakend.io> (@dhontecillas)
 GitRepo: https://github.com/krakendio/docker-library.git
 
 # Alpine images
-Tags: 2.11.0, 2.11, 2, latest
+Tags: 2.11.1, 2.11, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: f7b7d2505b87be94f8aaab83bc1049a515e2dbf1
-Directory: 2.11.0
+GitCommit: c465023494ef14bc33e1dbf68a5108595c46f027
+Directory: 2.11.1


### PR DESCRIPTION
Security release for CVE's:
- CVE-2025-47911
- CVE-2025-61724
- CVE-2025-61725
- CVE-2025-58187
- CVE-2025-61723
- CVE-2025-47912
- CVE-2025-58185
- CVE-2025-58186
- CVE-2025-58188
- CVE-2025-58183