### PR TITLE
"[oraclelinux] Updating 10and 10-slim for ca-certificates"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 118641f6d73577ff4989026ec184174304e49a5f
+amd64-GitCommit: d5ecb8b13a55dfeaa7b60279ba07b139f6581a34
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e5348f17f2cf63adbdd97939d67bd357c7248331
+arm64v8-GitCommit: d2759a6f139243ae19f96160e1f2ccc0b9728c8a
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for ca-certificates.

See the following for details:
https://linux.oracle.com/errata/ELBA-2025-19952.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
