### PR TITLE
eclipse-mosquitto 2.1.0

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,9 +1,12 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
-GitRepo: https://github.com/eclipse/mosquitto.git
-GitCommit: ff1187fd9c74ae3a7ba0097e7933828bdcdbce71
+GitRepo: https://github.com/eclipse-mosquitto/mosquitto.git
+GitCommit: bc1cbf5d81e6bd7e8eafca0d75a893165f43782b
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 2.0.22, 2.0.22-openssl, 2.0, 2.0-openssl, 2, 2-openssl, openssl, latest
+Tags: 2.1.0-alpine, 2.1-alpine, alpine, latest
+Directory: docker/2.1-alpine
+
+Tags: 2.0.22, 2.0.22-openssl, 2.0, 2.0-openssl, 2, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
 Tags: 1.6.15-openssl, 1.6-openssl


### PR DESCRIPTION
It's intentional not to have moved the `2` tag yet.