### PR TITLE
[oraclelinux] Updating 8 for ELSA-2026-2128

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 680aa04c8322230281615903403211b27ce567c1
+amd64-GitCommit: 9321883bc48b7c312d9ab790546096d6de395688
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8067af83e5f5036f428ac6fb94106e5dfd124090
+arm64v8-GitCommit: 56821c5cdf7fbcf33674592e1d67497f7533da8a
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-15366, CVE-2025-15367, CVE-2026-0865, CVE-2026-1299

See the following for details:

ELSA-2026-2128

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
