### PR TITLE
 Update Jetty versions to 12.0.28 & 12.1.2

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -119,15 +119,15 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
 GitCommit: d809b5668ca6c063cd913153dd0f5935f1276a4b
 
-Tags: 12.0.28-jdk24-alpine, 12.0-jdk24-alpine, 12.0.28-jdk24-alpine-eclipse-temurin, 12.0-jdk24-alpine-eclipse-temurin
+Tags: 12.0.28-jdk25-alpine, 12.0-jdk25-alpine, 12.0.28-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
 Architectures: amd64
-Directory: eclipse-temurin/12.0/jdk24-alpine
-GitCommit: d809b5668ca6c063cd913153dd0f5935f1276a4b
+Directory: eclipse-temurin/12.0/jdk25-alpine
+GitCommit: 5aaedc67275a1a013fdff517d86fc1383af70e1e
 
-Tags: 12.0.28-jdk24, 12.0-jdk24, 12.0.28-jdk24-eclipse-temurin, 12.0-jdk24-eclipse-temurin
+Tags: 12.0.28-jdk25, 12.0-jdk25, 12.0.28-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
 Architectures: amd64, arm64v8
-Directory: eclipse-temurin/12.0/jdk24
-GitCommit: d809b5668ca6c063cd913153dd0f5935f1276a4b
+Directory: eclipse-temurin/12.0/jdk25
+GitCommit: 5aaedc67275a1a013fdff517d86fc1383af70e1e
 
 Tags: 12.0.28-jdk21-alpine, 12.0-jdk21-alpine, 12.0.28-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
 Architectures: amd64
@@ -329,10 +329,10 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17
 GitCommit: d809b5668ca6c063cd913153dd0f5935f1276a4b
 
-Tags: 12.0.28-jdk24-al2023-amazoncorretto, 12.0-jdk24-al2023-amazoncorretto
+Tags: 12.0.28-jdk25-al2023-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto
 Architectures: amd64, arm64v8
-Directory: amazoncorretto/12.0/jdk24-al2023
-GitCommit: d809b5668ca6c063cd913153dd0f5935f1276a4b
+Directory: amazoncorretto/12.0/jdk25-al2023
+GitCommit: 5aaedc67275a1a013fdff517d86fc1383af70e1e
 
 Tags: 12.0.28-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8


### PR DESCRIPTION
###  Update Jetty versions
- `12.0.27` -> `12.0.28`
- `12.1.1` -> `12.1.2`