### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.9.20251105.0
+Tags: 2023, latest, 2023.9.20251110.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 0e77474a0e8d55c669a94347ca7bf24268ea5a53
+amd64-GitCommit: 3ad57ac25b349535f5290924b6a2125110be7412
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 2dafc30f770fa55490cffc55f2bfc427bce84de1
+arm64v8-GitCommit: 3d993d02f794ab9d223e3035e9d6c8fb37baa4e5
 
-Tags: 2, 2.0.20251105.0
+Tags: 2, 2.0.20251110.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 636f080212730dfc2e8a2e5f5811039e1406fe27
+amd64-GitCommit: 21640b88ffdb2768599539081529c4e8859b7b6d
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: df882aa449db7950f469afb626f7c136f0cac656
+arm64v8-GitCommit: 7fe1b60afee52c360a74c7956836977a176a17fc
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- libcurl-8.3.0-1.amzn2.0.10
- curl-8.3.0-1.amzn2.0.10
#### Packages addressing CVES:
- libcurl-8.3.0-1.amzn2.0.10, curl-8.3.0-1.amzn2.0.10
  - [CVE-2025-9086](https://alas.aws.amazon.com/cve/html/CVE-2025-9086.html)

### Updated Packages for Amazon Linux 2023:
- python3-libs-3.9.24-1.amzn2023.0.4
- amazon-linux-repo-cdn-2023.9.20251110-0.amzn2023
- system-release-2023.9.20251110-0.amzn2023
- libcap-2.73-1.amzn2023.0.4
- python3-3.9.24-1.amzn2023.0.4
- lz4-libs-1.9.4-1.amzn2023.0.3
#### Packages addressing CVES:
- libcap-2.73-1.amzn2023.0.4
  - [CVE-2025-58183](https://alas.aws.amazon.com/cve/html/CVE-2025-58183.html)
  - [CVE-2025-58185](https://alas.aws.amazon.com/cve/html/CVE-2025-58185.html)
  - [CVE-2025-58186](https://alas.aws.amazon.com/cve/html/CVE-2025-58186.html)
  - [CVE-2025-58188](https://alas.aws.amazon.com/cve/html/CVE-2025-58188.html)
  - [CVE-2025-61723](https://alas.aws.amazon.com/cve/html/CVE-2025-61723.html)
  - [CVE-2025-61725](https://alas.aws.amazon.com/cve/html/CVE-2025-61725.html)
- lz4-libs-1.9.4-1.amzn2023.0.3
  - [CVE-2025-62813](https://alas.aws.amazon.com/cve/html/CVE-2025-62813.html)