### PR TITLE
archlinux: Release 20260201.0.486523

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260125.0.484595
-GitCommit: f801885236de93f7a321dabc4ccbd9d92b0d990e
-GitFetch: refs/tags/v20260125.0.484595
+Tags: latest, base, base-20260201.0.486523
+GitCommit: bb850073419409b8f9065ed7b92dcff907442c15
+GitFetch: refs/tags/v20260201.0.486523
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260125.0.484595
-GitCommit: f801885236de93f7a321dabc4ccbd9d92b0d990e
-GitFetch: refs/tags/v20260125.0.484595
+Tags: base-devel, base-devel-20260201.0.486523
+GitCommit: bb850073419409b8f9065ed7b92dcff907442c15
+GitFetch: refs/tags/v20260201.0.486523
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260125.0.484595
-GitCommit: f801885236de93f7a321dabc4ccbd9d92b0d990e
-GitFetch: refs/tags/v20260125.0.484595
+Tags: multilib-devel, multilib-devel-20260201.0.486523
+GitCommit: bb850073419409b8f9065ed7b92dcff907442c15
+GitFetch: refs/tags/v20260201.0.486523
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks