### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2026-0936

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f4e0e15cdbced337be100318ab3d686da538f67b
+amd64-GitCommit: bc5498f5fc5e532f70a95bc41ef9db45f760c52f
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 46935a3b7ebea36139300afdf601b18452ae7737
+arm64v8-GitCommit: 69e3815369d3a572298ce2875789c5072fb8817e
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-13601, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0936.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
