### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2026-0728

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: dd28624cecc4d5e7dd47fc0727d390069326c8b7
+amd64-GitCommit: 3361dab3cdccef5900d3c0e6cb2941de1a1b23b7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4be2996c01727176adb35de4eea3c3c899deb51b
+arm64v8-GitCommit: 4a23af397bfdc5fe537f72a96225c6d29125a224
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-68973, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0728.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
