### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.9.20251117.1
+Tags: 2023, latest, 2023.9.20251208.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: af9f950543bd06e482cf2cc4fce32f988e1b0cc6
+amd64-GitCommit: 4d81e9ae45414f96bcf88c42239521c780b9753e
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 86eb74bfdeed44a90cd2681792b825cc19173eac
+arm64v8-GitCommit: ca85fcfbe368e16dd8346f4d3d7b625cd72e23a2
 
-Tags: 2, 2.0.20251110.1
+Tags: 2, 2.0.20251208.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 21640b88ffdb2768599539081529c4e8859b7b6d
+amd64-GitCommit: 7342ef4ca463b681795ea278281da1ba8e7b578b
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 7fe1b60afee52c360a74c7956836977a176a17fc
+arm64v8-GitCommit: b4a20ce21f51c29c4612a0d907d0fa8cda257b20
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- libcurl-8.3.0-1.amzn2.0.11
- glib2-2.56.1-9.amzn2.0.12
- curl-8.3.0-1.amzn2.0.11

Updated Packages for Amazon Linux 2023:
- glib2-2.82.2-767.amzn2023
- libcurl-minimal-8.11.1-4.amzn2023.0.3
- python3-libs-3.9.25-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.9.20251208-2.amzn2023
- system-release-2023.9.20251208-2.amzn2023
- sqlite-libs-3.40.0-1.amzn2023.0.7
- curl-minimal-8.11.1-4.amzn2023.0.3
- python3-3.9.25-1.amzn2023.0.1