### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev2, 3.4-dev, 3.4-dev2-trixie, 3.4-dev-trixie
+Tags: 3.4-dev3, 3.4-dev, 3.4-dev3-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 5b0117afe7ed3b1d9dd578a112295f1d32ce024e
 Directory: 3.4
 
-Tags: 3.4-dev2-alpine, 3.4-dev-alpine, 3.4-dev2-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev3-alpine, 3.4-dev-alpine, 3.4-dev3-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 5b0117afe7ed3b1d9dd578a112295f1d32ce024e
 Directory: 3.4/alpine
 
 Tags: 3.3.1, 3.3, latest, 3.3.1-trixie, 3.3-trixie, trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/5b0117a: Update 3.4 to 3.4-dev3