### PR TITLE
Release SonarQube Community Build 25.11 and add 2025.4-lta-edition tags

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -1,71 +1,70 @@
-Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassallo),
-             Jeremy Cotineau <jeremy.cotineau@sonarsource.com> (@jCOTINEAU)
+Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassallo)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
 Tags: 2025.5.0-developer, 2025.5-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
+GitCommit: 2d77476619099afc3df0129af7ebbf372fb72336
 GitFetch: refs/heads/master
 
 Tags: 2025.5.0-enterprise, 2025.5-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
+GitCommit: 2d77476619099afc3df0129af7ebbf372fb72336
 GitFetch: refs/heads/master
 
 Tags: 2025.5.0-datacenter-app, 2025.5-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
+GitCommit: 2d77476619099afc3df0129af7ebbf372fb72336
 GitFetch: refs/heads/master
 
 Tags: 2025.5.0-datacenter-search, 2025.5-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 4f77dc7067a3ed7761c56361e40ad7dda3cd9d6c
+GitCommit: 2d77476619099afc3df0129af7ebbf372fb72336
 GitFetch: refs/heads/master
 
-Tags: 2025.4.3-developer, 2025.4-developer
+Tags: 2025.4.3-developer, 2025.4-developer, 2025.4-lta-developer
 Directory: commercial-editions/developer
-GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitCommit: ef0050f30ef75089692a0808b6a002359083fb5a
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.3-enterprise, 2025.4-enterprise
+Tags: 2025.4.3-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitCommit: ef0050f30ef75089692a0808b6a002359083fb5a
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.3-datacenter-app, 2025.4-datacenter-app
+Tags: 2025.4.3-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitCommit: ef0050f30ef75089692a0808b6a002359083fb5a
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.3-datacenter-search, 2025.4-datacenter-search
+Tags: 2025.4.3-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 52f6f8a3a79daf2f4ed53b9f6313df16dcbb710a
+GitCommit: ef0050f30ef75089692a0808b6a002359083fb5a
 GitFetch: refs/heads/release/2025.4
 
 Tags: 2025.1.4-developer, 2025.1-developer, 2025-lta-developer
 Directory: commercial-editions/developer
-GitCommit: 175609a6b668d26878ea8d063d66677247272f38
+GitCommit: 5e2621e56095f67b6a28edd3016ef2f10bca2947
 GitFetch: refs/heads/release/2025.1
 
 Tags: 2025.1.4-enterprise, 2025.1-enterprise, 2025-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 175609a6b668d26878ea8d063d66677247272f38
+GitCommit: 5e2621e56095f67b6a28edd3016ef2f10bca2947
 GitFetch: refs/heads/release/2025.1
 
 Tags: 2025.1.4-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 175609a6b668d26878ea8d063d66677247272f38
+GitCommit: 5e2621e56095f67b6a28edd3016ef2f10bca2947
 GitFetch: refs/heads/release/2025.1
 
 Tags: 2025.1.4-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 175609a6b668d26878ea8d063d66677247272f38
+GitCommit: 5e2621e56095f67b6a28edd3016ef2f10bca2947
 GitFetch: refs/heads/release/2025.1
 
-Tags: 25.10.0.114319-community, community, latest
+Tags: 25.11.0.114957-community, community, latest
 Directory: community-build
-GitCommit: a5d28439b45d0a6002290fd28bf1b481c0182bb6
+GitCommit: 2d77476619099afc3df0129af7ebbf372fb72336
 GitFetch: refs/heads/master
 


### PR DESCRIPTION
Dear team,

we are releasing  SonarQube Community Build 25.11. Furthermore, we would like to add the tags `2025.4-lta-<edition>` to the existing 2025.4 editions.

I also brings a few small changes on the docs repo: https://github.com/docker-library/docs/pull/2634