### PR TITLE
Revert "Update Ubuntu 2026-01-15 (#20644)"

### DIFF
--- a/library/ubuntu
+++ b/library/ubuntu
@@ -7,51 +7,51 @@ GitCommit: fa42be9027eccb928a1f0f43d95ffd9a45d36737
 Builder: oci-import
 File: index.json
 
-# 20260109 (jammy)
-Tags: 22.04, jammy-20260109, jammy
+# 20251013 (jammy)
+Tags: 22.04, jammy-20251013, jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: oci
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-amd64-20260109-ae8fa966
-amd64-GitFetch: refs/tags/dist-jammy-amd64-20260109-ae8fa966
-amd64-GitCommit: ae8fa96632f4ac9782f8f49e24c771bcd052d32b
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-arm32v7-20260109-86c67dc6
-arm32v7-GitFetch: refs/tags/dist-jammy-arm32v7-20260109-86c67dc6
-arm32v7-GitCommit: 86c67dc6c18c913f848463f9d477d727b8188926
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-arm64v8-20260109-2b7d47f2
-arm64v8-GitFetch: refs/tags/dist-jammy-arm64v8-20260109-2b7d47f2
-arm64v8-GitCommit: 2b7d47f2e53430b3b656be7804f2746997215395
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-ppc64le-20260109-3903b566
-ppc64le-GitFetch: refs/tags/dist-jammy-ppc64le-20260109-3903b566
-ppc64le-GitCommit: 3903b566aba8f1edb78731c6e46dc2965184884d
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-riscv64-20260109-6fa40837
-riscv64-GitFetch: refs/tags/dist-jammy-riscv64-20260109-6fa40837
-riscv64-GitCommit: 6fa40837b215c33e150b7e2de6fcfa6474229f83
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-s390x-20260109-5eda312e
-s390x-GitFetch: refs/tags/dist-jammy-s390x-20260109-5eda312e
-s390x-GitCommit: 5eda312e8b3cbddca8cf2f2fdd8cdcbda5372e99
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-amd64-20251013-b40e3010
+amd64-GitFetch: refs/tags/dist-jammy-amd64-20251013-b40e3010
+amd64-GitCommit: b40e301002ccc279d4014443ac99c4a4bf12bc9e
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-arm32v7-20251013-18ef2926
+arm32v7-GitFetch: refs/tags/dist-jammy-arm32v7-20251013-18ef2926
+arm32v7-GitCommit: 18ef2926c3c9f2c51cf646262e066ce639dc45d5
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-arm64v8-20251013-862652f4
+arm64v8-GitFetch: refs/tags/dist-jammy-arm64v8-20251013-862652f4
+arm64v8-GitCommit: 862652f4b5e6a53fa30bc0d26e4fc19db5bbc5f8
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-ppc64le-20251013-823744a5
+ppc64le-GitFetch: refs/tags/dist-jammy-ppc64le-20251013-823744a5
+ppc64le-GitCommit: 823744a5597583ecd4f7236d8e2ed76625dd1524
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-riscv64-20251013-ada05123
+riscv64-GitFetch: refs/tags/dist-jammy-riscv64-20251013-ada05123
+riscv64-GitCommit: ada0512381e0cf24a3539ee6b775b153ec933c54
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-jammy-s390x-20251013-28bd7583
+s390x-GitFetch: refs/tags/dist-jammy-s390x-20251013-28bd7583
+s390x-GitCommit: 28bd758353ceaed5a27dc9ec800f4f3ca90d20d9
 
-# 20260113 (noble)
-Tags: 24.04, noble-20260113, noble, latest
+# 20251013 (noble)
+Tags: 24.04, noble-20251013, noble, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: oci
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-amd64-20260113-0204f0b5
-amd64-GitFetch: refs/tags/dist-noble-amd64-20260113-0204f0b5
-amd64-GitCommit: 0204f0b546818d54ed186e72b4fc4eba7e3c7136
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-arm32v7-20260113-6c99c4fd
-arm32v7-GitFetch: refs/tags/dist-noble-arm32v7-20260113-6c99c4fd
-arm32v7-GitCommit: 6c99c4fd7eff589c641c1c56c1e95b1230b5697d
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-arm64v8-20260113-c03ca7bd
-arm64v8-GitFetch: refs/tags/dist-noble-arm64v8-20260113-c03ca7bd
-arm64v8-GitCommit: c03ca7bd8f158c232799e60c2a2b1aea547111b0
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-ppc64le-20260113-96cd45fc
-ppc64le-GitFetch: refs/tags/dist-noble-ppc64le-20260113-96cd45fc
-ppc64le-GitCommit: 96cd45fc3e8eb86b38482d45e6fefe7dd4b79df0
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-riscv64-20260113-c3c95f07
-riscv64-GitFetch: refs/tags/dist-noble-riscv64-20260113-c3c95f07
-riscv64-GitCommit: c3c95f0772bdb5effb1d6ac5fb15ce53cc030dfb
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-s390x-20260113-b49e794b
-s390x-GitFetch: refs/tags/dist-noble-s390x-20260113-b49e794b
-s390x-GitCommit: b49e794bb7a4018da19e0783a6a7779b9e4208b6
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-amd64-20251013-6177ca63
+amd64-GitFetch: refs/tags/dist-noble-amd64-20251013-6177ca63
+amd64-GitCommit: 6177ca63f5beee0b6d2993721a62850b9146e474
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-arm32v7-20251013-de0d9a49
+arm32v7-GitFetch: refs/tags/dist-noble-arm32v7-20251013-de0d9a49
+arm32v7-GitCommit: de0d9a49d887c41c28a7531bd6fd66fe1e4b7c8d
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-arm64v8-20251013-6a6dcf57
+arm64v8-GitFetch: refs/tags/dist-noble-arm64v8-20251013-6a6dcf57
+arm64v8-GitCommit: 6a6dcf572c9f82db1cd393585928a5c03e151308
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-ppc64le-20251013-faaf0d1a
+ppc64le-GitFetch: refs/tags/dist-noble-ppc64le-20251013-faaf0d1a
+ppc64le-GitCommit: faaf0d1a3be388617cdab000bdf34698f0e3a312
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-riscv64-20251013-c1f21c0a
+riscv64-GitFetch: refs/tags/dist-noble-riscv64-20251013-c1f21c0a
+riscv64-GitCommit: c1f21c0a17e987239d074b9b8f36a5430912c879
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-noble-s390x-20251013-083722f1
+s390x-GitFetch: refs/tags/dist-noble-s390x-20251013-083722f1
+s390x-GitCommit: 083722f1b9a3277e0964c4787713cf1b4f6f3aa0
 
 # 20251001 (plucky)
 Tags: 25.04, plucky-20251001, plucky
@@ -99,25 +99,25 @@ riscv64-GitCommit: b8e624be1b921be8e3ec88a25bc4f3cd5f8c97ab
 s390x-GitFetch: refs/tags/dist-questing-s390x-20251217-6b4d506a
 s390x-GitCommit: 6b4d506a5d09422a94e8092c120977f38e20256d
 
-# 20260106.1 (resolute)
-Tags: 26.04, resolute-20260106.1, resolute, devel
+# 20251208 (resolute)
+Tags: 26.04, resolute-20251208, resolute, devel
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 Directory: oci
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-amd64-20260106.1-09ce3a9e
-amd64-GitFetch: refs/tags/dist-resolute-amd64-20260106.1-09ce3a9e
-amd64-GitCommit: 09ce3a9e74281df056d51bee1c0ef382253a736f
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-arm32v7-20260106.1-1d0b718c
-arm32v7-GitFetch: refs/tags/dist-resolute-arm32v7-20260106.1-1d0b718c
-arm32v7-GitCommit: 1d0b718c0b8d92616c7196fa648f420b7fa105a7
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-arm64v8-20260106.1-b94be0e9
-arm64v8-GitFetch: refs/tags/dist-resolute-arm64v8-20260106.1-b94be0e9
-arm64v8-GitCommit: b94be0e9ac8576d921595f9a30c62b767c5a7614
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-ppc64le-20260106.1-570a0d98
-ppc64le-GitFetch: refs/tags/dist-resolute-ppc64le-20260106.1-570a0d98
-ppc64le-GitCommit: 570a0d98c056f7869e06c4935296695456ea115d
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-riscv64-20260106.1-f978ba30
-riscv64-GitFetch: refs/tags/dist-resolute-riscv64-20260106.1-f978ba30
-riscv64-GitCommit: f978ba30cf481796b80b5a28c69c69b35d14ec63
-# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-s390x-20260106.1-e590e317
-s390x-GitFetch: refs/tags/dist-resolute-s390x-20260106.1-e590e317
-s390x-GitCommit: e590e317c6034bb08133b46496b00a76154ebc40
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-amd64-20251208-b6ced6db
+amd64-GitFetch: refs/tags/dist-resolute-amd64-20251208-b6ced6db
+amd64-GitCommit: b6ced6dbd0a1d454a570be117b73c25268876fcd
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-arm32v7-20251208-161ff39e
+arm32v7-GitFetch: refs/tags/dist-resolute-arm32v7-20251208-161ff39e
+arm32v7-GitCommit: 161ff39e70bfdf7d41e0f194d8af72788f01bc79
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-arm64v8-20251208-02987f35
+arm64v8-GitFetch: refs/tags/dist-resolute-arm64v8-20251208-02987f35
+arm64v8-GitCommit: 02987f354cb4186c4fcb3170ced0d0a9bd16acd4
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-ppc64le-20251208-2841189f
+ppc64le-GitFetch: refs/tags/dist-resolute-ppc64le-20251208-2841189f
+ppc64le-GitCommit: 2841189ff36cbabc50bb432ac3642059285ef468
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-riscv64-20251208-0e400c0f
+riscv64-GitFetch: refs/tags/dist-resolute-riscv64-20251208-0e400c0f
+riscv64-GitCommit: 0e400c0f76df692675d66fd196bac7defe767ad3
+# https://git.launchpad.net/cloud-images/+oci/ubuntu-base/tree/?h=dist-resolute-s390x-20251208-a55c7f08
+s390x-GitFetch: refs/tags/dist-resolute-s390x-20251208-a55c7f08
+s390x-GitCommit: a55c7f08428d7d61a6298a6d91b689aa5507e6c1


### PR DESCRIPTION
This reverts commit fa6fd048e3868bd7a8ec8836a02edc4402a8ce5b.

The [launchpad outage](https://status.canonical.com/#/incident/KNms6QK9ewuzz-7xUsPsNylV20jEt5kyKsd8A-3ptQFA0otkSvW4qkoaTFYxOQf6HRLmsHB8m0W-VOVAL1IzTg==) is preventing the `meta` job from calculating "needs build" since it can't fetch the `ubuntu` commits, so this is delaying the Go security update from being published 😢. I'll open another revert once this is in so that we can still get the Ubuntu update once the outage is over.