### PR TITLE
Update KrakenD to v2.13.0

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.12.1, 2.12, 2, latest
+Tags: 2.13.0, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: cf19ddf7432cae3758c0164f242aaa02da0c7011
-Directory: 2.12.1
+GitCommit: c49830a6157382db1498bd9d12f53b2fb9b3567d
+Directory: 2.13.0


### PR DESCRIPTION
Upgraded Go to 1.25.7 addressing several CVEs with disclosed descriptions:

[CVE-2025-61732](https://go.dev/issue/76697) A discrepancy between how Go and C/C++ comments were parsed allowed for code smuggling into the resulting cgo binary
[CVE-2025-68121](https://go.dev/issue/77217) Config.GetConfigForClient is documented to use the original Config’s session ticket keys unless explicitly overridden. This can cause unexpected behavior if the returned Config modifies authentication parameters