### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for "

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: fe3cfb9b6b7834daf2033b97256a4387b2c6dcf8
+amd64-GitCommit: 5c7b7cb78b5ab05da7d1f85bb9fff297de5cf54d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c7f16b39d226cd22d073bf3e44fabe2f11637d75
+arm64v8-GitCommit: 4cfb158e34117296e343aecf1b025745d5c10fc9
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for ca-certificates update

See the following for details:

https://linux.oracle.com/errata/ELBA-2025-19289.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
