### PR TITLE
archlinux: Release 20251214.0.467559

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20251019.0.436919
-GitCommit: 3d3996ec400b3b9ef1c04fa5b4b6b81725a8eaac
-GitFetch: refs/tags/v20251019.0.436919
+Tags: latest, base, base-20251214.0.467559
+GitCommit: 5ebeb831c5ce9a90d9775d082896402a9d33de57
+GitFetch: refs/tags/v20251214.0.467559
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20251019.0.436919
-GitCommit: 3d3996ec400b3b9ef1c04fa5b4b6b81725a8eaac
-GitFetch: refs/tags/v20251019.0.436919
+Tags: base-devel, base-devel-20251214.0.467559
+GitCommit: 5ebeb831c5ce9a90d9775d082896402a9d33de57
+GitFetch: refs/tags/v20251214.0.467559
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20251019.0.436919
-GitCommit: 3d3996ec400b3b9ef1c04fa5b4b6b81725a8eaac
-GitFetch: refs/tags/v20251019.0.436919
+Tags: multilib-devel, multilib-devel-20251214.0.467559
+GitCommit: 5ebeb831c5ce9a90d9775d082896402a9d33de57
+GitFetch: refs/tags/v20251214.0.467559
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks