### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.25.4-trixie, 1.25-trixie, 1-trixie, trixie
-SharedTags: 1.25.4, 1.25, 1, latest
+Tags: 1.25.5-trixie, 1.25-trixie, 1-trixie, trixie
+SharedTags: 1.25.5, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/trixie
 
-Tags: 1.25.4-bookworm, 1.25-bookworm, 1-bookworm, bookworm
+Tags: 1.25.5-bookworm, 1.25-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/bookworm
 
-Tags: 1.25.4-alpine3.22, 1.25-alpine3.22, 1-alpine3.22, alpine3.22, 1.25.4-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.5-alpine3.22, 1.25-alpine3.22, 1-alpine3.22, alpine3.22, 1.25.5-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/alpine3.22
 
-Tags: 1.25.4-alpine3.21, 1.25-alpine3.21, 1-alpine3.21, alpine3.21
+Tags: 1.25.5-alpine3.21, 1.25-alpine3.21, 1-alpine3.21, alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/alpine3.21
 
-Tags: 1.25.4-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 1.25.4-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.4, 1.25, 1, latest
+Tags: 1.25.5-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.25.5-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.5, 1.25, 1, latest
 Architectures: windows-amd64
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.25.4-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.25.4-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.4, 1.25, 1, latest
+Tags: 1.25.5-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.25.5-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.5, 1.25, 1, latest
 Architectures: windows-amd64
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.25.4-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 1.25.4-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.25.5-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 1.25.5-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.25.4-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.25.4-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.25.5-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.25.5-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 63f58b7160c9e82a88a7befcda362794b7d21750
+GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
 Directory: 1.25/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.24.10-trixie, 1.24-trixie
-SharedTags: 1.24.10, 1.24
+Tags: 1.24.11-trixie, 1.24-trixie
+SharedTags: 1.24.11, 1.24
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/trixie
 
-Tags: 1.24.10-bookworm, 1.24-bookworm
+Tags: 1.24.11-bookworm, 1.24-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/bookworm
 
-Tags: 1.24.10-alpine3.22, 1.24-alpine3.22, 1.24.10-alpine, 1.24-alpine
+Tags: 1.24.11-alpine3.22, 1.24-alpine3.22, 1.24.11-alpine, 1.24-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/alpine3.22
 
-Tags: 1.24.10-alpine3.21, 1.24-alpine3.21
+Tags: 1.24.11-alpine3.21, 1.24-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/alpine3.21
 
-Tags: 1.24.10-windowsservercore-ltsc2025, 1.24-windowsservercore-ltsc2025
-SharedTags: 1.24.10-windowsservercore, 1.24-windowsservercore, 1.24.10, 1.24
+Tags: 1.24.11-windowsservercore-ltsc2025, 1.24-windowsservercore-ltsc2025
+SharedTags: 1.24.11-windowsservercore, 1.24-windowsservercore, 1.24.11, 1.24
 Architectures: windows-amd64
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.24.10-windowsservercore-ltsc2022, 1.24-windowsservercore-ltsc2022
-SharedTags: 1.24.10-windowsservercore, 1.24-windowsservercore, 1.24.10, 1.24
+Tags: 1.24.11-windowsservercore-ltsc2022, 1.24-windowsservercore-ltsc2022
+SharedTags: 1.24.11-windowsservercore, 1.24-windowsservercore, 1.24.11, 1.24
 Architectures: windows-amd64
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.24.10-nanoserver-ltsc2025, 1.24-nanoserver-ltsc2025
-SharedTags: 1.24.10-nanoserver, 1.24-nanoserver
+Tags: 1.24.11-nanoserver-ltsc2025, 1.24-nanoserver-ltsc2025
+SharedTags: 1.24.11-nanoserver, 1.24-nanoserver
 Architectures: windows-amd64
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.24.10-nanoserver-ltsc2022, 1.24-nanoserver-ltsc2022
-SharedTags: 1.24.10-nanoserver, 1.24-nanoserver
+Tags: 1.24.11-nanoserver-ltsc2022, 1.24-nanoserver-ltsc2022
+SharedTags: 1.24.11-nanoserver, 1.24-nanoserver
 Architectures: windows-amd64
-GitCommit: 6302d466bdcf34f867e69179bddf77bfe701f0c9
+GitCommit: 40780952e94f21871629116080cf50fac6c991f6
 Directory: 1.24/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/5ac8de6: Update 1.25 to 1.25.5
- https://github.com/docker-library/golang/commit/4078095: Update 1.24 to 1.24.11