### PR TITLE
Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -6,120 +6,100 @@ GitRepo: https://github.com/docker-library/postgres.git
 
 Tags: 18.1, 18, latest, 18.1-trixie, 18-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 18/trixie
 
 Tags: 18.1-bookworm, 18-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 18/bookworm
 
 Tags: 18.1-alpine3.22, 18-alpine3.22, alpine3.22, 18.1-alpine, 18-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 18/alpine3.22
 
 Tags: 18.1-alpine3.21, 18-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8813daba48f758aea74a33e98a0f20a6102c3b57
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 18/alpine3.21
 
 Tags: 17.7, 17, 17.7-trixie, 17-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 17/trixie
 
 Tags: 17.7-bookworm, 17-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 17/bookworm
 
 Tags: 17.7-alpine3.22, 17-alpine3.22, 17.7-alpine, 17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 17/alpine3.22
 
 Tags: 17.7-alpine3.21, 17-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c02157db6a6f6d724de5ebf5291463a989076dd9
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 17/alpine3.21
 
 Tags: 16.11, 16, 16.11-trixie, 16-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 16/trixie
 
 Tags: 16.11-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 16/bookworm
 
 Tags: 16.11-alpine3.22, 16-alpine3.22, 16.11-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 16/alpine3.22
 
 Tags: 16.11-alpine3.21, 16-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3506774b36743758520ce084d4f25ec5800a5200
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 16/alpine3.21
 
 Tags: 15.15, 15, 15.15-trixie, 15-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 423adf955c25775878b0feabaffed699d504aafb
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 15/trixie
 
 Tags: 15.15-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 423adf955c25775878b0feabaffed699d504aafb
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 15/bookworm
 
 Tags: 15.15-alpine3.22, 15-alpine3.22, 15.15-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 423adf955c25775878b0feabaffed699d504aafb
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 15/alpine3.22
 
 Tags: 15.15-alpine3.21, 15-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 423adf955c25775878b0feabaffed699d504aafb
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 15/alpine3.21
 
 Tags: 14.20, 14, 14.20-trixie, 14-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 14/trixie
 
 Tags: 14.20-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 14/bookworm
 
 Tags: 14.20-alpine3.22, 14-alpine3.22, 14.20-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 14/alpine3.22
 
 Tags: 14.20-alpine3.21, 14-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7de0b51da56bdaec3fc09dd704bf2a001d75326d
+GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
 Directory: 14/alpine3.21
-
-Tags: 13.23, 13, 13.23-trixie, 13-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
-Directory: 13/trixie
-
-Tags: 13.23-bookworm, 13-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
-Directory: 13/bookworm
-
-Tags: 13.23-alpine3.22, 13-alpine3.22, 13.23-alpine, 13-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
-Directory: 13/alpine3.22
-
-Tags: 13.23-alpine3.21, 13-alpine3.21
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c2d83d0b2a14daec6799e313e5ef51786768d597
-Directory: 13/alpine3.21


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/9c51532: Merge pull request https://github.com/docker-library/postgres/pull/1382 from infosiftr/13-eol
- https://github.com/docker-library/postgres/commit/2925b19: Remove PostgreSQL 13 since it is end of life

Final 13.23 images have all 8 architectures, so this is good to go.