### PR TITLE
varnish: use prebuilt packages

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,33 +1,33 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/351d45e8503d1345369fb3beb43d8dac4383757c/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/9d19c601591be47c263b2390b1ac1701b6065f55/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 8.0.0, 8, 8.0, latest
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8
 Directory: fresh/debian
-GitCommit: 68b666606150f9aa637a23d4358906eb6a409252
+GitCommit: 8bac2b1f964998f3867aa5e338fedf25a5b9ff1c
 GitFetch: refs/heads/main
 
 Tags: fresh-alpine, 8.0.0-alpine, 8-alpine, 8.0-alpine, alpine
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8
 Directory: fresh/alpine
-GitCommit: 68b666606150f9aa637a23d4358906eb6a409252
+GitCommit: 9d19c601591be47c263b2390b1ac1701b6065f55
 GitFetch: refs/heads/main
 
 Tags: old, 7.7.3, 7.7
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8
 Directory: old/debian
-GitCommit: 68b666606150f9aa637a23d4358906eb6a409252
+GitCommit: b341feabd8feeafaa2d25d35fdf44eb27a2eaaa1
 GitFetch: refs/heads/main
 
 Tags: old-alpine, 7.7.3-alpine, 7.7-alpine
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8
 Directory: old/alpine
 GitCommit: 68b666606150f9aa637a23d4358906eb6a409252
 GitFetch: refs/heads/main
 
 Tags: stable, 6.0.16, 6.0
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm64v8
 Directory: stable/debian
 GitCommit: d41acec41c1251d0b512023abc7fd9cfd4a1490f
 GitFetch: refs/heads/main


### PR DESCRIPTION
following the discussion in #20653 (thanks again for the prompt advice!) this PR pivots the `fresh` `debian` image to use https://varnish.org/docs/install-guide/install-debian-ubuntu/ (built using https://github.com/varnish/all-packager)