### PR TITLE
Release SonarQube Server 2025.6.1

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -3,25 +3,25 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2025.6.0-developer, 2025.6-developer, developer
+Tags: 2025.6.1-developer, 2025.6-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 90fde0d5acb6278517a7de18ce162fc83edf7efe
-GitFetch: refs/heads/master
+GitCommit: 25640e1874256746c8df7134fa5042f0721cc3f2
+GitFetch: refs/heads/release/2025.6
 
-Tags: 2025.6.0-enterprise, 2025.6-enterprise, enterprise
+Tags: 2025.6.1-enterprise, 2025.6-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 90fde0d5acb6278517a7de18ce162fc83edf7efe
-GitFetch: refs/heads/master
+GitCommit: 25640e1874256746c8df7134fa5042f0721cc3f2
+GitFetch: refs/heads/release/2025.6
 
-Tags: 2025.6.0-datacenter-app, 2025.6-datacenter-app, datacenter-app
+Tags: 2025.6.1-datacenter-app, 2025.6-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 90fde0d5acb6278517a7de18ce162fc83edf7efe
-GitFetch: refs/heads/master
+GitCommit: 25640e1874256746c8df7134fa5042f0721cc3f2
+GitFetch: refs/heads/release/2025.6
 
-Tags: 2025.6.0-datacenter-search, 2025.6-datacenter-search, datacenter-search
+Tags: 2025.6.1-datacenter-search, 2025.6-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 90fde0d5acb6278517a7de18ce162fc83edf7efe
-GitFetch: refs/heads/master
+GitCommit: 25640e1874256746c8df7134fa5042f0721cc3f2
+GitFetch: refs/heads/release/2025.6
 
 Tags: 2025.4.4-developer, 2025.4-developer, 2025.4-lta-developer
 Directory: commercial-editions/developer


### PR DESCRIPTION
Dear team,

we would like to release SonarQube Server 2025.6.1.

