### PR TITLE
Add some contact persons for spark library

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -1,5 +1,4 @@
 Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark),
-             Dongjoon Hyun (@dongjoon-hyun),
              Hyukjin Kwon (@HyukjinKwon),
              Jie Yang (@LuciferYang),
              Kent Yao (@yaooqinn),


### PR DESCRIPTION
Picked active contributors from Spark Community who have both contributed to [spark-docker](https://github.com/apache/spark-docker/graphs/contributors) and also have served as a PMC Member.
