### PR TITLE
Update KrakenD to v2.11.2

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -2,10 +2,10 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
              Daniel López <dlopez@krakend.io> (@kpacha),
              Jorge Tarrero <jorge.tarrero@krakend.io> (@thedae),
              David Hontecillas <david.hontecillas@krakend.io> (@dhontecillas)
-GitRepo: https://github.com/krakendio/docker-library.git
+GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.11.1, 2.11, 2, latest
+Tags: 2.11.2, 2.11, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: c465023494ef14bc33e1dbf68a5108595c46f027
-Directory: 2.11.1
+GitCommit: 8f838ce2eaf9e375a0106b7d3e29fe211aea1314
+Directory: 2.11.2


### PR DESCRIPTION
So that you know, the repository URL has changed. It was already a redirection from github.com/krakendio to github.com/krakend, and we updated the URL to avoid a possible supply chain attack.

This update fixes CVE-2025-58187.

Thank you!