### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -6,12 +6,12 @@ GitRepo: https://github.com/docker-library/wordpress.git
 
 Tags: 6.9.1-php8.2-apache, 6.9-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.9.1-php8.2, 6.9-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.2/apache
 
 Tags: 6.9.1-php8.2-fpm, 6.9-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.2/fpm
 
 Tags: 6.9.1-php8.2-fpm-alpine, 6.9-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
@@ -21,12 +21,12 @@ Directory: latest/php8.2/fpm-alpine
 
 Tags: 6.9.1-apache, 6.9-apache, 6-apache, apache, 6.9.1, 6.9, 6, latest, 6.9.1-php8.3-apache, 6.9-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.9.1-php8.3, 6.9-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.3/apache
 
 Tags: 6.9.1-fpm, 6.9-fpm, 6-fpm, fpm, 6.9.1-php8.3-fpm, 6.9-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.3/fpm
 
 Tags: 6.9.1-fpm-alpine, 6.9-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.9.1-php8.3-fpm-alpine, 6.9-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
@@ -36,12 +36,12 @@ Directory: latest/php8.3/fpm-alpine
 
 Tags: 6.9.1-php8.4-apache, 6.9-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.9.1-php8.4, 6.9-php8.4, 6-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.4/apache
 
 Tags: 6.9.1-php8.4-fpm, 6.9-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.4/fpm
 
 Tags: 6.9.1-php8.4-fpm-alpine, 6.9-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
@@ -51,12 +51,12 @@ Directory: latest/php8.4/fpm-alpine
 
 Tags: 6.9.1-php8.5-apache, 6.9-php8.5-apache, 6-php8.5-apache, php8.5-apache, 6.9.1-php8.5, 6.9-php8.5, 6-php8.5, php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.5/apache
 
 Tags: 6.9.1-php8.5-fpm, 6.9-php8.5-fpm, 6-php8.5-fpm, php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
 Directory: latest/php8.5/fpm
 
 Tags: 6.9.1-php8.5-fpm-alpine, 6.9-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.5-fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/e9f9f56: Add AV1 and HEVC image encoding (https://github.com/docker-library/wordpress/pull/997)