### PR TITLE
[SECURITY] Redis 6.2.21, 7.2.12, 7.4.7, 8.0.5, 8.2.3

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -20,13 +20,13 @@ Directory: alpine
 
 Tags: 8.0.5, 8.0, 8.0.5-bookworm, 8.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
 GitFetch: refs/tags/v8.0.5
 Directory: debian
 
 Tags: 8.0.5-alpine, 8.0-alpine, 8.0.5-alpine3.21, 8.0-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c8a3cc8bf081db74a252c6423c932437682058a9
+GitCommit: 32adf916e545602f05e0bf031e789ab72012cf38
 GitFetch: refs/tags/v8.0.5
 Directory: alpine
 


### PR DESCRIPTION
8.2.3:
* CVE-2025-62507 Bug in XACKDEL may lead to stack overflow and potential RCE (!)

Notable fixes
* 8.0.5, 8.2.3: HGETEX: A missing numfields argument when FIELDS is used can lead to Redis crash

* Other versions: An overflow in HyperLogLog with 2GB+ entries may result in a Redis crash

See [Redis releases](https://github.com/redis/redis/releases) for more detailed list of fixes.