### PR TITLE
Mediawiki 1.39.17

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,7 +3,7 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: 07ac5c73aede979206c3b684ee03efa6d9adfa3d
+GitCommit: a9728b8cc1a50a6c0549c82810295962cb99d77c
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version
@@ -40,12 +40,12 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.43/fpm-alpine
 
 # current legacy lts version
-Tags: 1.39.16, 1.39
+Tags: 1.39.17, 1.39
 Directory: 1.39/apache
 
-Tags: 1.39.16-fpm, 1.39-fpm
+Tags: 1.39.17-fpm, 1.39-fpm
 Directory: 1.39/fpm
 
-Tags: 1.39.16-fpm-alpine, 1.39-fpm-alpine
+Tags: 1.39.17-fpm-alpine, 1.39-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.39/fpm-alpine


### PR DESCRIPTION
See https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/YRWHNMUHAUQZ547FQCVP7LAZTBN5SSVD/ for the mailing list announcement.

Related to https://github.com/wikimedia/mediawiki-docker/pull/163

Link: https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/YRWHNMUHAUQZ547FQCVP7LAZTBN5SSVD/