### PR TITLE
alpine: bump 3.23.2

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.23.0, 3.23, 3, latest
+Tags: 3.23.2, 3.23, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.23
-GitCommit: 24735c621e78574b49bb05b10dddac2497e423c2
+GitCommit: 13b62f5f47ffa526f9c372e0bd73b33ef2a5f865
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
various apk-tools fixes
fix a bug in busybox mount when parsing long lines in /proc/mounts