### PR TITLE
Update amazoncorretto for alpine 3.19 deprecation

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,7 +15,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: e9ad70888805b5c2d0b98e9523f20ea790d2880d
+GitCommit: 5cf76cde46d4c2293a5d709e1e8630a334cb61c5
 
 Tags: 8, 8u472, 8u472-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u472-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
@@ -36,14 +36,6 @@ Directory: 8/jre/al2
 Tags: 8-al2-native-jdk, 8u472-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
-
-Tags: 8-alpine3.19, 8u472-alpine3.19, 8-alpine3.19-full, 8-alpine3.19-jdk
-Architectures: amd64, arm64v8
-Directory: 8/jdk/alpine/3.19
-
-Tags: 8-alpine3.19-jre, 8u472-alpine3.19-jre
-Architectures: amd64, arm64v8
-Directory: 8/jre/alpine/3.19
 
 Tags: 8-alpine3.20, 8u472-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
 Architectures: amd64, arm64v8
@@ -93,10 +85,6 @@ Tags: 11-al2-native-jdk, 11.0.29-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.19, 11.0.29-alpine3.19, 11-alpine3.19-full, 11-alpine3.19-jdk
-Architectures: amd64, arm64v8
-Directory: 11/jdk/alpine/3.19
-
 Tags: 11-alpine3.20, 11.0.29-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.20
@@ -137,10 +125,6 @@ Tags: 17-al2-native-jdk, 17.0.17-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.19, 17.0.17-alpine3.19, 17-alpine3.19-full, 17-alpine3.19-jdk
-Architectures: amd64, arm64v8
-Directory: 17/jdk/alpine/3.19
-
 Tags: 17-alpine3.20, 17.0.17-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.20
@@ -169,10 +153,6 @@ Tags: 21-al2023-headful, 21.0.9-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 21/headful/al2023
 
-Tags: 21-alpine3.19, 21.0.9-alpine3.19, 21-alpine3.19-full, 21-alpine3.19-jdk
-Architectures: amd64, arm64v8
-Directory: 21/jdk/alpine/3.19
-
 Tags: 21-alpine3.20, 21.0.9-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.20
@@ -196,10 +176,6 @@ Directory: 25/headless/al2023
 Tags: 25-al2023-headful, 25.0.1-al2023-headful, 25-headful
 Architectures: amd64, arm64v8
 Directory: 25/headful/al2023
-
-Tags: 25-alpine3.19, 25.0.1-alpine3.19, 25-alpine3.19-full, 25-alpine3.19-jdk
-Architectures: amd64, arm64v8
-Directory: 25/jdk/alpine/3.19
 
 Tags: 25-alpine3.20, 25.0.1-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update amazoncorretto to remove alpine 3.19 images