### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,21 +4,6 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.9.0-php8.1-apache, 6.9-php8.1-apache, 6-php8.1-apache, php8.1-apache, 6.9.0-php8.1, 6.9-php8.1, 6-php8.1, php8.1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
-Directory: latest/php8.1/apache
-
-Tags: 6.9.0-php8.1-fpm, 6.9-php8.1-fpm, 6-php8.1-fpm, php8.1-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
-Directory: latest/php8.1/fpm
-
-Tags: 6.9.0-php8.1-fpm-alpine, 6.9-php8.1-fpm-alpine, 6-php8.1-fpm-alpine, php8.1-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
-Directory: latest/php8.1/fpm-alpine
-
 Tags: 6.9.0-php8.2-apache, 6.9-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.9.0-php8.2, 6.9-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
@@ -78,11 +63,6 @@ Tags: 6.9.0-php8.5-fpm-alpine, 6.9-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
 Directory: latest/php8.5/fpm-alpine
-
-Tags: cli-2.12.0-php8.1, cli-2.12-php8.1, cli-2-php8.1, cli-php8.1
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
-Directory: cli/php8.1/alpine
 
 Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/ecc7cdb: Drop PHP 8.1 (end of life) (https://github.com/docker-library/wordpress/pull/992)