### PR TITLE
rust: Update Rust version to 1.91.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,52 +1,52 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/3aad80112be66bf796c202713029d7ba93dff7fa/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/d244703b2150d3d586867aab0a02e24cdd688821/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.90-bullseye, 1.90.0-bullseye, bullseye
+Tags: 1-bullseye, 1.91-bullseye, 1.91.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.90-slim-bullseye, 1.90.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.91-slim-bullseye, 1.91.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.90-bookworm, 1.90.0-bookworm, bookworm
+Tags: 1-bookworm, 1.91-bookworm, 1.91.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.90-slim-bookworm, 1.90.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.91-slim-bookworm, 1.91.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.90-trixie, 1.90.0-trixie, trixie, 1, 1.90, 1.90.0, latest
+Tags: 1-trixie, 1.91-trixie, 1.91.0-trixie, trixie, 1, 1.91, 1.91.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.90-slim-trixie, 1.90.0-slim-trixie, slim-trixie, 1-slim, 1.90-slim, 1.90.0-slim, slim
+Tags: 1-slim-trixie, 1.91-slim-trixie, 1.91.0-slim-trixie, slim-trixie, 1-slim, 1.91-slim, 1.91.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.20, 1.90-alpine3.20, 1.90.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.91-alpine3.20, 1.91.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.90-alpine3.21, 1.90.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.91-alpine3.21, 1.91.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.90-alpine3.22, 1.90.0-alpine3.22, alpine3.22, 1-alpine, 1.90-alpine, 1.90.0-alpine, alpine
+Tags: 1-alpine3.22, 1.91-alpine3.22, 1.91.0-alpine3.22, alpine3.22, 1-alpine, 1.91-alpine, 1.91.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 3aad80112be66bf796c202713029d7ba93dff7fa
+GitCommit: d244703b2150d3d586867aab0a02e24cdd688821
 Directory: stable/alpine3.22
 


### PR DESCRIPTION
https://blog.rust-lang.org/2025/10/30/Rust-1.91.0/
https://github.com/rust-lang/rust/releases/tag/1.91.0