### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev12, 3.3-dev, 3.3-dev12-trixie, 3.3-dev-trixie
+Tags: 3.3-dev13, 3.3-dev, 3.3-dev13-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9728348c87cd7a64e12d34b07a4d34eeb5d0a299
+GitCommit: a7d9a0ce7defef21d4186f8fa72ee8e88cc53d16
 Directory: 3.3
 
-Tags: 3.3-dev12-alpine, 3.3-dev-alpine, 3.3-dev12-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev13-alpine, 3.3-dev-alpine, 3.3-dev13-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9728348c87cd7a64e12d34b07a4d34eeb5d0a299
+GitCommit: a7d9a0ce7defef21d4186f8fa72ee8e88cc53d16
 Directory: 3.3/alpine
 
 Tags: 3.2.8, 3.2, latest, lts, 3.2.8-trixie, 3.2-trixie, trixie, lts-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a7d9a0c: Update 3.3 to 3.3-dev13