### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-19835"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 316f6a1d2d219c9a181fb95d8f9e7058272d99d0
+amd64-GitCommit: 118641f6d73577ff4989026ec184174304e49a5f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7777363d34048b111765248e68182c9280f8b172
+arm64v8-GitCommit: e5348f17f2cf63adbdd97939d67bd357c7248331
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-40778, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-19835.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
