### PR TITLE
Update Jetty to 12.0.32 & 12.1.6, and remove EOL versions

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -4,442 +4,147 @@ Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 9.4.58-jre8-alpine, 9.4-jre8-alpine, 9-jre8-alpine, 9.4.58-jre8-alpine-eclipse-temurin, 9.4-jre8-alpine-eclipse-temurin, 9-jre8-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jre8-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre8, 9.4-jre8, 9-jre8, 9.4.58-jre8-eclipse-temurin, 9.4-jre8-eclipse-temurin, 9-jre8-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jre8
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre21-alpine, 9.4-jre21-alpine, 9-jre21-alpine, 9.4.58-jre21-alpine-eclipse-temurin, 9.4-jre21-alpine-eclipse-temurin, 9-jre21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jre21-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre21, 9.4-jre21, 9-jre21, 9.4.58-jre21-eclipse-temurin, 9.4-jre21-eclipse-temurin, 9-jre21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jre21
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre17-alpine, 9.4-jre17-alpine, 9-jre17-alpine, 9.4.58-jre17-alpine-eclipse-temurin, 9.4-jre17-alpine-eclipse-temurin, 9-jre17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jre17-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre17, 9.4-jre17, 9-jre17, 9.4.58-jre17-eclipse-temurin, 9.4-jre17-eclipse-temurin, 9-jre17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jre17
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre11-alpine, 9.4-jre11-alpine, 9-jre11-alpine, 9.4.58-jre11-alpine-eclipse-temurin, 9.4-jre11-alpine-eclipse-temurin, 9-jre11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jre11-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jre11, 9.4-jre11, 9-jre11, 9.4.58-jre11-eclipse-temurin, 9.4-jre11-eclipse-temurin, 9-jre11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jre11
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk8, 9.4-jdk8, 9-jdk8, 9.4.58-jdk8-eclipse-temurin, 9.4-jdk8-eclipse-temurin, 9-jdk8-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jdk8
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk21-alpine, 9.4-jdk21-alpine, 9-jdk21-alpine, 9.4.58-jdk21-alpine-eclipse-temurin, 9.4-jdk21-alpine-eclipse-temurin, 9-jdk21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jdk21-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58, 9.4, 9, 9.4.58-jdk21, 9.4-jdk21, 9-jdk21, 9.4.58-eclipse-temurin, 9.4-eclipse-temurin, 9-eclipse-temurin, 9.4.58-jdk21-eclipse-temurin, 9.4-jdk21-eclipse-temurin, 9-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jdk21
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk17-alpine, 9.4-jdk17-alpine, 9-jdk17-alpine, 9.4.58-jdk17-alpine-eclipse-temurin, 9.4-jdk17-alpine-eclipse-temurin, 9-jdk17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jdk17-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk17, 9.4-jdk17, 9-jdk17, 9.4.58-jdk17-eclipse-temurin, 9.4-jdk17-eclipse-temurin, 9-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jdk17
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk11-alpine, 9.4-jdk11-alpine, 9-jdk11-alpine, 9.4.58-jdk11-alpine-eclipse-temurin, 9.4-jdk11-alpine-eclipse-temurin, 9-jdk11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/9.4/jdk11-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk11, 9.4-jdk11, 9-jdk11, 9.4.58-jdk11-eclipse-temurin, 9.4-jdk11-eclipse-temurin, 9-jdk11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/9.4/jdk11
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 12.1.5-jdk25-alpine, 12.1-jdk25-alpine, 12-jdk25-alpine, 12.1.5-jdk25-alpine-eclipse-temurin, 12.1-jdk25-alpine-eclipse-temurin, 12-jdk25-alpine-eclipse-temurin
+Tags: 12.1.6-jdk25-alpine, 12.1-jdk25-alpine, 12-jdk25-alpine, 12.1.6-jdk25-alpine-eclipse-temurin, 12.1-jdk25-alpine-eclipse-temurin, 12-jdk25-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk25-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk25, 12.1-jdk25, 12-jdk25, 12.1.5-jdk25-eclipse-temurin, 12.1-jdk25-eclipse-temurin, 12-jdk25-eclipse-temurin
+Tags: 12.1.6, 12.1, 12, 12.1.6-jdk25, 12.1-jdk25, 12-jdk25, 12.1.6-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.6-jdk25-eclipse-temurin, 12.1-jdk25-eclipse-temurin, 12-jdk25-eclipse-temurin, latest, jdk25
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk25
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.5-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.1.6-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.6-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk21-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5, 12.1, 12, 12.1.5-jdk21, 12.1-jdk21, 12-jdk21, 12.1.5-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.5-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, latest, jdk21
+Tags: 12.1.6-jdk21, 12.1-jdk21, 12-jdk21, 12.1.6-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk21
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.5-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.1.6-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.6-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk17-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk17, 12.1-jdk17, 12-jdk17, 12.1.5-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.1.6-jdk17, 12.1-jdk17, 12-jdk17, 12.1.6-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk17
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jre21-alpine, 12.0-jre21-alpine, 12.0.31-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
+Tags: 12.0.32-jre21-alpine, 12.0-jre21-alpine, 12.0.32-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jre21, 12.0-jre21, 12.0.31-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
+Tags: 12.0.32-jre21, 12.0-jre21, 12.0.32-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jre17-alpine, 12.0-jre17-alpine, 12.0.31-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
+Tags: 12.0.32-jre17-alpine, 12.0-jre17-alpine, 12.0.32-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jre17, 12.0-jre17, 12.0.31-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
+Tags: 12.0.32-jre17, 12.0-jre17, 12.0.32-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk25-alpine, 12.0-jdk25-alpine, 12.0.31-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
+Tags: 12.0.32-jdk25-alpine, 12.0-jdk25-alpine, 12.0.32-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk25-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk25, 12.0-jdk25, 12.0.31-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
+Tags: 12.0.32, 12.0, 12.0.32-jdk25, 12.0-jdk25, 12.0.32-eclipse-temurin, 12.0-eclipse-temurin, 12.0.32-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk25
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk21-alpine, 12.0-jdk21-alpine, 12.0.31-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
+Tags: 12.0.32-jdk21-alpine, 12.0-jdk21-alpine, 12.0.32-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31, 12.0, 12.0.31-jdk21, 12.0-jdk21, 12.0.31-eclipse-temurin, 12.0-eclipse-temurin, 12.0.31-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
+Tags: 12.0.32-jdk21, 12.0-jdk21, 12.0.32-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk17-alpine, 12.0-jdk17-alpine, 12.0.31-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
+Tags: 12.0.32-jdk17-alpine, 12.0-jdk17-alpine, 12.0.32-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk17, 12.0-jdk17, 12.0.31-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
+Tags: 12.0.32-jdk17, 12.0-jdk17, 12.0.32-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 11.0.26-jre21-alpine, 11.0-jre21-alpine, 11-jre21-alpine, 11.0.26-jre21-alpine-eclipse-temurin, 11.0-jre21-alpine-eclipse-temurin, 11-jre21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0/jre21-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jre21, 11.0-jre21, 11-jre21, 11.0.26-jre21-eclipse-temurin, 11.0-jre21-eclipse-temurin, 11-jre21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0/jre21
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jre17-alpine, 11.0-jre17-alpine, 11-jre17-alpine, 11.0.26-jre17-alpine-eclipse-temurin, 11.0-jre17-alpine-eclipse-temurin, 11-jre17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0/jre17-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jre17, 11.0-jre17, 11-jre17, 11.0.26-jre17-eclipse-temurin, 11.0-jre17-eclipse-temurin, 11-jre17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0/jre17
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jre11-alpine, 11.0-jre11-alpine, 11-jre11-alpine, 11.0.26-jre11-alpine-eclipse-temurin, 11.0-jre11-alpine-eclipse-temurin, 11-jre11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0/jre11-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jre11, 11.0-jre11, 11-jre11, 11.0.26-jre11-eclipse-temurin, 11.0-jre11-eclipse-temurin, 11-jre11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0/jre11
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk21-alpine, 11.0-jdk21-alpine, 11-jdk21-alpine, 11.0.26-jdk21-alpine-eclipse-temurin, 11.0-jdk21-alpine-eclipse-temurin, 11-jdk21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0/jdk21-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26, 11.0, 11, 11.0.26-jdk21, 11.0-jdk21, 11-jdk21, 11.0.26-eclipse-temurin, 11.0-eclipse-temurin, 11-eclipse-temurin, 11.0.26-jdk21-eclipse-temurin, 11.0-jdk21-eclipse-temurin, 11-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0/jdk21
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk17-alpine, 11.0-jdk17-alpine, 11-jdk17-alpine, 11.0.26-jdk17-alpine-eclipse-temurin, 11.0-jdk17-alpine-eclipse-temurin, 11-jdk17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0/jdk17-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk17, 11.0-jdk17, 11-jdk17, 11.0.26-jdk17-eclipse-temurin, 11.0-jdk17-eclipse-temurin, 11-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0/jdk17
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk11-alpine, 11.0-jdk11-alpine, 11-jdk11-alpine, 11.0.26-jdk11-alpine-eclipse-temurin, 11.0-jdk11-alpine-eclipse-temurin, 11-jdk11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/11.0/jdk11-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk11, 11.0-jdk11, 11-jdk11, 11.0.26-jdk11-eclipse-temurin, 11.0-jdk11-eclipse-temurin, 11-jdk11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/11.0/jdk11
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jre21-alpine, 10.0-jre21-alpine, 10-jre21-alpine, 10.0.26-jre21-alpine-eclipse-temurin, 10.0-jre21-alpine-eclipse-temurin, 10-jre21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0/jre21-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jre21, 10.0-jre21, 10-jre21, 10.0.26-jre21-eclipse-temurin, 10.0-jre21-eclipse-temurin, 10-jre21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0/jre21
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jre17-alpine, 10.0-jre17-alpine, 10-jre17-alpine, 10.0.26-jre17-alpine-eclipse-temurin, 10.0-jre17-alpine-eclipse-temurin, 10-jre17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0/jre17-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jre17, 10.0-jre17, 10-jre17, 10.0.26-jre17-eclipse-temurin, 10.0-jre17-eclipse-temurin, 10-jre17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0/jre17
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jre11-alpine, 10.0-jre11-alpine, 10-jre11-alpine, 10.0.26-jre11-alpine-eclipse-temurin, 10.0-jre11-alpine-eclipse-temurin, 10-jre11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0/jre11-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jre11, 10.0-jre11, 10-jre11, 10.0.26-jre11-eclipse-temurin, 10.0-jre11-eclipse-temurin, 10-jre11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0/jre11
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk21-alpine, 10.0-jdk21-alpine, 10-jdk21-alpine, 10.0.26-jdk21-alpine-eclipse-temurin, 10.0-jdk21-alpine-eclipse-temurin, 10-jdk21-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0/jdk21-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26, 10.0, 10, 10.0.26-jdk21, 10.0-jdk21, 10-jdk21, 10.0.26-eclipse-temurin, 10.0-eclipse-temurin, 10-eclipse-temurin, 10.0.26-jdk21-eclipse-temurin, 10.0-jdk21-eclipse-temurin, 10-jdk21-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0/jdk21
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk17-alpine, 10.0-jdk17-alpine, 10-jdk17-alpine, 10.0.26-jdk17-alpine-eclipse-temurin, 10.0-jdk17-alpine-eclipse-temurin, 10-jdk17-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0/jdk17-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk17, 10.0-jdk17, 10-jdk17, 10.0.26-jdk17-eclipse-temurin, 10.0-jdk17-eclipse-temurin, 10-jdk17-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0/jdk17
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk11-alpine, 10.0-jdk11-alpine, 10-jdk11-alpine, 10.0.26-jdk11-alpine-eclipse-temurin, 10.0-jdk11-alpine-eclipse-temurin, 10-jdk11-alpine-eclipse-temurin
-Architectures: amd64
-Directory: eclipse-temurin/10.0/jdk11-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk11, 10.0-jdk11, 10-jdk11, 10.0.26-jdk11-eclipse-temurin, 10.0-jdk11-eclipse-temurin, 10-jdk11-eclipse-temurin
-Architectures: amd64, arm64v8
-Directory: eclipse-temurin/10.0/jdk11
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 9.4.58-jdk8-alpine-amazoncorretto, 9.4-jdk8-alpine-amazoncorretto, 9-jdk8-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk8-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk8-amazoncorretto, 9.4-jdk8-amazoncorretto, 9-jdk8-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk8
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk21-alpine-amazoncorretto, 9.4-jdk21-alpine-amazoncorretto, 9-jdk21-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk21-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-amazoncorretto, 9.4-amazoncorretto, 9-amazoncorretto, 9.4.58-jdk21-amazoncorretto, 9.4-jdk21-amazoncorretto, 9-jdk21-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk21
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk17-alpine-amazoncorretto, 9.4-jdk17-alpine-amazoncorretto, 9-jdk17-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk17-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk17-amazoncorretto, 9.4-jdk17-amazoncorretto, 9-jdk17-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk17
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk11-alpine-amazoncorretto, 9.4-jdk11-alpine-amazoncorretto, 9-jdk11-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk11-alpine
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 9.4.58-jdk11-amazoncorretto, 9.4-jdk11-amazoncorretto, 9-jdk11-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/9.4/jdk11
-GitCommit: eb7150579b055f3094f50e70f67678b9209baaf7
-
-Tags: 12.1.5-jdk25-alpine-amazoncorretto, 12.1-jdk25-alpine-amazoncorretto, 12-jdk25-alpine-amazoncorretto
+Tags: 12.1.6-jdk25-alpine-amazoncorretto, 12.1-jdk25-alpine-amazoncorretto, 12-jdk25-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk25-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk25-amazoncorretto, 12.1-jdk25-amazoncorretto, 12-jdk25-amazoncorretto
+Tags: 12.1.6-amazoncorretto, 12.1-amazoncorretto, 12-amazoncorretto, 12.1.6-jdk25-amazoncorretto, 12.1-jdk25-amazoncorretto, 12-jdk25-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk25
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.1.6-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-amazoncorretto, 12.1-amazoncorretto, 12-amazoncorretto, 12.1.5-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.1.6-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.1.6-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.1.5-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.1.6-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk25-al2023-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto
+Tags: 12.0.32-jdk25-al2023-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk25-al2023
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
+Tags: 12.0.32-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
+Tags: 12.0.32-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-al2023
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-amazoncorretto, 12.0-amazoncorretto, 12.0.31-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto
+Tags: 12.0.32-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
+Tags: 12.0.32-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
+Tags: 12.0.32-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-al2023
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b
 
-Tags: 12.0.31-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
+Tags: 12.0.32-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: 674ee96da163d9312b30958397e8ee568fb14635
-
-Tags: 11.0.26-jdk21-alpine-amazoncorretto, 11.0-jdk21-alpine-amazoncorretto, 11-jdk21-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/11.0/jdk21-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-amazoncorretto, 11.0-amazoncorretto, 11-amazoncorretto, 11.0.26-jdk21-amazoncorretto, 11.0-jdk21-amazoncorretto, 11-jdk21-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/11.0/jdk21
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk17-alpine-amazoncorretto, 11.0-jdk17-alpine-amazoncorretto, 11-jdk17-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/11.0/jdk17-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk17-amazoncorretto, 11.0-jdk17-amazoncorretto, 11-jdk17-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/11.0/jdk17
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk11-alpine-amazoncorretto, 11.0-jdk11-alpine-amazoncorretto, 11-jdk11-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/11.0/jdk11-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 11.0.26-jdk11-amazoncorretto, 11.0-jdk11-amazoncorretto, 11-jdk11-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/11.0/jdk11
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk21-alpine-amazoncorretto, 10.0-jdk21-alpine-amazoncorretto, 10-jdk21-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/10.0/jdk21-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-amazoncorretto, 10.0-amazoncorretto, 10-amazoncorretto, 10.0.26-jdk21-amazoncorretto, 10.0-jdk21-amazoncorretto, 10-jdk21-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/10.0/jdk21
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk17-alpine-amazoncorretto, 10.0-jdk17-alpine-amazoncorretto, 10-jdk17-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/10.0/jdk17-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk17-amazoncorretto, 10.0-jdk17-amazoncorretto, 10-jdk17-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/10.0/jdk17
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk11-alpine-amazoncorretto, 10.0-jdk11-alpine-amazoncorretto, 10-jdk11-alpine-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/10.0/jdk11-alpine
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
-
-Tags: 10.0.26-jdk11-amazoncorretto, 10.0-jdk11-amazoncorretto, 10-jdk11-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/10.0/jdk11
-GitCommit: 5a8d565c6959453cf11c2906059be01adc848004
+GitCommit: d8b2b68c7cd9c097ea8fe576c88435ae5e1a031b


### PR DESCRIPTION
- Update Jetty version `12.0.31` -> `12.0.32`.
- Update Jetty version `12.1.5` -> `12.1.6`.
- Remove EOL versions `9.4.x`, `10.0.x`, `11.0.x` which will receive no more public releases (see https://github.com/jetty/jetty.project/issues/13918).
- Update "latest" JDK to 25.