### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -7,23 +7,24 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Michael Mammo (@MichaelAbebaw),
              Piyush Talreja (@piyush-talreja),
              Akhila Katkuri (@Akhilark1202),
-             Neelkanth Poosa (@neelkanthpoosa)
+             Neelkanth Poosa (@neelkanthpoosa),
+             Ishwar Thirunavukkarasu (@ishwartg)
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.10.20260120.4
+Tags: 2023, latest, 2023.10.20260202.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: b3a3595d1f91b22ce0d4b1e692ef2c47b8da169b
+amd64-GitCommit: 5bf38a1e9fac9d7056dd38e74b2e1c1d32e55ae8
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 27da45c3a2173b8a8e874dd2a3c8eda1ef1e9862
+arm64v8-GitCommit: e4ef08ff4b154dfa4c1ccc37c3b2ff9514cb1e87
 
-Tags: 2, 2.0.20260120.1
+Tags: 2, 2.0.20260202.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: a549fc51871af52363c5edb742aee092b7f497ab
+amd64-GitCommit: 663d9bf516bbd3ffdcc80818093e5143ea771b93
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: dbbd95e97b9bddd39b7899a3d3d97afe544c7456
+arm64v8-GitCommit: 6597466bee690a6bdbf980e5b96091e7e244cd40
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- libtasn1-4.10-1.amzn2.0.8
- libxml2-2.9.1-6.amzn2.5.23
#### Packages addressing CVES:
- libtasn1-4.10-1.amzn2.0.8
  - [CVE-2025-13151](https://alas.aws.amazon.com/cve/html/CVE-2025-13151.html)
- libxml2-2.9.1-6.amzn2.5.23
  - [CVE-2026-0989](https://alas.aws.amazon.com/cve/html/CVE-2026-0989.html)

### Updated Packages for Amazon Linux 2023:
- glibc-minimal-langpack-2.34-231.amzn2023.0.3
- glibc-2.34-231.amzn2023.0.3
- libxml2-2.10.4-1.amzn2023.0.17
- openssl-fips-provider-latest-3.2.2-1.amzn2023.0.4
- amazon-linux-repo-cdn-2023.10.20260202-0.amzn2023
- system-release-2023.10.20260202-0.amzn2023
- glibc-common-2.34-231.amzn2023.0.3
- libcap-2.73-1.amzn2023.0.6
- libtasn1-4.19.0-1.amzn2023.0.6
- openssl-libs-3.2.2-1.amzn2023.0.4
- python3-pip-wheel-21.3.1-2.amzn2023.0.16
#### Packages addressing CVES:
- libxml2-2.10.4-1.amzn2023.0.17
  - [CVE-2026-0989](https://alas.aws.amazon.com/cve/html/CVE-2026-0989.html)
- openssl-fips-provider-latest-3.2.2-1.amzn2023.0.4, openssl-libs-3.2.2-1.amzn2023.0.4
  - [CVE-2025-15467](https://alas.aws.amazon.com/cve/html/CVE-2025-15467.html)
- libcap-2.73-1.amzn2023.0.6
  - [CVE-2025-61726](https://alas.aws.amazon.com/cve/html/CVE-2025-61726.html)
  - [CVE-2025-61728](https://alas.aws.amazon.com/cve/html/CVE-2025-61728.html)
  - [CVE-2025-61730](https://alas.aws.amazon.com/cve/html/CVE-2025-61730.html)
  - [CVE-2025-61731](https://alas.aws.amazon.com/cve/html/CVE-2025-61731.html)
  - [CVE-2025-68119](https://alas.aws.amazon.com/cve/html/CVE-2025-68119.html)
  - [CVE-2025-68121](https://alas.aws.amazon.com/cve/html/CVE-2025-68121.html)
- libtasn1-4.19.0-1.amzn2023.0.6
  - [CVE-2025-13151](https://alas.aws.amazon.com/cve/html/CVE-2025-13151.html)
- python3-pip-wheel-21.3.1-2.amzn2023.0.16
  - [CVE-2026-21441](https://alas.aws.amazon.com/cve/html/CVE-2026-21441.html)