### PR TITLE
Updated mainline nginx to 1.29.4

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,39 +3,39 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.29.3, mainline, 1, 1.29, latest, 1.29.3-trixie, mainline-trixie, 1-trixie, 1.29-trixie, trixie
+Tags: 1.29.4, mainline, 1, 1.29, latest, 1.29.4-trixie, mainline-trixie, 1-trixie, 1.29-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/debian
 
-Tags: 1.29.3-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.3-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.29-trixie-perl, trixie-perl
+Tags: 1.29.4-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.4-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.29-trixie-perl, trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/debian-perl
 
-Tags: 1.29.3-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.3-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.29-trixie-otel, trixie-otel
+Tags: 1.29.4-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.4-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.29-trixie-otel, trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/debian-otel
 
-Tags: 1.29.3-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.3-alpine3.22, mainline-alpine3.22, 1-alpine3.22, 1.29-alpine3.22, alpine3.22
+Tags: 1.29.4-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.4-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.29-alpine3.23, alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/alpine
 
-Tags: 1.29.3-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.3-alpine3.22-perl, mainline-alpine3.22-perl, 1-alpine3.22-perl, 1.29-alpine3.22-perl, alpine3.22-perl
+Tags: 1.29.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.4-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.29-alpine3.23-perl, alpine3.23-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/alpine-perl
 
-Tags: 1.29.3-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.3-alpine3.22-slim, mainline-alpine3.22-slim, 1-alpine3.22-slim, 1.29-alpine3.22-slim, alpine3.22-slim
+Tags: 1.29.4-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.4-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.29-alpine3.23-slim, alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/alpine-slim
 
-Tags: 1.29.3-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.3-alpine3.22-otel, mainline-alpine3.22-otel, 1-alpine3.22-otel, 1.29-alpine3.22-otel, alpine3.22-otel
+Tags: 1.29.4-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.4-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.29-alpine3.23-otel, alpine3.23-otel
 Architectures: amd64, arm64v8
-GitCommit: e4d5453581d9d3618f77c4aeccf2e6171a1cd6ff
+GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
 Directory: mainline/alpine-otel
 
 Tags: 1.28.0, stable, 1.28, 1.28.0-bookworm, stable-bookworm, 1.28-bookworm


### PR DESCRIPTION
While at it, move alpine-based images to Alpine Linux 3.23.