### PR TITLE
Updated swipl devel to 9.3.35

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: d3fa517447ac842ec77670b917ebfb578ebe6e28
+GitCommit: 0209567255681ccf4d012c15f62ea0141c1823c1
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 9.3.34
-Directory: 9.3.34/bookworm
+Tags: latest, 9.3.35
+Directory: 9.3.35/bookworm
 
 Tags: stable, 9.2.9
 Directory: 9.2.9/bookworm


### PR DESCRIPTION
This is a pre-release for what will be 10.0.0, making the stable series work properly again.