### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -138,3 +138,18 @@ Tags: questing, 25.10
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 99e7dc24c50c0a7be371ea9e6aed6134ce4cbfeb
 Directory: ubuntu/questing
+
+Tags: resolute-curl, 26.04-curl
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 8330ca1d2319b779c8b7a8aa64bb40dbe568e1e2
+Directory: ubuntu/resolute/curl
+
+Tags: resolute-scm, 26.04-scm
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 8330ca1d2319b779c8b7a8aa64bb40dbe568e1e2
+Directory: ubuntu/resolute/scm
+
+Tags: resolute, 26.04
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 8330ca1d2319b779c8b7a8aa64bb40dbe568e1e2
+Directory: ubuntu/resolute


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/8330ca1: Add `ubuntu/resolute`