### PR TITLE
add InfluxDB 2.8.0 and update latest tag

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,7 +6,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: ac3b314fc2db2ec551ef7fcfde3db635ecc28d01
+GitCommit: 8393f97ef79d3f9776bbecffc682ca147a143dc8
 
 Tags: 1.12, 1.12.2
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Add InfluxDB 2.8.0 and 2.8 tags. Update latest tag to 2.8.0.