### PR TITLE
Updated swipl stable to 10.0.0

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: 0209567255681ccf4d012c15f62ea0141c1823c1
+GitCommit: 05ad5d15db62bec4baaff317d43ad280e40f26c3
 Architectures: amd64, arm32v7, arm64v8
 
 Tags: latest, 9.3.35
 Directory: 9.3.35/bookworm
 
-Tags: stable, 9.2.9
-Directory: 9.2.9/bookworm
+Tags: stable, 10.0.0
+Directory: 10.0.0/bookworm


### PR DESCRIPTION
Version 10 is synced with the devel series, so it should properly build again.