### PR TITLE
Update fluentd to v1.16.10

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,10 +3,10 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Debian images
-Tags: v1.16.9-debian-1.0, v1.16-debian-1
+Tags: v1.16.10-debian-1.0, v1.16-debian-1
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitFetch: refs/heads/v1.16
-GitCommit: 505a1af75b4a4adb40d576df7b18cebab853264e
+GitCommit: e63e0aa7b96fafc49b55e72476503e02fc8144f8
 Directory: v1.16/debian
 
 # Debian images


### PR DESCRIPTION
See https://www.fluentd.org/blog/fluentd-v1.16.10-has-been-released