### PR TITLE
rust: Update Rust to version 1.93.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,53 +5,53 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.92-bullseye, 1.92.0-bullseye, bullseye
+Tags: 1-bullseye, 1.93-bullseye, 1.93.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.92-slim-bullseye, 1.92.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.93-slim-bullseye, 1.93.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.92-bookworm, 1.92.0-bookworm, bookworm
+Tags: 1-bookworm, 1.93-bookworm, 1.93.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.92-slim-bookworm, 1.92.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.93-slim-bookworm, 1.93.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.92-trixie, 1.92.0-trixie, trixie, 1, 1.92, 1.92.0, latest
+Tags: 1-trixie, 1.93-trixie, 1.93.0-trixie, trixie, 1, 1.93, 1.93.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.92-slim-trixie, 1.92.0-slim-trixie, slim-trixie, 1-slim, 1.92-slim, 1.92.0-slim, slim
+Tags: 1-slim-trixie, 1.93-slim-trixie, 1.93.0-slim-trixie, slim-trixie, 1-slim, 1.93-slim, 1.93.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.20, 1.92-alpine3.20, 1.92.0-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.93-alpine3.20, 1.93.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.92-alpine3.21, 1.92.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.93-alpine3.21, 1.93.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.92-alpine3.22, 1.92.0-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.93-alpine3.22, 1.93.0-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.92-alpine3.23, 1.92.0-alpine3.23, alpine3.23, 1-alpine, 1.92-alpine, 1.92.0-alpine, alpine
+Tags: 1-alpine3.23, 1.93-alpine3.23, 1.93.0-alpine3.23, alpine3.23, 1-alpine, 1.93-alpine, 1.93.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: c2c1f6504026242abc852c0ac82b3c30b4770dc5
+GitCommit: 37d9b1d21b5332c4ca4013bb492e18f68971594c
 Directory: stable/alpine3.23
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.93.0
https://blog.rust-lang.org/2026/01/22/Rust-1.93.0/