### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev1, 3.4-dev, 3.4-dev1-trixie, 3.4-dev-trixie
+Tags: 3.4-dev2, 3.4-dev, 3.4-dev2-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c4aae186fc7844beacf615a62c77760195abca7c
+GitCommit: a1d78dc260e6efbadce5c60750c3d87569596c20
 Directory: 3.4
 
-Tags: 3.4-dev1-alpine, 3.4-dev-alpine, 3.4-dev1-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev2-alpine, 3.4-dev-alpine, 3.4-dev2-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c4aae186fc7844beacf615a62c77760195abca7c
+GitCommit: a1d78dc260e6efbadce5c60750c3d87569596c20
 Directory: 3.4/alpine
 
 Tags: 3.3.1, 3.3, latest, 3.3.1-trixie, 3.3-trixie, trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/a1d78dc: Update 3.4 to 3.4-dev2