### PR TITLE
"[oraclelinux] Updating 9 for ELSA-2025-17742"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fa75806c1ac54ec4e937b364811231ef8eb5e5c6
+amd64-GitCommit: b2829f9d0fc61580befc8cb4eec461d14bacca37
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f6267a9259819d1e22003c6ee2522fbb39638356
+arm64v8-GitCommit: c4ad35010a71c1b77383bb9c2ec25aa5cb700875
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-53905, CVE-2025-53906, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-17742.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
