### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,24 +4,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev13, 3.3-dev, 3.3-dev13-trixie, 3.3-dev-trixie
+Tags: 3.3-dev14, 3.3-dev, 3.3-dev14-trixie, 3.3-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a7d9a0ce7defef21d4186f8fa72ee8e88cc53d16
+GitCommit: c1f08bf6346bd77d2862e0f6658f55fda8cc9e06
 Directory: 3.3
 
-Tags: 3.3-dev13-alpine, 3.3-dev-alpine, 3.3-dev13-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3-dev14-alpine, 3.3-dev-alpine, 3.3-dev14-alpine3.22, 3.3-dev-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a7d9a0ce7defef21d4186f8fa72ee8e88cc53d16
+GitCommit: c1f08bf6346bd77d2862e0f6658f55fda8cc9e06
 Directory: 3.3/alpine
 
-Tags: 3.2.8, 3.2, latest, lts, 3.2.8-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.9, 3.2, latest, lts, 3.2.9-trixie, 3.2-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4fd3078f4197405d08018930e1e0f386d7399be1
+GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
 Directory: 3.2
 
-Tags: 3.2.8-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.8-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.9-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.9-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4fd3078f4197405d08018930e1e0f386d7399be1
+GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
 Directory: 3.2/alpine
 
 Tags: 3.1.10, 3.1, 3.1.10-trixie, 3.1-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c1f08bf: Update 3.3 to 3.3-dev14
- https://github.com/docker-library/haproxy/commit/1721188: Update 3.2 to 3.2.9