### PR TITLE
Update jetty versions to 12.0.31 and 12.1.5 & add JDK25 variants

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -79,75 +79,85 @@ Architectures: amd64, arm64v8
 Directory: eclipse-temurin/9.4/jdk11
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.1.4-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.4-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.1.5-jdk25-alpine, 12.1-jdk25-alpine, 12-jdk25-alpine, 12.1.5-jdk25-alpine-eclipse-temurin, 12.1-jdk25-alpine-eclipse-temurin, 12-jdk25-alpine-eclipse-temurin
+Architectures: amd64
+Directory: eclipse-temurin/12.1/jdk25-alpine
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+
+Tags: 12.1.5-jdk25, 12.1-jdk25, 12-jdk25, 12.1.5-jdk25-eclipse-temurin, 12.1-jdk25-eclipse-temurin, 12-jdk25-eclipse-temurin
+Architectures: amd64, arm64v8
+Directory: eclipse-temurin/12.1/jdk25
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+
+Tags: 12.1.5-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.5-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk21-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.1.4, 12.1, 12, 12.1.4-jdk21, 12.1-jdk21, 12-jdk21, 12.1.4-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.4-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.1.5, 12.1, 12, 12.1.5-jdk21, 12.1-jdk21, 12-jdk21, 12.1.5-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.5-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk21
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.1.4-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.4-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.1.5-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.5-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk17-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.1.4-jdk17, 12.1-jdk17, 12-jdk17, 12.1.4-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.1.5-jdk17, 12.1-jdk17, 12-jdk17, 12.1.5-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk17
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jre21-alpine, 12.0-jre21-alpine, 12.0.30-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
+Tags: 12.0.31-jre21-alpine, 12.0-jre21-alpine, 12.0.31-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jre21, 12.0-jre21, 12.0.30-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
+Tags: 12.0.31-jre21, 12.0-jre21, 12.0.31-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jre17-alpine, 12.0-jre17-alpine, 12.0.30-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
+Tags: 12.0.31-jre17-alpine, 12.0-jre17-alpine, 12.0.31-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jre17, 12.0-jre17, 12.0.30-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
+Tags: 12.0.31-jre17, 12.0-jre17, 12.0.31-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk25-alpine, 12.0-jdk25-alpine, 12.0.30-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
+Tags: 12.0.31-jdk25-alpine, 12.0-jdk25-alpine, 12.0.31-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk25-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk25, 12.0-jdk25, 12.0.30-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
+Tags: 12.0.31-jdk25, 12.0-jdk25, 12.0.31-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk25
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk21-alpine, 12.0-jdk21-alpine, 12.0.30-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
+Tags: 12.0.31-jdk21-alpine, 12.0-jdk21-alpine, 12.0.31-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30, 12.0, 12.0.30-jdk21, 12.0-jdk21, 12.0.30-eclipse-temurin, 12.0-eclipse-temurin, 12.0.30-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
+Tags: 12.0.31, 12.0, 12.0.31-jdk21, 12.0-jdk21, 12.0.31-eclipse-temurin, 12.0-eclipse-temurin, 12.0.31-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk17-alpine, 12.0-jdk17-alpine, 12.0.30-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
+Tags: 12.0.31-jdk17-alpine, 12.0-jdk17-alpine, 12.0.31-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk17, 12.0-jdk17, 12.0.30-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
+Tags: 12.0.31-jdk17, 12.0-jdk17, 12.0.31-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
 Tags: 11.0.26-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.26-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
 Architectures: amd64
@@ -309,60 +319,70 @@ Architectures: amd64, arm64v8
 Directory: amazoncorretto/9.4/jdk11
 GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
 
-Tags: 12.1.4-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.1.5-jdk25-alpine-amazoncorretto, 12.1-jdk25-alpine-amazoncorretto, 12-jdk25-alpine-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.1/jdk25-alpine
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+
+Tags: 12.1.5-jdk25-amazoncorretto, 12.1-jdk25-amazoncorretto, 12-jdk25-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.1/jdk25
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+
+Tags: 12.1.5-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.1.4-amazoncorretto, 12.1-amazoncorretto, 12-amazoncorretto, 12.1.4-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.1.5-amazoncorretto, 12.1-amazoncorretto, 12-amazoncorretto, 12.1.5-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.1.4-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.1.5-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.1.4-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.1.5-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk25-al2023-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto
+Tags: 12.0.31-jdk25-al2023-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk25-al2023
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
+Tags: 12.0.31-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
+Tags: 12.0.31-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-al2023
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-amazoncorretto, 12.0-amazoncorretto, 12.0.30-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto
+Tags: 12.0.31-amazoncorretto, 12.0-amazoncorretto, 12.0.31-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
+Tags: 12.0.31-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
+Tags: 12.0.31-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-al2023
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
-Tags: 12.0.30-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
+Tags: 12.0.31-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: d810e2cd991b09d1c075f394180b488e3856ecfb
+GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
 
 Tags: 11.0.26-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8


### PR DESCRIPTION
- Update Jetty Versions
    - `12.0.30` -> `12.0.31`
    - `12.1.4` -> `12.0.5`
- Introduce JDK25 variants for Jetty 12.1.x versions.