### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.9.0-php8.2-apache, 6.9-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.9.0-php8.2, 6.9-php8.2, 6-php8.2, php8.2
+Tags: 6.9.1-php8.2-apache, 6.9-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.9.1-php8.2, 6.9-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.2/apache
 
-Tags: 6.9.0-php8.2-fpm, 6.9-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.9.1-php8.2-fpm, 6.9-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.2/fpm
 
-Tags: 6.9.0-php8.2-fpm-alpine, 6.9-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.9.1-php8.2-fpm-alpine, 6.9-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.9.0-apache, 6.9-apache, 6-apache, apache, 6.9.0, 6.9, 6, latest, 6.9.0-php8.3-apache, 6.9-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.9.0-php8.3, 6.9-php8.3, 6-php8.3, php8.3
+Tags: 6.9.1-apache, 6.9-apache, 6-apache, apache, 6.9.1, 6.9, 6, latest, 6.9.1-php8.3-apache, 6.9-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.9.1-php8.3, 6.9-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.3/apache
 
-Tags: 6.9.0-fpm, 6.9-fpm, 6-fpm, fpm, 6.9.0-php8.3-fpm, 6.9-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.9.1-fpm, 6.9-fpm, 6-fpm, fpm, 6.9.1-php8.3-fpm, 6.9-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.3/fpm
 
-Tags: 6.9.0-fpm-alpine, 6.9-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.9.0-php8.3-fpm-alpine, 6.9-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.9.1-fpm-alpine, 6.9-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.9.1-php8.3-fpm-alpine, 6.9-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.3/fpm-alpine
 
-Tags: 6.9.0-php8.4-apache, 6.9-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.9.0-php8.4, 6.9-php8.4, 6-php8.4, php8.4
+Tags: 6.9.1-php8.4-apache, 6.9-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.9.1-php8.4, 6.9-php8.4, 6-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.4/apache
 
-Tags: 6.9.0-php8.4-fpm, 6.9-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
+Tags: 6.9.1-php8.4-fpm, 6.9-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.4/fpm
 
-Tags: 6.9.0-php8.4-fpm-alpine, 6.9-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
+Tags: 6.9.1-php8.4-fpm-alpine, 6.9-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.4/fpm-alpine
 
-Tags: 6.9.0-php8.5-apache, 6.9-php8.5-apache, 6-php8.5-apache, php8.5-apache, 6.9.0-php8.5, 6.9-php8.5, 6-php8.5, php8.5
+Tags: 6.9.1-php8.5-apache, 6.9-php8.5-apache, 6-php8.5-apache, php8.5-apache, 6.9.1-php8.5, 6.9-php8.5, 6-php8.5, php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.5/apache
 
-Tags: 6.9.0-php8.5-fpm, 6.9-php8.5-fpm, 6-php8.5-fpm, php8.5-fpm
+Tags: 6.9.1-php8.5-fpm, 6.9-php8.5-fpm, 6-php8.5-fpm, php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.5/fpm
 
-Tags: 6.9.0-php8.5-fpm-alpine, 6.9-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.5-fpm-alpine
+Tags: 6.9.1-php8.5-fpm-alpine, 6.9-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c82afd7240879748c5e4a64e5fb04e2d34172686
+GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
 Directory: latest/php8.5/fpm-alpine
 
 Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
@@ -83,63 +83,3 @@ Tags: cli-2.12.0-php8.5, cli-2.12-php8.5, cli-2-php8.5, cli-php8.5
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.5/alpine
-
-Tags: beta-6.9.1-RC1-php8.2-apache, beta-6.9.1-php8.2-apache, beta-6.9-php8.2-apache, beta-6-php8.2-apache, beta-php8.2-apache, beta-6.9.1-RC1-php8.2, beta-6.9.1-php8.2, beta-6.9-php8.2, beta-6-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.2/apache
-
-Tags: beta-6.9.1-RC1-php8.2-fpm, beta-6.9.1-php8.2-fpm, beta-6.9-php8.2-fpm, beta-6-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.2/fpm
-
-Tags: beta-6.9.1-RC1-php8.2-fpm-alpine, beta-6.9.1-php8.2-fpm-alpine, beta-6.9-php8.2-fpm-alpine, beta-6-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.2/fpm-alpine
-
-Tags: beta-6.9.1-RC1-apache, beta-6.9.1-apache, beta-6.9-apache, beta-6-apache, beta-apache, beta-6.9.1-RC1, beta-6.9.1, beta-6.9, beta-6, beta, beta-6.9.1-RC1-php8.3-apache, beta-6.9.1-php8.3-apache, beta-6.9-php8.3-apache, beta-6-php8.3-apache, beta-php8.3-apache, beta-6.9.1-RC1-php8.3, beta-6.9.1-php8.3, beta-6.9-php8.3, beta-6-php8.3, beta-php8.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.3/apache
-
-Tags: beta-6.9.1-RC1-fpm, beta-6.9.1-fpm, beta-6.9-fpm, beta-6-fpm, beta-fpm, beta-6.9.1-RC1-php8.3-fpm, beta-6.9.1-php8.3-fpm, beta-6.9-php8.3-fpm, beta-6-php8.3-fpm, beta-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.3/fpm
-
-Tags: beta-6.9.1-RC1-fpm-alpine, beta-6.9.1-fpm-alpine, beta-6.9-fpm-alpine, beta-6-fpm-alpine, beta-fpm-alpine, beta-6.9.1-RC1-php8.3-fpm-alpine, beta-6.9.1-php8.3-fpm-alpine, beta-6.9-php8.3-fpm-alpine, beta-6-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.3/fpm-alpine
-
-Tags: beta-6.9.1-RC1-php8.4-apache, beta-6.9.1-php8.4-apache, beta-6.9-php8.4-apache, beta-6-php8.4-apache, beta-php8.4-apache, beta-6.9.1-RC1-php8.4, beta-6.9.1-php8.4, beta-6.9-php8.4, beta-6-php8.4, beta-php8.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.4/apache
-
-Tags: beta-6.9.1-RC1-php8.4-fpm, beta-6.9.1-php8.4-fpm, beta-6.9-php8.4-fpm, beta-6-php8.4-fpm, beta-php8.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.4/fpm
-
-Tags: beta-6.9.1-RC1-php8.4-fpm-alpine, beta-6.9.1-php8.4-fpm-alpine, beta-6.9-php8.4-fpm-alpine, beta-6-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.4/fpm-alpine
-
-Tags: beta-6.9.1-RC1-php8.5-apache, beta-6.9.1-php8.5-apache, beta-6.9-php8.5-apache, beta-6-php8.5-apache, beta-php8.5-apache, beta-6.9.1-RC1-php8.5, beta-6.9.1-php8.5, beta-6.9-php8.5, beta-6-php8.5, beta-php8.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.5/apache
-
-Tags: beta-6.9.1-RC1-php8.5-fpm, beta-6.9.1-php8.5-fpm, beta-6.9-php8.5-fpm, beta-6-php8.5-fpm, beta-php8.5-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.5/fpm
-
-Tags: beta-6.9.1-RC1-php8.5-fpm-alpine, beta-6.9.1-php8.5-fpm-alpine, beta-6.9-php8.5-fpm-alpine, beta-6-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0346769a1ae255cf8bd1a059f4db2a145121b814
-Directory: beta/php8.5/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/4eb711d: Update latest to 6.9.1
- https://github.com/docker-library/wordpress/commit/18af9df: Update beta to 6.9.1