### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,12 +11,12 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.9.20251110.1
+Tags: 2023, latest, 2023.9.20251117.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 3ad57ac25b349535f5290924b6a2125110be7412
+amd64-GitCommit: af9f950543bd06e482cf2cc4fce32f988e1b0cc6
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 3d993d02f794ab9d223e3035e9d6c8fb37baa4e5
+arm64v8-GitCommit: 86eb74bfdeed44a90cd2681792b825cc19173eac
 
 Tags: 2, 2.0.20251110.1
 Architectures: amd64, arm64v8


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.9.20251117-0.amzn2023
- system-release-2023.9.20251117-0.amzn2023
#### Packages addressing CVES:
