### PR TITLE
Swap "bundler-audit" for "bundler-compose" in "ruby-binstubs" test

### DIFF
--- a/test/tests/ruby-binstubs/Gemfile
+++ b/test/tests/ruby-binstubs/Gemfile
@@ -1,3 +1,11 @@
 source 'https://rubygems.org'
-gem 'bundler-audit', '0.9.1'
+
+if Gem::Version.create(RUBY_VERSION) >= Gem::Version.create('3.2')
+	gem 'bundler-compose', '0.0.2'
+else
+	# TODO when jruby:9 is EOL, we can remove this conditional (and the matching conditional in "container.sh")
+	# (it's only necessary because jruby:9 is Ruby 3.1 and bundler-compose needs 3.2+)
+	gem 'bundler-audit', '0.9.1'
+end
+
 gem 'brakeman', '5.4.1'

--- a/test/tests/ruby-binstubs/container.sh
+++ b/test/tests/ruby-binstubs/container.sh
@@ -1,5 +1,5 @@
-#!/bin/sh
-set -e
+#!/usr/bin/env sh
+set -eu
 
 dir="$(mktemp -d)"
 trap "rm -rf '$dir'" EXIT
@@ -9,4 +9,13 @@ cp Gemfile "$dir"
 cd "$dir"
 
 bundle install
-bundle audit version
+
+if bundle info bundler-compose; then
+	bundle compose help > /dev/null
+else
+	bundle info bundler-audit
+	bundle audit version
+fi
+
+bundle info brakeman
+brakeman --version


### PR DESCRIPTION
... conditionally (thanks to `jruby:9` being Ruby 3.1)

Also, improve the actual test to test the binstubs themselves more explicitly.

- see https://github.com/docker-library/ruby/pull/517