### PR TITLE
ELK remove 9.1.10 version

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -8,11 +8,6 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
 GitCommit: f7772a32e16a4867434d723b232842eec7393b9c
 
-Tags: 9.1.10
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/9.1
-GitCommit: 10fa6f806fc0304266001a20a94c2c4d3f31ee7c
-
 Tags: 9.2.5
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.2

--- a/library/kibana
+++ b/library/kibana
@@ -8,11 +8,6 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
 GitCommit: f7772a32e16a4867434d723b232842eec7393b9c
 
-Tags: 9.1.10
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/9.1
-GitCommit: 10fa6f806fc0304266001a20a94c2c4d3f31ee7c
-
 Tags: 9.2.5
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.2

--- a/library/logstash
+++ b/library/logstash
@@ -8,11 +8,6 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
 GitCommit: f7772a32e16a4867434d723b232842eec7393b9c
 
-Tags: 9.1.10
-Architectures: amd64, arm64v8
-GitFetch: refs/heads/9.1
-GitCommit: 10fa6f806fc0304266001a20a94c2c4d3f31ee7c
-
 Tags: 9.2.5
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.2


### PR DESCRIPTION
As `9.3.0` was released, removing `9.1.10` for ELK images.