### PR TITLE
alpine: fix 27th January 2026 OpenSSL vulnerabilties

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -1,10 +1,10 @@
 Maintainers: Natanael Copa <ncopa@alpinelinux.org> (@ncopa)
 GitRepo: https://github.com/alpinelinux/docker-alpine.git
 
-Tags: 20251224, edge
+Tags: 20260127, edge
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/edge
-GitCommit: aa1ddf2a246026931bf1031a58f8f7a5d197d1f1
+GitCommit: c5f299db02fde44c146488e2161773e1daebe581
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.23.2, 3.23, 3, latest
+Tags: 3.23.3, 3.23, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.23
-GitCommit: 13b62f5f47ffa526f9c372e0bd73b33ef2a5f865
+GitCommit: a037d70ba44f91b00dff940019d29a28f7ba1265
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -27,10 +27,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.22.2, 3.22
+Tags: 3.22.3, 3.22
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.22
-GitCommit: 4dc13cbc7caffe03c98aa99f28e27c2fb6f7e74d
+GitCommit: c65c121d664a527ec65e1fa4cecc9063fff656da
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -40,10 +40,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.21.5, 3.21
+Tags: 3.21.6, 3.21
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.21
-GitCommit: 2c30d5daeebb5090b1b6363a9e97dd88bf08a642
+GitCommit: d9ff52957b2fe5361ffeb5d871db8c321e5605d8
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -53,10 +53,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.20.8, 3.20
+Tags: 3.20.9, 3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.20
-GitCommit: f5ce8f036ef8a57481ae6f3f1cf7f2300cff8d29
+GitCommit: b3f87708e5052e29737a251b2e9865e182dafe0c
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -65,4 +65,3 @@ riscv64-Directory: riscv64/
 s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
-


### PR DESCRIPTION
- CVE-2025-11187
- CVE-2025-15467
- CVE-2025-15468
- CVE-2025-15469
- CVE-2025-66199
- CVE-2025-68160
- CVE-2025-69418
- CVE-2025-69419
- CVE-2025-69420
- CVE-2025-69421
- CVE-2026-22795
- CVE-2026-22796

https://alpinelinux.org/posts/Alpine-3.20.9-3.21.6-3.22.3-3.23.3-released.html
https://openssl-library.org/news/secadv/20260127.txt
