### PR TITLE
rust: Update version to 1.92.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,53 +5,53 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.91-bullseye, 1.91.1-bullseye, bullseye
+Tags: 1-bullseye, 1.92-bullseye, 1.92.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0ad6d349fa1a5d6cc64e3bd9a27e5f6762df9abc
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.91-slim-bullseye, 1.91.1-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.92-slim-bullseye, 1.92.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0ad6d349fa1a5d6cc64e3bd9a27e5f6762df9abc
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.91-bookworm, 1.91.1-bookworm, bookworm
+Tags: 1-bookworm, 1.92-bookworm, 1.92.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ad6d349fa1a5d6cc64e3bd9a27e5f6762df9abc
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.91-slim-bookworm, 1.91.1-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.92-slim-bookworm, 1.92.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 0ad6d349fa1a5d6cc64e3bd9a27e5f6762df9abc
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.91-trixie, 1.91.1-trixie, trixie, 1, 1.91, 1.91.1, latest
+Tags: 1-trixie, 1.92-trixie, 1.92.0-trixie, trixie, 1, 1.92, 1.92.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 0ad6d349fa1a5d6cc64e3bd9a27e5f6762df9abc
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.91-slim-trixie, 1.91.1-slim-trixie, slim-trixie, 1-slim, 1.91-slim, 1.91.1-slim, slim
+Tags: 1-slim-trixie, 1.92-slim-trixie, 1.92.0-slim-trixie, slim-trixie, 1-slim, 1.92-slim, 1.92.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 0ad6d349fa1a5d6cc64e3bd9a27e5f6762df9abc
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.20, 1.91-alpine3.20, 1.91.1-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.92-alpine3.20, 1.92.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 87dc1897ae38315b52ecedf77227576e4861487d
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.91-alpine3.21, 1.91.1-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.92-alpine3.21, 1.92.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 87dc1897ae38315b52ecedf77227576e4861487d
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.91-alpine3.22, 1.91.1-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.92-alpine3.22, 1.92.0-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 87dc1897ae38315b52ecedf77227576e4861487d
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.91-alpine3.23, 1.91.1-alpine3.23, alpine3.23, 1-alpine, 1.91-alpine, 1.91.1-alpine, alpine
+Tags: 1-alpine3.23, 1.92-alpine3.23, 1.92.0-alpine3.23, alpine3.23, 1-alpine, 1.92-alpine, 1.92.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 606fc92c104f66af9e7e5f2bea1bf2f5072d84b6
+GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
 Directory: stable/alpine3.23
 


### PR DESCRIPTION
https://blog.rust-lang.org/2025/12/11/Rust-1.92.0/
https://github.com/rust-lang/rust/releases/tag/1.92.0