### PR TITLE
varnish: update to 8.0.0-5, vmod-cfg on arm

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,11 +1,11 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/58af075d7a6979394b8099c31b7e66572dc741c3/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/9a68f156ac2fa5d6c2d08ebca5cd80fa7f5a4623/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
 Tags: fresh, 8.0.0, 8, 8.0, latest
 Architectures: amd64, arm64v8
 Directory: fresh/debian
-GitCommit: 58af075d7a6979394b8099c31b7e66572dc741c3
+GitCommit: 9a68f156ac2fa5d6c2d08ebca5cd80fa7f5a4623
 GitFetch: refs/heads/main
 
 Tags: fresh-alpine, 8.0.0-alpine, 8-alpine, 8.0-alpine, alpine


### PR DESCRIPTION
I talked with upstream and we now have `vmod-cfg` packages for `arm` too