### PR TITLE
"[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2025-23483 ELSA-2025-23480 ELSA-2025-23342 "

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3a9ec8f30b6e17eba8fdbdce95884952a5645b55
+amd64-GitCommit: de16dd5ddb84a36020f3f7affbc427a6fb1db4d6
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 3a4133dc6459f897992e27f62ec84738a89a4ceb
+arm64v8-GitCommit: fb1b55632c7cba4e39d1b9cabc637ddc14e64b88
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5987, CVE-2025-61984, CVE-2025-61985, CVE-2024-5642, CVE-2025-6069, CVE-2025-6075, CVE-2025-8291

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-23483.html
https://linux.oracle.com/errata/ELSA-2025-23480.html
https://linux.oracle.com/errata/ELSA-2025-23342.html
https://linux.oracle.com/errata/ELBA-2025-23464.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
