### PR TITLE
Odoo: update 17.0-19.0 to release 20251021

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: f24d0401287edf563bacf60de5f08f8edee8cf19
+GitCommit: 0ee804078811d2bc209b5fac3060f5f66de7747b
 
-Tags: 19.0-20251008, 19.0, 19, latest
+Tags: 19.0-20251021, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20251008, 18.0, 18
+Tags: 18.0-20251021, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20251008, 17.0, 17
+Tags: 17.0-20251021, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks