### PR TITLE
Bump Traefik to v2.11.36

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -20,22 +20,22 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 304f83d926652820cd4cbc7c92792a99b65ab9be
 Directory: v3.6/alpine
 
-Tags: v2.11.35-windowsservercore-ltsc2022, 2.11.35-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.36-windowsservercore-ltsc2022, 2.11.36-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 7d230718b0052756551f0ef84f256755c40463a1
+GitCommit: cce3f80cb9b088ee9d01791dc7705f8d966b292e
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.35-nanoserver-ltsc2022, 2.11.35-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.36-nanoserver-ltsc2022, 2.11.36-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 7d230718b0052756551f0ef84f256755c40463a1
+GitCommit: cce3f80cb9b088ee9d01791dc7705f8d966b292e
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.35, 2.11.35, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.36, 2.11.36, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 7d230718b0052756551f0ef84f256755c40463a1
+GitCommit: cce3f80cb9b088ee9d01791dc7705f8d966b292e
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v2.11.36](https://github.com/traefik/traefik/releases/tag/v2.11.36).

/cc @mmatur @kevinpollet

Cheers
