### PR TITLE
caddy: v2.11.0-beta.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,6 +1,6 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/33c593c5bd99287e66de4187a4e9a4097426253d/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/08508564e927b906aa16e561f46468c1b6fb2116/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
@@ -34,16 +34,16 @@ GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 2.11.0-beta.1-windowsnanoserver-ltsc2022, 2.11-windowsnanoserver-ltsc2022
-SharedTags: 2.11.0-beta.1-windowsnanoserver, 2.11-windowsnanoserver
+Tags: 2.11.0-beta.1-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
+SharedTags: 2.11.0-beta.1-nanoserver, 2.11-nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2022
 GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.1-windowsnanoserver-ltsc2025, 2.11-windowsnanoserver-ltsc2025
-SharedTags: 2.11.0-beta.1-windowsnanoserver, 2.11-windowsnanoserver
+Tags: 2.11.0-beta.1-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025
+SharedTags: 2.11.0-beta.1-nanoserver, 2.11-nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2025
 GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
@@ -96,16 +96,16 @@ GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 2.10.2-windowsnanoserver-ltsc2022, 2.10-windowsnanoserver-ltsc2022, 2-windowsnanoserver-ltsc2022, windowsnanoserver-ltsc2022
-SharedTags: 2.10.2-windowsnanoserver, 2.10-windowsnanoserver, 2-windowsnanoserver, windowsnanoserver
+Tags: 2.10.2-nanoserver-ltsc2022, 2.10-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.10.2-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-nanoserver/ltsc2022
 GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.10.2-windowsnanoserver-ltsc2025, 2.10-windowsnanoserver-ltsc2025, 2-windowsnanoserver-ltsc2025, windowsnanoserver-ltsc2025
-SharedTags: 2.10.2-windowsnanoserver, 2.10-windowsnanoserver, 2-windowsnanoserver, windowsnanoserver
+Tags: 2.10.2-nanoserver-ltsc2025, 2.10-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 2.10.2-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-nanoserver/ltsc2025
 GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.11.0-beta.1

https://github.com/caddyserver/caddy-docker/pull/430

Adds windows nanoserver support