### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-21977"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2c4edbd675692e38695b6a7a5b180cd5d98e3258
+amd64-GitCommit: 450929df1006fbf9e1798e43270ca54e177cecc7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0c983c198998d06e8171880c349afd2b9dab8c6c
+arm64v8-GitCommit: 234707ff57b65c50f517f04ade81dd20a4dc7faa
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5372, none, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-21977.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
