### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,161 +6,161 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.26rc1-trixie, 1.26-rc-trixie
-SharedTags: 1.26rc1, 1.26-rc
+Tags: 1.26rc2-trixie, 1.26-rc-trixie
+SharedTags: 1.26rc2, 1.26-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/trixie
 
-Tags: 1.26rc1-bookworm, 1.26-rc-bookworm
+Tags: 1.26rc2-bookworm, 1.26-rc-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/bookworm
 
-Tags: 1.26rc1-alpine3.23, 1.26-rc-alpine3.23, 1.26rc1-alpine, 1.26-rc-alpine
+Tags: 1.26rc2-alpine3.23, 1.26-rc-alpine3.23, 1.26rc2-alpine, 1.26-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/alpine3.23
 
-Tags: 1.26rc1-alpine3.22, 1.26-rc-alpine3.22
+Tags: 1.26rc2-alpine3.22, 1.26-rc-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/alpine3.22
 
-Tags: 1.26rc1-windowsservercore-ltsc2025, 1.26-rc-windowsservercore-ltsc2025
-SharedTags: 1.26rc1-windowsservercore, 1.26-rc-windowsservercore, 1.26rc1, 1.26-rc
+Tags: 1.26rc2-windowsservercore-ltsc2025, 1.26-rc-windowsservercore-ltsc2025
+SharedTags: 1.26rc2-windowsservercore, 1.26-rc-windowsservercore, 1.26rc2, 1.26-rc
 Architectures: windows-amd64
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.26rc1-windowsservercore-ltsc2022, 1.26-rc-windowsservercore-ltsc2022
-SharedTags: 1.26rc1-windowsservercore, 1.26-rc-windowsservercore, 1.26rc1, 1.26-rc
+Tags: 1.26rc2-windowsservercore-ltsc2022, 1.26-rc-windowsservercore-ltsc2022
+SharedTags: 1.26rc2-windowsservercore, 1.26-rc-windowsservercore, 1.26rc2, 1.26-rc
 Architectures: windows-amd64
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.26rc1-nanoserver-ltsc2025, 1.26-rc-nanoserver-ltsc2025
-SharedTags: 1.26rc1-nanoserver, 1.26-rc-nanoserver
+Tags: 1.26rc2-nanoserver-ltsc2025, 1.26-rc-nanoserver-ltsc2025
+SharedTags: 1.26rc2-nanoserver, 1.26-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.26rc1-nanoserver-ltsc2022, 1.26-rc-nanoserver-ltsc2022
-SharedTags: 1.26rc1-nanoserver, 1.26-rc-nanoserver
+Tags: 1.26rc2-nanoserver-ltsc2022, 1.26-rc-nanoserver-ltsc2022
+SharedTags: 1.26rc2-nanoserver, 1.26-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: fba8da6733b948b309e4bedebbfd85f3a20f98a1
+GitCommit: 12bb165f4ed0318d0425a869ed69b59f2e9a29c9
 Directory: 1.26-rc/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.25.5-trixie, 1.25-trixie, 1-trixie, trixie
-SharedTags: 1.25.5, 1.25, 1, latest
+Tags: 1.25.6-trixie, 1.25-trixie, 1-trixie, trixie
+SharedTags: 1.25.6, 1.25, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/trixie
 
-Tags: 1.25.5-bookworm, 1.25-bookworm, 1-bookworm, bookworm
+Tags: 1.25.6-bookworm, 1.25-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/bookworm
 
-Tags: 1.25.5-alpine3.23, 1.25-alpine3.23, 1-alpine3.23, alpine3.23, 1.25.5-alpine, 1.25-alpine, 1-alpine, alpine
+Tags: 1.25.6-alpine3.23, 1.25-alpine3.23, 1-alpine3.23, alpine3.23, 1.25.6-alpine, 1.25-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: adf0ff9a10a766d7dc1b394d52544f3a1b1da4e2
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/alpine3.23
 
-Tags: 1.25.5-alpine3.22, 1.25-alpine3.22, 1-alpine3.22, alpine3.22
+Tags: 1.25.6-alpine3.22, 1.25-alpine3.22, 1-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/alpine3.22
 
-Tags: 1.25.5-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 1.25.5-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.5, 1.25, 1, latest
+Tags: 1.25.6-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.25.6-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.6, 1.25, 1, latest
 Architectures: windows-amd64
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.25.5-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.25.5-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.5, 1.25, 1, latest
+Tags: 1.25.6-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.25.6-windowsservercore, 1.25-windowsservercore, 1-windowsservercore, windowsservercore, 1.25.6, 1.25, 1, latest
 Architectures: windows-amd64
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.25.5-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 1.25.5-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.25.6-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 1.25.6-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.25.5-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.25.5-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.25.6-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.25.6-nanoserver, 1.25-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 5ac8de688220e63940b9df4c27614898aae9e3fc
+GitCommit: 1c0ced42456a245f7952d1d3099c7bc51da8ef00
 Directory: 1.25/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.24.11-trixie, 1.24-trixie
-SharedTags: 1.24.11, 1.24
+Tags: 1.24.12-trixie, 1.24-trixie
+SharedTags: 1.24.12, 1.24
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/trixie
 
-Tags: 1.24.11-bookworm, 1.24-bookworm
+Tags: 1.24.12-bookworm, 1.24-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/bookworm
 
-Tags: 1.24.11-alpine3.23, 1.24-alpine3.23, 1.24.11-alpine, 1.24-alpine
+Tags: 1.24.12-alpine3.23, 1.24-alpine3.23, 1.24.12-alpine, 1.24-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: adf0ff9a10a766d7dc1b394d52544f3a1b1da4e2
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/alpine3.23
 
-Tags: 1.24.11-alpine3.22, 1.24-alpine3.22
+Tags: 1.24.12-alpine3.22, 1.24-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/alpine3.22
 
-Tags: 1.24.11-windowsservercore-ltsc2025, 1.24-windowsservercore-ltsc2025
-SharedTags: 1.24.11-windowsservercore, 1.24-windowsservercore, 1.24.11, 1.24
+Tags: 1.24.12-windowsservercore-ltsc2025, 1.24-windowsservercore-ltsc2025
+SharedTags: 1.24.12-windowsservercore, 1.24-windowsservercore, 1.24.12, 1.24
 Architectures: windows-amd64
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.24.11-windowsservercore-ltsc2022, 1.24-windowsservercore-ltsc2022
-SharedTags: 1.24.11-windowsservercore, 1.24-windowsservercore, 1.24.11, 1.24
+Tags: 1.24.12-windowsservercore-ltsc2022, 1.24-windowsservercore-ltsc2022
+SharedTags: 1.24.12-windowsservercore, 1.24-windowsservercore, 1.24.12, 1.24
 Architectures: windows-amd64
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.24.11-nanoserver-ltsc2025, 1.24-nanoserver-ltsc2025
-SharedTags: 1.24.11-nanoserver, 1.24-nanoserver
+Tags: 1.24.12-nanoserver-ltsc2025, 1.24-nanoserver-ltsc2025
+SharedTags: 1.24.12-nanoserver, 1.24-nanoserver
 Architectures: windows-amd64
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.24.11-nanoserver-ltsc2022, 1.24-nanoserver-ltsc2022
-SharedTags: 1.24.11-nanoserver, 1.24-nanoserver
+Tags: 1.24.12-nanoserver-ltsc2022, 1.24-nanoserver-ltsc2022
+SharedTags: 1.24.12-nanoserver, 1.24-nanoserver
 Architectures: windows-amd64
-GitCommit: 40780952e94f21871629116080cf50fac6c991f6
+GitCommit: 7262312f3644ba6a680fcf4e78575ebd1d10b98a
 Directory: 1.24/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/12bb165: Update 1.26-rc to 1.26rc2
- https://github.com/docker-library/golang/commit/1c0ced4: Update 1.25 to 1.25.6
- https://github.com/docker-library/golang/commit/7262312: Update 1.24 to 1.24.12