### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/9c5e1b35aba115938e93706b29a0b331d4de51a1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/c1c6e2e2606dcc7c638d09893803d119ba8f59c5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 9c5e1b35aba115938e93706b29a0b331d4de51a1
+GitCommit: c1c6e2e2606dcc7c638d09893803d119ba8f59c5
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e5b5178110ca0332364a77d5eb4fff87b0e2ba3f
+amd64-GitCommit: 3c91bcd92b2cd6c113a87c39bcada57fbccf00b0
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 711d4b9a23ae7756c495308ba39c4897b0ba6d1b
+arm32v5-GitCommit: 0304c4d54eb0ccd2f2f0440dfff8927fdca8ed91
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 2ea965c6956fa134dd72ddf7ab815788a865a7cb
+arm32v6-GitCommit: 51828b2e71143ac5772f87270676d348ff73f953
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: a4fac83861d137e9dcfce70b31d0b8fafea9346e
+arm32v7-GitCommit: 41862816ce89451518f38e22a190d509aa58541e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f30de561de9bf38da10058620e9c4c383ec8a905
+arm64v8-GitCommit: b938a081854f2252b114724eebc92c3a33fc53b1
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: e5ecee6181d9940bf853d2dc64005ce676c4444c
+i386-GitCommit: 8160ba0d3f75aa7f1fefacf416aa18f6fc3fec74
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 149c39d6036d77a55679c6b9e0c946ba2ad38555
+ppc64le-GitCommit: b98c7ac981bf068570533eaf66691fd7f5143388
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: eabe7cf678f2abbc0477a8603428519771ede877
+riscv64-GitCommit: 6a2bbfd2057ad1a7e644ff0bfdbdb5d89aa8340d
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 87c948a4fac6f84195e795486a8d650b0c9cc10d
+s390x-GitCommit: e170ce69420d2611a83d98c259acdea6fcab974f
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/c1c6e2e: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/df69512: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/a35d046: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/fa3deff: Update metadata for i386
- https://github.com/docker-library/busybox/commit/06be0e6: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/446d2c7: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/ccd7904: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/055006a: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/e2587c5: Merge pull request https://github.com/docker-library/busybox/pull/233 from infosiftr/inotifyd
- https://github.com/docker-library/busybox/commit/62c0061: Update amd64 metadata
- https://github.com/docker-library/busybox/commit/2ea1e24: Enable inotifyd