### PR TITLE
Remove Java 25 images

### DIFF
--- a/library/groovy
+++ b/library/groovy
@@ -1,25 +1,13 @@
 Maintainers: Keegan Witt <keeganwitt@gmail.com> (@keeganwitt)
 GitRepo: https://github.com/groovy/docker-groovy.git
 
-Tags: 5.0.3-jdk25, 5.0-jdk25, 5-jdk25, jdk25, 5.0.3-jdk25-noble, 5.0-jdk25-noble, 5-jdk25-noble, jdk25-noble, latest, 5.0.3-jdk, 5.0-jdk, 5-jdk, jdk, 5.0.3, 5.0, 4, 5.0.3-jdk-noble, 5.0-jdk-noble, 5-jdk-noble, jdk-noble, 5.0.3-noble, 5.0-noble, 5-noble, noble
-Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitFetch: refs/heads/master
-GitCommit: 4c69514606dd56641932a0253ded4932f808cf0b
-Directory: jdk25
-
-Tags: 5.0.3-jdk25-alpine, 5.0-jdk25-alpine, 5-jdk25-alpine, jdk25-alpine, 5.0.3-jdk-alpine, 5.0-jdk-alpine, 5-jdk-alpine, jdk-alpine, 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/master
-GitCommit: 4c69514606dd56641932a0253ded4932f808cf0b
-Directory: jdk25-alpine
-
-Tags: 5.0.3-jdk21, 5.0-jdk21, 5-jdk21, jdk21, 5.0.3-jdk21-noble, 5.0-jdk21-noble, 5-jdk21-noble, jdk21-noble
+Tags: 5.0.3-jdk21, 5.0-jdk21, 5-jdk21, jdk21, 5.0.3-jdk21-noble, 5.0-jdk21-noble, 5-jdk21-noble, jdk21-noble, latest, 5.0.3-jdk, 5.0-jdk, 5-jdk, jdk, 5.0.3, 5.0, 4, 5.0.3-jdk-noble, 5.0-jdk-noble, 5-jdk-noble, jdk-noble, 5.0.3-noble, 5.0-noble, 5-noble, noble
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
 GitFetch: refs/heads/master
 GitCommit: 4c69514606dd56641932a0253ded4932f808cf0b
 Directory: jdk21
 
-Tags: 5.0.3-jdk21-alpine, 5.0-jdk21-alpine, 5-jdk21-alpine, jdk21-alpine
+Tags: 5.0.3-jdk21-alpine, 5.0-jdk21-alpine, 5-jdk21-alpine, jdk21-alpine, 5.0.3-jdk-alpine, 5.0-jdk-alpine, 5-jdk-alpine, jdk-alpine, 5.0.3-alpine, 5.0-alpine, 5-alpine, alpine
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/master
 GitCommit: 4c69514606dd56641932a0253ded4932f808cf0b


### PR DESCRIPTION
Groovy doesn't fully support Java 25 yetbecause JavaParser doesn't support it yet. https://github.com/javaparser/javaparser/pull/4910 looks like it added support, but it hasn't been released yet.