### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,24 +34,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.2/alpine
 
-Tags: 3.1.10, 3.1, 3.1.10-trixie, 3.1-trixie
+Tags: 3.1.11, 3.1, 3.1.11-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b1e0ccb02df9fc432364fe391f9b094c1bc8688c
+GitCommit: 425a7b0aa3ef1e402166f568a958ae9e07450d49
 Directory: 3.1
 
-Tags: 3.1.10-alpine, 3.1-alpine, 3.1.10-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.11-alpine, 3.1-alpine, 3.1.11-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: 425a7b0aa3ef1e402166f568a958ae9e07450d49
 Directory: 3.1/alpine
 
-Tags: 3.0.12, 3.0, 3.0.12-trixie, 3.0-trixie
+Tags: 3.0.13, 3.0, 3.0.13-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: eb6f0ea88c4942107d57c65a9957bfaace56b23b
 Directory: 3.0
 
-Tags: 3.0.12-alpine, 3.0-alpine, 3.0.12-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.13-alpine, 3.0-alpine, 3.0.13-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: eb6f0ea88c4942107d57c65a9957bfaace56b23b
 Directory: 3.0/alpine
 
 Tags: 2.8.16, 2.8, 2.8.16-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/425a7b0: Update 3.1 to 3.1.11
- https://github.com/docker-library/haproxy/commit/eb6f0ea: Update 3.0 to 3.0.13