### PR TITLE
caddy: v2.11.0-beta.2 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,68 +1,68 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/08508564e927b906aa16e561f46468c1b6fb2116/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/f760f9dcc0e12d0729e26c968be313dc59ba584f/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
-Tags: 2.11.0-beta.1-alpine, 2.11-alpine
-SharedTags: 2.11.0-beta.1, 2.11
+Tags: 2.11.0-beta.2-alpine, 2.11-alpine
+SharedTags: 2.11.0-beta.2, 2.11
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/alpine
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.11.0-beta.1-builder-alpine, 2.11-builder-alpine
-SharedTags: 2.11.0-beta.1-builder, 2.11-builder
+Tags: 2.11.0-beta.2-builder-alpine, 2.11-builder-alpine
+SharedTags: 2.11.0-beta.2-builder, 2.11-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/builder
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.11.0-beta.1-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
-SharedTags: 2.11.0-beta.1-windowsservercore, 2.11-windowsservercore, 2.11.0-beta.1, 2.11
+Tags: 2.11.0-beta.2-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
+SharedTags: 2.11.0-beta.2-windowsservercore, 2.11-windowsservercore, 2.11.0-beta.2, 2.11
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows/ltsc2022
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.1-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025
-SharedTags: 2.11.0-beta.1-windowsservercore, 2.11-windowsservercore, 2.11.0-beta.1, 2.11
+Tags: 2.11.0-beta.2-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025
+SharedTags: 2.11.0-beta.2-windowsservercore, 2.11-windowsservercore, 2.11.0-beta.2, 2.11
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows/ltsc2025
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 2.11.0-beta.1-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
-SharedTags: 2.11.0-beta.1-nanoserver, 2.11-nanoserver
+Tags: 2.11.0-beta.2-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
+SharedTags: 2.11.0-beta.2-nanoserver, 2.11-nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2022
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.1-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025
-SharedTags: 2.11.0-beta.1-nanoserver, 2.11-nanoserver
+Tags: 2.11.0-beta.2-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025
+SharedTags: 2.11.0-beta.2-nanoserver, 2.11-nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2025
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 2.11.0-beta.1-builder-windowsservercore-ltsc2022, 2.11-builder-windowsservercore-ltsc2022
-SharedTags: 2.11.0-beta.1-builder, 2.11-builder
+Tags: 2.11.0-beta.2-builder-windowsservercore-ltsc2022, 2.11-builder-windowsservercore-ltsc2022
+SharedTags: 2.11.0-beta.2-builder, 2.11-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2022
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.1-builder-windowsservercore-ltsc2025, 2.11-builder-windowsservercore-ltsc2025
-SharedTags: 2.11.0-beta.1-builder, 2.11-builder
+Tags: 2.11.0-beta.2-builder-windowsservercore-ltsc2025, 2.11-builder-windowsservercore-ltsc2025
+SharedTags: 2.11.0-beta.2-builder, 2.11-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2025
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
@@ -70,21 +70,21 @@ Tags: 2.10.2-alpine, 2.10-alpine, 2-alpine, alpine
 SharedTags: 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/alpine
-GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
 Tags: 2.10.2-builder-alpine, 2.10-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/builder
-GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
+GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
 Tags: 2.10.2-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 SharedTags: 2.10.2-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows/ltsc2022
-GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
+GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
@@ -92,7 +92,7 @@ Tags: 2.10.2-windowsservercore-ltsc2025, 2.10-windowsservercore-ltsc2025, 2-wind
 SharedTags: 2.10.2-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows/ltsc2025
-GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
+GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
@@ -100,7 +100,7 @@ Tags: 2.10.2-nanoserver-ltsc2022, 2.10-nanoserver-ltsc2022, 2-nanoserver-ltsc202
 SharedTags: 2.10.2-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-nanoserver/ltsc2022
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
@@ -108,7 +108,7 @@ Tags: 2.10.2-nanoserver-ltsc2025, 2.10-nanoserver-ltsc2025, 2-nanoserver-ltsc202
 SharedTags: 2.10.2-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-nanoserver/ltsc2025
-GitCommit: 33c593c5bd99287e66de4187a4e9a4097426253d
+GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
@@ -116,7 +116,7 @@ Tags: 2.10.2-builder-windowsservercore-ltsc2022, 2.10-builder-windowsservercore-
 SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-builder/ltsc2022
-GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
+GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
@@ -124,7 +124,7 @@ Tags: 2.10.2-builder-windowsservercore-ltsc2025, 2.10-builder-windowsservercore-
 SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-builder/ltsc2025
-GitCommit: 5572371a83e48fd0368a4917d0fc48e44ef30582
+GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.11.0-beta.2

https://github.com/caddyserver/caddy-docker/pull/435

Normalized all `ENV` to use `=` syntax (quiets warnings)

Adds `curl` to alpine images, primarily as convenience for HEALTHCHECK for end-users