### PR TITLE
Gradle: Add UBI10 images and improve all UBI tags

### DIFF
--- a/library/gradle
+++ b/library/gradle
@@ -9,139 +9,151 @@ GitRepo: https://github.com/gradle/docker-gradle.git
 Tags: 9.2.1-jdk25, 9.2-jdk25, 9-jdk25, jdk25, 9.2.1-jdk25-noble, 9.2-jdk25-noble, 9-jdk25-noble, jdk25-noble, latest, 9.2.1-jdk, 9.2-jdk, 9-jdk, jdk, 9.2.1, 9.2, 9, 9.2.1-jdk-noble, 9.2-jdk-noble, 9-jdk-noble, jdk-noble, 9.2.1-noble, 9.2-noble, 9-noble, noble
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk25-noble
 
 Tags: 9.2.1-jdk25-alpine, 9.2-jdk25-alpine, 9-jdk25-alpine, jdk25-alpine, 9.2.1-jdk-alpine, 9.2-jdk-alpine, 9-jdk-alpine, jdk-alpine, 9.2.1-alpine, 9.2-alpine, 9-alpine, alpine
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk25-alpine
 
 Tags: 9.2.1-jdk25-corretto, 9.2-jdk25-corretto, 9-jdk25-corretto, jdk25-corretto, corretto, 9.2.1-jdk25-corretto-al2023, 9.2-jdk25-corretto-al2023, 9-jdk25-corretto-al2023, jdk25-corretto-al2023, corretto-al2023
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk25-corretto
 
-Tags: 9.2.1-jdk25-ubi, 9.2-jdk25-ubi, 9-jdk25-ubi, jdk25-ubi, ubi, 9.2.1-jdk25-ubi-minimal, 9.2-jdk25-ubi-minimal, 9-jdk25-ubi-minimal, jdk25-ubi-minimal, ubi-minimal
+Tags: 9.2.1-jdk25-ubi, 9.2-jdk25-ubi, 9-jdk25-ubi, jdk25-ubi, ubi, 9.2.1-jdk25-ubi10, 9.2-jdk25-ubi10, 9-jdk25-ubi10, jdk25-ubi10, ubi10
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk25-ubi10
 
 Tags: 9.2.1-jdk25-graal, 9.2-jdk25-graal, 9-jdk25-graal, jdk25-graal, 9.2.1-jdk-graal, 9.2-jdk-graal, 9-jdk-graal, jdk-graal, 9.2.1-graal, 9.2-graal, 9-graal, graal, 9.2.1-jdk25-graal-noble, 9.2-jdk25-graal-noble, 9-jdk25-graal-noble, jdk25-graal-noble, 9.2.1-jdk-graal-noble, 9.2-jdk-graal-noble, 9-jdk-graal-noble, jdk-graal-noble, 9.2.1-graal-noble, 9.2-graal-noble, 9-graal-noble, graal-noble
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk25-noble-graal
 
 Tags: 9.2.1-jdk21, 9.2-jdk21, 9-jdk21, jdk21, 9.2.1-jdk21-noble, 9.2-jdk21-noble, 9-jdk21-noble, jdk21-noble
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-noble
 
 Tags: 9.2.1-jdk21-jammy, 9.2-jdk21-jammy, 9-jdk21-jammy, jdk21-jammy, 9.2.1-jdk-jammy, 9.2-jdk-jammy, 9-jdk-jammy, jdk-jammy, 9.2.1-jammy, 9.2-jammy, 9-jammy, jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-jammy
 
 Tags: 9.2.1-jdk21-alpine, 9.2-jdk21-alpine, 9-jdk21-alpine, jdk21-alpine
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-alpine
 
 Tags: 9.2.1-jdk21-corretto, 9.2-jdk21-corretto, 9-jdk21-corretto, jdk21-corretto, 9.2.1-jdk21-corretto-al2023, 9.2-jdk21-corretto-al2023, 9-jdk21-corretto-al2023, jdk21-corretto-al2023
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-corretto
 
-Tags: 9.2.1-jdk21-ubi, 9.2-jdk21-ubi, 9-jdk21-ubi, jdk21-ubi, 9.2.1-jdk21-ubi-minimal, 9.2-jdk21-ubi-minimal, 9-jdk21-ubi-minimal, jdk21-ubi-minimal
+Tags: 9.2.1-jdk21-ubi, 9.2-jdk21-ubi, 9-jdk21-ubi, jdk21-ubi, 9.2.1-jdk21-ubi10, 9.2-jdk21-ubi10, 9-jdk21-ubi10, jdk21-ubi10
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
+Directory: jdk21-ubi10
+
+Tags: 9.2.1-jdk21-ubi9, 9.2-jdk21-ubi9, 9-jdk21-ubi9, jdk21-ubi9, ubi9
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitFetch: refs/heads/master
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-ubi9
 
 Tags: 9.2.1-jdk21-graal, 9.2-jdk21-graal, 9-jdk21-graal, jdk21-graal, 9.2.1-jdk21-graal-noble, 9.2-jdk21-graal-noble, 9-jdk21-graal-noble, jdk21-graal-noble
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-noble-graal
 
 Tags: 9.2.1-jdk21-graal-jammy, 9.2-jdk21-graal-jammy, 9-jdk21-graal-jammy, jdk21-graal-jammy, 9.2.1-jdk-graal-jammy, 9.2-jdk-graal-jammy, 9-jdk-graal-jammy, jdk-graal-jammy, 9.2.1-graal-jammy, 9.2-graal-jammy, 9-graal-jammy, graal-jammy
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk21-jammy-graal
 
 Tags: 9.2.1-jdk17, 9.2-jdk17, 9-jdk17, jdk17, 9.2.1-jdk17-noble, 9.2-jdk17-noble, 9-jdk17-noble, jdk17-noble
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-noble
 
 Tags: 9.2.1-jdk17-jammy, 9.2-jdk17-jammy, 9-jdk17-jammy, jdk17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-jammy
 
 Tags: 9.2.1-jdk17-alpine, 9.2-jdk17-alpine, 9-jdk17-alpine, jdk17-alpine
 Architectures: amd64
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-alpine
 
 Tags: 9.2.1-jdk17-corretto, 9.2-jdk17-corretto, 9-jdk17-corretto, jdk17-corretto, 9.2.1-jdk17-corretto-al2023, 9.2-jdk17-corretto-al2023, 9-jdk17-corretto-al2023, jdk17-corretto-al2023
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-corretto
 
-Tags: 9.2.1-jdk17-ubi, 9.2-jdk17-ubi, 9-jdk17-ubi, jdk17-ubi, 9.2.1-jdk17-ubi-minimal, 9.2-jdk17-ubi-minimal, 9-jdk17-ubi-minimal, jdk17-ubi-minimal
+Tags: 9.2.1-jdk17-ubi, 9.2-jdk17-ubi, 9-jdk17-ubi, jdk17-ubi, 9.2.1-jdk17-ubi10, 9.2-jdk17-ubi10, 9-jdk17-ubi10, jdk17-ubi10
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
+Directory: jdk17-ubi10
+
+Tags: 9.2.1-jdk17-ubi9, 9.2-jdk17-ubi9, 9-jdk17-ubi9, jdk17-ubi9
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitFetch: refs/heads/master
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-ubi9
 
 Tags: 9.2.1-jdk17-graal, 9.2-jdk17-graal, 9-jdk17-graal, jdk17-graal, 9.2.1-jdk17-graal-noble, 9.2-jdk17-graal-noble, 9-jdk17-graal-noble, jdk17-graal-noble
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-noble-graal
 
 Tags: 9.2.1-jdk17-graal-jammy, 9.2-jdk17-graal-jammy, 9-jdk17-graal-jammy, jdk17-graal-jammy
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk17-jammy-graal
 
 Tags: 9.2.1-jdk-lts-and-current, 9.2-jdk-lts-and-current, 9-jdk-lts-and-current, jdk-lts-and-current, 9.2.1-jdk-lts-and-current-noble, 9.2-jdk-lts-and-current-noble, 9-jdk-lts-and-current-noble, jdk-lts-and-current-noble, 9.2.1-jdk-25-and-25, 9.2-jdk-25-and-25, 9-jdk-25-and-25, jdk-25-and-25, 9.2.1-jdk-25-and-25-noble, 9.2-jdk-25-and-25-noble, 9-jdk-25-and-25-noble, jdk-25-and-25-noble
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk-lts-and-current
 
 Tags: 9.2.1-jdk-lts-and-current-alpine, 9.2-jdk-lts-and-current-alpine, 9-jdk-lts-and-current-alpine, jdk-lts-and-current-alpine, 9.2.1-jdk-25-and-25-alpine, 9.2-jdk-25-and-25-alpine, 9-jdk-25-and-25-alpine, jdk-25-and-25-alpine
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk-lts-and-current-alpine
 
 Tags: 9.2.1-jdk-lts-and-current-corretto, 9.2-jdk-lts-and-current-corretto, 9-jdk-lts-and-current-corretto, jdk-lts-and-current-corretto, 9.2.1-jdk-lts-and-current-corretto-al2023, 9.2-jdk-lts-and-current-corretto-al2023, 9-jdk-lts-and-current-corretto-al2023, jdk-lts-and-current-corretto-al2023, 9.2.1-jdk-25-and-25-corretto, 9.2-jdk-25-and-25-corretto, 9-jdk-25-and-25-corretto, jdk-25-and-25-corretto, 9.2.1-jdk-25-and-25-corretto-al2023, 9.2-jdk-25-and-25-corretto-al2023, 9-jdk-25-and-25-corretto-al2023, jdk-25-and-25-corretto-al2023
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk-lts-and-current-corretto
 
 Tags: 9.2.1-jdk-lts-and-current-graal, 9.2-jdk-lts-and-current-graal, 9-jdk-lts-and-current-graal, jdk-lts-and-current-graal, 9.2.1-jdk-lts-and-current-graal-noble, 9.2-jdk-lts-and-current-graal-noble, 9-jdk-lts-and-current-graal-noble, jdk-lts-and-current-graal-noble, 9.2.1-jdk-25-and-25-graal, 9.2-jdk-25-and-25-graal, 9-jdk-25-and-25-graal, jdk-25-and-25-graal, 9.2.1-jdk-25-and-25-graal-noble, 9.2-jdk-25-and-25-graal-noble, 9-jdk-25-and-25-graal-noble, jdk-25-and-25-graal-noble
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
-GitCommit: ed0ea425043215ae106a8240ee86cb5f5e1ca5fb
+GitCommit: 58cc723d247601cd5b92892753986600d39c9ca2
 Directory: jdk-lts-and-current-graal
 
 
@@ -171,7 +183,7 @@ GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
 Directory: jdk21-corretto
 
-Tags: 8.14.3-jdk21-ubi, 8.14-jdk21-ubi, 8-jdk21-ubi, 8.14.3-jdk21-ubi-minimal, 8.14-jdk21-ubi-minimal, 8-jdk21-ubi-minimal
+Tags: 8.14.3-jdk21-ubi, 8.14-jdk21-ubi, 8-jdk21-ubi, 8.14.3-jdk21-ubi9, 8.14-jdk21-ubi9, 8-jdk21-ubi9
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
@@ -213,7 +225,7 @@ GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
 Directory: jdk17-corretto
 
-Tags: 8.14.3-jdk17-ubi, 8.14-jdk17-ubi, 8-jdk17-ubi, 8.14.3-jdk17-ubi-minimal, 8.14-jdk17-ubi-minimal, 8-jdk17-ubi-minimal
+Tags: 8.14.3-jdk17-ubi, 8.14-jdk17-ubi, 8-jdk17-ubi, 8.14.3-jdk17-ubi9, 8.14-jdk17-ubi9, 8-jdk17-ubi9
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
@@ -249,7 +261,7 @@ GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
 Directory: jdk11-corretto
 
-Tags: 8.14.3-jdk11-ubi, 8.14-jdk11-ubi, 8-jdk11-ubi, jdk11-ubi, 8.14.3-jdk11-ubi-minimal, 8.14-jdk11-ubi-minimal, 8-jdk11-ubi-minimal, jdk11-ubi-minimal
+Tags: 8.14.3-jdk11-ubi, 8.14-jdk11-ubi, 8-jdk11-ubi, jdk11-ubi, 8.14.3-jdk11-ubi9, 8.14-jdk11-ubi9, 8-jdk11-ubi9, jdk11-ubi9
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
@@ -267,7 +279,7 @@ GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
 Directory: jdk8-corretto
 
-Tags: 8.14.3-jdk8-ubi, 8.14-jdk8-ubi, 8-jdk8-ubi, jdk8-ubi, 8.14.3-jdk8-ubi-minimal, 8.14-jdk8-ubi-minimal, 8-jdk8-ubi-minimal, jdk8-ubi-minimal
+Tags: 8.14.3-jdk8-ubi, 8.14-jdk8-ubi, 8-jdk8-ubi, jdk8-ubi, 8.14.3-jdk8-ubi9, 8.14-jdk8-ubi9, 8-jdk8-ubi9, jdk8-ubi9
 Architectures: amd64, arm64v8, ppc64le
 GitFetch: refs/heads/8
 GitCommit: fba2d36b492eab91f3eb95610354df7b8d12d46f
@@ -306,7 +318,7 @@ GitFetch: refs/heads/7
 GitCommit: 692045c708bc589ff8fa26fb083bdf1b23c0f8a5
 Directory: jdk17-corretto
 
-Tags: 7.6.6-jdk17-ubi, 7.6-jdk17-ubi, 7-jdk17-ubi, 7.6.6-jdk17-ubi-minimal, 7.6-jdk17-ubi-minimal, 7-jdk17-ubi-minimal
+Tags: 7.6.6-jdk17-ubi, 7.6-jdk17-ubi, 7-jdk17-ubi, 7.6.6-jdk17-ubi9, 7.6-jdk17-ubi9, 7-jdk17-ubi9
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/7
 GitCommit: 692045c708bc589ff8fa26fb083bdf1b23c0f8a5
@@ -342,7 +354,7 @@ GitFetch: refs/heads/7
 GitCommit: 692045c708bc589ff8fa26fb083bdf1b23c0f8a5
 Directory: jdk11-corretto
 
-Tags: 7.6.6-jdk11-ubi, 7.6-jdk11-ubi, 7-jdk11-ubi, 7.6.6-jdk11-ubi-minimal, 7.6-jdk11-ubi-minimal, 7-jdk11-ubi-minimal
+Tags: 7.6.6-jdk11-ubi, 7.6-jdk11-ubi, 7-jdk11-ubi, 7.6.6-jdk11-ubi9, 7.6-jdk11-ubi9, 7-jdk11-ubi9
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/7
 GitCommit: 692045c708bc589ff8fa26fb083bdf1b23c0f8a5
@@ -360,7 +372,7 @@ GitFetch: refs/heads/7
 GitCommit: 692045c708bc589ff8fa26fb083bdf1b23c0f8a5
 Directory: jdk8-corretto
 
-Tags: 7.6.6-jdk8-ubi, 7.6-jdk8-ubi, 7-jdk8-ubi, 7.6.6-jdk8-ubi-minimal, 7.6-jdk8-ubi-minimal, 7-jdk8-ubi-minimal
+Tags: 7.6.6-jdk8-ubi, 7.6-jdk8-ubi, 7-jdk8-ubi, 7.6.6-jdk8-ubi9, 7.6-jdk8-ubi9, 7-jdk8-ubi9
 Architectures: amd64, arm64v8, ppc64le
 GitFetch: refs/heads/7
 GitCommit: 692045c708bc589ff8fa26fb083bdf1b23c0f8a5
@@ -387,7 +399,7 @@ GitFetch: refs/heads/6
 GitCommit: 89adc634c8c98e9c132935942ed75ffce1d862f1
 Directory: jdk11-corretto
 
-Tags: 6.9.4-jdk11-ubi, 6.9-jdk11-ubi, 6-jdk11-ubi, 6.9.4-jdk11-ubi-minimal, 6.9-jdk11-ubi-minimal, 6-jdk11-ubi-minimal
+Tags: 6.9.4-jdk11-ubi, 6.9-jdk11-ubi, 6-jdk11-ubi, 6.9.4-jdk11-ubi9, 6.9-jdk11-ubi9, 6-jdk11-ubi9
 Architectures: amd64, arm64v8, ppc64le, s390x
 GitFetch: refs/heads/6
 GitCommit: 89adc634c8c98e9c132935942ed75ffce1d862f1
@@ -405,7 +417,7 @@ GitFetch: refs/heads/6
 GitCommit: 89adc634c8c98e9c132935942ed75ffce1d862f1
 Directory: jdk8-corretto
 
-Tags: 6.9.4-jdk8-ubi, 6.9-jdk8-ubi, 6-jdk8-ubi, 6.9.4-jdk8-ubi-minimal, 6.9-jdk8-ubi-minimal, 6-jdk8-ubi-minimal
+Tags: 6.9.4-jdk8-ubi, 6.9-jdk8-ubi, 6-jdk8-ubi, 6.9.4-jdk8-ubi9, 6.9-jdk8-ubi9, 6-jdk8-ubi9
 Architectures: amd64, arm64v8, ppc64le
 GitFetch: refs/heads/6
 GitCommit: 89adc634c8c98e9c132935942ed75ffce1d862f1


### PR DESCRIPTION
* Add UBI10 images to Gradle 9 Java 17 and Java 21
* Fix all images to be tagged with `-ubi9` or `-ubi10` instead of `-ubi-minimal`
