### PR TITLE
Update python

### DIFF
--- a/library/python
+++ b/library/python
@@ -239,33 +239,33 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 54a65f4ff531391810946ee17b0806accbda0fae
 Directory: 3.10/alpine3.21
 
-Tags: 3.9.24-trixie, 3.9-trixie
-SharedTags: 3.9.24, 3.9
+Tags: 3.9.25-trixie, 3.9-trixie
+SharedTags: 3.9.25, 3.9
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00c4cce6b91488475bfaf85921bae12604a56d4a
+GitCommit: 38aab6a1ab1db813a35d91953eb03283dc5bf0c6
 Directory: 3.9/trixie
 
-Tags: 3.9.24-slim-trixie, 3.9-slim-trixie, 3.9.24-slim, 3.9-slim
+Tags: 3.9.25-slim-trixie, 3.9-slim-trixie, 3.9.25-slim, 3.9-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00c4cce6b91488475bfaf85921bae12604a56d4a
+GitCommit: 38aab6a1ab1db813a35d91953eb03283dc5bf0c6
 Directory: 3.9/slim-trixie
 
-Tags: 3.9.24-bookworm, 3.9-bookworm
+Tags: 3.9.25-bookworm, 3.9-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 00c4cce6b91488475bfaf85921bae12604a56d4a
+GitCommit: 38aab6a1ab1db813a35d91953eb03283dc5bf0c6
 Directory: 3.9/bookworm
 
-Tags: 3.9.24-slim-bookworm, 3.9-slim-bookworm
+Tags: 3.9.25-slim-bookworm, 3.9-slim-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 00c4cce6b91488475bfaf85921bae12604a56d4a
+GitCommit: 38aab6a1ab1db813a35d91953eb03283dc5bf0c6
 Directory: 3.9/slim-bookworm
 
-Tags: 3.9.24-alpine3.22, 3.9-alpine3.22, 3.9.24-alpine, 3.9-alpine
+Tags: 3.9.25-alpine3.22, 3.9-alpine3.22, 3.9.25-alpine, 3.9-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00c4cce6b91488475bfaf85921bae12604a56d4a
+GitCommit: 38aab6a1ab1db813a35d91953eb03283dc5bf0c6
 Directory: 3.9/alpine3.22
 
-Tags: 3.9.24-alpine3.21, 3.9-alpine3.21
+Tags: 3.9.25-alpine3.21, 3.9-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00c4cce6b91488475bfaf85921bae12604a56d4a
+GitCommit: 38aab6a1ab1db813a35d91953eb03283dc5bf0c6
 Directory: 3.9/alpine3.21


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/python/commit/38aab6a1: Update 3.9 to 3.9.25

This should be the final 3.9 release; it is end of life now: https://devguide.python.org/versions/