### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 875a6dd82a46bc6474b8fa10003655f6103e7c67
 Directory: 3.4
 
-Tags: 3.4-dev0-alpine, 3.4-dev-alpine, 3.4-dev0-alpine3.22, 3.4-dev-alpine3.22
+Tags: 3.4-dev0-alpine, 3.4-dev-alpine, 3.4-dev0-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 875a6dd82a46bc6474b8fa10003655f6103e7c67
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.4/alpine
 
 Tags: 3.3.0, 3.3, latest, 3.3.0-trixie, 3.3-trixie, trixie
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: dca811ccdc2ce4736f2d3deee9d7f7f233a1d236
 Directory: 3.3
 
-Tags: 3.3.0-alpine, 3.3-alpine, alpine, 3.3.0-alpine3.22, 3.3-alpine3.22, alpine3.22
+Tags: 3.3.0-alpine, 3.3-alpine, alpine, 3.3.0-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dca811ccdc2ce4736f2d3deee9d7f7f233a1d236
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.3/alpine
 
 Tags: 3.2.9, 3.2, lts, 3.2.9-trixie, 3.2-trixie, lts-trixie
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
 Directory: 3.2
 
-Tags: 3.2.9-alpine, 3.2-alpine, lts-alpine, 3.2.9-alpine3.22, 3.2-alpine3.22, lts-alpine3.22
+Tags: 3.2.9-alpine, 3.2-alpine, lts-alpine, 3.2.9-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.2/alpine
 
 Tags: 3.1.10, 3.1, 3.1.10-trixie, 3.1-trixie
@@ -39,9 +39,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b1e0ccb02df9fc432364fe391f9b094c1bc8688c
 Directory: 3.1
 
-Tags: 3.1.10-alpine, 3.1-alpine, 3.1.10-alpine3.22, 3.1-alpine3.22
+Tags: 3.1.10-alpine, 3.1-alpine, 3.1.10-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b1e0ccb02df9fc432364fe391f9b094c1bc8688c
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.1/alpine
 
 Tags: 3.0.12, 3.0, 3.0.12-trixie, 3.0-trixie
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 3.0
 
-Tags: 3.0.12-alpine, 3.0-alpine, 3.0.12-alpine3.22, 3.0-alpine3.22
+Tags: 3.0.12-alpine, 3.0-alpine, 3.0.12-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.0/alpine
 
 Tags: 2.8.16, 2.8, 2.8.16-trixie, 2.8-trixie
@@ -59,9 +59,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.8
 
-Tags: 2.8.16-alpine, 2.8-alpine, 2.8.16-alpine3.22, 2.8-alpine3.22
+Tags: 2.8.16-alpine, 2.8-alpine, 2.8.16-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 2.8/alpine
 
 Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie
@@ -69,9 +69,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.6
 
-Tags: 2.6.23-alpine, 2.6-alpine, 2.6.23-alpine3.22, 2.6-alpine3.22
+Tags: 2.6.23-alpine, 2.6-alpine, 2.6.23-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 2.6/alpine
 
 Tags: 2.4.30, 2.4, 2.4.30-trixie, 2.4-trixie
@@ -79,7 +79,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
 Directory: 2.4
 
-Tags: 2.4.30-alpine, 2.4-alpine, 2.4.30-alpine3.22, 2.4-alpine3.22
+Tags: 2.4.30-alpine, 2.4-alpine, 2.4.30-alpine3.23, 2.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/aba0dd2: Merge pull request https://github.com/docker-library/haproxy/pull/256 from infosiftr/alpine3.23
- https://github.com/docker-library/haproxy/commit/bfbedbc: Update to Alpine 3.23