### PR TITLE
"[oraclelinux] Updating 10and 10-slim for ELSA-2025-18231"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6edef91130aebdd540d741c6244a3a3c35147d0e
+amd64-GitCommit: 50c32162f09085d53a06aa91a2031826d5a3a623
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d5f4c157cfc512f7fafbe675a68542fbbb75d870
+arm64v8-GitCommit: 33c0cbcb3ec5df570a685dc644e7d197e08b69ad
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5318, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-18231.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
