### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-1696

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0cc9cdc4920310f78c300d0ecd7405238511d782
+amd64-GitCommit: 0aac5ce748038dc81d9123574d5dffb6bc8ccba3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cc9b04bd374e862191c5576589aae69fa2291b87
+arm64v8-GitCommit: 552c8a883b7f17800c4d27e5b8793dc45747ae5f
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-14104

See the following for details:

ELSA-2026-1696

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
