### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: be4757e151254dc143f8dfb7cc25b39df8a01543
 Directory: 3.3/alpine
 
-Tags: 3.2.6, 3.2, latest, lts, 3.2.6-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.7, 3.2, latest, lts, 3.2.7-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 04b2168ff76f90727c02f01cb719f655e768f6fd
+GitCommit: e4c0de0b54fc42dd87f22cfb61aad93562dad787
 Directory: 3.2
 
-Tags: 3.2.6-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.6-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.7-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.7-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 04b2168ff76f90727c02f01cb719f655e768f6fd
+GitCommit: e4c0de0b54fc42dd87f22cfb61aad93562dad787
 Directory: 3.2/alpine
 
 Tags: 3.1.9, 3.1, 3.1.9-trixie, 3.1-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/e4c0de0: Update 3.2 to 3.2.7