### PR TITLE
[oraclelinux] Updating 10 for ELSA-2026-1828 and 8, 8-slim and 8-slim-fips for ELSA-2026-1852

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f6d7736ef3734bc01c2599b95162f44dbd7b0c97
+amd64-GitCommit: 1faa8108cf1b59ab3a5cea26f0edb055e766fc63
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 14ab044a4b49cf273ff7093522e3b44c8ac05213
+arm64v8-GitCommit: 1c90c0dfaa224b5d10bc0c0843a3696d04838c1b
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-12084, CVE-2025-13836, CVE-2025-14104

See the following for details:

ELSA-2026-1828
ELSA-2026-1852

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
