### PR TITLE
update influxdb3 to 3.7.0

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,7 +6,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 90a822e13f120254eff09740f8b16a2b2b275cc8
+GitCommit: 222eeaf138af2b69f346b8579816dcab39f00935
 
 Tags: 1.12, 1.12.2
 Architectures: amd64, arm64v8
@@ -56,10 +56,10 @@ Tags: 2-alpine, 2.7-alpine, 2.7.12-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.7/alpine
 
-Tags: 3-core, 3.6-core, 3.6.0-core, core
+Tags: 3-core, 3.7-core, 3.7.0-core, core
 Architectures: amd64, arm64v8
-Directory: influxdb/3.6-core
+Directory: influxdb/3.7-core
 
-Tags: 3-enterprise, 3.6-enterprise, 3.6.0-enterprise, enterprise
+Tags: 3-enterprise, 3.7-enterprise, 3.7.0-enterprise, enterprise
 Architectures: amd64, arm64v8
-Directory: influxdb/3.6-enterprise
+Directory: influxdb/3.7-enterprise


### PR DESCRIPTION
This commit bumps influxdb3 to our latest image 3.7.0