### PR TITLE
Update TeamSpeak 3.13.7 image

### DIFF
--- a/library/teamspeak
+++ b/library/teamspeak
@@ -2,9 +2,6 @@ Maintainers: Hubert Nöbauer <hubert.noebauer@teamspeak.com> (@HuppiN),
              Achim Klittich <achim.klittich@teamspeak.com> (@achimklittich)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
-#
-# Bump Alpine to 3.23.3, use refined Docker image, update maintainers
-#
 Tags: 3.13, 3.13.7, latest
-GitCommit: 2da4b0a5203bc5351d06c6ef2de20804205a1e7d
+GitCommit: e17fc2b955883f6ee1334d43a05208a7276d81d2
 Directory: alpine


### PR DESCRIPTION
- Bump Alpine base image from 3.18 (EOL) to 3.23.3                                                                                                                                                                                                                                                      
- Update maintainers                                                                                                                                                                                                                                              
- Smaller Docker container improvements
- Update GitCommit to [https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images/commit/4ed362fe2100ffda9a4fc7f2d8d60eeb79fb4b48](https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images/commit/4ed362fe2100ffda9a4fc7f2d8d60eeb79fb4b48)