### PR TITLE
archlinux: Release 20260111.0.480139

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260104.0.477168
-GitCommit: 380a7e40945468853717ced95fe18d236874f7ea
-GitFetch: refs/tags/v20260104.0.477168
+Tags: latest, base, base-20260111.0.480139
+GitCommit: 22acdd9c9c7a70f53aed4292aa03b70b4b994ad1
+GitFetch: refs/tags/v20260111.0.480139
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260104.0.477168
-GitCommit: 380a7e40945468853717ced95fe18d236874f7ea
-GitFetch: refs/tags/v20260104.0.477168
+Tags: base-devel, base-devel-20260111.0.480139
+GitCommit: 22acdd9c9c7a70f53aed4292aa03b70b4b994ad1
+GitFetch: refs/tags/v20260111.0.480139
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260104.0.477168
-GitCommit: 380a7e40945468853717ced95fe18d236874f7ea
-GitFetch: refs/tags/v20260104.0.477168
+Tags: multilib-devel, multilib-devel-20260111.0.480139
+GitCommit: 22acdd9c9c7a70f53aed4292aa03b70b4b994ad1
+GitFetch: refs/tags/v20260111.0.480139
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks