### PR TITLE
[oraclelinux] Updating 10and 10-slim for ELSA-2026-0002

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a48819a3d39fcf97d14093fcbf1016948505204f
+amd64-GitCommit: 520f33ebf6471da49390192d3234f05d2900058a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 31fe648419892baf9ec112c92aa4aecb235bb4e5
+arm64v8-GitCommit: f1f016a704b58ac90a429625e189d4276328c59c
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-45582, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0002.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
