### PR TITLE
"[oraclelinux] Updating 8 for ELSA-2025-21776"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d5ecb8b13a55dfeaa7b60279ba07b139f6581a34
+amd64-GitCommit: 2c4edbd675692e38695b6a7a5b180cd5d98e3258
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d2759a6f139243ae19f96160e1f2ccc0b9728c8a
+arm64v8-GitCommit: 0c983c198998d06e8171880c349afd2b9dab8c6c
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-59375, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-21776.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
