### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,26 +1,23 @@
-# this file is generated via https://github.com/docker-library/ghost/blob/2237b8ab43ce6b33ea5dbcf4c446c3fbdcea90cb/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/ghost/blob/98ead58b730477b94884db445c67f3251408cdc4/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
+GitCommit: 98ead58b730477b94884db445c67f3251408cdc4
 
-Tags: 6.5.3, 6.5, 6, latest
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 3a0fff73dd94321a446873efbb465b58893d4241
-Directory: 6/debian
+Tags: 6.6.0-bookworm, 6.6.0, 6.6-bookworm, 6.6, 6-bookworm, 6, bookworm, latest
+Directory: 6/bookworm
+Architectures: amd64, arm32v7, arm64v8, s390x
 
-Tags: 6.5.3-alpine, 6.5-alpine, 6-alpine, alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: 3a0fff73dd94321a446873efbb465b58893d4241
-Directory: 6/alpine
+Tags: 6.6.0-alpine3.22, 6.6.0-alpine, 6.6-alpine3.22, 6.6-alpine, 6-alpine3.22, 6-alpine, alpine3.22, alpine
+Directory: 6/alpine3.22
+Architectures: amd64, arm64v8
 
-Tags: 5.130.5, 5.130, 5
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: fdba3d80f50da610007165f5fe46f9b8af69764b
-Directory: 5/debian
+Tags: 5.130.5-bookworm, 5.130.5, 5.130-bookworm, 5.130, 5-bookworm, 5
+Directory: 5/bookworm
+Architectures: amd64, arm32v7, arm64v8, s390x
 
-Tags: 5.130.5-alpine, 5.130-alpine, 5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: fdba3d80f50da610007165f5fe46f9b8af69764b
-Directory: 5/alpine
+Tags: 5.130.5-alpine3.22, 5.130.5-alpine, 5.130-alpine3.22, 5.130-alpine, 5-alpine3.22, 5-alpine
+Directory: 5/alpine3.22
+Architectures: amd64, arm64v8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/0be0e8e: Merge pull request https://github.com/docker-library/ghost/pull/456 from infosiftr/jq-template
- https://github.com/docker-library/ghost/commit/98ead58: Add initial jq-based templating engine
- https://github.com/docker-library/ghost/commit/6c1aabe: Update to 6.6.0, ghost-cli 1.28.3