### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/8d1c3f17a946e665fbed3f9434e120cf3bc7e19a/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/64903e30a3bd3556c0974aa7b41da4f24f97b803/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 8d1c3f17a946e665fbed3f9434e120cf3bc7e19a
+GitCommit: 64903e30a3bd3556c0974aa7b41da4f24f97b803
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 133b79514ae3130e3e62d8188b0fb5f55c0577e1
+amd64-GitCommit: 9b4d4be67b9f2a68ddbd9975a6779bd5bdfe60fa
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 18438d06691ea289dcce9deb330dc62c26c86935
+arm32v5-GitCommit: fb7dd97d590a07d2e69650f8dc7aa5a23ab55589
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 9930e7a175886de1ffe71a18cae2387c5d68a39a
+arm32v6-GitCommit: e4def65e99453b20d5cb5a90b2029fe38825c3e3
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 684432628497342afb7e32292def246d36756f6e
+arm32v7-GitCommit: f9c0ba5920a85dbcb7a575880f0eb0c8a74e7309
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fcf763f5ddcd24c22080bfdc72bbc1494d3bc659
+arm64v8-GitCommit: d4b4fb07165bc3ee219eebc530b27c56dd28eba0
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: c53a8a8458514c08c4d61449c9d7b10edc522461
+i386-GitCommit: da1b602f27a56ff20e8e5e1ec23d5e44f5e47586
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 7b525dbf2c016f2bb0cbd9b2861df449da5aa80f
+ppc64le-GitCommit: 403811e3da78b5ad4d8356f99d78e9b4e1997a60
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: e874bcccff531e887471b07c6ac0661ac8c22ad6
+riscv64-GitCommit: b6d7978dcbd904ceb4aaa4c88224550d008ab274
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: effd5670a13892b667e45216f77908a2b97fbe63
+s390x-GitCommit: e2eb9d29e6467c31535f5fba9521b7b08238b933
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/64903e3: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/1c2ad1a: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/6e62ca4: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/a9f1869: Update metadata for i386
- https://github.com/docker-library/busybox/commit/2382013: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/d668da0: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/7ee2ec8: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/627f729: Update metadata for amd64