### PR TITLE
[oraclelinux] Updating 10and 10-slim for ELSA-2026-0975

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: bc5498f5fc5e532f70a95bc41ef9db45f760c52f
+amd64-GitCommit: d725ba4af669c89753c730d3b7b614961c3e5e3e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 69e3815369d3a572298ce2875789c5072fb8817e
+arm64v8-GitCommit: a239234253c96a97c00264799d2832811333e0d7
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-13601, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0975.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
