### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/c1c6e2e2606dcc7c638d09893803d119ba8f59c5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/52bdfd93f67bd57df20baf0a1dc7d3225f28d829/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: c1c6e2e2606dcc7c638d09893803d119ba8f59c5
+GitCommit: 52bdfd93f67bd57df20baf0a1dc7d3225f28d829
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3c91bcd92b2cd6c113a87c39bcada57fbccf00b0
+amd64-GitCommit: abc048ad9fb2d6e2015614a5c96f79952565900d
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 0304c4d54eb0ccd2f2f0440dfff8927fdca8ed91
+arm32v5-GitCommit: d10869c4a85e2172de4a0a17b6b9519d2350c51d
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 51828b2e71143ac5772f87270676d348ff73f953
+arm32v6-GitCommit: 6e666f6540b6e8de0f85acba6c74613cc9fd085b
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 41862816ce89451518f38e22a190d509aa58541e
+arm32v7-GitCommit: 99b2e566b7d44f1d19801c12608034a18f326c52
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b938a081854f2252b114724eebc92c3a33fc53b1
+arm64v8-GitCommit: 7d8ac7995d0081cab4d8a65eaa99c899fe98a0d2
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 8160ba0d3f75aa7f1fefacf416aa18f6fc3fec74
+i386-GitCommit: a9444bbbc047b2d564c5945bc32319cc3126a876
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: b98c7ac981bf068570533eaf66691fd7f5143388
+ppc64le-GitCommit: f14f2573a0c972608ee61417ae7778e14ec749e3
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 6a2bbfd2057ad1a7e644ff0bfdbdb5d89aa8340d
+riscv64-GitCommit: 8940b63caf1b160f8f714d71b5ec4bb22d85854b
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e170ce69420d2611a83d98c259acdea6fcab974f
+s390x-GitCommit: c2134503afb2dd1003c79137978651b6906650d8
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/52bdfd9: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/1d404ea: Update metadata for i386
- https://github.com/docker-library/busybox/commit/b8f46fe: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/be53271: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/211718b: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/6ae37ab: Merge pull request https://github.com/docker-library/busybox/pull/235 from infosiftr/buildroot-2025.08.2
- https://github.com/docker-library/busybox/commit/8b47db7: Update amd64 metadata
- https://github.com/docker-library/busybox/commit/7a014f9: Update buildroot to 2025.08.2
- https://github.com/docker-library/busybox/commit/fec302a: Merge pull request https://github.com/docker-library/busybox/pull/234 from infosiftr/curl-error
- https://github.com/docker-library/busybox/commit/7088210: Show curl errors
- https://github.com/docker-library/busybox/commit/31f1ebc: Update architecture checks to be more defensive against server failures