### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -6,80 +6,80 @@ GitRepo: https://github.com/docker-library/haproxy.git
 
 Tags: 3.4-dev2, 3.4-dev, 3.4-dev2-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a1d78dc260e6efbadce5c60750c3d87569596c20
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.4
 
 Tags: 3.4-dev2-alpine, 3.4-dev-alpine, 3.4-dev2-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a1d78dc260e6efbadce5c60750c3d87569596c20
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.4/alpine
 
 Tags: 3.3.1, 3.3, latest, 3.3.1-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bbce9cd3a36531337ab84dbf3f20bb4dad2b1245
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.3
 
 Tags: 3.3.1-alpine, 3.3-alpine, alpine, 3.3.1-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bbce9cd3a36531337ab84dbf3f20bb4dad2b1245
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.3/alpine
 
 Tags: 3.2.10, 3.2, lts, 3.2.10-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: eb767ff57dbf4d8140b011b7721a007ee6692b2d
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.2
 
 Tags: 3.2.10-alpine, 3.2-alpine, lts-alpine, 3.2.10-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: eb767ff57dbf4d8140b011b7721a007ee6692b2d
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.2/alpine
 
 Tags: 3.1.12, 3.1, 3.1.12-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6644abc009d377471fb93989b6a9336ce1840e00
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.1
 
 Tags: 3.1.12-alpine, 3.1-alpine, 3.1.12-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6644abc009d377471fb93989b6a9336ce1840e00
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.1/alpine
 
 Tags: 3.0.14, 3.0, 3.0.14-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e319b3b62ba8f22c1dfac44a81bb65a7ed67dac1
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.0
 
 Tags: 3.0.14-alpine, 3.0-alpine, 3.0.14-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e319b3b62ba8f22c1dfac44a81bb65a7ed67dac1
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 3.0/alpine
 
 Tags: 2.8.18, 2.8, 2.8.18-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 439f95bfe2bd3e6c15dc852a16d8d2e333d7fa37
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 2.8
 
 Tags: 2.8.18-alpine, 2.8-alpine, 2.8.18-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 439f95bfe2bd3e6c15dc852a16d8d2e333d7fa37
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 2.8/alpine
 
 Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 2.6
 
 Tags: 2.6.23-alpine, 2.6-alpine, 2.6.23-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 2.6/alpine
 
 Tags: 2.4.30, 2.4, 2.4.30-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3fc33290bfe9f17d101aa25f22fac86f4a71e571
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 2.4
 
 Tags: 2.4.30-alpine, 2.4-alpine, 2.4.30-alpine3.23, 2.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bfbedbcbf4d99b4fd71bd9aedab5d9c42ce66005
+GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/29f17a0: Merge pull request https://github.com/docker-library/haproxy/pull/257 from infosiftr/quic
- https://github.com/docker-library/haproxy/commit/68b7118: Add pthread emulation to speed up openssl
- https://github.com/docker-library/haproxy/commit/54f063d: Add QUIC to 3.2+