### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,122 +4,122 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 18.0, 18, latest, 18.0-trixie, 18-trixie, trixie
+Tags: 18.1, 18, latest, 18.1-trixie, 18-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
 Directory: 18/trixie
 
-Tags: 18.0-bookworm, 18-bookworm, bookworm
+Tags: 18.1-bookworm, 18-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
 Directory: 18/bookworm
 
-Tags: 18.0-alpine3.22, 18-alpine3.22, alpine3.22, 18.0-alpine, 18-alpine, alpine
+Tags: 18.1-alpine3.22, 18-alpine3.22, alpine3.22, 18.1-alpine, 18-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
 Directory: 18/alpine3.22
 
-Tags: 18.0-alpine3.21, 18-alpine3.21, alpine3.21
+Tags: 18.1-alpine3.21, 18-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
 Directory: 18/alpine3.21
 
-Tags: 17.6, 17, 17.6-trixie, 17-trixie
+Tags: 17.7, 17, 17.7-trixie, 17-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
 Directory: 17/trixie
 
-Tags: 17.6-bookworm, 17-bookworm
+Tags: 17.7-bookworm, 17-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
 Directory: 17/bookworm
 
-Tags: 17.6-alpine3.22, 17-alpine3.22, 17.6-alpine, 17-alpine
+Tags: 17.7-alpine3.22, 17-alpine3.22, 17.7-alpine, 17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
 Directory: 17/alpine3.22
 
-Tags: 17.6-alpine3.21, 17-alpine3.21
+Tags: 17.7-alpine3.21, 17-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
 Directory: 17/alpine3.21
 
-Tags: 16.10, 16, 16.10-trixie, 16-trixie
+Tags: 16.11, 16, 16.11-trixie, 16-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
 Directory: 16/trixie
 
-Tags: 16.10-bookworm, 16-bookworm
+Tags: 16.11-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
 Directory: 16/bookworm
 
-Tags: 16.10-alpine3.22, 16-alpine3.22, 16.10-alpine, 16-alpine
+Tags: 16.11-alpine3.22, 16-alpine3.22, 16.11-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
 Directory: 16/alpine3.22
 
-Tags: 16.10-alpine3.21, 16-alpine3.21
+Tags: 16.11-alpine3.21, 16-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
 Directory: 16/alpine3.21
 
-Tags: 15.14, 15, 15.14-trixie, 15-trixie
+Tags: 15.15, 15, 15.15-trixie, 15-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 423adf955c25775878b0feabaffed699d504aafb
 Directory: 15/trixie
 
-Tags: 15.14-bookworm, 15-bookworm
+Tags: 15.15-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 423adf955c25775878b0feabaffed699d504aafb
 Directory: 15/bookworm
 
-Tags: 15.14-alpine3.22, 15-alpine3.22, 15.14-alpine, 15-alpine
+Tags: 15.15-alpine3.22, 15-alpine3.22, 15.15-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 423adf955c25775878b0feabaffed699d504aafb
 Directory: 15/alpine3.22
 
-Tags: 15.14-alpine3.21, 15-alpine3.21
+Tags: 15.15-alpine3.21, 15-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 423adf955c25775878b0feabaffed699d504aafb
 Directory: 15/alpine3.21
 
-Tags: 14.19, 14, 14.19-trixie, 14-trixie
+Tags: 14.20, 14, 14.20-trixie, 14-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
 Directory: 14/trixie
 
-Tags: 14.19-bookworm, 14-bookworm
+Tags: 14.20-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
 Directory: 14/bookworm
 
-Tags: 14.19-alpine3.22, 14-alpine3.22, 14.19-alpine, 14-alpine
+Tags: 14.20-alpine3.22, 14-alpine3.22, 14.20-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
 Directory: 14/alpine3.22
 
-Tags: 14.19-alpine3.21, 14-alpine3.21
+Tags: 14.20-alpine3.21, 14-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
 Directory: 14/alpine3.21
 
-Tags: 13.22, 13, 13.22-trixie, 13-trixie
+Tags: 13.23, 13, 13.23-trixie, 13-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
 Directory: 13/trixie
 
-Tags: 13.22-bookworm, 13-bookworm
+Tags: 13.23-bookworm, 13-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
 Directory: 13/bookworm
 
-Tags: 13.22-alpine3.22, 13-alpine3.22, 13.22-alpine, 13-alpine
+Tags: 13.23-alpine3.22, 13-alpine3.22, 13.23-alpine, 13-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
 Directory: 13/alpine3.22
 
-Tags: 13.22-alpine3.21, 13-alpine3.21
+Tags: 13.23-alpine3.21, 13-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ec89312491bdaa2c42377a65ec0af2ecb774480
+GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
 Directory: 13/alpine3.21


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/8813dab: Update 18 to 18.1, trixie 18.1-1.pgdg13+2, bookworm 18.1-1.pgdg12+2
- https://github.com/docker-library/postgres/commit/c02157d: Update 17 to 17.7, trixie 17.7-3.pgdg13+1, bookworm 17.7-3.pgdg12+1
- https://github.com/docker-library/postgres/commit/3506774: Update 16 to 16.11, trixie 16.11-1.pgdg13+1, bookworm 16.11-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/423adf9: Update 15 to 15.15, trixie 15.15-1.pgdg13+1, bookworm 15.15-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/7de0b51: Update 14 to 14.20, trixie 14.20-1.pgdg13+1, bookworm 14.20-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/c2d83d0: Update 13 to 13.23, trixie 13.23-1.pgdg13+1, bookworm 13.23-1.pgdg12+1