### PR TITLE
[security] Update postgres

### DIFF
--- a/library/postgres
+++ b/library/postgres
@@ -4,102 +4,102 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/postgres.git
 
-Tags: 18.1, 18, latest, 18.1-trixie, 18-trixie, trixie
+Tags: 18.2, 18, latest, 18.2-trixie, 18-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 12eb5762e3cf3c44440ed078b59843b5dfbde570
 Directory: 18/trixie
 
-Tags: 18.1-bookworm, 18-bookworm, bookworm
+Tags: 18.2-bookworm, 18-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 12eb5762e3cf3c44440ed078b59843b5dfbde570
 Directory: 18/bookworm
 
-Tags: 18.1-alpine3.23, 18-alpine3.23, alpine3.23, 18.1-alpine, 18-alpine, alpine
+Tags: 18.2-alpine3.23, 18-alpine3.23, alpine3.23, 18.2-alpine, 18-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ec0cb67f0f214ae5d93e5a2254974462a27f44a1
+GitCommit: 12eb5762e3cf3c44440ed078b59843b5dfbde570
 Directory: 18/alpine3.23
 
-Tags: 18.1-alpine3.22, 18-alpine3.22, alpine3.22
+Tags: 18.2-alpine3.22, 18-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ec0cb67f0f214ae5d93e5a2254974462a27f44a1
+GitCommit: 12eb5762e3cf3c44440ed078b59843b5dfbde570
 Directory: 18/alpine3.22
 
-Tags: 17.7, 17, 17.7-trixie, 17-trixie
+Tags: 17.8, 17, 17.8-trixie, 17-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: fd482cfacff9eaef8e0833084d4f2407f8078c58
 Directory: 17/trixie
 
-Tags: 17.7-bookworm, 17-bookworm
+Tags: 17.8-bookworm, 17-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: fd482cfacff9eaef8e0833084d4f2407f8078c58
 Directory: 17/bookworm
 
-Tags: 17.7-alpine3.23, 17-alpine3.23, 17.7-alpine, 17-alpine
+Tags: 17.8-alpine3.23, 17-alpine3.23, 17.8-alpine, 17-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39623ba5d20db58a25c3010896baaf54b9aa6b6d
+GitCommit: fd482cfacff9eaef8e0833084d4f2407f8078c58
 Directory: 17/alpine3.23
 
-Tags: 17.7-alpine3.22, 17-alpine3.22
+Tags: 17.8-alpine3.22, 17-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: fd482cfacff9eaef8e0833084d4f2407f8078c58
 Directory: 17/alpine3.22
 
-Tags: 16.11, 16, 16.11-trixie, 16-trixie
+Tags: 16.12, 16, 16.12-trixie, 16-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: bf13909eb3ce10ecf5b24ec40069ebd6091e2347
 Directory: 16/trixie
 
-Tags: 16.11-bookworm, 16-bookworm
+Tags: 16.12-bookworm, 16-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: bf13909eb3ce10ecf5b24ec40069ebd6091e2347
 Directory: 16/bookworm
 
-Tags: 16.11-alpine3.23, 16-alpine3.23, 16.11-alpine, 16-alpine
+Tags: 16.12-alpine3.23, 16-alpine3.23, 16.12-alpine, 16-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39623ba5d20db58a25c3010896baaf54b9aa6b6d
+GitCommit: bf13909eb3ce10ecf5b24ec40069ebd6091e2347
 Directory: 16/alpine3.23
 
-Tags: 16.11-alpine3.22, 16-alpine3.22
+Tags: 16.12-alpine3.22, 16-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: bf13909eb3ce10ecf5b24ec40069ebd6091e2347
 Directory: 16/alpine3.22
 
-Tags: 15.15, 15, 15.15-trixie, 15-trixie
+Tags: 15.16, 15, 15.16-trixie, 15-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 2c1a455e1e9e5f0f0a791264c2eec5ef36e1e36f
 Directory: 15/trixie
 
-Tags: 15.15-bookworm, 15-bookworm
+Tags: 15.16-bookworm, 15-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 2c1a455e1e9e5f0f0a791264c2eec5ef36e1e36f
 Directory: 15/bookworm
 
-Tags: 15.15-alpine3.23, 15-alpine3.23, 15.15-alpine, 15-alpine
+Tags: 15.16-alpine3.23, 15-alpine3.23, 15.16-alpine, 15-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39623ba5d20db58a25c3010896baaf54b9aa6b6d
+GitCommit: 2c1a455e1e9e5f0f0a791264c2eec5ef36e1e36f
 Directory: 15/alpine3.23
 
-Tags: 15.15-alpine3.22, 15-alpine3.22
+Tags: 15.16-alpine3.22, 15-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 2c1a455e1e9e5f0f0a791264c2eec5ef36e1e36f
 Directory: 15/alpine3.22
 
-Tags: 14.20, 14, 14.20-trixie, 14-trixie
+Tags: 14.21, 14, 14.21-trixie, 14-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 9cd7083435c29ac323e890883415520b08458939
 Directory: 14/trixie
 
-Tags: 14.20-bookworm, 14-bookworm
+Tags: 14.21-bookworm, 14-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 9cd7083435c29ac323e890883415520b08458939
 Directory: 14/bookworm
 
-Tags: 14.20-alpine3.23, 14-alpine3.23, 14.20-alpine, 14-alpine
+Tags: 14.21-alpine3.23, 14-alpine3.23, 14.21-alpine, 14-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 39623ba5d20db58a25c3010896baaf54b9aa6b6d
+GitCommit: 9cd7083435c29ac323e890883415520b08458939
 Directory: 14/alpine3.23
 
-Tags: 14.20-alpine3.22, 14-alpine3.22
+Tags: 14.21-alpine3.22, 14-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2925b19f45ceeb8ab8488eec226f2736abf297e1
+GitCommit: 9cd7083435c29ac323e890883415520b08458939
 Directory: 14/alpine3.22


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/postgres/commit/12eb576: Update 18 to 18.2, trixie 18.2-1.pgdg13+1, bookworm 18.2-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/fd482cf: Update 17 to 17.8, trixie 17.8-1.pgdg13+1, bookworm 17.8-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/bf13909: Update 16 to 16.12, trixie 16.12-1.pgdg13+1, bookworm 16.12-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/2c1a455: Update 15 to 15.16, trixie 15.16-1.pgdg13+1, bookworm 15.16-1.pgdg12+1
- https://github.com/docker-library/postgres/commit/9cd7083: Update 14 to 14.21, trixie 14.21-1.pgdg13+1, bookworm 14.21-1.pgdg12+1