### PR TITLE
Bump Traefik to v3.5.6 and v3.6.0

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,40 +1,40 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.6.0-rc1-windowsservercore-ltsc2022, 3.6.0-rc1-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
+Tags: v3.6.0-windowsservercore-ltsc2022, 3.6.0-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: d7be81e1248be9c8fba7c3036c185a6574c562a7
+GitCommit: fc7224b7002a6a4df194014ab818103b4495d003
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.0-rc1-nanoserver-ltsc2022, 3.6.0-rc1-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
+Tags: v3.6.0-nanoserver-ltsc2022, 3.6.0-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: d7be81e1248be9c8fba7c3036c185a6574c562a7
+GitCommit: fc7224b7002a6a4df194014ab818103b4495d003
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.0-rc1, 3.6.0-rc1, ramequin
+Tags: v3.6.0, 3.6.0, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: d7be81e1248be9c8fba7c3036c185a6574c562a7
+GitCommit: fc7224b7002a6a4df194014ab818103b4495d003
 Directory: v3.6/alpine
 
-Tags: v3.5.6-windowsservercore-ltsc2022, 3.5.6-windowsservercore-ltsc2022, v3.5-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022
+Tags: v3.5.6-windowsservercore-ltsc2022, 3.5.6-windowsservercore-ltsc2022, v3.5-windowsservercore-ltsc2022, 3.5-windowsservercore-ltsc2022, chabichou-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f6417863a02885a4a85b6b973dcfc218a9a54626
 Directory: v3.5/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.5.6-nanoserver-ltsc2022, 3.5.6-nanoserver-ltsc2022, v3.5-nanoserver-ltsc2022, 3.5-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022
+Tags: v3.5.6-nanoserver-ltsc2022, 3.5.6-nanoserver-ltsc2022, v3.5-nanoserver-ltsc2022, 3.5-nanoserver-ltsc2022, chabichou-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f6417863a02885a4a85b6b973dcfc218a9a54626
 Directory: v3.5/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.5.6, 3.5.6, v3.5, 3.5, v3, 3, chabichou
+Tags: v3.5.6, 3.5.6, v3.5, 3.5, chabichou
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f6417863a02885a4a85b6b973dcfc218a9a54626


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.5.6](https://github.com/traefik/traefik/releases/tag/v3.5.6), and [v3.6.0](https://github.com/traefik/traefik/releases/tag/v3.6.0).

/cc @nmengin @mmatur @rtribotte

Cheers