### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2026-2042 ELSA-2026-1913

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1faa8108cf1b59ab3a5cea26f0edb055e766fc63
+amd64-GitCommit: 680aa04c8322230281615903403211b27ce567c1
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1c90c0dfaa224b5d10bc0c0843a3696d04838c1b
+arm64v8-GitCommit: 8067af83e5f5036f428ac6fb94106e5dfd124090
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6176, CVE-2025-14104

See the following for details:

ELSA-2026-1913
ELSA-2026-2042

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
