### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.2.3, 4.2, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 386be3f5db5c2e0a67f213b89d58b8872023f367
+GitCommit: ef3e8043c9a93b3b1f221cf551f5da456e9dccd5
 Directory: 4.2/ubuntu
 
 Tags: 4.2.3-management, 4.2-management, 4-management, management
@@ -17,7 +17,7 @@ Directory: 4.2/ubuntu/management
 
 Tags: 4.2.3-alpine, 4.2-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 386be3f5db5c2e0a67f213b89d58b8872023f367
+GitCommit: ef3e8043c9a93b3b1f221cf551f5da456e9dccd5
 Directory: 4.2/alpine
 
 Tags: 4.2.3-management-alpine, 4.2-management-alpine, 4-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 4.2/alpine/management
 
 Tags: 4.1.8, 4.1
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: f98c1de3298c18db684d37a9bb30595cea7de644
+GitCommit: 45e677c8a72a3dce73847d778d4697b9ad5a4008
 Directory: 4.1/ubuntu
 
 Tags: 4.1.8-management, 4.1-management
@@ -37,7 +37,7 @@ Directory: 4.1/ubuntu/management
 
 Tags: 4.1.8-alpine, 4.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f98c1de3298c18db684d37a9bb30595cea7de644
+GitCommit: 45e677c8a72a3dce73847d778d4697b9ad5a4008
 Directory: 4.1/alpine
 
 Tags: 4.1.8-management-alpine, 4.1-management-alpine
@@ -47,7 +47,7 @@ Directory: 4.1/alpine/management
 
 Tags: 4.0.9, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 022313824f2bdf21427f3885949b8570ec7d7dc9
+GitCommit: 3b417e8cd4d49d1aa93b17e74746bc7676814159
 Directory: 4.0/ubuntu
 
 Tags: 4.0.9-management, 4.0-management
@@ -57,7 +57,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.9-alpine, 4.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 022313824f2bdf21427f3885949b8570ec7d7dc9
+GitCommit: 3b417e8cd4d49d1aa93b17e74746bc7676814159
 Directory: 4.0/alpine
 
 Tags: 4.0.9-management-alpine, 4.0-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/ef3e804: Update 4.2 to openssl 3.5.5, otp 27.3.4.7
- https://github.com/docker-library/rabbitmq/commit/45e677c: Update 4.1 to otp 27.3.4.7
- https://github.com/docker-library/rabbitmq/commit/3b417e8: Update 4.0 to otp 27.3.4.7
- https://github.com/docker-library/rabbitmq/commit/38230b8: Update 4.2 to openssl 3.5.4