### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,122 +4,47 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 6.0.0-rc1, 6.0, 6.0.rc, 6.0.0-rc, 6.0.0-rc1-apache, 6.0-apache, 6.0.rc-apache, 6.0.0-rc-apache, 6.0.0-rc1-php8.3, 6.0-php8.3, 6.0.rc-php8.3, 6.0.0-rc-php8.3, 6.0.0-rc1-php8.3-apache, 6.0-php8.3-apache, 6.0.rc-php8.3-apache, 6.0.0-rc-php8.3-apache
+Tags: 6.0.0, 6.0, 6, latest, 6.0.0-apache, 6.0-apache, 6-apache, apache, 6.0.0-php8.3, 6.0-php8.3, 6-php8.3, php8.3, 6.0.0-php8.3-apache, 6.0-php8.3-apache, 6-php8.3-apache, php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 6.0.rc/php8.3/apache
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 6.0/php8.3/apache
 
-Tags: 6.0.0-rc1-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6.0.rc-php8.3-fpm-alpine, 6.0.0-rc-php8.3-fpm-alpine
+Tags: 6.0.0-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 6.0.rc/php8.3/fpm-alpine
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 6.0/php8.3/fpm-alpine
 
-Tags: 6.0.0-rc1-php8.3-fpm, 6.0-php8.3-fpm, 6.0.rc-php8.3-fpm, 6.0.0-rc-php8.3-fpm
+Tags: 6.0.0-php8.3-fpm, 6.0-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 6.0.rc/php8.3/fpm
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 6.0/php8.3/fpm
 
-Tags: 5.4.0-rc1-php8.2-apache, 5.4-php8.2-apache, 5.4.rc-php8.2-apache, 5.4.0-rc-php8.2-apache
+Tags: 5.4.0-php8.2-apache, 5.4-php8.2-apache, 5-php8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 5.4.rc/php8.2/apache
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 5.4/php8.2/apache
 
-Tags: 5.4.0-rc1-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5.4.rc-php8.2-fpm-alpine, 5.4.0-rc-php8.2-fpm-alpine
+Tags: 5.4.0-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 5.4.rc/php8.2/fpm-alpine
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 5.4/php8.2/fpm-alpine
 
-Tags: 5.4.0-rc1-php8.2-fpm, 5.4-php8.2-fpm, 5.4.rc-php8.2-fpm, 5.4.0-rc-php8.2-fpm
+Tags: 5.4.0-php8.2-fpm, 5.4-php8.2-fpm, 5-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 5.4.rc/php8.2/fpm
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 5.4/php8.2/fpm
 
-Tags: 5.4.0-rc1, 5.4, 5.4.rc, 5.4.0-rc, 5.4.0-rc1-apache, 5.4-apache, 5.4.rc-apache, 5.4.0-rc-apache, 5.4.0-rc1-php8.3, 5.4-php8.3, 5.4.rc-php8.3, 5.4.0-rc-php8.3, 5.4.0-rc1-php8.3-apache, 5.4-php8.3-apache, 5.4.rc-php8.3-apache, 5.4.0-rc-php8.3-apache
+Tags: 5.4.0, 5.4, 5, 5.4.0-apache, 5.4-apache, 5-apache, 5.4.0-php8.3, 5.4-php8.3, 5-php8.3, 5.4.0-php8.3-apache, 5.4-php8.3-apache, 5-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 5.4.rc/php8.3/apache
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 5.4/php8.3/apache
 
-Tags: 5.4.0-rc1-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5.4.rc-php8.3-fpm-alpine, 5.4.0-rc-php8.3-fpm-alpine
+Tags: 5.4.0-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 5.4.rc/php8.3/fpm-alpine
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 5.4/php8.3/fpm-alpine
 
-Tags: 5.4.0-rc1-php8.3-fpm, 5.4-php8.3-fpm, 5.4.rc-php8.3-fpm, 5.4.0-rc-php8.3-fpm
+Tags: 5.4.0-php8.3-fpm, 5.4-php8.3-fpm, 5-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: aef82542b636262efcb9ecd636b53a2fb0b87eaf
-Directory: 5.4.rc/php8.3/fpm
-
-Tags: 5.3.4-php8.1-apache, 5.3-php8.1-apache, 5-php8.1-apache, php8.1-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.1/apache
-
-Tags: 5.3.4-php8.1-fpm-alpine, 5.3-php8.1-fpm-alpine, 5-php8.1-fpm-alpine, php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.1/fpm-alpine
-
-Tags: 5.3.4-php8.1-fpm, 5.3-php8.1-fpm, 5-php8.1-fpm, php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.1/fpm
-
-Tags: 5.3.4-php8.2-apache, 5.3-php8.2-apache, 5-php8.2-apache, php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.2/apache
-
-Tags: 5.3.4-php8.2-fpm-alpine, 5.3-php8.2-fpm-alpine, 5-php8.2-fpm-alpine, php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.2/fpm-alpine
-
-Tags: 5.3.4-php8.2-fpm, 5.3-php8.2-fpm, 5-php8.2-fpm, php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.2/fpm
-
-Tags: 5.3.4, 5.3, 5, latest, 5.3.4-apache, 5.3-apache, 5-apache, apache, 5.3.4-php8.3, 5.3-php8.3, 5-php8.3, php8.3, 5.3.4-php8.3-apache, 5.3-php8.3-apache, 5-php8.3-apache, php8.3-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.3/apache
-
-Tags: 5.3.4-php8.3-fpm-alpine, 5.3-php8.3-fpm-alpine, 5-php8.3-fpm-alpine, php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.3/fpm-alpine
-
-Tags: 5.3.4-php8.3-fpm, 5.3-php8.3-fpm, 5-php8.3-fpm, php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 648ca79e48e868150bc346a315233f09770bc565
-Directory: 5.3/php8.3/fpm
-
-Tags: 4.4.14-php8.1-apache, 4.4-php8.1-apache, 4-php8.1-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c46c028c70bdd37a5526d72566cf6c52449b7fad
-Directory: 4.4/php8.1/apache
-
-Tags: 4.4.14-php8.1-fpm-alpine, 4.4-php8.1-fpm-alpine, 4-php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c46c028c70bdd37a5526d72566cf6c52449b7fad
-Directory: 4.4/php8.1/fpm-alpine
-
-Tags: 4.4.14-php8.1-fpm, 4.4-php8.1-fpm, 4-php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c46c028c70bdd37a5526d72566cf6c52449b7fad
-Directory: 4.4/php8.1/fpm
-
-Tags: 4.4.14, 4.4, 4, 4.4.14-apache, 4.4-apache, 4-apache, 4.4.14-php8.2, 4.4-php8.2, 4-php8.2, 4.4.14-php8.2-apache, 4.4-php8.2-apache, 4-php8.2-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c46c028c70bdd37a5526d72566cf6c52449b7fad
-Directory: 4.4/php8.2/apache
-
-Tags: 4.4.14-php8.2-fpm-alpine, 4.4-php8.2-fpm-alpine, 4-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c46c028c70bdd37a5526d72566cf6c52449b7fad
-Directory: 4.4/php8.2/fpm-alpine
-
-Tags: 4.4.14-php8.2-fpm, 4.4-php8.2-fpm, 4-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c46c028c70bdd37a5526d72566cf6c52449b7fad
-Directory: 4.4/php8.2/fpm
+GitCommit: e59b7df4c07b205c5e3f9df912cf2af0fec9e383
+Directory: 5.4/php8.3/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@e59b7df: Remove RC images. Release Joomla v6.0.0 and v5.4.0. Removed v5.3 and v4.4