### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-1334

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 7b070eae4793dcf51a3f98413a42974a907c428b
+amd64-GitCommit: 4862cdf6a44e1f0a73c50c974dcff9ae69107a31
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8892846c83f6a33e87f27009a4459dd7cbfbc000
+arm64v8-GitCommit: aa6353f90442fc1fe81c8173d9096d586535d263
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for , CVE-2026-0861, CVE-2026-0915, none, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-1334.html
https://linux.oracle.com/errata/ELSA-2026-1334.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
