### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -3,53 +3,102 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
-GitCommit: f17fabbdd8db9ae5976042d73470d5dce20533a0
+GitCommit: 1a4493542e94cba8ee91cefbefa5655646d13166
 
-Tags: 26-ea-26-jdk-oraclelinux9, 26-ea-26-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-ea-26-jdk-oracle, 26-ea-26-oracle, 26-ea-jdk-oracle, 26-ea-oracle
-SharedTags: 26-ea-26-jdk, 26-ea-26, 26-ea-jdk, 26-ea
+Tags: 26-ea-27-jdk-oraclelinux9, 26-ea-27-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-ea-27-jdk-oracle, 26-ea-27-oracle, 26-ea-jdk-oracle, 26-ea-oracle
+SharedTags: 26-ea-27-jdk, 26-ea-27, 26-ea-jdk, 26-ea
 Directory: 26/oraclelinux9
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-26-jdk-oraclelinux8, 26-ea-26-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8
+Tags: 26-ea-27-jdk-oraclelinux8, 26-ea-27-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8
 Directory: 26/oraclelinux8
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-26-jdk-trixie, 26-ea-26-trixie, 26-ea-jdk-trixie, 26-ea-trixie
+Tags: 26-ea-27-jdk-trixie, 26-ea-27-trixie, 26-ea-jdk-trixie, 26-ea-trixie
 Directory: 26/trixie
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-26-jdk-slim-trixie, 26-ea-26-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-ea-26-jdk-slim, 26-ea-26-slim, 26-ea-jdk-slim, 26-ea-slim
+Tags: 26-ea-27-jdk-slim-trixie, 26-ea-27-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-ea-27-jdk-slim, 26-ea-27-slim, 26-ea-jdk-slim, 26-ea-slim
 Directory: 26/slim-trixie
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-26-jdk-bookworm, 26-ea-26-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm
+Tags: 26-ea-27-jdk-bookworm, 26-ea-27-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm
 Directory: 26/bookworm
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-26-jdk-slim-bookworm, 26-ea-26-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm
+Tags: 26-ea-27-jdk-slim-bookworm, 26-ea-27-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm
 Directory: 26/slim-bookworm
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-26-jdk-windowsservercore-ltsc2025, 26-ea-26-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025
-SharedTags: 26-ea-26-jdk-windowsservercore, 26-ea-26-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-26-jdk, 26-ea-26, 26-ea-jdk, 26-ea
+Tags: 26-ea-27-jdk-windowsservercore-ltsc2025, 26-ea-27-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025
+SharedTags: 26-ea-27-jdk-windowsservercore, 26-ea-27-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-27-jdk, 26-ea-27, 26-ea-jdk, 26-ea
 Directory: 26/windows/windowsservercore-ltsc2025
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-26-jdk-windowsservercore-ltsc2022, 26-ea-26-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022
-SharedTags: 26-ea-26-jdk-windowsservercore, 26-ea-26-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-26-jdk, 26-ea-26, 26-ea-jdk, 26-ea
+Tags: 26-ea-27-jdk-windowsservercore-ltsc2022, 26-ea-27-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022
+SharedTags: 26-ea-27-jdk-windowsservercore, 26-ea-27-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-27-jdk, 26-ea-27, 26-ea-jdk, 26-ea
 Directory: 26/windows/windowsservercore-ltsc2022
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-26-jdk-nanoserver-ltsc2025, 26-ea-26-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025
-SharedTags: 26-ea-26-jdk-nanoserver, 26-ea-26-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
+Tags: 26-ea-27-jdk-nanoserver-ltsc2025, 26-ea-27-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025
+SharedTags: 26-ea-27-jdk-nanoserver, 26-ea-27-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
 Directory: 26/windows/nanoserver-ltsc2025
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-26-jdk-nanoserver-ltsc2022, 26-ea-26-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022
-SharedTags: 26-ea-26-jdk-nanoserver, 26-ea-26-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
+Tags: 26-ea-27-jdk-nanoserver-ltsc2022, 26-ea-27-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022
+SharedTags: 26-ea-27-jdk-nanoserver, 26-ea-27-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
 Directory: 26/windows/nanoserver-ltsc2022
+Architectures: windows-amd64
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 27-ea-1-jdk-oraclelinux9, 27-ea-1-oraclelinux9, 27-ea-jdk-oraclelinux9, 27-ea-oraclelinux9, 27-ea-1-jdk-oracle, 27-ea-1-oracle, 27-ea-jdk-oracle, 27-ea-oracle
+SharedTags: 27-ea-1-jdk, 27-ea-1, 27-ea-jdk, 27-ea
+Directory: 27/oraclelinux9
+Architectures: amd64, arm64v8
+
+Tags: 27-ea-1-jdk-oraclelinux8, 27-ea-1-oraclelinux8, 27-ea-jdk-oraclelinux8, 27-ea-oraclelinux8
+Directory: 27/oraclelinux8
+Architectures: amd64, arm64v8
+
+Tags: 27-ea-1-jdk-trixie, 27-ea-1-trixie, 27-ea-jdk-trixie, 27-ea-trixie
+Directory: 27/trixie
+Architectures: amd64, arm64v8
+
+Tags: 27-ea-1-jdk-slim-trixie, 27-ea-1-slim-trixie, 27-ea-jdk-slim-trixie, 27-ea-slim-trixie, 27-ea-1-jdk-slim, 27-ea-1-slim, 27-ea-jdk-slim, 27-ea-slim
+Directory: 27/slim-trixie
+Architectures: amd64, arm64v8
+
+Tags: 27-ea-1-jdk-bookworm, 27-ea-1-bookworm, 27-ea-jdk-bookworm, 27-ea-bookworm
+Directory: 27/bookworm
+Architectures: amd64, arm64v8
+
+Tags: 27-ea-1-jdk-slim-bookworm, 27-ea-1-slim-bookworm, 27-ea-jdk-slim-bookworm, 27-ea-slim-bookworm
+Directory: 27/slim-bookworm
+Architectures: amd64, arm64v8
+
+Tags: 27-ea-1-jdk-windowsservercore-ltsc2025, 27-ea-1-windowsservercore-ltsc2025, 27-ea-jdk-windowsservercore-ltsc2025, 27-ea-windowsservercore-ltsc2025
+SharedTags: 27-ea-1-jdk-windowsservercore, 27-ea-1-windowsservercore, 27-ea-jdk-windowsservercore, 27-ea-windowsservercore, 27-ea-1-jdk, 27-ea-1, 27-ea-jdk, 27-ea
+Directory: 27/windows/windowsservercore-ltsc2025
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2025
+
+Tags: 27-ea-1-jdk-windowsservercore-ltsc2022, 27-ea-1-windowsservercore-ltsc2022, 27-ea-jdk-windowsservercore-ltsc2022, 27-ea-windowsservercore-ltsc2022
+SharedTags: 27-ea-1-jdk-windowsservercore, 27-ea-1-windowsservercore, 27-ea-jdk-windowsservercore, 27-ea-windowsservercore, 27-ea-1-jdk, 27-ea-1, 27-ea-jdk, 27-ea
+Directory: 27/windows/windowsservercore-ltsc2022
+Architectures: windows-amd64
+Constraints: windowsservercore-ltsc2022
+
+Tags: 27-ea-1-jdk-nanoserver-ltsc2025, 27-ea-1-nanoserver-ltsc2025, 27-ea-jdk-nanoserver-ltsc2025, 27-ea-nanoserver-ltsc2025
+SharedTags: 27-ea-1-jdk-nanoserver, 27-ea-1-nanoserver, 27-ea-jdk-nanoserver, 27-ea-nanoserver
+Directory: 27/windows/nanoserver-ltsc2025
+Architectures: windows-amd64
+Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
+
+Tags: 27-ea-1-jdk-nanoserver-ltsc2022, 27-ea-1-nanoserver-ltsc2022, 27-ea-jdk-nanoserver-ltsc2022, 27-ea-nanoserver-ltsc2022
+SharedTags: 27-ea-1-jdk-nanoserver, 27-ea-1-nanoserver, 27-ea-jdk-nanoserver, 27-ea-nanoserver
+Directory: 27/windows/nanoserver-ltsc2022
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/1a44935: Add images for OpenJDK 27 EA builds (https://github.com/docker-library/openjdk/pull/553)
- https://github.com/docker-library/openjdk/commit/66754a4: Update 26 to 26-ea+27