### PR TITLE
Release SonarQube Community Build 26.1

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -63,7 +63,7 @@ Directory: commercial-editions/datacenter/search
 GitCommit: f4734dd45fbe00d4ce4393fec3e3b833a601173c
 GitFetch: refs/heads/release/2025.1
 
-Tags: 25.12.0.117093-community, community, latest
+Tags: 26.1.0.118079-community, community, latest
 Directory: community-build
-GitCommit: 90fde0d5acb6278517a7de18ce162fc83edf7efe
+GitCommit: 892abf9355a52edda737d58809abfd436073e518
 GitFetch: refs/heads/master


### PR DESCRIPTION
Dear team,

we would like to release a new version of the SonarQube Community Build.