### PR TITLE
archlinux: Release 20260125.0.484595

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260118.0.482696
-GitCommit: 410fd2c7199dea8dd45f4cc99c0364f1dc501634
-GitFetch: refs/tags/v20260118.0.482696
+Tags: latest, base, base-20260125.0.484595
+GitCommit: f801885236de93f7a321dabc4ccbd9d92b0d990e
+GitFetch: refs/tags/v20260125.0.484595
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260118.0.482696
-GitCommit: 410fd2c7199dea8dd45f4cc99c0364f1dc501634
-GitFetch: refs/tags/v20260118.0.482696
+Tags: base-devel, base-devel-20260125.0.484595
+GitCommit: f801885236de93f7a321dabc4ccbd9d92b0d990e
+GitFetch: refs/tags/v20260125.0.484595
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260118.0.482696
-GitCommit: 410fd2c7199dea8dd45f4cc99c0364f1dc501634
-GitFetch: refs/tags/v20260118.0.482696
+Tags: multilib-devel, multilib-devel-20260125.0.484595
+GitCommit: f801885236de93f7a321dabc4ccbd9d92b0d990e
+GitFetch: refs/tags/v20260125.0.484595
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks