### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev9, 3.3-dev, 3.3-dev9-trixie, 3.3-dev-trixie
+Tags: 3.3-dev10, 3.3-dev, 3.3-dev10-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4cd7a3775e0995919e129289cfa2e314e37fb15e
+GitCommit: be4757e151254dc143f8dfb7cc25b39df8a01543
 Directory: 3.3
 
-Tags: 3.3-dev9-alpine, 3.3-dev-alpine, 3.3-dev9-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev10-alpine, 3.3-dev-alpine, 3.3-dev10-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4cd7a3775e0995919e129289cfa2e314e37fb15e
+GitCommit: be4757e151254dc143f8dfb7cc25b39df8a01543
 Directory: 3.3/alpine
 
 Tags: 3.2.6, 3.2, latest, lts, 3.2.6-trixie, 3.2-trixie, trixie, lts-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/be4757e: Update 3.3 to 3.3-dev10