### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.3.0, 6.3, 6, latest
+Tags: 6.3.1, 6.3, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 2f3e896dfc7110d63a154e249b51ad64d39db2ba
+GitCommit: d9131c1c24594d782e0ddac3a98daae9237a1202
 Directory: 6/debian
 
-Tags: 6.3.0-alpine, 6.3-alpine, 6-alpine, alpine
+Tags: 6.3.1-alpine, 6.3-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 2f3e896dfc7110d63a154e249b51ad64d39db2ba
+GitCommit: d9131c1c24594d782e0ddac3a98daae9237a1202
 Directory: 6/alpine
 
 Tags: 5.130.5, 5.130, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/d9131c1: Update to 6.3.1, ghost-cli 1.28.3