### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,70 +6,70 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 3.3-dev11, 3.3-dev, 3.3-dev11-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 531c0c0d9c002e8f43ab020ff9e529c6168b287c
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.3
 
 Tags: 3.3-dev11-alpine, 3.3-dev-alpine, 3.3-dev11-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 531c0c0d9c002e8f43ab020ff9e529c6168b287c
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.3/alpine
 
 Tags: 3.2.7, 3.2, latest, lts, 3.2.7-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4c0de0b54fc42dd87f22cfb61aad93562dad787
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.2
 
 Tags: 3.2.7-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.7-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4c0de0b54fc42dd87f22cfb61aad93562dad787
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.2/alpine
 
 Tags: 3.1.9, 3.1, 3.1.9-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d89f493da93a6e40d26926929cf12bf95fbec5b
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.1
 
 Tags: 3.1.9-alpine, 3.1-alpine, 3.1.9-alpine3.22, 3.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d89f493da93a6e40d26926929cf12bf95fbec5b
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.1/alpine
 
 Tags: 3.0.12, 3.0, 3.0.12-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0390f3e72676323955e3a7d230393c7b5478f0b0
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.0
 
 Tags: 3.0.12-alpine, 3.0-alpine, 3.0.12-alpine3.22, 3.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0390f3e72676323955e3a7d230393c7b5478f0b0
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.0/alpine
 
 Tags: 2.8.16, 2.8, 2.8.16-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 97dd996d667932ef9359dcb8f2b3242eb54b253e
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.8
 
 Tags: 2.8.16-alpine, 2.8-alpine, 2.8.16-alpine3.22, 2.8-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 97dd996d667932ef9359dcb8f2b3242eb54b253e
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.8/alpine
 
 Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 926111706a0ffd8b815e1edfd317aae52d06d083
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.6
 
 Tags: 2.6.23-alpine, 2.6-alpine, 2.6.23-alpine3.22, 2.6-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 926111706a0ffd8b815e1edfd317aae52d06d083
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.6/alpine
 
 Tags: 2.4.30, 2.4, 2.4.30-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c55eb01d1a1866a421e20e21bace391080fc58ba
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.4
 
 Tags: 2.4.30-alpine, 2.4-alpine, 2.4.30-alpine3.22, 2.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c55eb01d1a1866a421e20e21bace391080fc58ba
+GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/1f56bf5: Merge pull request https://github.com/docker-library/haproxy/pull/250 from infosiftr/socat
- https://github.com/docker-library/haproxy/commit/3fc3329: Add `socat` to the image