### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.9.20250929.0
+Tags: 2023, latest, 2023.9.20251027.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 929de1dd8d1747a34701660136a6654d5ef312cc
+amd64-GitCommit: c666d32da5468884cfa42ccd80455bc856e07785
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: b5c8d4d3115e5985262be7fc9ef69cd89b208e25
+arm64v8-GitCommit: 66c04d49501d91410e86b1ff9357d7d9eb30b2be
 
-Tags: 2, 2.0.20250929.2
+Tags: 2, 2.0.20251027.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: bd6f28b0f4dac5ef4dadc1e141d005d65ef60be1
+amd64-GitCommit: ed40df28f69622fa062061566027d2c798d8baf8
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: b71f2b91c30d85b457f99c5073adc7a5a61370c0
+arm64v8-GitCommit: 0fa26978d5023563dad518ed4bd42c826daf9519
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- glibc-2.26-64.amzn2.0.5
- glibc-minimal-langpack-2.26-64.amzn2.0.5
- glibc-common-2.26-64.amzn2.0.5
- libcrypt-2.26-64.amzn2.0.5
- glibc-langpack-en-2.26-64.amzn2.0.5

Updated Packages for Amazon Linux 2023:
- audit-libs-3.1.5-1.amzn2023.0.2
- python3-libs-3.9.24-1.amzn2023.0.3
- librepo-1.14.5-2.amzn2023.0.2
- python3-libdnf-0.69.0-8.amzn2023.0.6
- amazon-linux-repo-cdn-2023.9.20251027-0.amzn2023
- system-release-2023.9.20251027-0.amzn2023
- python3-3.9.24-1.amzn2023.0.3
- libdnf-0.69.0-8.amzn2023.0.6
- python3-hawkey-0.69.0-8.amzn2023.0.6