### PR TITLE
Updates for release 25.0.0.11

### DIFF
--- a/library/open-liberty
+++ b/library/open-liberty
@@ -52,6 +52,36 @@ Directory: releases/latest/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
+Tags: 25.0.0.3-kernel-slim-java8-openj9
+Directory: releases/25.0.0.3/kernel-slim
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk8
+
+Tags: 25.0.0.3-kernel-slim-java11-openj9
+Directory: releases/25.0.0.3/kernel-slim
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk11
+
+Tags: 25.0.0.3-kernel-slim-java17-openj9
+Directory: releases/25.0.0.3/kernel-slim
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk17
+
+Tags: 25.0.0.3-full-java8-openj9
+Directory: releases/25.0.0.3/full
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk8
+
+Tags: 25.0.0.3-full-java11-openj9
+Directory: releases/25.0.0.3/full
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk11
+
+Tags: 25.0.0.3-full-java17-openj9
+Directory: releases/25.0.0.3/full
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk17
+
 Tags: 25.0.0.6-kernel-slim-java8-openj9
 Directory: releases/25.0.0.6/kernel-slim
 Architectures: amd64, arm64v8, ppc64le, s390x

--- a/library/websphere-liberty
+++ b/library/websphere-liberty
@@ -35,6 +35,34 @@ Directory: ga/latest/full
 Architectures: amd64, arm64v8, ppc64le, s390x
 File: Dockerfile.ubuntu.openjdk17
 
+Tags: 25.0.0.3-kernel-java8-ibmjava
+Directory: ga/25.0.0.3/kernel
+File: Dockerfile.ubuntu.ibmjava8
+
+Tags: 25.0.0.3-kernel-java11-openj9
+Directory: ga/25.0.0.3/kernel
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk11
+
+Tags: 25.0.0.3-kernel-java17-openj9
+Directory: ga/25.0.0.3/kernel
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk17
+
+Tags: 25.0.0.3-full-java8-ibmjava
+Directory: ga/25.0.0.3/full
+File: Dockerfile.ubuntu.ibmjava8
+
+Tags: 25.0.0.3-full-java11-openj9
+Directory: ga/25.0.0.3/full
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk11
+
+Tags: 25.0.0.3-full-java17-openj9
+Directory: ga/25.0.0.3/full
+Architectures: amd64, arm64v8, ppc64le, s390x
+File: Dockerfile.ubuntu.openjdk17
+
 Tags: 25.0.0.6-kernel-java8-ibmjava
 Directory: ga/25.0.0.6/kernel
 File: Dockerfile.ubuntu.ibmjava8


### PR DESCRIPTION
And restore entries for 25.0.0.3 images; these are again mentioned in https://[public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml](https://public.dhe.ibm.com/ibmdl/export/pub/software/websphere/wasdev/downloads/wlp/index.yml).