### PR TITLE
eclipse-mosquitto 2.1.1

### DIFF
--- a/library/eclipse-mosquitto
+++ b/library/eclipse-mosquitto
@@ -1,12 +1,12 @@
 Maintainers: Roger Light <roger@atchoo.org> (@ralight)
 GitRepo: https://github.com/eclipse-mosquitto/mosquitto.git
-GitCommit: 3bddd1affe63b501de83c6e8e5ffbf23912cd29d
+GitCommit: 502dfb75d6547002cb8cfdb8f662740302efb4e8
 Architectures: amd64, arm32v6, arm64v8, i386, ppc64le, s390x
 
-Tags: 2.1.0-alpine, 2.1-alpine, alpine, latest
+Tags: 2.1.1-alpine, 2.1-alpine, alpine, 2, latest
 Directory: docker/2.1-alpine
 
-Tags: 2.0.22, 2.0.22-openssl, 2.0, 2.0-openssl, 2, 2-openssl, openssl
+Tags: 2.0.22, 2.0.22-openssl, 2.0, 2.0-openssl, 2-openssl, openssl
 Directory: docker/2.0-openssl
 
 Tags: 1.6.15-openssl, 1.6-openssl


### PR DESCRIPTION
Update to alpine 3.23
Replace obsolete labels with oci versions
Move `2` tag to the 2.1 line