### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/cassandra/blob/75187df9c5b4b5200e1c59fd46163f087d4f798a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/cassandra/blob/89284c78af6d2541d326a661e4a5e3006ae55860/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -18,13 +18,3 @@ Tags: 4.0.19, 4.0, 4.0.19-jammy, 4.0-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 23531063a5aefaa47cbd5166c7d02ae75c44c262
 Directory: 4.0
-
-Tags: 3.11.19, 3.11, 3, 3.11.19-jammy, 3.11-jammy, 3-jammy
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 793ea6b2a8097d629252fe77585775443b53e4c3
-Directory: 3.11
-
-Tags: 3.0.32, 3.0, 3.0.32-jammy, 3.0-jammy
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 793ea6b2a8097d629252fe77585775443b53e4c3
-Directory: 3.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/eb68265: Merge pull request https://github.com/docker-library/cassandra/pull/291 from infosiftr/eol-3.x
- https://github.com/docker-library/cassandra/commit/89284c7: Remove EOL 3.x versions