### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-1825 and 8 for ELSA-2026-1631

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0aac5ce748038dc81d9123574d5dffb6bc8ccba3
+amd64-GitCommit: f6d7736ef3734bc01c2599b95162f44dbd7b0c97
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 552c8a883b7f17800c4d27e5b8793dc45747ae5f
+arm64v8-GitCommit: 14ab044a4b49cf273ff7093522e3b44c8ac05213
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-9086, CVE-2025-12084

See the following for details:

ELSA-2026-1631
ELSA-2026-1825

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
