### PR TITLE
Remove deprecated flag in ruby bundle install test

### DIFF
--- a/test/tests/ruby-bundler/container.sh
+++ b/test/tests/ruby-bundler/container.sh
@@ -13,5 +13,5 @@ cp Gemfile.lock Gemfile.lock.orig
 BUNDLE_FROZEN=1 bundle install
 diff -u Gemfile.lock.orig Gemfile.lock >&2
 
-bundle install --deployment
+BUNDLE_DEPLOYMENT=1 bundle install
 diff -u Gemfile.lock.orig Gemfile.lock >&2


### PR DESCRIPTION
The `--deployment` flag is a breaking option in bundler [4.0.0.dev](https://github.com/ruby/rubygems/pull/9002) ([included](https://github.com/ruby/ruby/pull/14800) in ruby `4.0.0-preview2`) and has a deprecation warning in all versions of ruby we have. So, we can just move to the environment variable version.

Fixes some of the failures on 4.0.0: https://github.com/docker-library/ruby/pull/517#issuecomment-3544166020

```console
$ ./test/run.sh -t ruby-bundler -t ruby-nonroot ruby:4.0.0-preview2
testing ruby:4.0.0-preview2
        'ruby-bundler' [1/2]...passed
        'ruby-nonroot' [2/2]...passed
```

Ref: https://github.com/ruby/rubygems/pull/8958

