### PR TITLE
Update to R 4.5.2 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.5.1, latest
+Tags: 4.5.2, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6971f6286e907991a3b78e9d261ede20f9c31f49
-Directory: r-base/4.5.1
+GitCommit: 446076ee8e7dc3a18bad99b84737af9dd28f0231
+Directory: r-base/4.5.2
 


### PR DESCRIPTION
Standard update to the new R release made by upstream this morning, and using the Debian (unstable, as made today) package prepared earlier.

No changes in the container setup or build besides the upgrade from R 4.5.1 to R 4.5.2, and with the commit in our repo correctly including referenced directory 4.5.2 as well as latest (with identical Dockerfiles).