### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2026-1473 ELSA-2026-1478

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: d3c14afb47b82ec8d12923c0b028edf22bc89510
+amd64-GitCommit: 0cc9cdc4920310f78c300d0ecd7405238511d782
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: bd8ae700632002207af5c63b3fabce022348bcaf
+arm64v8-GitCommit: cc9b04bd374e862191c5576589aae69fa2291b87
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-11187, CVE-2025-15467, CVE-2025-15468, CVE-2025-15469, CVE-2025-66199, CVE-2025-68160, CVE-2025-69418, CVE-2025-69419, CVE-2025-69420, CVE-2025-69421, CVE-2026-22795, CVE-2026-22796, CVE-2025-12084, 

See the following for details:

https://linux.oracle.com/errata/ELSA-2026-1473.html
https://linux.oracle.com/errata/ELSA-2026-1478.html

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
