### PR TITLE
cleaner build tests when run in a tty

### DIFF
--- a/test/tests/matomo-fpm-run/run.sh
+++ b/test/tests/matomo-fpm-run/run.sh
@@ -7,13 +7,17 @@ image="$1"
 
 # Build a client image with cgi-fcgi for testing
 clientImage='librarytest/matomo-fpm-run:fcgi-client'
-docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:trixie-slim
+if ! error="$(docker build -t "$clientImage" - 2>&1 <<-'EOF'
+	FROM debian:trixie-slim
 
-RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
+	RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
 
-ENTRYPOINT ["cgi-fcgi"]
-EOF
+	ENTRYPOINT ["cgi-fcgi"]
+	EOF
+)"; then
+	echo "$error" >&2
+	exit 1
+fi
 
 # Create an instance of the container-under-test
 cid="$(docker run -d "$image")"

--- a/test/tests/monica-fpm-run/run.sh
+++ b/test/tests/monica-fpm-run/run.sh
@@ -6,14 +6,18 @@ dir="$(dirname "$(readlink -f "$BASH_SOURCE")")"
 image="$1"
 
 # Build a client image with cgi-fcgi for testing
-clientImage="librarytest/monica-fpm-run:fcgi-client"
-docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:trixie-slim
+clientImage='librarytest/monica-fpm-run:fcgi-client'
+if ! error="$(docker build -t "$clientImage" - 2>&1 <<-'EOF'
+	FROM debian:trixie-slim
 
-RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
+	RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
 
-ENTRYPOINT ["cgi-fcgi"]
-EOF
+	ENTRYPOINT ["cgi-fcgi"]
+	EOF
+)"; then
+	echo "$error" >&2
+	exit 1
+fi
 
 dbImage='mysql:8.0'
 # ensure the dbImage is ready and available

--- a/test/tests/nextcloud-fpm-run/real-run.sh
+++ b/test/tests/nextcloud-fpm-run/real-run.sh
@@ -7,13 +7,17 @@ image="$1"
 
 # Build a client image with cgi-fcgi for testing
 clientImage='librarytest/nextcloud-fpm-run:fcgi-client'
-docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:trixie-slim
+if ! error="$(docker build -t "$clientImage" - 2>&1 <<-'EOF'
+	FROM debian:trixie-slim
 
-RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
+	RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
 
-ENTRYPOINT ["cgi-fcgi"]
-EOF
+	ENTRYPOINT ["cgi-fcgi"]
+	EOF
+)"; then
+	echo "$error" >&2
+	exit 1
+fi
 
 # Create an instance of the container-under-test
 cid="$(docker run -d "$image")"

--- a/test/tests/php-fpm-hello-web/run.sh
+++ b/test/tests/php-fpm-hello-web/run.sh
@@ -7,13 +7,17 @@ image="$1"
 
 # Build a client image with cgi-fcgi for testing
 clientImage='librarytest/php-fpm-hello-web:fcgi-client'
-docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:trixie-slim
+if ! error="$(docker build -t "$clientImage" - 2>&1 <<-'EOF'
+	FROM debian:trixie-slim
 
-RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
+	RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
 
-ENTRYPOINT ["cgi-fcgi"]
-EOF
+	ENTRYPOINT ["cgi-fcgi"]
+	EOF
+)"; then
+	echo "$error" >&2
+	exit 1
+fi
 
 serverImage="$("$dir/../image-name.sh" librarytest/php-fpm-hello-web "$image")"
 "$dir/../docker-build.sh" "$dir" "$serverImage" <<EOD

--- a/test/tests/postfixadmin-fpm-run/run.sh
+++ b/test/tests/postfixadmin-fpm-run/run.sh
@@ -7,13 +7,17 @@ image="$1"
 
 # Build a client image with cgi-fcgi for testing
 clientImage='librarytest/posfixadmin-fpm-run:fcgi-client'
-docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:trixie-slim
+if ! error="$(docker build -t "$clientImage" - 2>&1 <<-'EOF'
+	FROM debian:trixie-slim
 
-RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
+	RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
 
-ENTRYPOINT ["cgi-fcgi"]
-EOF
+	ENTRYPOINT ["cgi-fcgi"]
+	EOF
+)"; then
+	echo "$error" >&2
+	exit 1
+fi
 
 # Create an instance of the container-under-test
 cid="$(docker run -d "$image")"

--- a/test/tests/wordpress-fpm-run/run.sh
+++ b/test/tests/wordpress-fpm-run/run.sh
@@ -7,13 +7,17 @@ image="$1"
 
 # Build a client image with cgi-fcgi for testing
 clientImage='librarytest/wordpress-fpm-run:fcgi-client'
-docker build -t "$clientImage" - > /dev/null <<'EOF'
-FROM debian:trixie-slim
+if ! error="$(docker build -t "$clientImage" - 2>&1 <<-'EOF'
+	FROM debian:trixie-slim
 
-RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
+	RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean
 
-ENTRYPOINT ["cgi-fcgi"]
-EOF
+	ENTRYPOINT ["cgi-fcgi"]
+	EOF
+)"; then
+	echo "$error" >&2
+	exit 1
+fi
 
 mysqlImage='mysql:5.7'
 # ensure the mysqlImage is ready and available


### PR DESCRIPTION
Otherwise buildkit mucks with the output.

Current behavior (with line rewrites and build log hiding). Note the missing test name output `'wordpress-fpm-run' [1/1]...`.
```console
$ ./test/run.sh -t wordpress-fpm-run wordpress:fpm
testing wordpress:fpm
[+] Building 5.4s (6/6) FINISHED                                                                                             docker:default
 => [internal] load build definition from Dockerfile                                                                                   0.0s
 => => transferring dockerfile: 198B                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/debian:trixie-slim                                                                  0.0s
 => [internal] load .dockerignore                                                                                                      0.0s
 => => transferring context: 2B                                                                                                        0.0s
 => [1/2] FROM docker.io/library/debian:trixie-slim@sha256:18764e98673c3baf1a6f8d960b5b5a1ec69092049522abac4e24a7726425b016            0.0s
 => => resolve docker.io/library/debian:trixie-slim@sha256:18764e98673c3baf1a6f8d960b5b5a1ec69092049522abac4e24a7726425b016            0.0s
 => [2/2] RUN set -x && apt-get update && apt-get install -y --no-install-recommends libfcgi-bin && apt-get dist-clean                 5.0s
 => exporting to image                                                                                                                 0.2s
 => => exporting layers                                                                                                                0.1s
 => => exporting manifest sha256:f7b89ef6d4a8a5bf88c5f9f37ca10b267e72bf93235b1e39b431bced9279fa52                                      0.0s
 => => exporting config sha256:30b0bb64211b19f1e7a42f9bd30e38cc96b2319a4241cd3e1f2b891bbd6ea6ca                                        0.0s
 => => exporting attestation manifest sha256:b733fdeca91a48b68c271d2df519acbbba22a5f8fd80006c49520a677a52ed0c                          0.0s
 => => exporting manifest list sha256:4fc034a1d4a732ab759b6bb3d4cb03e05e81dd0eea452b193e3f537d30eb813d                                 0.0s
 => => naming to docker.io/librarytest/wordpress-fpm-run:fcgi-client                                                                   0.0s
 => => unpacking to docker.io/librarytest/wordpress-fpm-run:fcgi-client                                                                0.0s
passed
```

New behavior (also prints the log when there is a build error):
```console
$ ./test/run.sh -t wordpress-fpm-run wordpress:fpm
testing wordpress:fpm
        'wordpress-fpm-run' [1/1]...passed
```