### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/8e274c06ead9b88b43eb33dc2eb8d62d7d3e9a68/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/8d1c3f17a946e665fbed3f9434e120cf3bc7e19a/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 8e274c06ead9b88b43eb33dc2eb8d62d7d3e9a68
+GitCommit: 8d1c3f17a946e665fbed3f9434e120cf3bc7e19a
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: cf5073498e5dd419f77f0a6af431fcec847de048
+amd64-GitCommit: 133b79514ae3130e3e62d8188b0fb5f55c0577e1
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 36426ad7ac2f3d5c807cef900d8dbee0e29ba477
+arm32v5-GitCommit: 18438d06691ea289dcce9deb330dc62c26c86935
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 82fd84f9ed404a63494a1e08f812885c5ef051db
+arm32v6-GitCommit: 9930e7a175886de1ffe71a18cae2387c5d68a39a
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: e36bb53e58b98ea14b6974c374f7a25c45215c72
+arm32v7-GitCommit: 684432628497342afb7e32292def246d36756f6e
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f9967ecdd4c9957e38cac7a1327949b262c593b7
+arm64v8-GitCommit: fcf763f5ddcd24c22080bfdc72bbc1494d3bc659
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 81727bf17c1db6d3bf38dd853028cad04380c1d7
+i386-GitCommit: c53a8a8458514c08c4d61449c9d7b10edc522461
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 782c2e1ec06596179dcfaeb54c5b98dae706b398
+ppc64le-GitCommit: 7b525dbf2c016f2bb0cbd9b2861df449da5aa80f
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 7075be67a8b05f6d4fd03c0662f7653ebcdd8dd6
+riscv64-GitCommit: e874bcccff531e887471b07c6ac0661ac8c22ad6
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 12a7475c2080084ba5091bddfe227a896859ef41
+s390x-GitCommit: effd5670a13892b667e45216f77908a2b97fbe63
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/8d1c3f1: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/cb72672: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/34ebfb9: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/0295a05: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/b4ea197: Merge pull request https://github.com/docker-library/busybox/pull/242 from infosiftr/buildroot-2025.11.1
- https://github.com/docker-library/busybox/commit/71615db: Update metadata for amd64 and i386
- https://github.com/docker-library/busybox/commit/81d2cd6: Update buildroot to 2025.11.1