### PR TITLE
Bump Traefik to v3.6.5

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,23 +1,23 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.6.4-windowsservercore-ltsc2022, 3.6.4-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.5-windowsservercore-ltsc2022, 3.6.5-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8b91fec86e866244fd81015413e9a3036b350663
+GitCommit: 87ae3f90a938b0159e557ba5b6abcfd63effb714
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.4-nanoserver-ltsc2022, 3.6.4-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.5-nanoserver-ltsc2022, 3.6.5-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8b91fec86e866244fd81015413e9a3036b350663
+GitCommit: 87ae3f90a938b0159e557ba5b6abcfd63effb714
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.4, 3.6.4, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.5, 3.6.5, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 8b91fec86e866244fd81015413e9a3036b350663
+GitCommit: 87ae3f90a938b0159e557ba5b6abcfd63effb714
 Directory: v3.6/alpine
 
 Tags: v2.11.32-windowsservercore-ltsc2022, 2.11.32-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.6.5](https://github.com/traefik/traefik/releases/tag/v3.6.5).

/cc @nmengin @mmatur @rtribotte

Cheers