### PR TITLE
Updated nginx stable to 1.28.2, mainline to 1.29.5, and module njs to 0.9.5.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,72 +3,72 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.29.4, mainline, 1, 1.29, latest, 1.29.4-trixie, mainline-trixie, 1-trixie, 1.29-trixie, trixie
+Tags: 1.29.5, mainline, 1, 1.29, latest, 1.29.5-trixie, mainline-trixie, 1-trixie, 1.29-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/debian
 
-Tags: 1.29.4-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.4-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.29-trixie-perl, trixie-perl
+Tags: 1.29.5-perl, mainline-perl, 1-perl, 1.29-perl, perl, 1.29.5-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.29-trixie-perl, trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/debian-perl
 
-Tags: 1.29.4-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.4-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.29-trixie-otel, trixie-otel
+Tags: 1.29.5-otel, mainline-otel, 1-otel, 1.29-otel, otel, 1.29.5-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.29-trixie-otel, trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/debian-otel
 
-Tags: 1.29.4-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.4-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.29-alpine3.23, alpine3.23
+Tags: 1.29.5-alpine, mainline-alpine, 1-alpine, 1.29-alpine, alpine, 1.29.5-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.29-alpine3.23, alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 3a5661a6374fd9e0752cf82bbd61fdcf5df59e54
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/alpine
 
-Tags: 1.29.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.4-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.29-alpine3.23-perl, alpine3.23-perl
+Tags: 1.29.5-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.29-alpine-perl, alpine-perl, 1.29.5-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.29-alpine3.23-perl, alpine3.23-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: f3bf9f4eb388557afc31025a8e8587e09755adf1
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/alpine-perl
 
-Tags: 1.29.4-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.4-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.29-alpine3.23-slim, alpine3.23-slim
+Tags: 1.29.5-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.5-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.29-alpine3.23-slim, alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: afa829ae8cd9e25cf539cb03167dff1162f852cb
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/alpine-slim
 
-Tags: 1.29.4-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.4-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.29-alpine3.23-otel, alpine3.23-otel
+Tags: 1.29.5-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.5-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.29-alpine3.23-otel, alpine3.23-otel
 Architectures: amd64, arm64v8
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: mainline/alpine-otel
 
-Tags: 1.28.1, stable, 1.28, 1.28.1-trixie, stable-trixie, 1.28-trixie
+Tags: 1.28.2, stable, 1.28, 1.28.2-trixie, stable-trixie, 1.28-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/debian
 
-Tags: 1.28.1-perl, stable-perl, 1.28-perl, 1.28.1-trixie-perl, stable-trixie-perl, 1.28-trixie-perl
+Tags: 1.28.2-perl, stable-perl, 1.28-perl, 1.28.2-trixie-perl, stable-trixie-perl, 1.28-trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/debian-perl
 
-Tags: 1.28.1-otel, stable-otel, 1.28-otel, 1.28.1-trixie-otel, stable-trixie-otel, 1.28-trixie-otel
+Tags: 1.28.2-otel, stable-otel, 1.28-otel, 1.28.2-trixie-otel, stable-trixie-otel, 1.28-trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/debian-otel
 
-Tags: 1.28.1-alpine, stable-alpine, 1.28-alpine, 1.28.1-alpine3.23, stable-alpine3.23, 1.28-alpine3.23
+Tags: 1.28.2-alpine, stable-alpine, 1.28-alpine, 1.28.2-alpine3.23, stable-alpine3.23, 1.28-alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 3a5661a6374fd9e0752cf82bbd61fdcf5df59e54
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/alpine
 
-Tags: 1.28.1-alpine-perl, stable-alpine-perl, 1.28-alpine-perl, 1.28.1-alpine3.23-perl, stable-alpine3.23-perl, 1.28-alpine3.23-perl
+Tags: 1.28.2-alpine-perl, stable-alpine-perl, 1.28-alpine-perl, 1.28.2-alpine3.23-perl, stable-alpine3.23-perl, 1.28-alpine3.23-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: f3bf9f4eb388557afc31025a8e8587e09755adf1
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/alpine-perl
 
-Tags: 1.28.1-alpine-slim, stable-alpine-slim, 1.28-alpine-slim, 1.28.1-alpine3.23-slim, stable-alpine3.23-slim, 1.28-alpine3.23-slim
+Tags: 1.28.2-alpine-slim, stable-alpine-slim, 1.28-alpine-slim, 1.28.2-alpine3.23-slim, stable-alpine3.23-slim, 1.28-alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 50dc9c37b0668fd9e7760c9841c3bef50e8d4227
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/alpine-slim
 
-Tags: 1.28.1-alpine-otel, stable-alpine-otel, 1.28-alpine-otel, 1.28.1-alpine3.23-otel, stable-alpine3.23-otel, 1.28-alpine3.23-otel
+Tags: 1.28.2-alpine-otel, stable-alpine-otel, 1.28-alpine-otel, 1.28.2-alpine3.23-otel, stable-alpine3.23-otel, 1.28-alpine3.23-otel
 Architectures: amd64, arm64v8
-GitCommit: a306285ea2e4267c63ca539c66e8bc242bdce917
+GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
 Directory: stable/alpine-otel


### PR DESCRIPTION
Update nginx to mitigate CVE-2026-1642:

- mainline 1.29.5
- stable 1.28.2

While at it - update njs module to version 0.9.5.