### PR TITLE
[security] Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 6.1.0, 6.1, 6, latest, 6.1.0-trixie, 6.1-trixie, 6-trixie, trixie
+Tags: 6.1.1, 6.1, 6, latest, 6.1.1-trixie, 6.1-trixie, 6-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
 Directory: 6.1/trixie
 
-Tags: 6.1.0-bookworm, 6.1-bookworm, 6-bookworm, bookworm
+Tags: 6.1.1-bookworm, 6.1-bookworm, 6-bookworm, bookworm
 Architectures: amd64, arm64v8
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
 Directory: 6.1/bookworm
 
-Tags: 6.1.0-alpine3.23, 6.1-alpine3.23, 6-alpine3.23, alpine3.23, 6.1.0-alpine, 6.1-alpine, 6-alpine, alpine
+Tags: 6.1.1-alpine3.23, 6.1-alpine3.23, 6-alpine3.23, alpine3.23, 6.1.1-alpine, 6.1-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5778aa9d0ce7d46048ceab38c10deffef53ea24a
+GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
 Directory: 6.1/alpine3.23
 
-Tags: 6.1.0-alpine3.22, 6.1-alpine3.22, 6-alpine3.22, alpine3.22
+Tags: 6.1.1-alpine3.22, 6.1-alpine3.22, 6-alpine3.22, alpine3.22
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
 Directory: 6.1/alpine3.22
 
-Tags: 6.0.7, 6.0, 6.0.7-trixie, 6.0-trixie
+Tags: 6.0.8, 6.0, 6.0.8-trixie, 6.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
 Directory: 6.0/trixie
 
-Tags: 6.0.7-bookworm, 6.0-bookworm
+Tags: 6.0.8-bookworm, 6.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
 Directory: 6.0/bookworm
 
-Tags: 6.0.7-alpine3.23, 6.0-alpine3.23, 6.0.7-alpine, 6.0-alpine
+Tags: 6.0.8-alpine3.23, 6.0-alpine3.23, 6.0.8-alpine, 6.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5778aa9d0ce7d46048ceab38c10deffef53ea24a
+GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
 Directory: 6.0/alpine3.23
 
-Tags: 6.0.7-alpine3.22, 6.0-alpine3.22
+Tags: 6.0.8-alpine3.22, 6.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
 Directory: 6.0/alpine3.22
 
-Tags: 5.1.10, 5.1, 5, 5.1.10-trixie, 5.1-trixie, 5-trixie
+Tags: 5.1.11, 5.1, 5, 5.1.11-trixie, 5.1-trixie, 5-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
 Directory: 5.1/trixie
 
-Tags: 5.1.10-bookworm, 5.1-bookworm, 5-bookworm
+Tags: 5.1.11-bookworm, 5.1-bookworm, 5-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
 Directory: 5.1/bookworm
 
-Tags: 5.1.10-alpine3.23, 5.1-alpine3.23, 5-alpine3.23, 5.1.10-alpine, 5.1-alpine, 5-alpine
+Tags: 5.1.11-alpine3.23, 5.1-alpine3.23, 5-alpine3.23, 5.1.11-alpine, 5.1-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5778aa9d0ce7d46048ceab38c10deffef53ea24a
+GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
 Directory: 5.1/alpine3.23
 
-Tags: 5.1.10-alpine3.22, 5.1-alpine3.22, 5-alpine3.22
+Tags: 5.1.11-alpine3.22, 5.1-alpine3.22, 5-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 508e443b35ffefb6472f7e7d8591ce9f2f1879ae
+GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
 Directory: 5.1/alpine3.22


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/3230e2b: Update 6.1 to 6.1.1
- https://github.com/docker-library/redmine/commit/f216e86: Update 6.0 to 6.0.8
- https://github.com/docker-library/redmine/commit/9526f1d: Update 5.1 to 5.1.11