### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -3,53 +3,53 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
-GitCommit: 1f2d17ae66ab17cd0b8618e779ddac972a206bdc
+GitCommit: 4fa5ca2625a7b228723b6f55a04d9e0716a19405
 
-Tags: 26-ea-24-jdk-oraclelinux9, 26-ea-24-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-ea-24-jdk-oracle, 26-ea-24-oracle, 26-ea-jdk-oracle, 26-ea-oracle
-SharedTags: 26-ea-24-jdk, 26-ea-24, 26-ea-jdk, 26-ea
+Tags: 26-ea-25-jdk-oraclelinux9, 26-ea-25-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-ea-25-jdk-oracle, 26-ea-25-oracle, 26-ea-jdk-oracle, 26-ea-oracle
+SharedTags: 26-ea-25-jdk, 26-ea-25, 26-ea-jdk, 26-ea
 Directory: 26/oraclelinux9
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-24-jdk-oraclelinux8, 26-ea-24-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8
+Tags: 26-ea-25-jdk-oraclelinux8, 26-ea-25-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8
 Directory: 26/oraclelinux8
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-24-jdk-trixie, 26-ea-24-trixie, 26-ea-jdk-trixie, 26-ea-trixie
+Tags: 26-ea-25-jdk-trixie, 26-ea-25-trixie, 26-ea-jdk-trixie, 26-ea-trixie
 Directory: 26/trixie
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-24-jdk-slim-trixie, 26-ea-24-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-ea-24-jdk-slim, 26-ea-24-slim, 26-ea-jdk-slim, 26-ea-slim
+Tags: 26-ea-25-jdk-slim-trixie, 26-ea-25-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-ea-25-jdk-slim, 26-ea-25-slim, 26-ea-jdk-slim, 26-ea-slim
 Directory: 26/slim-trixie
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-24-jdk-bookworm, 26-ea-24-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm
+Tags: 26-ea-25-jdk-bookworm, 26-ea-25-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm
 Directory: 26/bookworm
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-24-jdk-slim-bookworm, 26-ea-24-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm
+Tags: 26-ea-25-jdk-slim-bookworm, 26-ea-25-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm
 Directory: 26/slim-bookworm
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-24-jdk-windowsservercore-ltsc2025, 26-ea-24-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025
-SharedTags: 26-ea-24-jdk-windowsservercore, 26-ea-24-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-24-jdk, 26-ea-24, 26-ea-jdk, 26-ea
+Tags: 26-ea-25-jdk-windowsservercore-ltsc2025, 26-ea-25-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025
+SharedTags: 26-ea-25-jdk-windowsservercore, 26-ea-25-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-25-jdk, 26-ea-25, 26-ea-jdk, 26-ea
 Directory: 26/windows/windowsservercore-ltsc2025
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-24-jdk-windowsservercore-ltsc2022, 26-ea-24-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022
-SharedTags: 26-ea-24-jdk-windowsservercore, 26-ea-24-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-24-jdk, 26-ea-24, 26-ea-jdk, 26-ea
+Tags: 26-ea-25-jdk-windowsservercore-ltsc2022, 26-ea-25-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022
+SharedTags: 26-ea-25-jdk-windowsservercore, 26-ea-25-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-25-jdk, 26-ea-25, 26-ea-jdk, 26-ea
 Directory: 26/windows/windowsservercore-ltsc2022
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-24-jdk-nanoserver-ltsc2025, 26-ea-24-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025
-SharedTags: 26-ea-24-jdk-nanoserver, 26-ea-24-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
+Tags: 26-ea-25-jdk-nanoserver-ltsc2025, 26-ea-25-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025
+SharedTags: 26-ea-25-jdk-nanoserver, 26-ea-25-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
 Directory: 26/windows/nanoserver-ltsc2025
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-24-jdk-nanoserver-ltsc2022, 26-ea-24-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022
-SharedTags: 26-ea-24-jdk-nanoserver, 26-ea-24-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
+Tags: 26-ea-25-jdk-nanoserver-ltsc2022, 26-ea-25-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022
+SharedTags: 26-ea-25-jdk-nanoserver, 26-ea-25-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
 Directory: 26/windows/nanoserver-ltsc2022
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/4fa5ca2: Update 26 to 26-ea+25