### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-18275"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 50c32162f09085d53a06aa91a2031826d5a3a623
+amd64-GitCommit: e0e3b68e819337a954b2d56ce76f311bb59c6bd8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 33c0cbcb3ec5df570a685dc644e7d197e08b69ad
+arm64v8-GitCommit: 68c003dc48391a960b29b11dc066dc70123492e6
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5318

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-18275.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
