### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2026-2389

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9321883bc48b7c312d9ab790546096d6de395688
+amd64-GitCommit: a11a4b4af1554e204d9a4b90769c2459ee13e855
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 56821c5cdf7fbcf33674592e1d67497f7533da8a
+arm64v8-GitCommit: e9b8c36b409b70b46ec58bd05ed21c023eb8b3b9
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-6176

See the following for details:

ELSA-2026-2389

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
