### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -13,19 +13,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.7.20250512.0
+Tags: 2023, latest, 2023.9.20251027.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: dacb9d52e9344a2977503cb4ecfc0879b69de878
+amd64-GitCommit: c666d32da5468884cfa42ccd80455bc856e07785
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: a37632ff24fdf2d838fe84fc358d8844ecdcd365
+arm64v8-GitCommit: 66c04d49501d91410e86b1ff9357d7d9eb30b2be
 
-Tags: 2, 2.0.20250512.0
+Tags: 2, 2.0.20251027.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 943ba6f33d9edd4b4dce773a0501b914af2d39f8
+amd64-GitCommit: ed40df28f69622fa062061566027d2c798d8baf8
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 9194c0e5c6b27fe9a7c575b783debdf946cafe84
+arm64v8-GitCommit: 0fa26978d5023563dad518ed4bd42c826daf9519
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- glibc-2.26-64.amzn2.0.5
- glibc-minimal-langpack-2.26-64.amzn2.0.5
- glibc-common-2.26-64.amzn2.0.5
- libcrypt-2.26-64.amzn2.0.5
- glibc-langpack-en-2.26-64.amzn2.0.5

Updated Packages for Amazon Linux 2023:
- audit-libs-3.1.5-1.amzn2023.0.2
- python3-libs-3.9.24-1.amzn2023.0.3
- librepo-1.14.5-2.amzn2023.0.2
- python3-libdnf-0.69.0-8.amzn2023.0.6
- amazon-linux-repo-cdn-2023.9.20251027-0.amzn2023
- system-release-2023.9.20251027-0.amzn2023
- python3-3.9.24-1.amzn2023.0.3
- libdnf-0.69.0-8.amzn2023.0.6
- python3-hawkey-0.69.0-8.amzn2023.0.6