### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,24 +34,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: eb767ff57dbf4d8140b011b7721a007ee6692b2d
 Directory: 3.2/alpine
 
-Tags: 3.1.11, 3.1, 3.1.11-trixie, 3.1-trixie
+Tags: 3.1.12, 3.1, 3.1.12-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 425a7b0aa3ef1e402166f568a958ae9e07450d49
+GitCommit: 6644abc009d377471fb93989b6a9336ce1840e00
 Directory: 3.1
 
-Tags: 3.1.11-alpine, 3.1-alpine, 3.1.11-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.12-alpine, 3.1-alpine, 3.1.12-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 425a7b0aa3ef1e402166f568a958ae9e07450d49
+GitCommit: 6644abc009d377471fb93989b6a9336ce1840e00
 Directory: 3.1/alpine
 
-Tags: 3.0.13, 3.0, 3.0.13-trixie, 3.0-trixie
+Tags: 3.0.14, 3.0, 3.0.14-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: eb6f0ea88c4942107d57c65a9957bfaace56b23b
+GitCommit: e319b3b62ba8f22c1dfac44a81bb65a7ed67dac1
 Directory: 3.0
 
-Tags: 3.0.13-alpine, 3.0-alpine, 3.0.13-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.14-alpine, 3.0-alpine, 3.0.14-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: eb6f0ea88c4942107d57c65a9957bfaace56b23b
+GitCommit: e319b3b62ba8f22c1dfac44a81bb65a7ed67dac1
 Directory: 3.0/alpine
 
 Tags: 2.8.17, 2.8, 2.8.17-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6644abc: Update 3.1 to 3.1.12
- https://github.com/docker-library/haproxy/commit/e319b3b: Update 3.0 to 3.0.14