### PR TITLE
Haskell: bump ghc 9.10 to 9.10.3 + refreshed Dockerfiles

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -12,6 +12,16 @@ Architectures: amd64, arm64v8
 GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
 Directory: 9.12/slim-bookworm
 
+Tags: 9.10.3-bookworm, 9.10-bookworm
+Architectures: amd64, arm64v8
+GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+Directory: 9.10/bookworm
+
+Tags: 9.10.3-slim-bookworm, 9.10-slim-bookworm
+Architectures: amd64, arm64v8
+GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+Directory: 9.10/slim-bookworm
+
 Tags: 9.10.3-bullseye, 9.10-bullseye, 9-bullseye, bullseye, 9.10.3, 9.10
 Architectures: amd64, arm64v8
 GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1


### PR DESCRIPTION
See https://github.com/haskell/docker-haskell/pull/166

Also since the last commit a new image `9.10.3-bookworm` and `9.10.3-slim-bookworm` was added, chnaging the `9.10` tag to point to bookworm wouldn't be a good idea, so I didn't do that