### PR TITLE
Update Semeru OE versions with the Q1 release.

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -5,136 +5,136 @@ GitRepo: https://github.com/ibmruntimes/semeru-containers.git
 GitFetch: refs/heads/ibm
 
 #-----------------------------openj9 v8 images---------------------------------
-Tags: open-8u472-b08-jdk-jammy, open-8-jdk-jammy
+Tags: open-8u482-b08-jdk-jammy, open-8-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u472-b08-jdk-noble, open-8-jdk-noble
-SharedTags: open-8u472-b08-jdk, open-8-jdk
+Tags: open-8u482-b08-jdk-noble, open-8-jdk-noble
+SharedTags: open-8u482-b08-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 8/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-8u472-b08-jre-jammy, open-8-jre-jammy
+Tags: open-8u482-b08-jre-jammy, open-8-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8u472-b08-jre-noble, open-8-jre-noble
-SharedTags: open-8u472-b08-jre, open-8-jre
+Tags: open-8u482-b08-jre-noble, open-8-jre-noble
+SharedTags: open-8u482-b08-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 8/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
-Tags: open-11.0.29_7-jdk-jammy, open-11-jdk-jammy
+Tags: open-11.0.30_7-jdk-jammy, open-11-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.29_7-jdk-noble, open-11-jdk-noble
-SharedTags: open-11.0.29_7-jdk, open-11-jdk
+Tags: open-11.0.30_7-jdk-noble, open-11-jdk-noble
+SharedTags: open-11.0.30_7-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 11/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.29_7-jre-jammy, open-11-jre-jammy
+Tags: open-11.0.30_7-jre-jammy, open-11-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.29_7-jre-noble, open-11-jre-noble
-SharedTags: open-11.0.29_7-jre, open-11-jre
+Tags: open-11.0.30_7-jre-noble, open-11-jre-noble
+SharedTags: open-11.0.30_7-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 11/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
-Tags: open-17.0.17_9-jdk-jammy, open-17-jdk-jammy
+Tags: open-17.0.18_8-jdk-jammy, open-17-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.17_9-jdk-noble, open-17-jdk-noble
-SharedTags: open-17.0.17_9-jdk, open-17-jdk
+Tags: open-17.0.18_8-jdk-noble, open-17-jdk-noble
+SharedTags: open-17.0.18_8-jdk, open-17-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 17/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.17_9-jre-jammy, open-17-jre-jammy
+Tags: open-17.0.18_8-jre-jammy, open-17-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.17_9-jre-noble, open-17-jre-noble
-SharedTags: open-17.0.17_9-jre, open-17-jre
+Tags: open-17.0.18_8-jre-noble, open-17-jre-noble
+SharedTags: open-17.0.18_8-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 17/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v21 images---------------------------------
-Tags: open-21.0.9_10-jdk-jammy, open-21-jdk-jammy
+Tags: open-21.0.10_7-jdk-jammy, open-21-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 21/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.9_10-jdk-noble, open-21-jdk-noble
-SharedTags: open-21.0.9_10-jdk, open-21-jdk
+Tags: open-21.0.10_7-jdk-noble, open-21-jdk-noble
+SharedTags: open-21.0.10_7-jdk, open-21-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 21/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.9_10-jre-jammy, open-21-jre-jammy
+Tags: open-21.0.10_7-jre-jammy, open-21-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 21/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.9_10-jre-noble, open-21-jre-noble
-SharedTags: open-21.0.9_10-jre, open-21-jre
+Tags: open-21.0.10_7-jre-noble, open-21-jre-noble
+SharedTags: open-21.0.10_7-jre, open-21-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 21/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v25 images---------------------------------
-Tags: open-jdk-25.0.1_8-jdk-jammy, open-25-jdk-jammy
+Tags: open-jdk-25.0.2_10-jdk-jammy, open-25-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 25/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.1_8-jdk-noble, open-25-jdk-noble
-SharedTags: open-jdk-25.0.1_8-jdk, open-25-jdk
+Tags: open-jdk-25.0.2_10-jdk-noble, open-25-jdk-noble
+SharedTags: open-jdk-25.0.2_10-jdk, open-25-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 25/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.1_8-jre-jammy, open-25-jre-jammy
+Tags: open-jdk-25.0.2_10-jre-jammy, open-25-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 25/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.1_8-jre-noble, open-25-jre-noble
-SharedTags: open-jdk-25.0.1_8-jre, open-25-jre
+Tags: open-jdk-25.0.2_10-jre-noble, open-25-jre-noble
+SharedTags: open-jdk-25.0.2_10-jre, open-25-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: ea7c829c68017a394b768f9bc4bbb807242ec3bd
+GitCommit: 5242482eaa80dc302bdbcaccee52b8d0b9d04988
 Directory: 25/jre/ubuntu/noble
 File: Dockerfile.open.releases.full


### PR DESCRIPTION
BUMP Semeru JDK/JRE versions to 8u482,11.0.30,17.0.18,21.0.10,25.0.2