### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.9.20251208.0
+Tags: 2023, latest, 2023.10.20260105.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 4d81e9ae45414f96bcf88c42239521c780b9753e
+amd64-GitCommit: 04deb3726fb51cc796dbc6c41247508c9374aafb
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: ca85fcfbe368e16dd8346f4d3d7b625cd72e23a2
+arm64v8-GitCommit: c391f5983d10c0cde6061bdb7f81d6edf425177e
 
-Tags: 2, 2.0.20251208.0
+Tags: 2, 2.0.20260109.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 7342ef4ca463b681795ea278281da1ba8e7b578b
+amd64-GitCommit: 25a6475c4c396055267d70a4c4e1803631d1397e
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: b4a20ce21f51c29c4612a0d907d0fa8cda257b20
+arm64v8-GitCommit: 16aeeb3daee4a726a2f25d805a6d5b4849c1aba5
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- libgcc-7.3.1-18.amzn2
- libuuid-2.30.2-2.amzn2.0.13
- libblkid-2.30.2-2.amzn2.0.13
- libstdc++-7.3.1-18.amzn2
- libmount-2.30.2-2.amzn2.0.13
- glib2-2.56.1-9.amzn2.0.13

Updated Packages for Amazon Linux 2023:
- openssl-fips-provider-latest-3.2.2-1.amzn2023.0.3
- glib2-2.82.2-769.amzn2023
- libcurl-minimal-8.15.0-4.amzn2023.0.1
- python3-libs-3.9.25-1.amzn2023.0.3
- amazon-linux-repo-cdn-2023.10.20260105-0.amzn2023
- system-release-2023.10.20260105-0.amzn2023
- libcap-2.73-1.amzn2023.0.5
- openssl-libs-3.2.2-1.amzn2023.0.3
- curl-minimal-8.15.0-4.amzn2023.0.1
- python3-3.9.25-1.amzn2023.0.3