### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,14 +14,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c4aae186fc7844beacf615a62c77760195abca7c
 Directory: 3.4/alpine
 
-Tags: 3.3.0, 3.3, latest, 3.3.0-trixie, 3.3-trixie, trixie
+Tags: 3.3.1, 3.3, latest, 3.3.1-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dca811ccdc2ce4736f2d3deee9d7f7f233a1d236
+GitCommit: bbce9cd3a36531337ab84dbf3f20bb4dad2b1245
 Directory: 3.3
 
-Tags: 3.3.0-alpine, 3.3-alpine, alpine, 3.3.0-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.1-alpine, 3.3-alpine, alpine, 3.3.1-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: bbce9cd3a36531337ab84dbf3f20bb4dad2b1245
 Directory: 3.3/alpine
 
 Tags: 3.2.10, 3.2, lts, 3.2.10-trixie, 3.2-trixie, lts-trixie
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: eb6f0ea88c4942107d57c65a9957bfaace56b23b
 Directory: 3.0/alpine
 
-Tags: 2.8.16, 2.8, 2.8.16-trixie, 2.8-trixie
+Tags: 2.8.17, 2.8, 2.8.17-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 8919100f1503492c1c786ffb6b9a0392ebfd071e
 Directory: 2.8
 
-Tags: 2.8.16-alpine, 2.8-alpine, 2.8.16-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.17-alpine, 2.8-alpine, 2.8.17-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: 8919100f1503492c1c786ffb6b9a0392ebfd071e
 Directory: 2.8/alpine
 
 Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/bbce9cd: Update 3.3 to 3.3.1
- https://github.com/docker-library/haproxy/commit/8919100: Update 2.8 to 2.8.17