### PR TITLE
Add amazonlinux release

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.9.20251027.0
+Tags: 2023, latest, 2023.9.20251105.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: c666d32da5468884cfa42ccd80455bc856e07785
+amd64-GitCommit: 0e77474a0e8d55c669a94347ca7bf24268ea5a53
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 66c04d49501d91410e86b1ff9357d7d9eb30b2be
+arm64v8-GitCommit: 2dafc30f770fa55490cffc55f2bfc427bce84de1
 
-Tags: 2, 2.0.20251027.1
+Tags: 2, 2.0.20251105.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: ed40df28f69622fa062061566027d2c798d8baf8
+amd64-GitCommit: 636f080212730dfc2e8a2e5f5811039e1406fe27
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 0fa26978d5023563dad518ed4bd42c826daf9519
+arm64v8-GitCommit: df882aa449db7950f469afb626f7c136f0cac656
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.9.20251105-0.amzn2023
- system-release-2023.9.20251105-0.amzn2023