### PR TITLE
Bump Traefik to v2.11.32

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,22 +20,22 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: bb8aabb8cf7d02824896d6274f81764090346a96
 Directory: v3.6/alpine
 
-Tags: v2.11.31-windowsservercore-ltsc2022, 2.11.31-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.32-windowsservercore-ltsc2022, 2.11.32-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3eca893d22ccb8b76fd9254483c930e424dee7
+GitCommit: d35ff0c3dbec642588c6284b0732407679ddeee2
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.31-nanoserver-ltsc2022, 2.11.31-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.32-nanoserver-ltsc2022, 2.11.32-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3eca893d22ccb8b76fd9254483c930e424dee7
+GitCommit: d35ff0c3dbec642588c6284b0732407679ddeee2
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.31, 2.11.31, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.32, 2.11.32, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3eca893d22ccb8b76fd9254483c930e424dee7
+GitCommit: d35ff0c3dbec642588c6284b0732407679ddeee2
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.32](https://github.com/traefik/traefik/releases/tag/v2.11.32).

/cc @nmengin @mmatur @rtribotte

Cheers