### PR TITLE
[security] Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: c2c23e09052bb6680ed9f812493a2ae1c93375fd
 Directory: 3.4/alpine
 
-Tags: 3.3.2, 3.3, latest, 3.3.2-trixie, 3.3-trixie, trixie
+Tags: 3.3.3, 3.3, latest, 3.3.3-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 23e56698c0d6c1bdbadee439911e706d56d19856
+GitCommit: 3673c64e349585c71434dd8391cbbb86314b10a7
 Directory: 3.3
 
-Tags: 3.3.2-alpine, 3.3-alpine, alpine, 3.3.2-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.3-alpine, 3.3-alpine, alpine, 3.3.3-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 23e56698c0d6c1bdbadee439911e706d56d19856
+GitCommit: 3673c64e349585c71434dd8391cbbb86314b10a7
 Directory: 3.3/alpine
 
-Tags: 3.2.11, 3.2, lts, 3.2.11-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.12, 3.2, lts, 3.2.12-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6c0a780e41aad7705535e3cc79e41c30e3c2ebfc
+GitCommit: a911c4d9764e7a369eee4a6d03f97d5aabb58d26
 Directory: 3.2
 
-Tags: 3.2.11-alpine, 3.2-alpine, lts-alpine, 3.2.11-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.12-alpine, 3.2-alpine, lts-alpine, 3.2.12-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6c0a780e41aad7705535e3cc79e41c30e3c2ebfc
+GitCommit: a911c4d9764e7a369eee4a6d03f97d5aabb58d26
 Directory: 3.2/alpine
 
-Tags: 3.1.13, 3.1, 3.1.13-trixie, 3.1-trixie
+Tags: 3.1.14, 3.1, 3.1.14-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f3d75b9335ea849791b318d49b529ada1c0e3fc1
+GitCommit: 5404a22c963e815aac92a616b4ddf4423bc7fd3f
 Directory: 3.1
 
-Tags: 3.1.13-alpine, 3.1-alpine, 3.1.13-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.14-alpine, 3.1-alpine, 3.1.14-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f3d75b9335ea849791b318d49b529ada1c0e3fc1
+GitCommit: 5404a22c963e815aac92a616b4ddf4423bc7fd3f
 Directory: 3.1/alpine
 
-Tags: 3.0.15, 3.0, 3.0.15-trixie, 3.0-trixie
+Tags: 3.0.16, 3.0, 3.0.16-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 61e9c67a3c5e624b84fbbfe99ab516f08ab12e6f
+GitCommit: fbc20658be6d68d4565301a1546d7c0fc2aa088d
 Directory: 3.0
 
-Tags: 3.0.15-alpine, 3.0-alpine, 3.0.15-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.16-alpine, 3.0-alpine, 3.0.16-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 61e9c67a3c5e624b84fbbfe99ab516f08ab12e6f
+GitCommit: fbc20658be6d68d4565301a1546d7c0fc2aa088d
 Directory: 3.0/alpine
 
 Tags: 2.8.18, 2.8, 2.8.18-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3673c64: Update 3.3 to 3.3.3
- https://github.com/docker-library/haproxy/commit/a911c4d: Update 3.2 to 3.2.12
- https://github.com/docker-library/haproxy/commit/5404a22: Update 3.1 to 3.1.14
- https://github.com/docker-library/haproxy/commit/fbc2065: Update 3.0 to 3.0.16

https://www.haproxy.com/blog/cves-2026-quic-denial-of-service