### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-17415 ELSA-2025-17715"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a5c2a9eb92c73cbb5e5b402521c6c565b44b3cfb
+amd64-GitCommit: fa75806c1ac54ec4e937b364811231ef8eb5e5c6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7aa36179bef9776fe6f301bf019730578c7077ea
+arm64v8-GitCommit: f6267a9259819d1e22003c6ee2522fbb39638356
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-32988, CVE-2025-32990, CVE-2025-6395, CVE-2025-53905, CVE-2025-53906, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-17415.html
https://linux.oracle.com/errata/ELSA-2025-17715.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
