### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -6,490 +6,490 @@ GitRepo: https://github.com/docker-library/php.git
 
 Tags: 8.5.2RC1-cli-trixie, 8.5-rc-cli-trixie, 8.5.2RC1-trixie, 8.5-rc-trixie, 8.5.2RC1-cli, 8.5-rc-cli, 8.5.2RC1, 8.5-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/trixie/cli
 
 Tags: 8.5.2RC1-apache-trixie, 8.5-rc-apache-trixie, 8.5.2RC1-apache, 8.5-rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/trixie/apache
 
 Tags: 8.5.2RC1-fpm-trixie, 8.5-rc-fpm-trixie, 8.5.2RC1-fpm, 8.5-rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/trixie/fpm
 
 Tags: 8.5.2RC1-zts-trixie, 8.5-rc-zts-trixie, 8.5.2RC1-zts, 8.5-rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/trixie/zts
 
 Tags: 8.5.2RC1-cli-bookworm, 8.5-rc-cli-bookworm, 8.5.2RC1-bookworm, 8.5-rc-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/bookworm/cli
 
 Tags: 8.5.2RC1-apache-bookworm, 8.5-rc-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/bookworm/apache
 
 Tags: 8.5.2RC1-fpm-bookworm, 8.5-rc-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/bookworm/fpm
 
 Tags: 8.5.2RC1-zts-bookworm, 8.5-rc-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/bookworm/zts
 
 Tags: 8.5.2RC1-cli-alpine3.23, 8.5-rc-cli-alpine3.23, 8.5.2RC1-alpine3.23, 8.5-rc-alpine3.23, 8.5.2RC1-cli-alpine, 8.5-rc-cli-alpine, 8.5.2RC1-alpine, 8.5-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/alpine3.23/cli
 
 Tags: 8.5.2RC1-fpm-alpine3.23, 8.5-rc-fpm-alpine3.23, 8.5.2RC1-fpm-alpine, 8.5-rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/alpine3.23/fpm
 
 Tags: 8.5.2RC1-zts-alpine3.23, 8.5-rc-zts-alpine3.23, 8.5.2RC1-zts-alpine, 8.5-rc-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/alpine3.23/zts
 
 Tags: 8.5.2RC1-cli-alpine3.22, 8.5-rc-cli-alpine3.22, 8.5.2RC1-alpine3.22, 8.5-rc-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/alpine3.22/cli
 
 Tags: 8.5.2RC1-fpm-alpine3.22, 8.5-rc-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/alpine3.22/fpm
 
 Tags: 8.5.2RC1-zts-alpine3.22, 8.5-rc-zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0d2677ff25ecb7aaf880f4958797bc991d8cd282
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5-rc/alpine3.22/zts
 
 Tags: 8.5.1-cli-trixie, 8.5-cli-trixie, 8-cli-trixie, cli-trixie, 8.5.1-trixie, 8.5-trixie, 8-trixie, trixie, 8.5.1-cli, 8.5-cli, 8-cli, cli, 8.5.1, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/trixie/cli
 
 Tags: 8.5.1-apache-trixie, 8.5-apache-trixie, 8-apache-trixie, apache-trixie, 8.5.1-apache, 8.5-apache, 8-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/trixie/apache
 
 Tags: 8.5.1-fpm-trixie, 8.5-fpm-trixie, 8-fpm-trixie, fpm-trixie, 8.5.1-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/trixie/fpm
 
 Tags: 8.5.1-zts-trixie, 8.5-zts-trixie, 8-zts-trixie, zts-trixie, 8.5.1-zts, 8.5-zts, 8-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/trixie/zts
 
 Tags: 8.5.1-cli-bookworm, 8.5-cli-bookworm, 8-cli-bookworm, cli-bookworm, 8.5.1-bookworm, 8.5-bookworm, 8-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/bookworm/cli
 
 Tags: 8.5.1-apache-bookworm, 8.5-apache-bookworm, 8-apache-bookworm, apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/bookworm/apache
 
 Tags: 8.5.1-fpm-bookworm, 8.5-fpm-bookworm, 8-fpm-bookworm, fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/bookworm/fpm
 
 Tags: 8.5.1-zts-bookworm, 8.5-zts-bookworm, 8-zts-bookworm, zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/bookworm/zts
 
 Tags: 8.5.1-cli-alpine3.23, 8.5-cli-alpine3.23, 8-cli-alpine3.23, cli-alpine3.23, 8.5.1-alpine3.23, 8.5-alpine3.23, 8-alpine3.23, alpine3.23, 8.5.1-cli-alpine, 8.5-cli-alpine, 8-cli-alpine, cli-alpine, 8.5.1-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/alpine3.23/cli
 
 Tags: 8.5.1-fpm-alpine3.23, 8.5-fpm-alpine3.23, 8-fpm-alpine3.23, fpm-alpine3.23, 8.5.1-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/alpine3.23/fpm
 
 Tags: 8.5.1-zts-alpine3.23, 8.5-zts-alpine3.23, 8-zts-alpine3.23, zts-alpine3.23, 8.5.1-zts-alpine, 8.5-zts-alpine, 8-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/alpine3.23/zts
 
 Tags: 8.5.1-cli-alpine3.22, 8.5-cli-alpine3.22, 8-cli-alpine3.22, cli-alpine3.22, 8.5.1-alpine3.22, 8.5-alpine3.22, 8-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/alpine3.22/cli
 
 Tags: 8.5.1-fpm-alpine3.22, 8.5-fpm-alpine3.22, 8-fpm-alpine3.22, fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/alpine3.22/fpm
 
 Tags: 8.5.1-zts-alpine3.22, 8.5-zts-alpine3.22, 8-zts-alpine3.22, zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9ed36f437441cc3d7301d136d0c8cfc418dcf1aa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.5/alpine3.22/zts
 
 Tags: 8.4.17RC1-cli-trixie, 8.4-rc-cli-trixie, 8.4.17RC1-trixie, 8.4-rc-trixie, 8.4.17RC1-cli, 8.4-rc-cli, 8.4.17RC1, 8.4-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/trixie/cli
 
 Tags: 8.4.17RC1-apache-trixie, 8.4-rc-apache-trixie, 8.4.17RC1-apache, 8.4-rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/trixie/apache
 
 Tags: 8.4.17RC1-fpm-trixie, 8.4-rc-fpm-trixie, 8.4.17RC1-fpm, 8.4-rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/trixie/fpm
 
 Tags: 8.4.17RC1-zts-trixie, 8.4-rc-zts-trixie, 8.4.17RC1-zts, 8.4-rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/trixie/zts
 
 Tags: 8.4.17RC1-cli-bookworm, 8.4-rc-cli-bookworm, 8.4.17RC1-bookworm, 8.4-rc-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/bookworm/cli
 
 Tags: 8.4.17RC1-apache-bookworm, 8.4-rc-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/bookworm/apache
 
 Tags: 8.4.17RC1-fpm-bookworm, 8.4-rc-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/bookworm/fpm
 
 Tags: 8.4.17RC1-zts-bookworm, 8.4-rc-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/bookworm/zts
 
 Tags: 8.4.17RC1-cli-alpine3.23, 8.4-rc-cli-alpine3.23, 8.4.17RC1-alpine3.23, 8.4-rc-alpine3.23, 8.4.17RC1-cli-alpine, 8.4-rc-cli-alpine, 8.4.17RC1-alpine, 8.4-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/alpine3.23/cli
 
 Tags: 8.4.17RC1-fpm-alpine3.23, 8.4-rc-fpm-alpine3.23, 8.4.17RC1-fpm-alpine, 8.4-rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/alpine3.23/fpm
 
 Tags: 8.4.17RC1-zts-alpine3.23, 8.4-rc-zts-alpine3.23, 8.4.17RC1-zts-alpine, 8.4-rc-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/alpine3.23/zts
 
 Tags: 8.4.17RC1-cli-alpine3.22, 8.4-rc-cli-alpine3.22, 8.4.17RC1-alpine3.22, 8.4-rc-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/alpine3.22/cli
 
 Tags: 8.4.17RC1-fpm-alpine3.22, 8.4-rc-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/alpine3.22/fpm
 
 Tags: 8.4.17RC1-zts-alpine3.22, 8.4-rc-zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be2cb18ac76a03aada34d08e35da6b069b46d147
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4-rc/alpine3.22/zts
 
 Tags: 8.4.16-cli-trixie, 8.4-cli-trixie, 8.4.16-trixie, 8.4-trixie, 8.4.16-cli, 8.4-cli, 8.4.16, 8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/trixie/cli
 
 Tags: 8.4.16-apache-trixie, 8.4-apache-trixie, 8.4.16-apache, 8.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/trixie/apache
 
 Tags: 8.4.16-fpm-trixie, 8.4-fpm-trixie, 8.4.16-fpm, 8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/trixie/fpm
 
 Tags: 8.4.16-zts-trixie, 8.4-zts-trixie, 8.4.16-zts, 8.4-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/trixie/zts
 
 Tags: 8.4.16-cli-bookworm, 8.4-cli-bookworm, 8.4.16-bookworm, 8.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/bookworm/cli
 
 Tags: 8.4.16-apache-bookworm, 8.4-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/bookworm/apache
 
 Tags: 8.4.16-fpm-bookworm, 8.4-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/bookworm/fpm
 
 Tags: 8.4.16-zts-bookworm, 8.4-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/bookworm/zts
 
 Tags: 8.4.16-cli-alpine3.23, 8.4-cli-alpine3.23, 8.4.16-alpine3.23, 8.4-alpine3.23, 8.4.16-cli-alpine, 8.4-cli-alpine, 8.4.16-alpine, 8.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/alpine3.23/cli
 
 Tags: 8.4.16-fpm-alpine3.23, 8.4-fpm-alpine3.23, 8.4.16-fpm-alpine, 8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/alpine3.23/fpm
 
 Tags: 8.4.16-zts-alpine3.23, 8.4-zts-alpine3.23, 8.4.16-zts-alpine, 8.4-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/alpine3.23/zts
 
 Tags: 8.4.16-cli-alpine3.22, 8.4-cli-alpine3.22, 8.4.16-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/alpine3.22/cli
 
 Tags: 8.4.16-fpm-alpine3.22, 8.4-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/alpine3.22/fpm
 
 Tags: 8.4.16-zts-alpine3.22, 8.4-zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b98566d51f5856a9bbff14d299d6614274e4baa
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.4/alpine3.22/zts
 
 Tags: 8.3.30RC1-cli-trixie, 8.3-rc-cli-trixie, 8.3.30RC1-trixie, 8.3-rc-trixie, 8.3.30RC1-cli, 8.3-rc-cli, 8.3.30RC1, 8.3-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/trixie/cli
 
 Tags: 8.3.30RC1-apache-trixie, 8.3-rc-apache-trixie, 8.3.30RC1-apache, 8.3-rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/trixie/apache
 
 Tags: 8.3.30RC1-fpm-trixie, 8.3-rc-fpm-trixie, 8.3.30RC1-fpm, 8.3-rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/trixie/fpm
 
 Tags: 8.3.30RC1-zts-trixie, 8.3-rc-zts-trixie, 8.3.30RC1-zts, 8.3-rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/trixie/zts
 
 Tags: 8.3.30RC1-cli-bookworm, 8.3-rc-cli-bookworm, 8.3.30RC1-bookworm, 8.3-rc-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/bookworm/cli
 
 Tags: 8.3.30RC1-apache-bookworm, 8.3-rc-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/bookworm/apache
 
 Tags: 8.3.30RC1-fpm-bookworm, 8.3-rc-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/bookworm/fpm
 
 Tags: 8.3.30RC1-zts-bookworm, 8.3-rc-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/bookworm/zts
 
 Tags: 8.3.30RC1-cli-alpine3.23, 8.3-rc-cli-alpine3.23, 8.3.30RC1-alpine3.23, 8.3-rc-alpine3.23, 8.3.30RC1-cli-alpine, 8.3-rc-cli-alpine, 8.3.30RC1-alpine, 8.3-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/alpine3.23/cli
 
 Tags: 8.3.30RC1-fpm-alpine3.23, 8.3-rc-fpm-alpine3.23, 8.3.30RC1-fpm-alpine, 8.3-rc-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/alpine3.23/fpm
 
 Tags: 8.3.30RC1-zts-alpine3.23, 8.3-rc-zts-alpine3.23, 8.3.30RC1-zts-alpine, 8.3-rc-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/alpine3.23/zts
 
 Tags: 8.3.30RC1-cli-alpine3.22, 8.3-rc-cli-alpine3.22, 8.3.30RC1-alpine3.22, 8.3-rc-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/alpine3.22/cli
 
 Tags: 8.3.30RC1-fpm-alpine3.22, 8.3-rc-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/alpine3.22/fpm
 
 Tags: 8.3.30RC1-zts-alpine3.22, 8.3-rc-zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 685496435c53b46ee37b43c1d7e1671848072c39
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3-rc/alpine3.22/zts
 
 Tags: 8.3.29-cli-trixie, 8.3-cli-trixie, 8.3.29-trixie, 8.3-trixie, 8.3.29-cli, 8.3-cli, 8.3.29, 8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/trixie/cli
 
 Tags: 8.3.29-apache-trixie, 8.3-apache-trixie, 8.3.29-apache, 8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/trixie/apache
 
 Tags: 8.3.29-fpm-trixie, 8.3-fpm-trixie, 8.3.29-fpm, 8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/trixie/fpm
 
 Tags: 8.3.29-zts-trixie, 8.3-zts-trixie, 8.3.29-zts, 8.3-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/trixie/zts
 
 Tags: 8.3.29-cli-bookworm, 8.3-cli-bookworm, 8.3.29-bookworm, 8.3-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/bookworm/cli
 
 Tags: 8.3.29-apache-bookworm, 8.3-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/bookworm/apache
 
 Tags: 8.3.29-fpm-bookworm, 8.3-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/bookworm/fpm
 
 Tags: 8.3.29-zts-bookworm, 8.3-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/bookworm/zts
 
 Tags: 8.3.29-cli-alpine3.23, 8.3-cli-alpine3.23, 8.3.29-alpine3.23, 8.3-alpine3.23, 8.3.29-cli-alpine, 8.3-cli-alpine, 8.3.29-alpine, 8.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/alpine3.23/cli
 
 Tags: 8.3.29-fpm-alpine3.23, 8.3-fpm-alpine3.23, 8.3.29-fpm-alpine, 8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/alpine3.23/fpm
 
 Tags: 8.3.29-zts-alpine3.23, 8.3-zts-alpine3.23, 8.3.29-zts-alpine, 8.3-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/alpine3.23/zts
 
 Tags: 8.3.29-cli-alpine3.22, 8.3-cli-alpine3.22, 8.3.29-alpine3.22, 8.3-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/alpine3.22/cli
 
 Tags: 8.3.29-fpm-alpine3.22, 8.3-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/alpine3.22/fpm
 
 Tags: 8.3.29-zts-alpine3.22, 8.3-zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4ec8d1a273d591fb56b15780438721264ffaf073
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.3/alpine3.22/zts
 
 Tags: 8.2.30-cli-trixie, 8.2-cli-trixie, 8.2.30-trixie, 8.2-trixie, 8.2.30-cli, 8.2-cli, 8.2.30, 8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/trixie/cli
 
 Tags: 8.2.30-apache-trixie, 8.2-apache-trixie, 8.2.30-apache, 8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/trixie/apache
 
 Tags: 8.2.30-fpm-trixie, 8.2-fpm-trixie, 8.2.30-fpm, 8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/trixie/fpm
 
 Tags: 8.2.30-zts-trixie, 8.2-zts-trixie, 8.2.30-zts, 8.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/trixie/zts
 
 Tags: 8.2.30-cli-bookworm, 8.2-cli-bookworm, 8.2.30-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/bookworm/cli
 
 Tags: 8.2.30-apache-bookworm, 8.2-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/bookworm/apache
 
 Tags: 8.2.30-fpm-bookworm, 8.2-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/bookworm/fpm
 
 Tags: 8.2.30-zts-bookworm, 8.2-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/bookworm/zts
 
 Tags: 8.2.30-cli-alpine3.23, 8.2-cli-alpine3.23, 8.2.30-alpine3.23, 8.2-alpine3.23, 8.2.30-cli-alpine, 8.2-cli-alpine, 8.2.30-alpine, 8.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/alpine3.23/cli
 
 Tags: 8.2.30-fpm-alpine3.23, 8.2-fpm-alpine3.23, 8.2.30-fpm-alpine, 8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/alpine3.23/fpm
 
 Tags: 8.2.30-zts-alpine3.23, 8.2-zts-alpine3.23, 8.2.30-zts-alpine, 8.2-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/alpine3.23/zts
 
 Tags: 8.2.30-cli-alpine3.22, 8.2-cli-alpine3.22, 8.2.30-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/alpine3.22/cli
 
 Tags: 8.2.30-fpm-alpine3.22, 8.2-fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/alpine3.22/fpm
 
 Tags: 8.2.30-zts-alpine3.22, 8.2-zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a5cbc2e51fc91e5f8f00e8a30a1dcf6a58534db9
+GitCommit: 6485b53a1da0f2c4c5b564808de75ae62c023286
 Directory: 8.2/alpine3.22/zts


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/6485b53a: Set `sysconfdir` explicitly during build (https://github.com/docker-library/php/pull/1636)
- https://github.com/docker-library/php/commit/f26909cd: Move fpm listen for easier config override (https://github.com/docker-library/php/pull/1635)
- https://github.com/docker-library/php/commit/bc5b3fdc: Move `variants` calculation into `jq` (https://github.com/docker-library/php/pull/1640)
- https://github.com/docker-library/php/commit/91d35430: Post 8.1 EOL cleanup (https://github.com/docker-library/php/pull/1642)