### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -5,14 +5,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
 
-Tags: 6.5.0, 6.5, 6, latest
+Tags: 6.5.1, 6.5, 6, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: f952f7615274894d6efb0fbc765f5368580fb39a
+GitCommit: 179922f823264f1d318bf54247a845dbabf12b07
 Directory: 6/debian
 
-Tags: 6.5.0-alpine, 6.5-alpine, 6-alpine, alpine
+Tags: 6.5.1-alpine, 6.5-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: f952f7615274894d6efb0fbc765f5368580fb39a
+GitCommit: 179922f823264f1d318bf54247a845dbabf12b07
 Directory: 6/alpine
 
 Tags: 5.130.5, 5.130, 5


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/179922f: Update to 6.5.1, ghost-cli 1.28.3