### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-22376"

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ba931e60ee5391b6829a51d1ad3ac0be969821da
+amd64-GitCommit: acd3b60b5a0676578d2201eac29e9d357b0dadc6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f2c204572aa0b8e73692a9eba9e8d6c9d21da5fe
+arm64v8-GitCommit: e880a5725a83f4d151d982a9d93066e5db3ffafc
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-9714, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-22376.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
