### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/44d78f65f676a0566d8e22294adf76986d5b9a46/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/1447b3e410bc610f5af822fb10e13ea6f5d931d9/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 44d78f65f676a0566d8e22294adf76986d5b9a46
+GitCommit: 1447b3e410bc610f5af822fb10e13ea6f5d931d9
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 04a7128fc48c4897f6c9cf97bd1be3c1b52bdbac
+amd64-GitCommit: 8d0487eb4336a9281dba965f5b1d656a79222142
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 9f4508a33ee9639eb7292315206fb2c6088e1e7d
+arm32v5-GitCommit: 509fb7597f1ecda778827122f5a2c4a4cc3543a8
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 608e473216e3603839626553477bd786ba97c214
+arm32v6-GitCommit: 892c25ca70a2e2b913fec8430d81024637ca248c
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 6842f61ca0324119e92d2005e1d4d24eea85a404
+arm32v7-GitCommit: cb9b3f9c4a552e6a0d63104bfe4df17c5758909e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d6add23713c2e571739f448dd202c3bee510483d
+arm64v8-GitCommit: 3e612c8d62200c473ecf57caa12b7527a343b961
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 4e1c3ea6db868282e233983de5a84894d5ea0a68
+i386-GitCommit: 05b8b179e4eb6bb323a104da3d11aa9d688beec0
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 15e3cd1fd5771a1cbbfcc5780e11ac16118f760a
+ppc64le-GitCommit: 6e9826123133b170cb811f1bb7470b9176d03c21
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 51a4c38a08927dac2e0a4a59fcfb77edab8ccce6
+riscv64-GitCommit: d4b376adde9b9c13dff7c7fe509857a1adda5994
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 50473f8eb1ab0715898fd8ce7a84b0f50af32ff1
+s390x-GitCommit: 10d013ab17d86b5ba2e80f98d603d033351afcf5
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/1447b3e: Merge pull request https://github.com/docker-library/busybox/pull/241 from infosiftr/buildroot-2025.11
- https://github.com/docker-library/busybox/commit/32accb8: Update metadata for amd64 and i386
- https://github.com/docker-library/busybox/commit/0f3153e: Update buildroot to 2025.11