### PR TITLE
Update Redis to 8.4.0

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,25 +6,25 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.4-rc1, 8.4-rc1-bookworm
+Tags: 8.4.0, 8.4, 8, 8.4.0-bookworm, 8.4-bookworm, 8-bookworm, latest, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 47386b7d1129abbe0f2ccc745903da1613977c79
-GitFetch: refs/tags/v8.4-rc1
+GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49
+GitFetch: refs/tags/v8.4.0
 Directory: debian
 
-Tags: 8.4-rc1-alpine, 8.4-rc1-alpine3.22
+Tags: 8.4.0-alpine, 8.4-alpine, 8-alpine, 8.4.0-alpine3.22, 8.4-alpine3.22, 8-alpine3.22, alpine, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 47386b7d1129abbe0f2ccc745903da1613977c79
-GitFetch: refs/tags/v8.4-rc1
+GitCommit: de8bb5f3e3ead8584e76834816b9e7e332d2bd49
+GitFetch: refs/tags/v8.4.0
 Directory: alpine
 
-Tags: 8.2.3, 8.2, 8, 8.2.3-bookworm, 8.2-bookworm, 8-bookworm, latest, bookworm
+Tags: 8.2.3, 8.2, 8.2.3-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
 GitFetch: refs/tags/v8.2.3
 Directory: debian
 
-Tags: 8.2.3-alpine, 8.2-alpine, 8-alpine, 8.2.3-alpine3.22, 8.2-alpine3.22, 8-alpine3.22, alpine, alpine3.22
+Tags: 8.2.3-alpine, 8.2-alpine, 8.2.3-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: bcbc692165ce2241e194035041c5b5e01d2e1a5f
 GitFetch: refs/tags/v8.2.3


### PR DESCRIPTION
Note: we haven't yet updated the bookworm to trixie since trixie is missing the `linux/mips64le` architecture