### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-1472

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4862cdf6a44e1f0a73c50c974dcff9ae69107a31
+amd64-GitCommit: d3c14afb47b82ec8d12923c0b028edf22bc89510
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: aa6353f90442fc1fe81c8173d9096d586535d263
+arm64v8-GitCommit: bd8ae700632002207af5c63b3fabce022348bcaf
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-11187, CVE-2025-15467, CVE-2025-15468, CVE-2025-15469, CVE-2025-66199, CVE-2025-68160, CVE-2025-69418, CVE-2025-69419, CVE-2025-69420, CVE-2025-69421, CVE-2026-22795, CVE-2026-22796, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-1472.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
