### PR TITLE
Updated nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -20,7 +20,7 @@ Directory: mainline/debian-otel
 
 Tags: 1.29.4-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.4-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.29-alpine3.23, alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: 3a5661a6374fd9e0752cf82bbd61fdcf5df59e54
 Directory: mainline/alpine
 
 Tags: 1.29.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.4-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.29-alpine3.23-perl, alpine3.23-perl
@@ -55,7 +55,7 @@ Directory: stable/debian-otel
 
 Tags: 1.28.1-alpine, stable-alpine, 1.28-alpine, 1.28.1-alpine3.23, stable-alpine3.23, 1.28-alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: 3a5661a6374fd9e0752cf82bbd61fdcf5df59e54
 Directory: stable/alpine
 
 Tags: 1.28.1-alpine-perl, stable-alpine-perl, 1.28-alpine-perl, 1.28.1-alpine3.23-perl, stable-alpine3.23-perl, 1.28-alpine3.23-perl


### PR DESCRIPTION
Fixes build failures on arm32v6 by skipping acme module on this architecture.