### PR TITLE
Update Eclipse Temurin version to 21.0.9_10

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -421,138 +421,138 @@ Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
 
 #------------------------------v21 images---------------------------------
-Tags: 21.0.8_9-jdk-alpine-3.20, 21-jdk-alpine-3.20, 21-alpine-3.20
+Tags: 21.0.9_10-jdk-alpine-3.20, 21-jdk-alpine-3.20, 21-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/alpine/3.20
 
-Tags: 21.0.8_9-jdk-alpine-3.21, 21-jdk-alpine-3.21, 21-alpine-3.21
+Tags: 21.0.9_10-jdk-alpine-3.21, 21-jdk-alpine-3.21, 21-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/alpine/3.21
 
-Tags: 21.0.8_9-jdk-alpine-3.22, 21-jdk-alpine-3.22, 21-alpine-3.22, 21.0.8_9-jdk-alpine, 21-jdk-alpine, 21-alpine
+Tags: 21.0.9_10-jdk-alpine-3.22, 21-jdk-alpine-3.22, 21-alpine-3.22, 21.0.9_10-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/alpine/3.22
 
-Tags: 21.0.8_9-jdk-jammy, 21-jdk-jammy, 21-jammy
+Tags: 21.0.9_10-jdk-jammy, 21-jdk-jammy, 21-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/ubuntu/jammy
 
-Tags: 21.0.8_9-jdk-noble, 21-jdk-noble, 21-noble
-SharedTags: 21.0.8_9-jdk, 21-jdk, 21
+Tags: 21.0.9_10-jdk-noble, 21-jdk-noble, 21-noble
+SharedTags: 21.0.9_10-jdk, 21-jdk, 21
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/ubuntu/noble
 
-Tags: 21.0.8_9-jdk-ubi10-minimal, 21-jdk-ubi10-minimal, 21-ubi10-minimal
+Tags: 21.0.9_10-jdk-ubi10-minimal, 21-jdk-ubi10-minimal, 21-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/ubi/ubi10-minimal
 
-Tags: 21.0.8_9-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Tags: 21.0.9_10-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/ubi/ubi9-minimal
 
-Tags: 21.0.8_9-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
-SharedTags: 21.0.8_9-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.8_9-jdk, 21-jdk, 21
+Tags: 21.0.9_10-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
+SharedTags: 21.0.9_10-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.9_10-jdk, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 21.0.8_9-jdk-nanoserver-ltsc2025, 21-jdk-nanoserver-ltsc2025, 21-nanoserver-ltsc2025
-SharedTags: 21.0.8_9-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.9_10-jdk-nanoserver-ltsc2025, 21-jdk-nanoserver-ltsc2025, 21-nanoserver-ltsc2025
+SharedTags: 21.0.9_10-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 21.0.8_9-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21.0.8_9-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.8_9-jdk, 21-jdk, 21
+Tags: 21.0.9_10-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21.0.9_10-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.9_10-jdk, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.8_9-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
-SharedTags: 21.0.8_9-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.9_10-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
+SharedTags: 21.0.9_10-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.8_9-jre-alpine-3.20, 21-jre-alpine-3.20
+Tags: 21.0.9_10-jre-alpine-3.20, 21-jre-alpine-3.20
 Architectures: amd64, arm64v8
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/alpine/3.20
 
-Tags: 21.0.8_9-jre-alpine-3.21, 21-jre-alpine-3.21
+Tags: 21.0.9_10-jre-alpine-3.21, 21-jre-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/alpine/3.21
 
-Tags: 21.0.8_9-jre-alpine-3.22, 21-jre-alpine-3.22, 21.0.8_9-jre-alpine, 21-jre-alpine
+Tags: 21.0.9_10-jre-alpine-3.22, 21-jre-alpine-3.22, 21.0.9_10-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/alpine/3.22
 
-Tags: 21.0.8_9-jre-jammy, 21-jre-jammy
+Tags: 21.0.9_10-jre-jammy, 21-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/ubuntu/jammy
 
-Tags: 21.0.8_9-jre-noble, 21-jre-noble
-SharedTags: 21.0.8_9-jre, 21-jre
+Tags: 21.0.9_10-jre-noble, 21-jre-noble
+SharedTags: 21.0.9_10-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/ubuntu/noble
 
-Tags: 21.0.8_9-jre-ubi10-minimal, 21-jre-ubi10-minimal
+Tags: 21.0.9_10-jre-ubi10-minimal, 21-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/ubi/ubi10-minimal
 
-Tags: 21.0.8_9-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Tags: 21.0.9_10-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/ubi/ubi9-minimal
 
-Tags: 21.0.8_9-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
-SharedTags: 21.0.8_9-jre-windowsservercore, 21-jre-windowsservercore, 21.0.8_9-jre, 21-jre
+Tags: 21.0.9_10-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
+SharedTags: 21.0.9_10-jre-windowsservercore, 21-jre-windowsservercore, 21.0.9_10-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 21.0.8_9-jre-nanoserver-ltsc2025, 21-jre-nanoserver-ltsc2025
-SharedTags: 21.0.8_9-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.9_10-jre-nanoserver-ltsc2025, 21-jre-nanoserver-ltsc2025
+SharedTags: 21.0.9_10-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 21.0.8_9-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
-SharedTags: 21.0.8_9-jre-windowsservercore, 21-jre-windowsservercore, 21.0.8_9-jre, 21-jre
+Tags: 21.0.9_10-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
+SharedTags: 21.0.9_10-jre-windowsservercore, 21-jre-windowsservercore, 21.0.9_10-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.8_9-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
-SharedTags: 21.0.8_9-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.9_10-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
+SharedTags: 21.0.9_10-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: fc54f27893bb7c1ffb1d7eb82f2d22d7605e57bc
+GitCommit: 22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,
The JDK 21.0.9 has just been released, and the Adoptium containers are now up to date.

I’m I’m keen to update to upgrade my setup using the latest Adoptium base image, and I’d like to propose this merge request to integrate it into the official Docker repository.

Please feel free to let me know if anything in this PR is incorrect or if there’s a better way to approach this.

i use this commit as reference https://github.com/adoptium/containers/commit/22cdd3dcdf8d43a55e27f617d61d80bb1fb55d2b

Thanks in advance!

@gdams @sxa 