### PR TITLE
Improve ruby-gems test and update gem list

### DIFF
--- a/test/tests/ruby-gems/container.sh
+++ b/test/tests/ruby-gems/container.sh
@@ -5,26 +5,37 @@ gems="$(ruby -e '
 	# list taken from https://rubygems.org/stats
 	gems = %w{
 		bundler
-		multi_json
-		rake
-		rack
-		json
-		mime-types
-		activesupport
-		thor
+		aws-sdk-core
 		i18n
+		activesupport
+		rack
+		rake
+		concurrent-ruby
+		json
+		tzinfo
+		nokogiri
 		diff-lcs
 	}
-	# last updated 2017-11-15
+	# last updated 2026-01-12
+	# to try to get a wider coverage of common gems, this list skips the direct deps of aws-sdk-core
+	# (aws-eventstream, aws-partitions, aws-sigv4, jmespath)
+	# skip minitest, it has native deps (needs a compiler for c code, which will not work in jruby images)
 
 	require "json"
 	require "open-uri"
 
+	# only install gems where the current ruby version is new enough for the gem
 	for gem in gems
-		# ruby 2.2.2+: rack activesupport
-		# ruby 2.0+: mime-types
-		# (jruby 1.7 is ruby 1.9)
+		# grabbing the first item might be checking ruby_version against a pre-release version of the gem
+		# TODO also save version of the gem for the gem install? `gem install [GEM] -v [VERSION]`
+		# TODO or skip pre-releases?
 		gemRubyVersion = JSON.load(URI.open("https://rubygems.org/api/v1/versions/#{ gem }.json"))[0]["ruby_version"]
+
+		# https://github.com/rubygems/rubygems.org/blob/d05f69e8e800acf1dd21bb6f8e5f174410f81a33/app/models/version.rb#L304
+		# https://github.com/ruby/rubygems/blob/e7cb04353fc8fe85d359d34d9d467d17d33bdbd3/lib/rubygems/specification.rb#L148
+		# https://github.com/ruby/rubygems/blob/e7cb04353fc8fe85d359d34d9d467d17d33bdbd3/lib/rubygems/requirement.rb#L259-L261
+		gemRubyVersion = gemRubyVersion.split(", ")
+
 		if Gem::Dependency.new("", gemRubyVersion).match?("", RUBY_VERSION)
 			puts gem
 		else


### PR DESCRIPTION
Updating the list of gems we attempt since the last list was from 2017-11-15.

From failing tests:
>/usr/local/lib/ruby/4.0.0/rubygems/requirement.rb:107:in 'Gem::Requirement.parse': Illformed requirement [">= 3.2.0, < 5"] (Gem::Requirement::BadRequirementError)

A gem might have a `ruby_version` with more than one requirement: `">= 3.2.0, < 5"` (like [diff-lcs](https://github.com/halostatue/diff-lcs/blob/v2.0.0.beta.1/diff-lcs.gemspec#L21)). This updates the test to handle this.