### PR TITLE
Update xwiki LTS to 17.10.2

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -7,12 +7,12 @@ Architectures: amd64, arm64v8
 Directory: 17/mysql-tomcat
 GitCommit: a7602018132edae5f6fc023fd172692ff2794452
 
-Tags: 17-postgres-tomcat, 17.10-postgres-tomcat, 17.10.0-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres, lts-postgres-tomcat, lts-postgres
+Tags: 17-postgres-tomcat, 17.10-postgres-tomcat, 17.10.2-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 17/postgres-tomcat
 GitCommit: a7602018132edae5f6fc023fd172692ff2794452
 
-Tags: 17-mariadb-tomcat, 17.10-mariadb-tomcat, 17.10.0-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb, lts-mariadb-tomcat, lts-mariadb
+Tags: 17-mariadb-tomcat, 17.10-mariadb-tomcat, 17.10.2-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb, lts-mariadb-tomcat, lts-mariadb
 Architectures: amd64, arm64v8
 Directory: 17/mariadb-tomcat
 GitCommit: a7602018132edae5f6fc023fd172692ff2794452


### PR DESCRIPTION
Also provide tags for XWiki 17.10.1 which was apparently missing