### PR TITLE
SapMachine Q1/26 updates

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,222 +1,222 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Arno Zeller <sapmachine@sap.com> (@ArnoZeller)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: latest, ubuntu, jdk, jdk-ubuntu, lts, lts-ubuntu, 25, 25-ubuntu, 25.0.1, 25.0.1-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.1-jdk, 25.0.1-jdk-ubuntu, lts-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.1-ubuntu-noble, 25.0.1-ubuntu-24.04, 25.0.1-jdk-ubuntu-noble, 25.0.1-jdk-ubuntu-24.04
+Tags: latest, ubuntu, jdk, jdk-ubuntu, lts, lts-ubuntu, 25, 25-ubuntu, 25.0.2, 25.0.2-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.2-jdk, 25.0.2-jdk-ubuntu, lts-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.2-ubuntu-noble, 25.0.2-ubuntu-24.04, 25.0.2-jdk-ubuntu-noble, 25.0.2-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jdk
 
-Tags: jdk-headless, jdk-headless-ubuntu, 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.1-jdk-headless, 25.0.1-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.1-jdk-headless-ubuntu-noble, 25.0.1-jdk-headless-ubuntu-24.04
+Tags: jdk-headless, jdk-headless-ubuntu, 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.2-jdk-headless, 25.0.2-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.2-jdk-headless-ubuntu-noble, 25.0.2-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jdk-headless
 
-Tags: jre, jre-ubuntu, 25-jre, 25-jre-ubuntu, 25.0.1-jre, 25.0.1-jre-ubuntu, lts-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.1-jre-ubuntu-noble, 25.0.1-jre-ubuntu-24.04
+Tags: jre, jre-ubuntu, 25-jre, 25-jre-ubuntu, 25.0.2-jre, 25.0.2-jre-ubuntu, lts-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.2-jre-ubuntu-noble, 25.0.2-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jre
 
-Tags: jre-headless, jre-headless-ubuntu, 25-jre-headless, 25-jre-headless-ubuntu, 25.0.1-jre-headless, 25.0.1-jre-headless-ubuntu, lts-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.1-jre-headless-ubuntu-noble, 25.0.1-jre-headless-ubuntu-24.04
+Tags: jre-headless, jre-headless-ubuntu, 25-jre-headless, 25-jre-headless-ubuntu, 25.0.2-jre-headless, 25.0.2-jre-headless-ubuntu, lts-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.2-jre-headless-ubuntu-noble, 25.0.2-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jre-headless
 
-Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.1-ubuntu-jammy, 25.0.1-ubuntu-22.04, 25.0.1-jdk-ubuntu-jammy, 25.0.1-jdk-ubuntu-22.04
+Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.2-ubuntu-jammy, 25.0.2-ubuntu-22.04, 25.0.2-jdk-ubuntu-jammy, 25.0.2-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jdk
 
-Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.1-jdk-headless-ubuntu-jammy, 25.0.1-jdk-headless-ubuntu-22.04
+Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.2-jdk-headless-ubuntu-jammy, 25.0.2-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jdk-headless
 
-Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.1-jre-ubuntu-jammy, 25.0.1-jre-ubuntu-22.04
+Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.2-jre-ubuntu-jammy, 25.0.2-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jre
 
-Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.1-jre-headless-ubuntu-jammy, 25.0.1-jre-headless-ubuntu-22.04
+Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.2-jre-headless-ubuntu-jammy, 25.0.2-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jre-headless
 
-Tags: alpine, jdk-alpine, lts-alpine, 25-alpine, 25.0.1-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.1-jdk-alpine, alpine-3.22, jdk-alpine-3.22, lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.1-alpine-3.22, 25.0.1-jdk-alpine-3.22
+Tags: alpine, jdk-alpine, lts-alpine, 25-alpine, 25.0.2-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.2-jdk-alpine, alpine-3.22, jdk-alpine-3.22, lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.2-alpine-3.22, 25.0.2-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_22/jdk
 
-Tags: jre-alpine, lts-jre-alpine, 25-jre-alpine, 25.0.1-jre-alpine, jre-alpine-3.22, lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.1-jre-alpine-3.22
+Tags: jre-alpine, lts-jre-alpine, 25-jre-alpine, 25.0.2-jre-alpine, jre-alpine-3.22, lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.2-jre-alpine-3.22
 Architectures: amd64
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_22/jre
 
-Tags: alpine-3.21, jdk-alpine-3.21, lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.1-alpine-3.21, 25.0.1-jdk-alpine-3.21
+Tags: alpine-3.21, jdk-alpine-3.21, lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.2-alpine-3.21, 25.0.2-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_21/jdk
 
-Tags: jre-alpine-3.21, lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.1-jre-alpine-3.21
+Tags: jre-alpine-3.21, lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.2-jre-alpine-3.21
 Architectures: amd64
-GitCommit: eecb8129379011a0a9eef9cc51095447e36c4fe7
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_21/jre
 
-Tags: 21, 21-ubuntu, 21.0.9, 21.0.9-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.9-jdk, 21.0.9-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.9-ubuntu-noble, 21.0.9-ubuntu-24.04, 21.0.9-jdk-ubuntu-noble, 21.0.9-jdk-ubuntu-24.04
+Tags: 21, 21-ubuntu, 21.0.10, 21.0.10-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.10-jdk, 21.0.10-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.10-ubuntu-noble, 21.0.10-ubuntu-24.04, 21.0.10-jdk-ubuntu-noble, 21.0.10-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/24_04/jdk
 
-Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.9-jdk-headless, 21.0.9-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.9-jdk-headless-ubuntu-noble, 21.0.9-jdk-headless-ubuntu-24.04
+Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.10-jdk-headless, 21.0.10-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.10-jdk-headless-ubuntu-noble, 21.0.10-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
-Tags: 21-jre, 21-jre-ubuntu, 21.0.9-jre, 21.0.9-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.9-jre-ubuntu-noble, 21.0.9-jre-ubuntu-24.04
+Tags: 21-jre, 21-jre-ubuntu, 21.0.10-jre, 21.0.10-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.10-jre-ubuntu-noble, 21.0.10-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/24_04/jre
 
-Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.9-jre-headless, 21.0.9-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.9-jre-headless-ubuntu-noble, 21.0.9-jre-headless-ubuntu-24.04
+Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.10-jre-headless, 21.0.10-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.10-jre-headless-ubuntu-noble, 21.0.10-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
-Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.9-ubuntu-jammy, 21.0.9-ubuntu-22.04, 21.0.9-jdk-ubuntu-jammy, 21.0.9-jdk-ubuntu-22.04
+Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.10-ubuntu-jammy, 21.0.10-ubuntu-22.04, 21.0.10-jdk-ubuntu-jammy, 21.0.10-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/22_04/jdk
 
-Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.9-jdk-headless-ubuntu-jammy, 21.0.9-jdk-headless-ubuntu-22.04
+Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.10-jdk-headless-ubuntu-jammy, 21.0.10-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
 
-Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.9-jre-ubuntu-jammy, 21.0.9-jre-ubuntu-22.04
+Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.10-jre-ubuntu-jammy, 21.0.10-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/22_04/jre
 
-Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.9-jre-headless-ubuntu-jammy, 21.0.9-jre-headless-ubuntu-22.04
+Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.10-jre-headless-ubuntu-jammy, 21.0.10-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
-Tags: 21-alpine, 21.0.9-alpine, 21-jdk-alpine, 21.0.9-jdk-alpine, 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.9-alpine-3.22, 21.0.9-jdk-alpine-3.22
+Tags: 21-alpine, 21.0.10-alpine, 21-jdk-alpine, 21.0.10-jdk-alpine, 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.10-alpine-3.22, 21.0.10-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/alpine/3_22/jdk
 
-Tags: 21-jre-alpine, 21.0.9-jre-alpine, 21-jre-alpine-3.22, 21.0.9-jre-alpine-3.22
+Tags: 21-jre-alpine, 21.0.10-jre-alpine, 21-jre-alpine-3.22, 21.0.10-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/alpine/3_22/jre
 
-Tags: 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.9-alpine-3.21, 21.0.9-jdk-alpine-3.21
+Tags: 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.10-alpine-3.21, 21.0.10-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/alpine/3_21/jdk
 
-Tags: 21-jre-alpine-3.21, 21.0.9-jre-alpine-3.21
+Tags: 21-jre-alpine-3.21, 21.0.10-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 2604e69a438d534e1837e9407354f9a87a4a60e8
+GitCommit: 155e23d8a81f894d100568c4bb86936641eccfb0
 Directory: dockerfiles/21/alpine/3_21/jre
 
-Tags: 17, 17-ubuntu, 17.0.17, 17.0.17-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.17-jdk, 17.0.17-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.17-ubuntu-noble, 17.0.17-ubuntu-24.04, 17.0.17-jdk-ubuntu-noble, 17.0.17-jdk-ubuntu-24.04
+Tags: 17, 17-ubuntu, 17.0.18, 17.0.18-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.18-jdk, 17.0.18-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.18-ubuntu-noble, 17.0.18-ubuntu-24.04, 17.0.18-jdk-ubuntu-noble, 17.0.18-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/24_04/jdk
 
-Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.17-jdk-headless, 17.0.17-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.17-jdk-headless-ubuntu-noble, 17.0.17-jdk-headless-ubuntu-24.04
+Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.18-jdk-headless, 17.0.18-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.18-jdk-headless-ubuntu-noble, 17.0.18-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
-Tags: 17-jre, 17-jre-ubuntu, 17.0.17-jre, 17.0.17-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.17-jre-ubuntu-noble, 17.0.17-jre-ubuntu-24.04
+Tags: 17-jre, 17-jre-ubuntu, 17.0.18-jre, 17.0.18-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.18-jre-ubuntu-noble, 17.0.18-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/24_04/jre
 
-Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.17-jre-headless, 17.0.17-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.17-jre-headless-ubuntu-noble, 17.0.17-jre-headless-ubuntu-24.04
+Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.18-jre-headless, 17.0.18-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.18-jre-headless-ubuntu-noble, 17.0.18-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
-Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.17-ubuntu-jammy, 17.0.17-ubuntu-22.04, 17.0.17-jdk-ubuntu-jammy, 17.0.17-jdk-ubuntu-22.04
+Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.18-ubuntu-jammy, 17.0.18-ubuntu-22.04, 17.0.18-jdk-ubuntu-jammy, 17.0.18-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/22_04/jdk
 
-Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.17-jdk-headless-ubuntu-jammy, 17.0.17-jdk-headless-ubuntu-22.04
+Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.18-jdk-headless-ubuntu-jammy, 17.0.18-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
 
-Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.17-jre-ubuntu-jammy, 17.0.17-jre-ubuntu-22.04
+Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.18-jre-ubuntu-jammy, 17.0.18-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/22_04/jre
 
-Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.17-jre-headless-ubuntu-jammy, 17.0.17-jre-headless-ubuntu-22.04
+Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.18-jre-headless-ubuntu-jammy, 17.0.18-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
-Tags: 17-alpine, 17.0.17-alpine, 17-jdk-alpine, 17.0.17-jdk-alpine, 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.17-alpine-3.22, 17.0.17-jdk-alpine-3.22
+Tags: 17-alpine, 17.0.18-alpine, 17-jdk-alpine, 17.0.18-jdk-alpine, 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.18-alpine-3.22, 17.0.18-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_22/jdk
 
-Tags: 17-jre-alpine, 17.0.17-jre-alpine, 17-jre-alpine-3.22, 17.0.17-jre-alpine-3.22
+Tags: 17-jre-alpine, 17.0.18-jre-alpine, 17-jre-alpine-3.22, 17.0.18-jre-alpine-3.22
 Architectures: amd64
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_22/jre
 
-Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.17-alpine-3.21, 17.0.17-jdk-alpine-3.21
+Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.18-alpine-3.21, 17.0.18-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_21/jdk
 
-Tags: 17-jre-alpine-3.21, 17.0.17-jre-alpine-3.21
+Tags: 17-jre-alpine-3.21, 17.0.18-jre-alpine-3.21
 Architectures: amd64
-GitCommit: c4644bb93c3d247b15c8193ed6c998e9355fbcde
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_21/jre
 
-Tags: 11, 11-ubuntu, 11.0.29, 11.0.29-ubuntu, 11-jdk, 11-jdk-ubuntu, 11.0.29-jdk, 11.0.29-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.29-ubuntu-noble, 11.0.29-ubuntu-24.04, 11.0.29-jdk-ubuntu-noble, 11.0.29-jdk-ubuntu-24.04
+Tags: 11, 11-ubuntu, 11.0.30, 11.0.30-ubuntu, 11-jdk, 11-jdk-ubuntu, 11.0.30-jdk, 11.0.30-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.30-ubuntu-noble, 11.0.30-ubuntu-24.04, 11.0.30-jdk-ubuntu-noble, 11.0.30-jdk-ubuntu-24.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/24_04/jdk
 
-Tags: 11-jdk-headless, 11-jdk-headless-ubuntu, 11.0.29-jdk-headless, 11.0.29-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.29-jdk-headless-ubuntu-noble, 11.0.29-jdk-headless-ubuntu-24.04
+Tags: 11-jdk-headless, 11-jdk-headless-ubuntu, 11.0.30-jdk-headless, 11.0.30-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.30-jdk-headless-ubuntu-noble, 11.0.30-jdk-headless-ubuntu-24.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/24_04/jdk-headless
 
-Tags: 11-jre, 11-jre-ubuntu, 11.0.29-jre, 11.0.29-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.29-jre-ubuntu-noble, 11.0.29-jre-ubuntu-24.04
+Tags: 11-jre, 11-jre-ubuntu, 11.0.30-jre, 11.0.30-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.30-jre-ubuntu-noble, 11.0.30-jre-ubuntu-24.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/24_04/jre
 
-Tags: 11-jre-headless, 11-jre-headless-ubuntu, 11.0.29-jre-headless, 11.0.29-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.29-jre-headless-ubuntu-noble, 11.0.29-jre-headless-ubuntu-24.04
+Tags: 11-jre-headless, 11-jre-headless-ubuntu, 11.0.30-jre-headless, 11.0.30-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.30-jre-headless-ubuntu-noble, 11.0.30-jre-headless-ubuntu-24.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/24_04/jre-headless
 
-Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.29-ubuntu-jammy, 11.0.29-ubuntu-22.04, 11.0.29-jdk-ubuntu-jammy, 11.0.29-jdk-ubuntu-22.04
+Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.30-ubuntu-jammy, 11.0.30-ubuntu-22.04, 11.0.30-jdk-ubuntu-jammy, 11.0.30-jdk-ubuntu-22.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/22_04/jdk
 
-Tags: 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.29-jdk-headless-ubuntu-jammy, 11.0.29-jdk-headless-ubuntu-22.04
+Tags: 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.30-jdk-headless-ubuntu-jammy, 11.0.30-jdk-headless-ubuntu-22.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/22_04/jdk-headless
 
-Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.29-jre-ubuntu-jammy, 11.0.29-jre-ubuntu-22.04
+Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.30-jre-ubuntu-jammy, 11.0.30-jre-ubuntu-22.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/22_04/jre
 
-Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.29-jre-headless-ubuntu-jammy, 11.0.29-jre-headless-ubuntu-22.04
+Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.30-jre-headless-ubuntu-jammy, 11.0.30-jre-headless-ubuntu-22.04
 Architectures: amd64
-GitCommit: e4d018e5f421f7de356040c75eba68a3de98a175
+GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
 Directory: dockerfiles/11/ubuntu/22_04/jre-headless


### PR DESCRIPTION
This updates SapMachine base images with the January JDK updates.