### PR TITLE
Add MistServer 3.11

### DIFF
--- a/library/mistserver
+++ b/library/mistserver
@@ -1,0 +1,15 @@
+Maintainers: Jaron Viëtor <jaron.vietor@ddvtech.com> (@Thulinma),
+             Marco van Dijk <marco.van.dijk@ddvtech.com> (@stronk-dev),
+             Carina van der Meer <carina.van.der.meer@ddvtech.com> (@thoronwen),
+             Balder Viëtor <balder.vietor@ddvtech.com> (@Rokamun),
+             Ramkoemar Bhoera <ramkoemar.bhoera@ddvtech.com> (@ramkoemar),
+             Juno Jense <unit-stamp-sled@duck.com> (@junojense)
+GitRepo: https://github.com/DDVTECH/mistserver-docker-builder.git
+GitFetch: refs/heads/main
+GitCommit: a0d4de02e3f9c3044a652cf6cbd56d4aba8c0315
+Builder: buildkit
+
+Tags: latest, 3.9.2
+Architectures: amd64, arm64v8
+Directory: 3.9.2
+File: Dockerfile.mistserver

--- a/library/mistserver
+++ b/library/mistserver
@@ -6,10 +6,9 @@ Maintainers: Jaron Viëtor <jaron.vietor@ddvtech.com> (@Thulinma),
              Juno Jense <unit-stamp-sled@duck.com> (@junojense)
 GitRepo: https://github.com/DDVTECH/mistserver-docker-builder.git
 GitFetch: refs/heads/main
-GitCommit: a0d4de02e3f9c3044a652cf6cbd56d4aba8c0315
-Builder: buildkit
+GitCommit: 6ad8faed85bf59bc95173fd9832f1867df55a278
 
-Tags: latest, 3.9.2
+Tags: latest, 3.11.1
 Architectures: amd64, arm64v8
-Directory: 3.9.2
+Directory: 3.11.1
 File: Dockerfile.mistserver


### PR DESCRIPTION
# Checklist for Review

**NOTE:** This checklist is intended for the use of the Official Images maintainers both to track the status of your PR and to help inform you and others of where we're at. As such, please leave the "checking" of items to the repository maintainers. If there is a point below for which you would like to provide additional information or note completion, please do so by commenting on the PR. Thanks! (and thanks for staying patient with us :heart:)

-	[x] associated with or contacted upstream?
	- repo under https://github.com/DDVTECH (https://github.com/DDVTECH/mistserver is upstream)
-	[x] available under [an OSI-approved license](https://opensource.org/licenses)?
	- "unlicense" (public domain)
-	[x] does it fit into one of the common categories? ("service", "language stack", "base distribution")
	- service
-	[ ] is it reasonably popular, or does it solve a particular use case well?
-	[x] does a [documentation](https://github.com/docker-library/docs/blob/master/README.md) PR exist? (should be reviewed and merged at roughly the same time so that we don't have an empty image page on the Hub for very long)
	- https://github.com/docker-library/docs/pull/2640
-	[ ] official-images maintainer dockerization review for best practices and cache gotchas/improvements (ala [the official review guidelines](https://github.com/docker-library/official-images/blob/master/README.md#review-guidelines))?
-	[ ] 2+ official-images maintainer dockerization review?
-	[ ] existing official images have been considered as a base? (ie, if `foobar` needs Node.js, has `FROM node:...` instead of grabbing `node` via other means been considered?)
-	[x] ~~if `FROM scratch`, tarballs only exist in a single commit within the associated history?~~
-	[ ] passes current tests? any simple new tests that might be appropriate to add, [assuming this image has any other images it might be interchangeable with](https://github.com/docker-library/official-images/tree/HEAD/test#what-tests-belong-here)?

## Extra Information
I am associated with upstream, the forked repository is contained in the official MistServer organisation. Our software is public domain, and is "licensed" under the [unlicense](https://opensource.org/license/unlicense). The current image on Docker hub builds off alpine and can be found [here](https://hub.docker.com/r/ddvtech/mistserver). The tests seem to be passing. I have also created a [documentation PR](https://github.com/docker-library/docs/pull/2640) which passes the markdown formatter.