### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,25 +1,35 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/c153740fe581f5c43c6c5571acd00055e49e478d/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/875a6dd82a46bc6474b8fa10003655f6103e7c67/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.3-dev14, 3.3-dev, 3.3-dev14-trixie, 3.3-dev-trixie
+Tags: 3.4-dev0, 3.4-dev, 3.4-dev0-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c1f08bf6346bd77d2862e0f6658f55fda8cc9e06
+GitCommit: 875a6dd82a46bc6474b8fa10003655f6103e7c67
+Directory: 3.4
+
+Tags: 3.4-dev0-alpine, 3.4-dev-alpine, 3.4-dev0-alpine3.22, 3.4-dev-alpine3.22
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 875a6dd82a46bc6474b8fa10003655f6103e7c67
+Directory: 3.4/alpine
+
+Tags: 3.3.0, 3.3, latest, 3.3.0-trixie, 3.3-trixie, trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: dca811ccdc2ce4736f2d3deee9d7f7f233a1d236
 Directory: 3.3
 
-Tags: 3.3-dev14-alpine, 3.3-dev-alpine, 3.3-dev14-alpine3.22, 3.3-dev-alpine3.22
+Tags: 3.3.0-alpine, 3.3-alpine, alpine, 3.3.0-alpine3.22, 3.3-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c1f08bf6346bd77d2862e0f6658f55fda8cc9e06
+GitCommit: dca811ccdc2ce4736f2d3deee9d7f7f233a1d236
 Directory: 3.3/alpine
 
-Tags: 3.2.9, 3.2, latest, lts, 3.2.9-trixie, 3.2-trixie, trixie, lts-trixie
+Tags: 3.2.9, 3.2, lts, 3.2.9-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
 Directory: 3.2
 
-Tags: 3.2.9-alpine, 3.2-alpine, alpine, lts-alpine, 3.2.9-alpine3.22, 3.2-alpine3.22, alpine3.22, lts-alpine3.22
+Tags: 3.2.9-alpine, 3.2-alpine, lts-alpine, 3.2.9-alpine3.22, 3.2-alpine3.22, lts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
 Directory: 3.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b95c37f: Merge pull request https://github.com/docker-library/haproxy/pull/255 from TimWolla/haproxy-3.4
- https://github.com/docker-library/haproxy/commit/875a6dd: Update for HAProxy 3.3 Stable Release
- https://github.com/docker-library/haproxy/commit/dca811c: Update 3.3 to 3.3.0