### PR TITLE
archlinux: Release 20251228.0.475343

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20251221.0.472429
-GitCommit: 99af2a3970b4390402086c110d983b37f36c6c9b
-GitFetch: refs/tags/v20251221.0.472429
+Tags: latest, base, base-20251228.0.475343
+GitCommit: 7b28125444143257312d4689765bd9da9300fa2b
+GitFetch: refs/tags/v20251228.0.475343
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20251221.0.472429
-GitCommit: 99af2a3970b4390402086c110d983b37f36c6c9b
-GitFetch: refs/tags/v20251221.0.472429
+Tags: base-devel, base-devel-20251228.0.475343
+GitCommit: 7b28125444143257312d4689765bd9da9300fa2b
+GitFetch: refs/tags/v20251228.0.475343
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20251221.0.472429
-GitCommit: 99af2a3970b4390402086c110d983b37f36c6c9b
-GitFetch: refs/tags/v20251221.0.472429
+Tags: multilib-devel, multilib-devel-20251228.0.475343
+GitCommit: 7b28125444143257312d4689765bd9da9300fa2b
+GitFetch: refs/tags/v20251228.0.475343
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks