### PR TITLE
Update KrakenD to v2.12.1

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.12.0, 2.12, 2, latest
+Tags: 2.12.1, 2.12, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 30d1716507fbe8fb80c3b19542240ce21ca5a5b2
-Directory: 2.12.0
+GitCommit: cf19ddf7432cae3758c0164f242aaa02da0c7011
+Directory: 2.12.1


### PR DESCRIPTION
Upgraded Go to 1.25.6 addressing several CVEs with disclosed descriptions:

[CVE-2025-61728](https://go.dev/issue/77102) Super-linear filename indexing causes DoS on malicious ZIPs (false positive)
[CVE-2025-61726](https://go.dev/issue/77101) Memory exhaustion from excessive form key-value pairs
[CVE-2025-68121](https://go.dev/issue/77113) Config.Clone leaks session keys; ignores full cert chain expiration
[CVE-2025-61731](https://go.dev/issue/77100) CgoPkgConfig flag bypass leads to arbitrary code execution (false positive)
[CVE-2025-68119](https://go.dev/issue/77099) VCS toolchain misinterpretation enables code exec/file writes (false positive)
[CVE-2025-61727](https://nvd.nist.gov/vuln/detail/CVE-2025-61727) An excluded subdomain constraint in a certificate chain does not restrict the usage of wildcard SANs in the leaf certificate
[CVE-2025-61729](https://nvd.nist.gov/vuln/detail/CVE-2025-61729) Within HostnameError.Error(), when constructing an error string, there is no limit to the number of hosts that will be printed out.

Upgraded the golang.org/x/crypto package to address [CVE-2025-58181](https://nvd.nist.gov/vuln/detail/CVE-2025-58181) and [CVE-2025-47914](https://nvd.nist.gov/vuln/detail/CVE-2025-47914) (false-positives)