### PR TITLE
mariadb: 2025Q4 Maintaince release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -8,60 +8,60 @@ Builder: buildkit
 
 Tags: 12.1.1-ubi10-rc, 12.1-ubi10-rc, 12.1.1-ubi-rc, 12.1-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: dd7e1e1e35422011e9dbfa46f22c9e24f49e9fba
+GitCommit: 46c443c353dea7d232536a03df3b8a5b998cc78d
 Directory: 12.1-ubi
 
 Tags: 12.1.1-noble-rc, 12.1-noble-rc, 12.1.1-rc, 12.1-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cdffb7d2fd712249f3f386497117825be6442afa
+GitCommit: 46c443c353dea7d232536a03df3b8a5b998cc78d
 Directory: 12.1
 
 Tags: 12.0.2-ubi10, 12.0-ubi10, 12-ubi10, 12.0.2-ubi, 12.0-ubi, 12-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: dd7e1e1e35422011e9dbfa46f22c9e24f49e9fba
+GitCommit: 46c443c353dea7d232536a03df3b8a5b998cc78d
 Directory: 12.0-ubi
 
 Tags: 12.0.2-noble, 12.0-noble, 12-noble, noble, 12.0.2, 12.0, 12, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 6a5611cd9dd70a8dcb24195cc8dd2147dd6471e3
+GitCommit: 46c443c353dea7d232536a03df3b8a5b998cc78d
 Directory: 12.0
 
-Tags: 11.8.3-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.3-ubi, 11.8-ubi, 11-ubi, lts-ubi
+Tags: 11.8.4-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.4-ubi, 11.8-ubi, 11-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: dd7e1e1e35422011e9dbfa46f22c9e24f49e9fba
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 11.8-ubi
 
-Tags: 11.8.3-noble, 11.8-noble, 11-noble, lts-noble, 11.8.3, 11.8, 11, lts
+Tags: 11.8.4-noble, 11.8-noble, 11-noble, lts-noble, 11.8.4, 11.8, 11, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cdffb7d2fd712249f3f386497117825be6442afa
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 11.8
 
-Tags: 11.4.8-ubi9, 11.4-ubi9, 11.4.8-ubi, 11.4-ubi
+Tags: 11.4.9-ubi9, 11.4-ubi9, 11.4.9-ubi, 11.4-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: dd7e1e1e35422011e9dbfa46f22c9e24f49e9fba
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 11.4-ubi
 
-Tags: 11.4.8-noble, 11.4-noble, 11.4.8, 11.4
+Tags: 11.4.9-noble, 11.4-noble, 11.4.9, 11.4
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cdffb7d2fd712249f3f386497117825be6442afa
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 11.4
 
-Tags: 10.11.14-ubi9, 10.11-ubi9, 10-ubi9, 10.11.14-ubi, 10.11-ubi, 10-ubi
+Tags: 10.11.15-ubi9, 10.11-ubi9, 10-ubi9, 10.11.15-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: dd7e1e1e35422011e9dbfa46f22c9e24f49e9fba
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 10.11-ubi
 
-Tags: 10.11.14-jammy, 10.11-jammy, 10-jammy, 10.11.14, 10.11, 10
+Tags: 10.11.15-jammy, 10.11-jammy, 10-jammy, 10.11.15, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cdffb7d2fd712249f3f386497117825be6442afa
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 10.11
 
-Tags: 10.6.23-ubi9, 10.6-ubi9, 10.6.23-ubi, 10.6-ubi
+Tags: 10.6.24-ubi9, 10.6-ubi9, 10.6.24-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: dd7e1e1e35422011e9dbfa46f22c9e24f49e9fba
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 10.6-ubi
 
-Tags: 10.6.23-jammy, 10.6-jammy, 10.6.23, 10.6
+Tags: 10.6.24-jammy, 10.6-jammy, 10.6.24, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cdffb7d2fd712249f3f386497117825be6442afa
+GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
 Directory: 10.6


### PR DESCRIPTION
new gosu version. Nothing else particularly noteworthy.

And gperftools-libs for tcmalloc, based on jemalloc https://biggo.com/news/202506130712_jemalloc_Development_Ends_After_20_Years. At some point I'll symlink jemalloc paths to tcmalloc as its there when a user configures `LD_PRELOAD` on these libraries.