### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.5, 5.0, 5, latest, 5.0.5-jammy, 5.0-jammy, 5-jammy, jammy
+Tags: 5.0.6, 5.0, 5, latest, 5.0.6-jammy, 5.0-jammy, 5-jammy, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 793ea6b2a8097d629252fe77585775443b53e4c3
+GitCommit: 6d75217eb8c69b8d9dd94766b781d829a56fbd2d
 Directory: 5.0
 
 Tags: 4.1.10, 4.1, 4, 4.1.10-jammy, 4.1-jammy, 4-jammy


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/6d75217: Update 5.0 to 5.0.6