### PR TITLE
Release SonarQube Server 2026.1.0

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -5,22 +5,22 @@ Builder: buildkit
 
 Tags: 2026.1.0-developer, 2026.1-developer, developer, 2026-lta-developer
 Directory: commercial-editions/developer
-GitCommit: 3e2728fcf20f2f5420cdb87104bb557650b0d3ba
+GitCommit: a067605a9abfd0b56a9e19a63cc2636d5cd7a4e5
 GitFetch: refs/heads/master
 
 Tags: 2026.1.0-enterprise, 2026.1-enterprise, enterprise, 2026-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 3e2728fcf20f2f5420cdb87104bb557650b0d3ba
+GitCommit: a067605a9abfd0b56a9e19a63cc2636d5cd7a4e5
 GitFetch: refs/heads/master
 
 Tags: 2026.1.0-datacenter-app, 2026.1-datacenter-app, datacenter-app, 2026-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 3e2728fcf20f2f5420cdb87104bb557650b0d3ba
+GitCommit: a067605a9abfd0b56a9e19a63cc2636d5cd7a4e5
 GitFetch: refs/heads/master
 
 Tags: 2026.1.0-datacenter-search, 2026.1-datacenter-search, datacenter-search, 2026-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 3e2728fcf20f2f5420cdb87104bb557650b0d3ba
+GitCommit: a067605a9abfd0b56a9e19a63cc2636d5cd7a4e5
 GitFetch: refs/heads/master
 
 Tags: 2025.4.4-developer, 2025.4-developer, 2025.4-lta-developer
@@ -65,5 +65,5 @@ GitFetch: refs/heads/release/2025.1
 
 Tags: 26.1.0.118079-community, community, latest
 Directory: community-build
-GitCommit: 3e2728fcf20f2f5420cdb87104bb557650b0d3ba
+GitCommit: a067605a9abfd0b56a9e19a63cc2636d5cd7a4e5
 GitFetch: refs/heads/master


### PR DESCRIPTION
Dear team,

we would like to release new version of SonarQube Server: 2026.1.0

p.s.
We did also open [a related PR](https://github.com/docker-library/docs/pull/2650) on the `docker-library/docs` repo.