### PR TITLE
MariaDB Server Maintenance Releases Q1 2026

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/3ca7af6aaaf6284d8e7c238bf114894cbfef37d0/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/8eaa6638a5bcb18849a6cd1b6ee55620d624a861/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
@@ -8,60 +8,60 @@ Builder: buildkit
 
 Tags: 12.2.1-ubi10-rc, 12.2-ubi10-rc, 12.2.1-ubi-rc, 12.2-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 430ef0c93be28f7beca08980d3454b311988d42b
+GitCommit: b6c0c786de44bb9651d687daa9561d0643bb3d2e
 Directory: 12.2-ubi
 
 Tags: 12.2.1-noble-rc, 12.2-noble-rc, 12.2.1-rc, 12.2-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 430ef0c93be28f7beca08980d3454b311988d42b
+GitCommit: 4ef487565005c1acf62dcfaa87110a39262b8150
 Directory: 12.2
 
 Tags: 12.1.2-ubi10, 12.1-ubi10, 12-ubi10, 12.1.2-ubi, 12.1-ubi, 12-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: a709b5a5bbe6580a3d2c97a8a841a2eac7f9c886
+GitCommit: b6c0c786de44bb9651d687daa9561d0643bb3d2e
 Directory: 12.1-ubi
 
 Tags: 12.1.2-noble, 12.1-noble, 12-noble, noble, 12.1.2, 12.1, 12, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a709b5a5bbe6580a3d2c97a8a841a2eac7f9c886
+GitCommit: 4ef487565005c1acf62dcfaa87110a39262b8150
 Directory: 12.1
 
-Tags: 11.8.5-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.5-ubi, 11.8-ubi, 11-ubi, lts-ubi
+Tags: 11.8.6-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.6-ubi, 11.8-ubi, 11-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: e95d4eddd8f5b3644a7c163e1363ff2bbd07d3e6
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 11.8-ubi
 
-Tags: 11.8.5-noble, 11.8-noble, 11-noble, lts-noble, 11.8.5, 11.8, 11, lts
+Tags: 11.8.6-noble, 11.8-noble, 11-noble, lts-noble, 11.8.6, 11.8, 11, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: e95d4eddd8f5b3644a7c163e1363ff2bbd07d3e6
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 11.8
 
-Tags: 11.4.9-ubi9, 11.4-ubi9, 11.4.9-ubi, 11.4-ubi
+Tags: 11.4.10-ubi9, 11.4-ubi9, 11.4.10-ubi, 11.4-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 11.4-ubi
 
-Tags: 11.4.9-noble, 11.4-noble, 11.4.9, 11.4
+Tags: 11.4.10-noble, 11.4-noble, 11.4.10, 11.4
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 11.4
 
-Tags: 10.11.15-ubi9, 10.11-ubi9, 10-ubi9, 10.11.15-ubi, 10.11-ubi, 10-ubi
+Tags: 10.11.16-ubi9, 10.11-ubi9, 10-ubi9, 10.11.16-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 10.11-ubi
 
-Tags: 10.11.15-jammy, 10.11-jammy, 10-jammy, 10.11.15, 10.11, 10
+Tags: 10.11.16-jammy, 10.11-jammy, 10-jammy, 10.11.16, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 10.11
 
-Tags: 10.6.24-ubi9, 10.6-ubi9, 10.6.24-ubi, 10.6-ubi
+Tags: 10.6.25-ubi9, 10.6-ubi9, 10.6.25-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 10.6-ubi
 
-Tags: 10.6.24-jammy, 10.6-jammy, 10.6.24, 10.6
+Tags: 10.6.25-jammy, 10.6-jammy, 10.6.25, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 5ad00a82b5bb2705825c7afb670f6547b1bed316
+GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
 Directory: 10.6


### PR DESCRIPTION
Update the library file to reflect the latest releases of MariaDB Server: 11.8.6, 11.4.10, 10.11.16, 10.6.25.