### PR TITLE
Bump Traefik to v2.11.37 and to v3.6.8

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,41 +1,41 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.6.7-windowsservercore-ltsc2022, 3.6.7-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.8-windowsservercore-ltsc2022, 3.6.8-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 304f83d926652820cd4cbc7c92792a99b65ab9be
+GitCommit: c55f3ab46832bd745fc4b0367f0ed6256f4427d6
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.7-nanoserver-ltsc2022, 3.6.7-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.8-nanoserver-ltsc2022, 3.6.8-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 304f83d926652820cd4cbc7c92792a99b65ab9be
+GitCommit: c55f3ab46832bd745fc4b0367f0ed6256f4427d6
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.7, 3.6.7, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.8, 3.6.8, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 304f83d926652820cd4cbc7c92792a99b65ab9be
+GitCommit: c55f3ab46832bd745fc4b0367f0ed6256f4427d6
 Directory: v3.6/alpine
 
-Tags: v2.11.36-windowsservercore-ltsc2022, 2.11.36-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.37-windowsservercore-ltsc2022, 2.11.37-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cce3f80cb9b088ee9d01791dc7705f8d966b292e
+GitCommit: 296803e3754612a2910e83ba1c4aed2b9414e4ac
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.36-nanoserver-ltsc2022, 2.11.36-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.37-nanoserver-ltsc2022, 2.11.37-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cce3f80cb9b088ee9d01791dc7705f8d966b292e
+GitCommit: 296803e3754612a2910e83ba1c4aed2b9414e4ac
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.36, 2.11.36, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.37, 2.11.37, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cce3f80cb9b088ee9d01791dc7705f8d966b292e
+GitCommit: 296803e3754612a2910e83ba1c4aed2b9414e4ac
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.37](https://github.com/traefik/traefik/releases/tag/v2.11.37), and [v3.6.8](https://github.com/traefik/traefik/releases/tag/v3.6.8).

/cc @nmengin @rtribotte  @kevinpollet