### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,34 +4,34 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev11, 3.3-dev, 3.3-dev11-trixie, 3.3-dev-trixie
+Tags: 3.3-dev12, 3.3-dev, 3.3-dev12-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 9728348c87cd7a64e12d34b07a4d34eeb5d0a299
 Directory: 3.3
 
-Tags: 3.3-dev11-alpine, 3.3-dev-alpine, 3.3-dev11-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev12-alpine, 3.3-dev-alpine, 3.3-dev12-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 9728348c87cd7a64e12d34b07a4d34eeb5d0a299
 Directory: 3.3/alpine
 
-Tags: 3.2.7, 3.2, latest, lts, 3.2.7-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.8, 3.2, latest, lts, 3.2.8-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 4fd3078f4197405d08018930e1e0f386d7399be1
 Directory: 3.2
 
-Tags: 3.2.7-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.7-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.8-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.8-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 4fd3078f4197405d08018930e1e0f386d7399be1
 Directory: 3.2/alpine
 
-Tags: 3.1.9, 3.1, 3.1.9-trixie, 3.1-trixie
+Tags: 3.1.10, 3.1, 3.1.10-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: b1e0ccb02df9fc432364fe391f9b094c1bc8688c
 Directory: 3.1
 
-Tags: 3.1.9-alpine, 3.1-alpine, 3.1.9-alpine3.22, 3.1-alpine3.22
+Tags: 3.1.10-alpine, 3.1-alpine, 3.1.10-alpine3.22, 3.1-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: b1e0ccb02df9fc432364fe391f9b094c1bc8688c
 Directory: 3.1/alpine
 
 Tags: 3.0.12, 3.0, 3.0.12-trixie, 3.0-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9728348: Update 3.3 to 3.3-dev12
- https://github.com/docker-library/haproxy/commit/b1e0ccb: Update 3.1 to 3.1.10
- https://github.com/docker-library/haproxy/commit/4fd3078: Update 3.2 to 3.2.8