### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.2.0, 6.2, 6, latest
+Tags: 6.3.0, 6.3, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: d2feb10e3b16dbb44fe0e2d85a48d55d0bc9a39d
+GitCommit: 2f3e896dfc7110d63a154e249b51ad64d39db2ba
 Directory: 6/debian
 
-Tags: 6.2.0-alpine, 6.2-alpine, 6-alpine, alpine
+Tags: 6.3.0-alpine, 6.3-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: d2feb10e3b16dbb44fe0e2d85a48d55d0bc9a39d
+GitCommit: 2f3e896dfc7110d63a154e249b51ad64d39db2ba
 Directory: 6/alpine
 
 Tags: 5.130.5, 5.130, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/2f3e896: Update to 6.3.0, ghost-cli 1.28.3