### PR TITLE
archlinux: Release 20260118.0.482696

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260111.0.480139
-GitCommit: 22acdd9c9c7a70f53aed4292aa03b70b4b994ad1
-GitFetch: refs/tags/v20260111.0.480139
+Tags: latest, base, base-20260118.0.482696
+GitCommit: 410fd2c7199dea8dd45f4cc99c0364f1dc501634
+GitFetch: refs/tags/v20260118.0.482696
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260111.0.480139
-GitCommit: 22acdd9c9c7a70f53aed4292aa03b70b4b994ad1
-GitFetch: refs/tags/v20260111.0.480139
+Tags: base-devel, base-devel-20260118.0.482696
+GitCommit: 410fd2c7199dea8dd45f4cc99c0364f1dc501634
+GitFetch: refs/tags/v20260118.0.482696
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260111.0.480139
-GitCommit: 22acdd9c9c7a70f53aed4292aa03b70b4b994ad1
-GitFetch: refs/tags/v20260111.0.480139
+Tags: multilib-devel, multilib-devel-20260118.0.482696
+GitCommit: 410fd2c7199dea8dd45f4cc99c0364f1dc501634
+GitFetch: refs/tags/v20260118.0.482696
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks