### PR TITLE
Add debian-latest tag

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -178,7 +178,7 @@ Tags: trixie-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: trixie/backports
 
-Tags: trixie-slim, trixie-20251117-slim, 13.2-slim, 13-slim
+Tags: trixie-slim, trixie-20251117-slim, 13.2-slim, 13-slim, latest-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: trixie/slim/oci


### PR DESCRIPTION
 - Add a `latest-slim` tag to the debian image. This new tag should point to the latest version of the `slim` release (currently trixie-slim) 