### PR TITLE
Test for zstd in Python 3.14+

### DIFF
--- a/test/tests/python-imports/container.py
+++ b/test/tests/python-imports/container.py
@@ -24,6 +24,11 @@ if not isCaveman:
     import lzma
     assert(lzma.decompress(lzma.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
 
+    if sys.version_info[1] >= 14:
+        # https://docs.python.org/3.14/library/compression.zstd.html
+        from compression import zstd
+        assert(zstd.decompress(zstd.compress(b'IT WORKS IT WORKS IT WORKS')) == b'IT WORKS IT WORKS IT WORKS')
+
     # https://github.com/docker-library/python/pull/954
     shouldHaveSetuptoolsAndWheel = sys.version_info[0] == 3 and sys.version_info[1] < 12
     import importlib.util


### PR DESCRIPTION
- related to https://github.com/docker-library/python/issues/1085

```console
$ ./test/tests/python-imports/run.sh python:3.14-slim
Traceback (most recent call last):
  File "/tmp/test-dir/python-imports/./container.py", line 29, in <module>
    from compression import zstd
  File "/usr/local/lib/python3.14/compression/zstd/__init__.py", line 29, in <module>
    import _zstd
ModuleNotFoundError: No module named '_zstd'
```