### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,140 +6,175 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.8.3-php8.1-apache, 6.8-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.8.3-php8.1, 6.8-php8.1, 6-php8.1, php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.1/apache
 
 Tags: 6.8.3-php8.1-fpm, 6.8-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.1/fpm
 
 Tags: 6.8.3-php8.1-fpm-alpine, 6.8-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.1/fpm-alpine
 
 Tags: 6.8.3-php8.2-apache, 6.8-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.8.3-php8.2, 6.8-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.2/apache
 
 Tags: 6.8.3-php8.2-fpm, 6.8-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.2/fpm
 
 Tags: 6.8.3-php8.2-fpm-alpine, 6.8-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.2/fpm-alpine
 
 Tags: 6.8.3-apache, 6.8-apache, 6-apache, apache, 6.8.3, 6.8, 6, latest, 6.8.3-php8.3-apache, 6.8-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.8.3-php8.3, 6.8-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.3/apache
 
 Tags: 6.8.3-fpm, 6.8-fpm, 6-fpm, fpm, 6.8.3-php8.3-fpm, 6.8-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.3/fpm
 
 Tags: 6.8.3-fpm-alpine, 6.8-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.8.3-php8.3-fpm-alpine, 6.8-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.3/fpm-alpine
 
 Tags: 6.8.3-php8.4-apache, 6.8-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.8.3-php8.4, 6.8-php8.4, 6-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.4/apache
 
 Tags: 6.8.3-php8.4-fpm, 6.8-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.4/fpm
 
 Tags: 6.8.3-php8.4-fpm-alpine, 6.8-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f143dd4b24dcefc3b633e4a10ed3534d92b91c23
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: latest/php8.4/fpm-alpine
+
+Tags: 6.8.3-php8.5-apache, 6.8-php8.5-apache, 6-php8.5-apache, php8.5-apache, 6.8.3-php8.5, 6.8-php8.5, 6-php8.5, php8.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: latest/php8.5/apache
+
+Tags: 6.8.3-php8.5-fpm, 6.8-php8.5-fpm, 6-php8.5-fpm, php8.5-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: latest/php8.5/fpm
+
+Tags: 6.8.3-php8.5-fpm-alpine, 6.8-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.5-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: latest/php8.5/fpm-alpine
 
 Tags: cli-2.12.0-php8.1, cli-2.12-php8.1, cli-2-php8.1, cli-php8.1
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.1/alpine
 
 Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.2/alpine
 
 Tags: cli-2.12.0, cli-2.12, cli-2, cli, cli-2.12.0-php8.3, cli-2.12-php8.3, cli-2-php8.3, cli-php8.3
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.3/alpine
 
 Tags: cli-2.12.0-php8.4, cli-2.12-php8.4, cli-2-php8.4, cli-php8.4
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 50da133eabc137fa07c620c77788c1237cf55c8b
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.4/alpine
 
-Tags: beta-6.9-RC3-php8.1-apache, beta-6.9-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.9-RC3-php8.1, beta-6.9-php8.1, beta-6-php8.1, beta-php8.1
+Tags: cli-2.12.0-php8.5, cli-2.12-php8.5, cli-2-php8.5, cli-php8.5
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: cli/php8.5/alpine
+
+Tags: beta-6.9-RC4-php8.1-apache, beta-6.9-php8.1-apache, beta-6-php8.1-apache, beta-php8.1-apache, beta-6.9-RC4-php8.1, beta-6.9-php8.1, beta-6-php8.1, beta-php8.1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.1/apache
 
-Tags: beta-6.9-RC3-php8.1-fpm, beta-6.9-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
+Tags: beta-6.9-RC4-php8.1-fpm, beta-6.9-php8.1-fpm, beta-6-php8.1-fpm, beta-php8.1-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.1/fpm
 
-Tags: beta-6.9-RC3-php8.1-fpm-alpine, beta-6.9-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
+Tags: beta-6.9-RC4-php8.1-fpm-alpine, beta-6.9-php8.1-fpm-alpine, beta-6-php8.1-fpm-alpine, beta-php8.1-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.1/fpm-alpine
 
-Tags: beta-6.9-RC3-php8.2-apache, beta-6.9-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.9-RC3-php8.2, beta-6.9-php8.2, beta-6-php8.2, beta-php8.2
+Tags: beta-6.9-RC4-php8.2-apache, beta-6.9-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.9-RC4-php8.2, beta-6.9-php8.2, beta-6-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.2/apache
 
-Tags: beta-6.9-RC3-php8.2-fpm, beta-6.9-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-6.9-RC4-php8.2-fpm, beta-6.9-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.2/fpm
 
-Tags: beta-6.9-RC3-php8.2-fpm-alpine, beta-6.9-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-6.9-RC4-php8.2-fpm-alpine, beta-6.9-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.2/fpm-alpine
 
-Tags: beta-6.9-RC3-apache, beta-6.9-apache, beta-6-apache, beta-apache, beta-6.9-RC3, beta-6.9, beta-6, beta, beta-6.9-RC3-php8.3-apache, beta-6.9-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.9-RC3-php8.3, beta-6.9-php8.3, beta-6-php8.3, beta-php8.3
+Tags: beta-6.9-RC4-apache, beta-6.9-apache, beta-6-apache, beta-apache, beta-6.9-RC4, beta-6.9, beta-6, beta, beta-6.9-RC4-php8.3-apache, beta-6.9-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.9-RC4-php8.3, beta-6.9-php8.3, beta-6-php8.3, beta-php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.3/apache
 
-Tags: beta-6.9-RC3-fpm, beta-6.9-fpm, beta-6-fpm, beta-fpm, beta-6.9-RC3-php8.3-fpm, beta-6.9-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
+Tags: beta-6.9-RC4-fpm, beta-6.9-fpm, beta-6-fpm, beta-fpm, beta-6.9-RC4-php8.3-fpm, beta-6.9-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.3/fpm
 
-Tags: beta-6.9-RC3-fpm-alpine, beta-6.9-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.9-RC3-php8.3-fpm-alpine, beta-6.9-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Tags: beta-6.9-RC4-fpm-alpine, beta-6.9-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.9-RC4-php8.3-fpm-alpine, beta-6.9-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.3/fpm-alpine
 
-Tags: beta-6.9-RC3-php8.4-apache, beta-6.9-php8.4-apache, beta-6-php8.4-apache, beta-php8.4-apache, beta-6.9-RC3-php8.4, beta-6.9-php8.4, beta-6-php8.4, beta-php8.4
+Tags: beta-6.9-RC4-php8.4-apache, beta-6.9-php8.4-apache, beta-6-php8.4-apache, beta-php8.4-apache, beta-6.9-RC4-php8.4, beta-6.9-php8.4, beta-6-php8.4, beta-php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.4/apache
 
-Tags: beta-6.9-RC3-php8.4-fpm, beta-6.9-php8.4-fpm, beta-6-php8.4-fpm, beta-php8.4-fpm
+Tags: beta-6.9-RC4-php8.4-fpm, beta-6.9-php8.4-fpm, beta-6-php8.4-fpm, beta-php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.4/fpm
 
-Tags: beta-6.9-RC3-php8.4-fpm-alpine, beta-6.9-php8.4-fpm-alpine, beta-6-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
+Tags: beta-6.9-RC4-php8.4-fpm-alpine, beta-6.9-php8.4-fpm-alpine, beta-6-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 86e645ec776571fee63faaa482e90fb3f6442587
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: beta/php8.4/fpm-alpine
+
+Tags: beta-6.9-RC4-php8.5-apache, beta-6.9-php8.5-apache, beta-6-php8.5-apache, beta-php8.5-apache, beta-6.9-RC4-php8.5, beta-6.9-php8.5, beta-6-php8.5, beta-php8.5
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: beta/php8.5/apache
+
+Tags: beta-6.9-RC4-php8.5-fpm, beta-6.9-php8.5-fpm, beta-6-php8.5-fpm, beta-php8.5-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: beta/php8.5/fpm
+
+Tags: beta-6.9-RC4-php8.5-fpm-alpine, beta-6.9-php8.5-fpm-alpine, beta-6-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
+Directory: beta/php8.5/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/b962e97: Use PHP_INI_DIR provided by the php base images (https://github.com/docker-library/wordpress/pull/991)
- https://github.com/docker-library/wordpress/commit/ee43abe: Update beta
- https://github.com/docker-library/wordpress/commit/3ca512a: Add PHP 8.5 support (https://github.com/docker-library/wordpress/pull/986)
- https://github.com/docker-library/wordpress/commit/63ce84b: Update beta to 6.9-RC4