### PR TITLE
[security] Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.2.3, 4.2, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: f05d64ebe56152b204e2c0179a225b84cbe9cd66
+GitCommit: a84af41e33e961626ff54497a10a8995a0c7323b
 Directory: 4.2/ubuntu
 
 Tags: 4.2.3-management, 4.2-management, 4-management, management
@@ -17,7 +17,7 @@ Directory: 4.2/ubuntu/management
 
 Tags: 4.2.3-alpine, 4.2-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f05d64ebe56152b204e2c0179a225b84cbe9cd66
+GitCommit: a84af41e33e961626ff54497a10a8995a0c7323b
 Directory: 4.2/alpine
 
 Tags: 4.2.3-management-alpine, 4.2-management-alpine, 4-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 4.2/alpine/management
 
 Tags: 4.1.8, 4.1
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 7c79aeee0bb93c5208c68ba676b0b26f89c94e3e
+GitCommit: f98c1de3298c18db684d37a9bb30595cea7de644
 Directory: 4.1/ubuntu
 
 Tags: 4.1.8-management, 4.1-management
@@ -37,7 +37,7 @@ Directory: 4.1/ubuntu/management
 
 Tags: 4.1.8-alpine, 4.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7c79aeee0bb93c5208c68ba676b0b26f89c94e3e
+GitCommit: f98c1de3298c18db684d37a9bb30595cea7de644
 Directory: 4.1/alpine
 
 Tags: 4.1.8-management-alpine, 4.1-management-alpine
@@ -47,7 +47,7 @@ Directory: 4.1/alpine/management
 
 Tags: 4.0.9, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: dac149a9a18d6db92160052dc25026071ccaaaed
+GitCommit: 022313824f2bdf21427f3885949b8570ec7d7dc9
 Directory: 4.0/ubuntu
 
 Tags: 4.0.9-management, 4.0-management
@@ -57,7 +57,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.9-alpine, 4.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f5aa704ed471c25717c83ac89567431ee3adb641
+GitCommit: 022313824f2bdf21427f3885949b8570ec7d7dc9
 Directory: 4.0/alpine
 
 Tags: 4.0.9-management-alpine, 4.0-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/a84af41: Update 4.2 to openssl 3.5.5
- https://github.com/docker-library/rabbitmq/commit/f98c1de: Update 4.1 to openssl 3.5.5
- https://github.com/docker-library/rabbitmq/commit/0223138: Update 4.0 to openssl 3.5.5

https://github.com/openssl/openssl/releases/tag/openssl-3.5.5
> OpenSSL 3.5.5 is a security patch release. The most severe CVE fixed in this release is High.