### PR TITLE
archlinux: Release 20251221.0.472429

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20251214.0.467559
-GitCommit: 5ebeb831c5ce9a90d9775d082896402a9d33de57
-GitFetch: refs/tags/v20251214.0.467559
+Tags: latest, base, base-20251221.0.472429
+GitCommit: 99af2a3970b4390402086c110d983b37f36c6c9b
+GitFetch: refs/tags/v20251221.0.472429
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20251214.0.467559
-GitCommit: 5ebeb831c5ce9a90d9775d082896402a9d33de57
-GitFetch: refs/tags/v20251214.0.467559
+Tags: base-devel, base-devel-20251221.0.472429
+GitCommit: 99af2a3970b4390402086c110d983b37f36c6c9b
+GitFetch: refs/tags/v20251221.0.472429
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20251214.0.467559
-GitCommit: 5ebeb831c5ce9a90d9775d082896402a9d33de57
-GitFetch: refs/tags/v20251214.0.467559
+Tags: multilib-devel, multilib-devel-20251221.0.472429
+GitCommit: 99af2a3970b4390402086c110d983b37f36c6c9b
+GitFetch: refs/tags/v20251221.0.472429
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks