### PR TITLE
Drop Fluentd v1.16 alpine image

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -2,13 +2,6 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
              Fluentd developers <fluentd@googlegroups.com> (@fluent/admins)
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
-# Alpine images
-Tags: v1.16.9-1.0, v1.16-1
-Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
-GitFetch: refs/heads/v1.16
-GitCommit: 505a1af75b4a4adb40d576df7b18cebab853264e
-Directory: v1.16/alpine
-
 # Debian images
 Tags: v1.16.9-debian-1.0, v1.16-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x


### PR DESCRIPTION
alpine 3.19 had alreay reached EOL.

See https://alpinelinux.org/releases/

NOTE: Fluentd v1.16 alpine image will not follow newer alpine image, so just drop it.
