### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-18286"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e0e3b68e819337a954b2d56ce76f311bb59c6bd8
+amd64-GitCommit: fe3cfb9b6b7834daf2033b97256a4387b2c6dcf8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 68c003dc48391a960b29b11dc066dc70123492e6
+arm64v8-GitCommit: c7f16b39d226cd22d073bf3e44fabe2f11637d75
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5318

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-18286.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
