### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2026-0991

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d725ba4af669c89753c730d3b7b614961c3e5e3e
+amd64-GitCommit: 19f4185ed0f644649c4a49ed7c38471df2f34457
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a239234253c96a97c00264799d2832811333e0d7
+arm64v8-GitCommit: f0045dd1125f9380cd9020c67f0429ff9a0aecb0
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-13601, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-0991.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
