### PR TITLE
Update fluentd to v1.19.1

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -17,7 +17,7 @@ GitCommit: 505a1af75b4a4adb40d576df7b18cebab853264e
 Directory: v1.16/debian
 
 # Debian images
-Tags: v1.19.0-debian-1.0, v1.19-debian-1, v1.19.0-1.0, v1.19-1, latest
+Tags: v1.19.1-debian-1.0, v1.19-debian-1, v1.19.0-1.0, v1.19-1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 42a0afa30b3821482bce1ba8e67266d745619724
+GitCommit: 1e7ff373975402c1e5b10e9b2ae41e50b3d273a3
 Directory: v1.19/debian


### PR DESCRIPTION
See https://www.fluentd.org/blog/fluentd-v1.19.1-has-been-released