### PR TITLE
mariadb -11.8.5 out of band release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -26,14 +26,14 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 46c443c353dea7d232536a03df3b8a5b998cc78d
 Directory: 12.0
 
-Tags: 11.8.4-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.4-ubi, 11.8-ubi, 11-ubi, lts-ubi
+Tags: 11.8.5-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.5-ubi, 11.8-ubi, 11-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: e95d4eddd8f5b3644a7c163e1363ff2bbd07d3e6
 Directory: 11.8-ubi
 
-Tags: 11.8.4-noble, 11.8-noble, 11-noble, lts-noble, 11.8.4, 11.8, 11, lts
+Tags: 11.8.5-noble, 11.8-noble, 11-noble, lts-noble, 11.8.5, 11.8, 11, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: e95d4eddd8f5b3644a7c163e1363ff2bbd07d3e6
 Directory: 11.8
 
 Tags: 11.4.9-ubi9, 11.4-ubi9, 11.4.9-ubi, 11.4-ubi


### PR DESCRIPTION
Post release regression found https://mariadb.com/docs/release-notes/community-server/11.8/11.8.5 and this fix of just this version.

Closes: https://github.com/MariaDB/mariadb-docker/issues/667