### PR TITLE
Update for Q1 2026 release

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,176 +15,200 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: 5cf76cde46d4c2293a5d709e1e8630a334cb61c5
+GitCommit: 76af93747cdf98f483faacf3f9805c3d9b117c0f
 
-Tags: 8, 8u472, 8u472-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u472-al2-generic, 8-al2-generic-jdk, latest
+Tags: 8, 8u482, 8u482-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u482-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2-generic
 
-Tags: 8-al2023, 8u472-al2023, 8-al2023-jdk
+Tags: 8-al2023, 8u482-al2023, 8-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2023-jre, 8u472-al2023-jre
+Tags: 8-al2023-jre, 8u482-al2023-jre
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2-native-jre, 8u472-al2-native-jre
+Tags: 8-al2-native-jre, 8u482-al2-native-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2
 
-Tags: 8-al2-native-jdk, 8u472-al2-native-jdk
+Tags: 8-al2-native-jdk, 8u482-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.20, 8u472-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
+Tags: 8-alpine3.20, 8u482-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.20
 
-Tags: 8-alpine3.20-jre, 8u472-alpine3.20-jre
+Tags: 8-alpine3.20-jre, 8u482-alpine3.20-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.20
 
-Tags: 8-alpine3.21, 8u472-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
+Tags: 8-alpine3.21, 8u482-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8-alpine3.21-jre, 8u472-alpine3.21-jre
+Tags: 8-alpine3.21-jre, 8u482-alpine3.21-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.21
 
-Tags: 8-alpine3.22, 8u472-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk, 8-alpine, 8u472-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.22, 8u482-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.22
 
-Tags: 8-alpine3.22-jre, 8u472-alpine3.22-jre, 8-alpine-jre, 8u472-alpine-jre
+Tags: 8-alpine3.22-jre, 8u482-alpine3.22-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.22
 
-Tags: 11, 11.0.29, 11.0.29-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.29-al2-generic, 11-al2-generic-jdk
+Tags: 8-alpine3.23, 8u482-alpine3.23, 8-alpine3.23-full, 8-alpine3.23-jdk, 8-alpine, 8u482-alpine, 8-alpine-full, 8-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 8/jdk/alpine/3.23
+
+Tags: 8-alpine3.23-jre, 8u482-alpine3.23-jre, 8-alpine-jre, 8u482-alpine-jre
+Architectures: amd64, arm64v8
+Directory: 8/jre/alpine/3.23
+
+Tags: 11, 11.0.30, 11.0.30-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.30-al2-generic, 11-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2-generic
 
-Tags: 11-al2023, 11.0.29-al2023, 11-al2023-jdk
+Tags: 11-al2023, 11.0.30-al2023, 11-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2023
 
-Tags: 11-al2023-headless, 11.0.29-al2023-headless
+Tags: 11-al2023-headless, 11.0.30-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2023
 
-Tags: 11-al2023-headful, 11.0.29-al2023-headful
+Tags: 11-al2023-headful, 11.0.30-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 11/headful/al2023
 
-Tags: 11-al2-native-headless, 11.0.29-al2-native-headless
+Tags: 11-al2-native-headless, 11.0.30-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2
 
-Tags: 11-al2-native-jdk, 11.0.29-al2-native-jdk
+Tags: 11-al2-native-jdk, 11.0.30-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.20, 11.0.29-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
+Tags: 11-alpine3.20, 11.0.30-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.20
 
-Tags: 11-alpine3.21, 11.0.29-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
+Tags: 11-alpine3.21, 11.0.30-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.21
 
-Tags: 11-alpine3.22, 11.0.29-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk, 11-alpine, 11.0.29-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine3.22, 11.0.30-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.22
 
-Tags: 17, 17.0.17, 17.0.17-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.17-al2-generic, 17-al2-generic-jdk
+Tags: 11-alpine3.23, 11.0.30-alpine3.23, 11-alpine3.23-full, 11-alpine3.23-jdk, 11-alpine, 11.0.30-alpine, 11-alpine-full, 11-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 11/jdk/alpine/3.23
+
+Tags: 17, 17.0.18, 17.0.18-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.18-al2-generic, 17-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2-generic
 
-Tags: 17-al2023, 17.0.17-al2023, 17-al2023-jdk
+Tags: 17-al2023, 17.0.18-al2023, 17-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2023
 
-Tags: 17-al2023-headless, 17.0.17-al2023-headless
+Tags: 17-al2023-headless, 17.0.18-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2023
 
-Tags: 17-al2023-headful, 17.0.17-al2023-headful
+Tags: 17-al2023-headful, 17.0.18-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2023
 
-Tags: 17-al2-native-headless, 17.0.17-al2-native-headless
+Tags: 17-al2-native-headless, 17.0.18-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2
 
-Tags: 17-al2-native-headful, 17.0.17-al2-native-headful
+Tags: 17-al2-native-headful, 17.0.18-al2-native-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2
 
-Tags: 17-al2-native-jdk, 17.0.17-al2-native-jdk
+Tags: 17-al2-native-jdk, 17.0.18-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.20, 17.0.17-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
+Tags: 17-alpine3.20, 17.0.18-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.20
 
-Tags: 17-alpine3.21, 17.0.17-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
+Tags: 17-alpine3.21, 17.0.18-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.21
 
-Tags: 17-alpine3.22, 17.0.17-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk, 17-alpine, 17.0.17-alpine, 17-alpine-full, 17-alpine-jdk
+Tags: 17-alpine3.22, 17.0.18-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.22
 
-Tags: 21, 21.0.9, 21.0.9-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.9-al2-generic, 21-al2-generic-jdk
+Tags: 17-alpine3.23, 17.0.18-alpine3.23, 17-alpine3.23-full, 17-alpine3.23-jdk, 17-alpine, 17.0.18-alpine, 17-alpine-full, 17-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 17/jdk/alpine/3.23
+
+Tags: 21, 21.0.10, 21.0.10-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.10-al2-generic, 21-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2-generic
 
-Tags: 21-al2023, 21.0.9-al2023, 21-al2023-jdk
+Tags: 21-al2023, 21.0.10-al2023, 21-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2023
 
-Tags: 21-al2023-headless, 21.0.9-al2023-headless
+Tags: 21-al2023-headless, 21.0.10-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 21/headless/al2023
 
-Tags: 21-al2023-headful, 21.0.9-al2023-headful
+Tags: 21-al2023-headful, 21.0.10-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 21/headful/al2023
 
-Tags: 21-alpine3.20, 21.0.9-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
+Tags: 21-alpine3.20, 21.0.10-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.20
 
-Tags: 21-alpine3.21, 21.0.9-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
+Tags: 21-alpine3.21, 21.0.10-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.21
 
-Tags: 21-alpine3.22, 21.0.9-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk, 21-alpine, 21.0.9-alpine, 21-alpine-full, 21-alpine-jdk
+Tags: 21-alpine3.22, 21.0.10-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.22
 
-Tags: 25-al2023, 25.0.1-al2023, 25-al2023-jdk, 25, 25-jdk, 25.0.1
+Tags: 21-alpine3.23, 21.0.10-alpine3.23, 21-alpine3.23-full, 21-alpine3.23-jdk, 21-alpine, 21.0.10-alpine, 21-alpine-full, 21-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 21/jdk/alpine/3.23
+
+Tags: 25-al2023, 25.0.2-al2023, 25-al2023-jdk, 25, 25-jdk, 25.0.2
 Architectures: amd64, arm64v8
 Directory: 25/jdk/al2023
 
-Tags: 25-al2023-headless, 25.0.1-al2023-headless, 25-headless
+Tags: 25-al2023-headless, 25.0.2-al2023-headless, 25-headless
 Architectures: amd64, arm64v8
 Directory: 25/headless/al2023
 
-Tags: 25-al2023-headful, 25.0.1-al2023-headful, 25-headful
+Tags: 25-al2023-headful, 25.0.2-al2023-headful, 25-headful
 Architectures: amd64, arm64v8
 Directory: 25/headful/al2023
 
-Tags: 25-alpine3.20, 25.0.1-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
+Tags: 25-alpine3.20, 25.0.2-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.20
 
-Tags: 25-alpine3.21, 25.0.1-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
+Tags: 25-alpine3.21, 25.0.2-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.21
 
-Tags: 25-alpine3.22, 25.0.1-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk, 25-alpine, 25.0.1-alpine, 25-alpine-full, 25-alpine-jdk
+Tags: 25-alpine3.22, 25.0.2-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.22
+
+Tags: 25-alpine3.23, 25.0.2-alpine3.23, 25-alpine3.23-full, 25-alpine3.23-jdk, 25-alpine, 25.0.2-alpine, 25-alpine-full, 25-alpine-jdk
+Architectures: amd64, arm64v8
+Directory: 25/jdk/alpine/3.23


### PR DESCRIPTION
Update amazoncorretto for 2026 Q1 release. For more details, see the following:

* [corretto/corretto-docker repo](https://github.com/corretto/corretto-docker/commit/a0a76f7752b8f021d4cfda4ee586a1d561ad5d28)
* [corretto/corretto-25 release](https://github.com/corretto/corretto-25/releases/tag/25.0.1.9.1)
* [corretto/corretto-21 release](https://github.com/corretto/corretto-21/releases/tag/21.0.9.11.1)
* [corretto/corretto-17 release](https://github.com/corretto/corretto-17/releases/tag/17.0.18.8.1)
* [corretto/corretto-11 release](https://github.com/corretto/corretto-11/releases/tag/11.0.30.7.1)
* [corretto/corretto-8 release](https://github.com/corretto/corretto-8/releases/tag/8.482.08.1)

This release also adds images for Alpine 3.23 