### PR TITLE
update influxdb3 to 3.8.0

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,7 +6,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 8393f97ef79d3f9776bbecffc682ca147a143dc8
+GitCommit: a501127168426f260dd1b2a6281f0be8a9a605bd
 
 Tags: 1.12, 1.12.2
 Architectures: amd64, arm64v8
@@ -64,10 +64,10 @@ Tags: 2-alpine, 2.8-alpine, 2.8.0-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.8/alpine
 
-Tags: 3-core, 3.7-core, 3.7.0-core, core
+Tags: 3-core, 3.8-core, 3.8.0-core, core
 Architectures: amd64, arm64v8
-Directory: influxdb/3.7-core
+Directory: influxdb/3.8-core
 
-Tags: 3-enterprise, 3.7-enterprise, 3.7.0-enterprise, enterprise
+Tags: 3-enterprise, 3.8-enterprise, 3.8.0-enterprise, enterprise
 Architectures: amd64, arm64v8
-Directory: influxdb/3.7-enterprise
+Directory: influxdb/3.8-enterprise


### PR DESCRIPTION
This commit bumps influxdb3 to our latest image, 3.8.0.
