### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/a1ff62b9bd0496e16831a4b2899f705b82305ce1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/44d78f65f676a0566d8e22294adf76986d5b9a46/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: a1ff62b9bd0496e16831a4b2899f705b82305ce1
+GitCommit: 44d78f65f676a0566d8e22294adf76986d5b9a46
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: ed6ea952e3d3441fc79cb7efe1bd286dca85b8de
+amd64-GitCommit: 04a7128fc48c4897f6c9cf97bd1be3c1b52bdbac
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 275f86f20770073777a9773285676386259498ed
+arm32v5-GitCommit: 9f4508a33ee9639eb7292315206fb2c6088e1e7d
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: d0aa7cb24b93f2caa52a739feaf9f0e40d528657
+arm32v6-GitCommit: 608e473216e3603839626553477bd786ba97c214
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: b888c2ea1e0bf700741b2eeefaf69586ab405e3f
+arm32v7-GitCommit: 6842f61ca0324119e92d2005e1d4d24eea85a404
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7e47d30907ecd0b4568de2e1224b742330cfa743
+arm64v8-GitCommit: d6add23713c2e571739f448dd202c3bee510483d
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 2a83094a222dd02c128d506d982fb4b23734f984
+i386-GitCommit: 4e1c3ea6db868282e233983de5a84894d5ea0a68
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 098a93a40c1456ca3bb36dd4158e912ad10e73e6
+ppc64le-GitCommit: 15e3cd1fd5771a1cbbfcc5780e11ac16118f760a
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 5c78ce6b6f8ec6d78a7032a7b48d1aa1a7eabf6e
+riscv64-GitCommit: 51a4c38a08927dac2e0a4a59fcfb77edab8ccce6
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 3b13fd0d07d5d0c497d91dca0e814f7a8a78f7b8
+s390x-GitCommit: 50473f8eb1ab0715898fd8ce7a84b0f50af32ff1
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/44d78f6: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/64a97d1: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/4ac7025: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/cf329c0: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/f76a082: Merge pull request https://github.com/docker-library/busybox/pull/240 from infosiftr/buildroot-2025.08.3
- https://github.com/docker-library/busybox/commit/6627216: Update metadata for amd64 and i386
- https://github.com/docker-library/busybox/commit/a5e63b7: Update buildroot to 2025.08.3