### PR TITLE
[oraclelinux] Updating 10and 10-slim for ELSA-2025-23484 ELSA-2025-23479 ELSA-2025-23940ELSA-2025-23940

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 14fbb138b00af6f05fe2f4072b4d8d4b17dc656a
+amd64-GitCommit: a48819a3d39fcf97d14093fcbf1016948505204f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 85206da0cfcb656f3b5571874de0cd51a9f7f2ab
+arm64v8-GitCommit: 31fe648419892baf9ec112c92aa4aecb235bb4e5
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-5987, CVE-2025-61984, CVE-2025-61985, CVE-2025-8291, tzdata-2025c

See the following for details:

https://linux.oracle.com/errata/ELSA-2025-23484.html
https://linux.oracle.com/errata/ELSA-2025-23479.html
https://linux.oracle.com/errata/ELSA-2025-23940.html
https://linux.oracle.com/errata/ELBA-2025-23464.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
