### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -24,14 +24,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
 Directory: 3.3/alpine
 
-Tags: 3.2.9, 3.2, lts, 3.2.9-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.10, 3.2, lts, 3.2.10-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1721188a635768ae6d4867274f60c65339fbb05e
+GitCommit: eb767ff57dbf4d8140b011b7721a007ee6692b2d
 Directory: 3.2
 
-Tags: 3.2.9-alpine, 3.2-alpine, lts-alpine, 3.2.9-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.10-alpine, 3.2-alpine, lts-alpine, 3.2.10-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: eb767ff57dbf4d8140b011b7721a007ee6692b2d
 Directory: 3.2/alpine
 
 Tags: 3.1.11, 3.1, 3.1.11-trixie, 3.1-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/eb767ff: Update 3.2 to 3.2.10