### PR TITLE
[security] Update mongo, esp. for CVE-2025-14847

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/mongo/blob/c71ac3a4c7784a1c004a05cdbfeedd73ebc6567a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/mongo/blob/f91923968d124196f9d3dc16de787fc96044015f/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -83,4 +83,85 @@ SharedTags: 7.0.28-nanoserver, 7.0-nanoserver, 7-nanoserver
 Architectures: windows-amd64
 GitCommit: 005cf5957292a46cdada392a610687e56d04b225
 Directory: 7.0/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 6.0.27-jammy, 6.0-jammy, 6-jammy
+SharedTags: 6.0.27, 6.0, 6
+Architectures: amd64, arm64v8
+GitCommit: 6674f2b071d74581d20e5eb81418fcfe2b675a85
+Directory: 6.0
+
+Tags: 6.0.27-windowsservercore-ltsc2025, 6.0-windowsservercore-ltsc2025, 6-windowsservercore-ltsc2025
+SharedTags: 6.0.27-windowsservercore, 6.0-windowsservercore, 6-windowsservercore, 6.0.27, 6.0, 6
+Architectures: windows-amd64
+GitCommit: 6674f2b071d74581d20e5eb81418fcfe2b675a85
+Directory: 6.0/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
+Tags: 6.0.27-windowsservercore-ltsc2022, 6.0-windowsservercore-ltsc2022, 6-windowsservercore-ltsc2022
+SharedTags: 6.0.27-windowsservercore, 6.0-windowsservercore, 6-windowsservercore, 6.0.27, 6.0, 6
+Architectures: windows-amd64
+GitCommit: 6674f2b071d74581d20e5eb81418fcfe2b675a85
+Directory: 6.0/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 6.0.27-nanoserver-ltsc2022, 6.0-nanoserver-ltsc2022, 6-nanoserver-ltsc2022
+SharedTags: 6.0.27-nanoserver, 6.0-nanoserver, 6-nanoserver
+Architectures: windows-amd64
+GitCommit: 6674f2b071d74581d20e5eb81418fcfe2b675a85
+Directory: 6.0/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 5.0.32-focal, 5.0-focal
+SharedTags: 5.0.32, 5.0
+Architectures: amd64, arm64v8
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 5.0
+
+Tags: 5.0.32-windowsservercore-ltsc2025, 5.0-windowsservercore-ltsc2025
+SharedTags: 5.0.32-windowsservercore, 5.0-windowsservercore, 5.0.32, 5.0
+Architectures: windows-amd64
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 5.0/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
+Tags: 5.0.32-windowsservercore-ltsc2022, 5.0-windowsservercore-ltsc2022
+SharedTags: 5.0.32-windowsservercore, 5.0-windowsservercore, 5.0.32, 5.0
+Architectures: windows-amd64
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 5.0/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 5.0.32-nanoserver-ltsc2022, 5.0-nanoserver-ltsc2022
+SharedTags: 5.0.32-nanoserver, 5.0-nanoserver
+Architectures: windows-amd64
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 5.0/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 4.4.30-focal, 4.4-focal
+SharedTags: 4.4.30, 4.4
+Architectures: amd64, arm64v8
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 4.4
+
+Tags: 4.4.30-windowsservercore-ltsc2025, 4.4-windowsservercore-ltsc2025
+SharedTags: 4.4.30-windowsservercore, 4.4-windowsservercore, 4.4.30, 4.4
+Architectures: windows-amd64
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 4.4/windows/windowsservercore-ltsc2025
+Constraints: windowsservercore-ltsc2025
+
+Tags: 4.4.30-windowsservercore-ltsc2022, 4.4-windowsservercore-ltsc2022
+SharedTags: 4.4.30-windowsservercore, 4.4-windowsservercore, 4.4.30, 4.4
+Architectures: windows-amd64
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 4.4/windows/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 4.4.30-nanoserver-ltsc2022, 4.4-nanoserver-ltsc2022
+SharedTags: 4.4.30-nanoserver, 4.4-nanoserver
+Architectures: windows-amd64
+GitCommit: f91923968d124196f9d3dc16de787fc96044015f
+Directory: 4.4/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
CVE-2025-14847 ("MongoBleed"; https://jira.mongodb.org/browse/SERVER-115508; https://github.com/docker-library/mongo/issues/742)

This includes 4.4 and 5.0 which are on the EOL Ubuntu 20.04 (Focal) release for a one-off rebuild -- once the builds are done and published, these will be removed again (with 6.0) as they're all extremely end-of-life and should not be used.

Changes:

- https://github.com/docker-library/mongo/commit/1f45e2b: Merge pull request https://github.com/docker-library/mongo/pull/744 from infosiftr/eol
- https://github.com/docker-library/mongo/commit/f919239: Temporarily add back 4.4 and 5.0 for CVE-2025-14847
- https://github.com/docker-library/mongo/commit/2328ca2: Minor fixup to EOL dates
- https://github.com/docker-library/mongo/commit/85ba256: Merge pull request https://github.com/docker-library/mongo/pull/743 from orgads/mongobleed-legacy
- https://github.com/docker-library/mongo/commit/6674f2b: Revive 6.0 to deploy mongobleed fix