### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -54,14 +54,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: e319b3b62ba8f22c1dfac44a81bb65a7ed67dac1
 Directory: 3.0/alpine
 
-Tags: 2.8.17, 2.8, 2.8.17-trixie, 2.8-trixie
+Tags: 2.8.18, 2.8, 2.8.18-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8919100f1503492c1c786ffb6b9a0392ebfd071e
+GitCommit: 439f95bfe2bd3e6c15dc852a16d8d2e333d7fa37
 Directory: 2.8
 
-Tags: 2.8.17-alpine, 2.8-alpine, 2.8.17-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.18-alpine, 2.8-alpine, 2.8.18-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8919100f1503492c1c786ffb6b9a0392ebfd071e
+GitCommit: 439f95bfe2bd3e6c15dc852a16d8d2e333d7fa37
 Directory: 2.8/alpine
 
 Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/439f95b: Update 2.8 to 2.8.18