### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,26 +4,26 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 9.5.0, 9.5, 9, innovation, latest, 9.5.0-oraclelinux9, 9.5-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.5.0-oracle, 9.5-oracle, 9-oracle, innovation-oracle, oracle
+Tags: 9.6.0, 9.6, 9, innovation, latest, 9.6.0-oraclelinux9, 9.6-oraclelinux9, 9-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 9.6.0-oracle, 9.6-oracle, 9-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 70c7d9777ced9f553109306404fe3c8700b3e9f7
+GitCommit: f8c2facfccdc3c8b8b2c9b5a6aec31db3115105b
 Directory: innovation
 File: Dockerfile.oracle
 
-Tags: 8.4.7, 8.4, 8, lts, 8.4.7-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.7-oracle, 8.4-oracle, 8-oracle, lts-oracle
+Tags: 8.4.8, 8.4, 8, lts, 8.4.8-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, lts-oraclelinux9, 8.4.8-oracle, 8.4-oracle, 8-oracle, lts-oracle
 Architectures: amd64, arm64v8
-GitCommit: ddb031e406121b1a298563775d521c044452a508
+GitCommit: 9dc8e79d60e4b10f30eb040ebd2d6c0f63b737bd
 Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.44, 8.0, 8.0.44-oraclelinux9, 8.0-oraclelinux9, 8.0.44-oracle, 8.0-oracle
+Tags: 8.0.45, 8.0, 8.0.45-oraclelinux9, 8.0-oraclelinux9, 8.0.45-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: ca7d66e7cb817097f7b3aec9497ba1ffcce230e7
+GitCommit: 7a8f81aad11e871baf1dbc755dbff1652e13cba5
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.44-bookworm, 8.0-bookworm, 8.0.44-debian, 8.0-debian
+Tags: 8.0.45-bookworm, 8.0-bookworm, 8.0.45-debian, 8.0-debian
 Architectures: amd64
-GitCommit: ca7d66e7cb817097f7b3aec9497ba1ffcce230e7
+GitCommit: 7a8f81aad11e871baf1dbc755dbff1652e13cba5
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/f8c2fac: Update innovation to 9.6.0, oracle 9.6.0-1.el9, mysql-shell 9.6.0-1.el9
- https://github.com/docker-library/mysql/commit/9dc8e79: Update 8.4 to 8.4.8, oracle 8.4.8-1.el9, mysql-shell 8.4.8-1.el9
- https://github.com/docker-library/mysql/commit/7a8f81a: Update 8.0 to 8.0.45, debian 8.0.45-1debian12, oracle 8.0.45-1.el9, mysql-shell 8.0.45-1.el9
- https://github.com/docker-library/mysql/commit/4b1eb60: update mysql key comment with new expiration