### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/aa77a9af77b7c3b8c56bb9e00f5d150d80241261/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/9c5e1b35aba115938e93706b29a0b331d4de51a1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: aa77a9af77b7c3b8c56bb9e00f5d150d80241261
+GitCommit: 9c5e1b35aba115938e93706b29a0b331d4de51a1
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9c2d0c6fbaaf2ca1b4c19027fa515d9e797e7199
+amd64-GitCommit: e5b5178110ca0332364a77d5eb4fff87b0e2ba3f
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d687cd5484009bdf2ee3e79a78600f01a7edc912
+arm32v5-GitCommit: 711d4b9a23ae7756c495308ba39c4897b0ba6d1b
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: cc1f10900971ca90ea354645e1d676209d7342d0
+arm32v6-GitCommit: 2ea965c6956fa134dd72ddf7ab815788a865a7cb
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: c773a028ec0e18dc92e89e0bc57898883897ef8d
+arm32v7-GitCommit: a4fac83861d137e9dcfce70b31d0b8fafea9346e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8141f5b047a1fbeefd842388244c045825a61c90
+arm64v8-GitCommit: f30de561de9bf38da10058620e9c4c383ec8a905
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: ddcda848177fffa1df68fbed9cda06bd17757dad
+i386-GitCommit: e5ecee6181d9940bf853d2dc64005ce676c4444c
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: ddb1ced9350261eb7aa6d117052d04a5ad8dd1b7
+ppc64le-GitCommit: 149c39d6036d77a55679c6b9e0c946ba2ad38555
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: aa4b2b5fc1583c52a2806f38772d2f684f3c3185
+riscv64-GitCommit: eabe7cf678f2abbc0477a8603428519771ede877
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 52d5ab6b9089780aaa39f36c7d4562ee0f7ce3d5
+s390x-GitCommit: 87c948a4fac6f84195e795486a8d650b0c9cc10d
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/9c5e1b3: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/2efdef7: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/5ddab61: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/12648ec: Update metadata for i386
- https://github.com/docker-library/busybox/commit/d17bc50: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/36707a0: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/cfe3ad7: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/672d956: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/d23d6b5: Merge pull request https://github.com/docker-library/busybox/pull/231 from infosiftr/buildroot-2025.08.1
- https://github.com/docker-library/busybox/commit/f43c8ae: Update amd64 metadata
- https://github.com/docker-library/busybox/commit/3dc87d7: Update buildroot to 2025.08.1