### PR TITLE
Odoo: update 17.0-19.0 to release 20251222

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: fa9d68a03f140c162e5acdb7f8e81d22ed3ccb9f
+GitCommit: cee8710442112aad57f34f797459df1ab1d5ef6a
 
-Tags: 19.0-20251208, 19.0, 19, latest
+Tags: 19.0-20251222, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20251208, 18.0, 18
+Tags: 18.0-20251222, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20251208, 17.0, 17
+Tags: 17.0-20251222, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks and Merry Christmas