### PR TITLE
archlinux: Release 20251012.0.434149

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20251005.0.430597
-GitCommit: bab15f2a96c4dab1c0e0bbc6620900f5ba79d171
-GitFetch: refs/tags/v20251005.0.430597
+Tags: latest, base, base-20251012.0.434149
+GitCommit: 1ad524c13b57eb60b01a2d576c65dd4ed2140fd0
+GitFetch: refs/tags/v20251012.0.434149
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20251005.0.430597
-GitCommit: bab15f2a96c4dab1c0e0bbc6620900f5ba79d171
-GitFetch: refs/tags/v20251005.0.430597
+Tags: base-devel, base-devel-20251012.0.434149
+GitCommit: 1ad524c13b57eb60b01a2d576c65dd4ed2140fd0
+GitFetch: refs/tags/v20251012.0.434149
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20251005.0.430597
-GitCommit: bab15f2a96c4dab1c0e0bbc6620900f5ba79d171
-GitFetch: refs/tags/v20251005.0.430597
+Tags: multilib-devel, multilib-devel-20251012.0.434149
+GitCommit: 1ad524c13b57eb60b01a2d576c65dd4ed2140fd0
+GitFetch: refs/tags/v20251012.0.434149
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks