### PR TITLE
caddy: `chmod 1777` for arbitrary UID/GID, bump Go to 1.26 for builders

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -8,14 +8,14 @@ Tags: 2.11.0-beta.2-alpine, 2.11-alpine
 SharedTags: 2.11.0-beta.2, 2.11
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/alpine
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 272e3f8bf40120000fbd9deb4a9003892a8e7c5e
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
 Tags: 2.11.0-beta.2-builder-alpine, 2.11-builder-alpine
 SharedTags: 2.11.0-beta.2-builder, 2.11-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/builder
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
 Tags: 2.11.0-beta.2-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
@@ -54,7 +54,7 @@ Tags: 2.11.0-beta.2-builder-windowsservercore-ltsc2022, 2.11-builder-windowsserv
 SharedTags: 2.11.0-beta.2-builder, 2.11-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2022
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
@@ -62,7 +62,7 @@ Tags: 2.11.0-beta.2-builder-windowsservercore-ltsc2025, 2.11-builder-windowsserv
 SharedTags: 2.11.0-beta.2-builder, 2.11-builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2025
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
@@ -70,14 +70,14 @@ Tags: 2.10.2-alpine, 2.10-alpine, 2-alpine, alpine
 SharedTags: 2.10.2, 2.10, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/alpine
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 272e3f8bf40120000fbd9deb4a9003892a8e7c5e
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
 Tags: 2.10.2-builder-alpine, 2.10-builder-alpine, 2-builder-alpine, builder-alpine
 SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/builder
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
 Tags: 2.10.2-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
@@ -116,7 +116,7 @@ Tags: 2.10.2-builder-windowsservercore-ltsc2022, 2.10-builder-windowsservercore-
 SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-builder/ltsc2022
-GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
+GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
@@ -124,7 +124,7 @@ Tags: 2.10.2-builder-windowsservercore-ltsc2025, 2.10-builder-windowsservercore-
 SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.10/windows-builder/ltsc2025
-GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
+GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 


### PR DESCRIPTION
- https://github.com/caddyserver/caddy-docker/commit/272e3f8bf40120000fbd9deb4a9003892a8e7c5e by @tianon 
- https://github.com/caddyserver/caddy-docker/commit/300a68ffcad36145ac11498abbd3b90a69be6aca by myself