### PR TITLE
Updated swipl devel to 9.3.32

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,7 +1,7 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: 69b22e9613a29ff6079ee9783502afe91e7b16b5
+GitCommit: d4411aa88faba036ab47f95f744f77b4fec6749d
 Architectures: amd64, arm32v7, arm64v8
 
 Tags: latest, 9.3.32


### PR DESCRIPTION
Updates RocksDB package as well.    This updates RocksDB itself and hopefully fixes https://github.com/docker-library/official-images/pull/16167#issuecomment-3363537774.   