### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 5b0117afe7ed3b1d9dd578a112295f1d32ce024e
 Directory: 3.4/alpine
 
-Tags: 3.3.1, 3.3, latest, 3.3.1-trixie, 3.3-trixie, trixie
+Tags: 3.3.2, 3.3, latest, 3.3.2-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 23e56698c0d6c1bdbadee439911e706d56d19856
 Directory: 3.3
 
-Tags: 3.3.1-alpine, 3.3-alpine, alpine, 3.3.1-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.2-alpine, 3.3-alpine, alpine, 3.3.2-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 23e56698c0d6c1bdbadee439911e706d56d19856
 Directory: 3.3/alpine
 
-Tags: 3.2.10, 3.2, lts, 3.2.10-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.11, 3.2, lts, 3.2.11-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 6c0a780e41aad7705535e3cc79e41c30e3c2ebfc
 Directory: 3.2
 
-Tags: 3.2.10-alpine, 3.2-alpine, lts-alpine, 3.2.10-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.11-alpine, 3.2-alpine, lts-alpine, 3.2.11-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 6c0a780e41aad7705535e3cc79e41c30e3c2ebfc
 Directory: 3.2/alpine
 
-Tags: 3.1.12, 3.1, 3.1.12-trixie, 3.1-trixie
+Tags: 3.1.13, 3.1, 3.1.13-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: f3d75b9335ea849791b318d49b529ada1c0e3fc1
 Directory: 3.1
 
-Tags: 3.1.12-alpine, 3.1-alpine, 3.1.12-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.13-alpine, 3.1-alpine, 3.1.13-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: f3d75b9335ea849791b318d49b529ada1c0e3fc1
 Directory: 3.1/alpine
 
-Tags: 3.0.14, 3.0, 3.0.14-trixie, 3.0-trixie
+Tags: 3.0.15, 3.0, 3.0.15-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 61e9c67a3c5e624b84fbbfe99ab516f08ab12e6f
 Directory: 3.0
 
-Tags: 3.0.14-alpine, 3.0-alpine, 3.0.14-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.15-alpine, 3.0-alpine, 3.0.15-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 61e9c67a3c5e624b84fbbfe99ab516f08ab12e6f
 Directory: 3.0/alpine
 
 Tags: 2.8.18, 2.8, 2.8.18-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/23e5669: Update 3.3 to 3.3.2
- https://github.com/docker-library/haproxy/commit/6c0a780: Update 3.2 to 3.2.11
- https://github.com/docker-library/haproxy/commit/f3d75b9: Update 3.1 to 3.1.13
- https://github.com/docker-library/haproxy/commit/61e9c67: Update 3.0 to 3.0.15