### PR TITLE
Update for corretto 2025 Q4 release

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,228 +15,200 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: da3b725e5c2e6dd6732320efc68288938486b3cd
+GitCommit: da9c78f521c6ae2e0d63eaf6827a9d27168ff6d8
 
-Tags: 8, 8u462, 8u462-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u462-al2-generic, 8-al2-generic-jdk, latest
+Tags: 8, 8u472, 8u472-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u472-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2-generic
 
-Tags: 8-al2023, 8u462-al2023, 8-al2023-jdk
+Tags: 8-al2023, 8u472-al2023, 8-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2023-jre, 8u462-al2023-jre
+Tags: 8-al2023-jre, 8u472-al2023-jre
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2-native-jre, 8u462-al2-native-jre
+Tags: 8-al2-native-jre, 8u472-al2-native-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2
 
-Tags: 8-al2-native-jdk, 8u462-al2-native-jdk
+Tags: 8-al2-native-jdk, 8u472-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.19, 8u462-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk
+Tags: 8-alpine3.19, 8u472-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.19
 
-Tags: 8-alpine3.19-jre, 8u462-alpine3.19-jre
+Tags: 8-alpine3.19-jre, 8u472-alpine3.19-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.19
 
-Tags: 8-alpine3.20, 8u462-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
+Tags: 8-alpine3.20, 8u472-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.20
 
-Tags: 8-alpine3.20-jre, 8u462-alpine3.20-jre
+Tags: 8-alpine3.20-jre, 8u472-alpine3.20-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.20
 
-Tags: 8-alpine3.21, 8u462-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
+Tags: 8-alpine3.21, 8u472-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8-alpine3.21-jre, 8u462-alpine3.21-jre
+Tags: 8-alpine3.21-jre, 8u472-alpine3.21-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.21
 
-Tags: 8-alpine3.22, 8u462-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk, 8-alpine, 8u462-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.22, 8u472-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk, 8-alpine, 8u472-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.22
 
-Tags: 8-alpine3.22-jre, 8u462-alpine3.22-jre, 8-alpine-jre, 8u462-alpine-jre
+Tags: 8-alpine3.22-jre, 8u472-alpine3.22-jre, 8-alpine-jre, 8u472-alpine-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.22
 
-Tags: 11, 11.0.28, 11.0.28-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.28-al2-generic, 11-al2-generic-jdk
+Tags: 11, 11.0.29, 11.0.29-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.29-al2-generic, 11-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2-generic
 
-Tags: 11-al2023, 11.0.28-al2023, 11-al2023-jdk
+Tags: 11-al2023, 11.0.29-al2023, 11-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2023
 
-Tags: 11-al2023-headless, 11.0.28-al2023-headless
+Tags: 11-al2023-headless, 11.0.29-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2023
 
-Tags: 11-al2023-headful, 11.0.28-al2023-headful
+Tags: 11-al2023-headful, 11.0.29-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 11/headful/al2023
 
-Tags: 11-al2-native-headless, 11.0.28-al2-native-headless
+Tags: 11-al2-native-headless, 11.0.29-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2
 
-Tags: 11-al2-native-jdk, 11.0.28-al2-native-jdk
+Tags: 11-al2-native-jdk, 11.0.29-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.19, 11.0.28-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk
+Tags: 11-alpine3.19, 11.0.29-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.19
 
-Tags: 11-alpine3.20, 11.0.28-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
+Tags: 11-alpine3.20, 11.0.29-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.20
 
-Tags: 11-alpine3.21, 11.0.28-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
+Tags: 11-alpine3.21, 11.0.29-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.21
 
-Tags: 11-alpine3.22, 11.0.28-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk, 11-alpine, 11.0.28-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine3.22, 11.0.29-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk, 11-alpine, 11.0.29-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.22
 
-Tags: 17, 17.0.16, 17.0.16-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.16-al2-generic, 17-al2-generic-jdk
+Tags: 17, 17.0.17, 17.0.17-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.17-al2-generic, 17-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2-generic
 
-Tags: 17-al2023, 17.0.16-al2023, 17-al2023-jdk
+Tags: 17-al2023, 17.0.17-al2023, 17-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2023
 
-Tags: 17-al2023-headless, 17.0.16-al2023-headless
+Tags: 17-al2023-headless, 17.0.17-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2023
 
-Tags: 17-al2023-headful, 17.0.16-al2023-headful
+Tags: 17-al2023-headful, 17.0.17-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2023
 
-Tags: 17-al2-native-headless, 17.0.16-al2-native-headless
+Tags: 17-al2-native-headless, 17.0.17-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2
 
-Tags: 17-al2-native-headful, 17.0.16-al2-native-headful
+Tags: 17-al2-native-headful, 17.0.17-al2-native-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2
 
-Tags: 17-al2-native-jdk, 17.0.16-al2-native-jdk
+Tags: 17-al2-native-jdk, 17.0.17-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.19, 17.0.16-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk
+Tags: 17-alpine3.19, 17.0.17-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.19
 
-Tags: 17-alpine3.20, 17.0.16-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
+Tags: 17-alpine3.20, 17.0.17-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.20
 
-Tags: 17-alpine3.21, 17.0.16-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
+Tags: 17-alpine3.21, 17.0.17-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.21
 
-Tags: 17-alpine3.22, 17.0.16-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk, 17-alpine, 17.0.16-alpine, 17-alpine-full, 17-alpine-jdk
+Tags: 17-alpine3.22, 17.0.17-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk, 17-alpine, 17.0.17-alpine, 17-alpine-full, 17-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.22
 
-Tags: 21, 21.0.8, 21.0.8-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.8-al2-generic, 21-al2-generic-jdk
+Tags: 21, 21.0.9, 21.0.9-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.9-al2-generic, 21-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2-generic
 
-Tags: 21-al2023, 21.0.8-al2023, 21-al2023-jdk
+Tags: 21-al2023, 21.0.9-al2023, 21-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2023
 
-Tags: 21-al2023-headless, 21.0.8-al2023-headless
+Tags: 21-al2023-headless, 21.0.9-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 21/headless/al2023
 
-Tags: 21-al2023-headful, 21.0.8-al2023-headful
+Tags: 21-al2023-headful, 21.0.9-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 21/headful/al2023
 
-Tags: 21-alpine3.19, 21.0.8-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk
+Tags: 21-alpine3.19, 21.0.9-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.19
 
-Tags: 21-alpine3.20, 21.0.8-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
+Tags: 21-alpine3.20, 21.0.9-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.20
 
-Tags: 21-alpine3.21, 21.0.8-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
+Tags: 21-alpine3.21, 21.0.9-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.21
 
-Tags: 21-alpine3.22, 21.0.8-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk, 21-alpine, 21.0.8-alpine, 21-alpine-full, 21-alpine-jdk
+Tags: 21-alpine3.22, 21.0.9-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk, 21-alpine, 21.0.9-alpine, 21-alpine-full, 21-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.22
 
-Tags: 24-al2023, 24.0.2-al2023, 24-al2023-jdk, 24, 24-jdk
-Architectures: amd64, arm64v8
-Directory: 24/jdk/al2023
-
-Tags: 24-al2023-headless, 24.0.2-al2023-headless, 24-headless
-Architectures: amd64, arm64v8
-Directory: 24/headless/al2023
-
-Tags: 24-al2023-headful, 24.0.2-al2023-headful, 24-headful
-Architectures: amd64, arm64v8
-Directory: 24/headful/al2023
-
-Tags: 24-alpine3.19, 24.0.2-alpine3.19, 24-alpine3.19-full, 24-alpine3.19-jdk
-Architectures: amd64, arm64v8
-Directory: 24/jdk/alpine/3.19
-
-Tags: 24-alpine3.20, 24.0.2-alpine3.20, 24-alpine3.20-full, 24-alpine3.20-jdk
-Architectures: amd64, arm64v8
-Directory: 24/jdk/alpine/3.20
-
-Tags: 24-alpine3.21, 24.0.2-alpine3.21, 24-alpine3.21-full, 24-alpine3.21-jdk
-Architectures: amd64, arm64v8
-Directory: 24/jdk/alpine/3.21
-
-Tags: 24-alpine3.22, 24.0.2-alpine3.22, 24-alpine3.22-full, 24-alpine3.22-jdk, 24-alpine, 24.0.2-alpine, 24-alpine-full, 24-alpine-jdk
-Architectures: amd64, arm64v8
-Directory: 24/jdk/alpine/3.22
-
-Tags: 25-al2023, 25.0.0-al2023, 25-al2023-jdk, 25, 25-jdk
+Tags: 25-al2023, 25.0.1-al2023, 25-al2023-jdk, 25, 25-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/al2023
 
-Tags: 25-al2023-headless, 25.0.0-al2023-headless, 25-headless
+Tags: 25-al2023-headless, 25.0.1-al2023-headless, 25-headless
 Architectures: amd64, arm64v8
 Directory: 25/headless/al2023
 
-Tags: 25-al2023-headful, 25.0.0-al2023-headful, 25-headful
+Tags: 25-al2023-headful, 25.0.1-al2023-headful, 25-headful
 Architectures: amd64, arm64v8
 Directory: 25/headful/al2023
 
-Tags: 25-alpine3.19, 25.0.0-alpine3.19, 25-alpine3.19-full, 25-alpine3.19-jdk
+Tags: 25-alpine3.19, 25.0.1-alpine3.19, 25-alpine3.19-full, 25-alpine3.19-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.19
 
-Tags: 25-alpine3.20, 25.0.0-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
+Tags: 25-alpine3.20, 25.0.1-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.20
 
-Tags: 25-alpine3.21, 25.0.0-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
+Tags: 25-alpine3.21, 25.0.1-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.21
 
-Tags: 25-alpine3.22, 25.0.0-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk, 25-alpine, 25.0.0-alpine, 25-alpine-full, 25-alpine-jdk
+Tags: 25-alpine3.22, 25.0.1-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk, 25-alpine, 25.0.1-alpine, 25-alpine-full, 25-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.22


### PR DESCRIPTION
Update amazoncorretto for 2025 Q4 release. For more details, see:
- https://github.com/corretto/corretto-docker/pull/256
- https://github.com/corretto/corretto-8/releases/tag/8.472.08.1
- https://github.com/corretto/corretto-11/releases/tag/11.0.29.7.1
- https://github.com/corretto/corretto-17/releases/tag/17.0.17.10.1
- https://github.com/corretto/corretto-21/releases/tag/21.0.9.10.1
- https://github.com/corretto/corretto-25/releases/tag/25.0.1.8.1
