### PR TITLE
[Friendica] Update to new source tarball handling

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -36,15 +36,15 @@ Directory: 2025.02-dev/fpm-alpine
 
 Tags: 2025.07-rc-apache, rc-apache, 2025.07-rc, rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe4374468345b2ddaedbb075f80b2b810e3ef6af
+GitCommit: 567780fda826aeaf8ec328fd48225f5d6a48e4e8
 Directory: 2025.07-rc/apache
 
 Tags: 2025.07-rc-fpm, rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe4374468345b2ddaedbb075f80b2b810e3ef6af
+GitCommit: 567780fda826aeaf8ec328fd48225f5d6a48e4e8
 Directory: 2025.07-rc/fpm
 
 Tags: 2025.07-rc-fpm-alpine, rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fe4374468345b2ddaedbb075f80b2b810e3ef6af
+GitCommit: 567780fda826aeaf8ec328fd48225f5d6a48e4e8
 Directory: 2025.07-rc/fpm-alpine


### PR DESCRIPTION
Updated the entrypoint-dev.sh to make use of the new single tarball for friendica and its addons.