### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2026-0719

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6974169a5aa3e2b6256cec9906c91235a20d03a0
+amd64-GitCommit: dd28624cecc4d5e7dd47fc0727d390069326c8b7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a87471d745b4b967a7c407f35ddfb50bfab4856d
+arm64v8-GitCommit: 4be2996c01727176adb35de4eea3c3c899deb51b
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-68973, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0719.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
