### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2026-0337

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5dce45f1c2a645c6122b7786e0d147f41ab2a173
+amd64-GitCommit: 6974169a5aa3e2b6256cec9906c91235a20d03a0
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d00886e3dd12e87a47aa39905de18e4045e8b9ad
+arm64v8-GitCommit: a87471d745b4b967a7c407f35ddfb50bfab4856d
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-9230, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0337.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
