### PR TITLE
"[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2025-23383 ELSA-2025-23481 "

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3a9ec8f30b6e17eba8fdbdce95884952a5645b55
+amd64-GitCommit: 14fbb138b00af6f05fe2f4072b4d8d4b17dc656a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 3a4133dc6459f897992e27f62ec84738a89a4ceb
+arm64v8-GitCommit: 85206da0cfcb656f3b5571874de0cd51a9f7f2ab
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-9086, CVE-2025-61984, CVE-2025-61985

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-23383.html
https://linux.oracle.com/errata/ELSA-2025-23481.html
https://linux.oracle.com/errata/ELBA-2025-23464.html
Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
