### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/52bdfd93f67bd57df20baf0a1dc7d3225f28d829/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/a1ff62b9bd0496e16831a4b2899f705b82305ce1/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 52bdfd93f67bd57df20baf0a1dc7d3225f28d829
+GitCommit: a1ff62b9bd0496e16831a4b2899f705b82305ce1
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: abc048ad9fb2d6e2015614a5c96f79952565900d
+amd64-GitCommit: ed6ea952e3d3441fc79cb7efe1bd286dca85b8de
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: d10869c4a85e2172de4a0a17b6b9519d2350c51d
+arm32v5-GitCommit: 275f86f20770073777a9773285676386259498ed
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 6e666f6540b6e8de0f85acba6c74613cc9fd085b
+arm32v6-GitCommit: d0aa7cb24b93f2caa52a739feaf9f0e40d528657
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 99b2e566b7d44f1d19801c12608034a18f326c52
+arm32v7-GitCommit: b888c2ea1e0bf700741b2eeefaf69586ab405e3f
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7d8ac7995d0081cab4d8a65eaa99c899fe98a0d2
+arm64v8-GitCommit: 7e47d30907ecd0b4568de2e1224b742330cfa743
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: a9444bbbc047b2d564c5945bc32319cc3126a876
+i386-GitCommit: 2a83094a222dd02c128d506d982fb4b23734f984
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: f14f2573a0c972608ee61417ae7778e14ec749e3
+ppc64le-GitCommit: 098a93a40c1456ca3bb36dd4158e912ad10e73e6
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 8940b63caf1b160f8f714d71b5ec4bb22d85854b
+riscv64-GitCommit: 5c78ce6b6f8ec6d78a7032a7b48d1aa1a7eabf6e
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: c2134503afb2dd1003c79137978651b6906650d8
+s390x-GitCommit: 3b13fd0d07d5d0c497d91dca0e814f7a8a78f7b8
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/a1ff62b: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/f89f5fe: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/baaa350: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/ced8183: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/d0711b5: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/a88cddd: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/bc4735f: Merge pull request https://github.com/docker-library/busybox/pull/239 from infosiftr/i386
- https://github.com/docker-library/busybox/commit/32603b7: Add i386 builds to GHA (excluding uclibc)
- https://github.com/docker-library/busybox/commit/0486ea4: Update metadata for i386
- https://github.com/docker-library/busybox/commit/c57cfde: Fix i386 musl builds (broken by Alpine 3.23)
- https://github.com/docker-library/busybox/commit/6b907b1: Merge pull request https://github.com/docker-library/busybox/pull/238 from infosiftr/alpine3.23
- https://github.com/docker-library/busybox/commit/506789b: Update metadata for amd64
- https://github.com/docker-library/busybox/commit/2b8de43: Update to Alpine 3.23