### PR TITLE
Bump Traefik to v3.6.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.6.1-windowsservercore-ltsc2022, 3.6.1-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.2-windowsservercore-ltsc2022, 3.6.2-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 119b382b07da098c6d4d7f341d08326f656730dd
+GitCommit: bb8aabb8cf7d02824896d6274f81764090346a96
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.1-nanoserver-ltsc2022, 3.6.1-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.2-nanoserver-ltsc2022, 3.6.2-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 119b382b07da098c6d4d7f341d08326f656730dd
+GitCommit: bb8aabb8cf7d02824896d6274f81764090346a96
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.1, 3.6.1, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.2, 3.6.2, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 119b382b07da098c6d4d7f341d08326f656730dd
+GitCommit: bb8aabb8cf7d02824896d6274f81764090346a96
 Directory: v3.6/alpine
 
 Tags: v2.11.31-windowsservercore-ltsc2022, 2.11.31-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.6.2](https://github.com/traefik/traefik/releases/tag/v3.6.2).

/cc @mmatur @kevinpollet

Cheers
