### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,19 +11,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.10.20260105.0
+Tags: 2023, latest, 2023.10.20260120.4
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 04deb3726fb51cc796dbc6c41247508c9374aafb
+amd64-GitCommit: b3a3595d1f91b22ce0d4b1e692ef2c47b8da169b
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: c391f5983d10c0cde6061bdb7f81d6edf425177e
+arm64v8-GitCommit: 27da45c3a2173b8a8e874dd2a3c8eda1ef1e9862
 
-Tags: 2, 2.0.20260109.1
+Tags: 2, 2.0.20260120.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 25a6475c4c396055267d70a4c4e1803631d1397e
+amd64-GitCommit: a549fc51871af52363c5edb742aee092b7f497ab
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 16aeeb3daee4a726a2f25d805a6d5b4849c1aba5
+arm64v8-GitCommit: dbbd95e97b9bddd39b7899a3d3d97afe544c7456
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- python-libs-2.7.18-1.amzn2.0.15
- gnupg2-2.0.22-5.amzn2.0.6
- tzdata-2025c-1.amzn2.0.1
- libxml2-2.9.1-6.amzn2.5.21
- python-2.7.18-1.amzn2.0.15
#### Packages addressing CVES:
- python-libs-2.7.18-1.amzn2.0.15, python-2.7.18-1.amzn2.0.15
  - [CVE-2025-12084](https://alas.aws.amazon.com/cve/html/CVE-2025-12084.html)
- gnupg2-2.0.22-5.amzn2.0.6
  - [CVE-2025-68973](https://alas.aws.amazon.com/cve/html/CVE-2025-68973.html)
- libxml2-2.9.1-6.amzn2.5.21
  - [CVE-2025-8732](https://alas.aws.amazon.com/cve/html/CVE-2025-8732.html)

### Updated Packages for Amazon Linux 2023:
- libxml2-2.10.4-1.amzn2023.0.15
- gnupg2-minimal-2.3.7-1.amzn2023.0.6
- tzdata-2025c-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.10.20260120-0.amzn2023
- system-release-2023.10.20260120-0.amzn2023
- python3-pip-wheel-21.3.1-2.amzn2023.0.15
#### Packages addressing CVES:
- libxml2-2.10.4-1.amzn2023.0.15
  - [CVE-2025-8732](https://alas.aws.amazon.com/cve/html/CVE-2025-8732.html)
- python3-pip-wheel-21.3.1-2.amzn2023.0.15
  - [CVE-2025-66418](https://alas.aws.amazon.com/cve/html/CVE-2025-66418.html)
  - [CVE-2025-66471](https://alas.aws.amazon.com/cve/html/CVE-2025-66471.html)