### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-0845

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 3361dab3cdccef5900d3c0e6cb2941de1a1b23b7
+amd64-GitCommit: f4e0e15cdbced337be100318ab3d686da538f67b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4a23af397bfdc5fe537f72a96225c6d29125a224
+arm64v8-GitCommit: 46935a3b7ebea36139300afdf601b18452ae7737
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6176, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0845.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
