### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -3,102 +3,102 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
-GitCommit: f52f4b9dd759bef8d55f6eb06235d35e8d1dc75d
+GitCommit: 4ee1b3b9de1d29c869bc7091bc48a2057f2009c4
 
-Tags: 26-ea-33-jdk-oraclelinux9, 26-ea-33-oraclelinux9, 26-ea-jdk-oraclelinux9, 26-ea-oraclelinux9, 26-ea-33-jdk-oracle, 26-ea-33-oracle, 26-ea-jdk-oracle, 26-ea-oracle
-SharedTags: 26-ea-33-jdk, 26-ea-33, 26-ea-jdk, 26-ea
+Tags: 26-rc-jdk-oraclelinux9, 26-rc-oraclelinux9, 26-rc-jdk-oracle, 26-rc-oracle
+SharedTags: 26-rc-jdk, 26-rc
 Directory: 26/oraclelinux9
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-33-jdk-oraclelinux8, 26-ea-33-oraclelinux8, 26-ea-jdk-oraclelinux8, 26-ea-oraclelinux8
+Tags: 26-rc-jdk-oraclelinux8, 26-rc-oraclelinux8
 Directory: 26/oraclelinux8
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-33-jdk-trixie, 26-ea-33-trixie, 26-ea-jdk-trixie, 26-ea-trixie
+Tags: 26-rc-jdk-trixie, 26-rc-trixie
 Directory: 26/trixie
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-33-jdk-slim-trixie, 26-ea-33-slim-trixie, 26-ea-jdk-slim-trixie, 26-ea-slim-trixie, 26-ea-33-jdk-slim, 26-ea-33-slim, 26-ea-jdk-slim, 26-ea-slim
+Tags: 26-rc-jdk-slim-trixie, 26-rc-slim-trixie, 26-rc-jdk-slim, 26-rc-slim
 Directory: 26/slim-trixie
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-33-jdk-bookworm, 26-ea-33-bookworm, 26-ea-jdk-bookworm, 26-ea-bookworm
+Tags: 26-rc-jdk-bookworm, 26-rc-bookworm
 Directory: 26/bookworm
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-33-jdk-slim-bookworm, 26-ea-33-slim-bookworm, 26-ea-jdk-slim-bookworm, 26-ea-slim-bookworm
+Tags: 26-rc-jdk-slim-bookworm, 26-rc-slim-bookworm
 Directory: 26/slim-bookworm
 Architectures: amd64, arm64v8
 
-Tags: 26-ea-33-jdk-windowsservercore-ltsc2025, 26-ea-33-windowsservercore-ltsc2025, 26-ea-jdk-windowsservercore-ltsc2025, 26-ea-windowsservercore-ltsc2025
-SharedTags: 26-ea-33-jdk-windowsservercore, 26-ea-33-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-33-jdk, 26-ea-33, 26-ea-jdk, 26-ea
+Tags: 26-rc-jdk-windowsservercore-ltsc2025, 26-rc-windowsservercore-ltsc2025
+SharedTags: 26-rc-jdk-windowsservercore, 26-rc-windowsservercore, 26-rc-jdk, 26-rc
 Directory: 26/windows/windowsservercore-ltsc2025
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 26-ea-33-jdk-windowsservercore-ltsc2022, 26-ea-33-windowsservercore-ltsc2022, 26-ea-jdk-windowsservercore-ltsc2022, 26-ea-windowsservercore-ltsc2022
-SharedTags: 26-ea-33-jdk-windowsservercore, 26-ea-33-windowsservercore, 26-ea-jdk-windowsservercore, 26-ea-windowsservercore, 26-ea-33-jdk, 26-ea-33, 26-ea-jdk, 26-ea
+Tags: 26-rc-jdk-windowsservercore-ltsc2022, 26-rc-windowsservercore-ltsc2022
+SharedTags: 26-rc-jdk-windowsservercore, 26-rc-windowsservercore, 26-rc-jdk, 26-rc
 Directory: 26/windows/windowsservercore-ltsc2022
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 26-ea-33-jdk-nanoserver-ltsc2025, 26-ea-33-nanoserver-ltsc2025, 26-ea-jdk-nanoserver-ltsc2025, 26-ea-nanoserver-ltsc2025
-SharedTags: 26-ea-33-jdk-nanoserver, 26-ea-33-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
+Tags: 26-rc-jdk-nanoserver-ltsc2025, 26-rc-nanoserver-ltsc2025
+SharedTags: 26-rc-jdk-nanoserver, 26-rc-nanoserver
 Directory: 26/windows/nanoserver-ltsc2025
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 26-ea-33-jdk-nanoserver-ltsc2022, 26-ea-33-nanoserver-ltsc2022, 26-ea-jdk-nanoserver-ltsc2022, 26-ea-nanoserver-ltsc2022
-SharedTags: 26-ea-33-jdk-nanoserver, 26-ea-33-nanoserver, 26-ea-jdk-nanoserver, 26-ea-nanoserver
+Tags: 26-rc-jdk-nanoserver-ltsc2022, 26-rc-nanoserver-ltsc2022
+SharedTags: 26-rc-jdk-nanoserver, 26-rc-nanoserver
 Directory: 26/windows/nanoserver-ltsc2022
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 27-ea-7-jdk-oraclelinux9, 27-ea-7-oraclelinux9, 27-ea-jdk-oraclelinux9, 27-ea-oraclelinux9, 27-ea-7-jdk-oracle, 27-ea-7-oracle, 27-ea-jdk-oracle, 27-ea-oracle
-SharedTags: 27-ea-7-jdk, 27-ea-7, 27-ea-jdk, 27-ea
+Tags: 27-ea-8-jdk-oraclelinux9, 27-ea-8-oraclelinux9, 27-ea-jdk-oraclelinux9, 27-ea-oraclelinux9, 27-ea-8-jdk-oracle, 27-ea-8-oracle, 27-ea-jdk-oracle, 27-ea-oracle
+SharedTags: 27-ea-8-jdk, 27-ea-8, 27-ea-jdk, 27-ea
 Directory: 27/oraclelinux9
 Architectures: amd64, arm64v8
 
-Tags: 27-ea-7-jdk-oraclelinux8, 27-ea-7-oraclelinux8, 27-ea-jdk-oraclelinux8, 27-ea-oraclelinux8
+Tags: 27-ea-8-jdk-oraclelinux8, 27-ea-8-oraclelinux8, 27-ea-jdk-oraclelinux8, 27-ea-oraclelinux8
 Directory: 27/oraclelinux8
 Architectures: amd64, arm64v8
 
-Tags: 27-ea-7-jdk-trixie, 27-ea-7-trixie, 27-ea-jdk-trixie, 27-ea-trixie
+Tags: 27-ea-8-jdk-trixie, 27-ea-8-trixie, 27-ea-jdk-trixie, 27-ea-trixie
 Directory: 27/trixie
 Architectures: amd64, arm64v8
 
-Tags: 27-ea-7-jdk-slim-trixie, 27-ea-7-slim-trixie, 27-ea-jdk-slim-trixie, 27-ea-slim-trixie, 27-ea-7-jdk-slim, 27-ea-7-slim, 27-ea-jdk-slim, 27-ea-slim
+Tags: 27-ea-8-jdk-slim-trixie, 27-ea-8-slim-trixie, 27-ea-jdk-slim-trixie, 27-ea-slim-trixie, 27-ea-8-jdk-slim, 27-ea-8-slim, 27-ea-jdk-slim, 27-ea-slim
 Directory: 27/slim-trixie
 Architectures: amd64, arm64v8
 
-Tags: 27-ea-7-jdk-bookworm, 27-ea-7-bookworm, 27-ea-jdk-bookworm, 27-ea-bookworm
+Tags: 27-ea-8-jdk-bookworm, 27-ea-8-bookworm, 27-ea-jdk-bookworm, 27-ea-bookworm
 Directory: 27/bookworm
 Architectures: amd64, arm64v8
 
-Tags: 27-ea-7-jdk-slim-bookworm, 27-ea-7-slim-bookworm, 27-ea-jdk-slim-bookworm, 27-ea-slim-bookworm
+Tags: 27-ea-8-jdk-slim-bookworm, 27-ea-8-slim-bookworm, 27-ea-jdk-slim-bookworm, 27-ea-slim-bookworm
 Directory: 27/slim-bookworm
 Architectures: amd64, arm64v8
 
-Tags: 27-ea-7-jdk-windowsservercore-ltsc2025, 27-ea-7-windowsservercore-ltsc2025, 27-ea-jdk-windowsservercore-ltsc2025, 27-ea-windowsservercore-ltsc2025
-SharedTags: 27-ea-7-jdk-windowsservercore, 27-ea-7-windowsservercore, 27-ea-jdk-windowsservercore, 27-ea-windowsservercore, 27-ea-7-jdk, 27-ea-7, 27-ea-jdk, 27-ea
+Tags: 27-ea-8-jdk-windowsservercore-ltsc2025, 27-ea-8-windowsservercore-ltsc2025, 27-ea-jdk-windowsservercore-ltsc2025, 27-ea-windowsservercore-ltsc2025
+SharedTags: 27-ea-8-jdk-windowsservercore, 27-ea-8-windowsservercore, 27-ea-jdk-windowsservercore, 27-ea-windowsservercore, 27-ea-8-jdk, 27-ea-8, 27-ea-jdk, 27-ea
 Directory: 27/windows/windowsservercore-ltsc2025
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 27-ea-7-jdk-windowsservercore-ltsc2022, 27-ea-7-windowsservercore-ltsc2022, 27-ea-jdk-windowsservercore-ltsc2022, 27-ea-windowsservercore-ltsc2022
-SharedTags: 27-ea-7-jdk-windowsservercore, 27-ea-7-windowsservercore, 27-ea-jdk-windowsservercore, 27-ea-windowsservercore, 27-ea-7-jdk, 27-ea-7, 27-ea-jdk, 27-ea
+Tags: 27-ea-8-jdk-windowsservercore-ltsc2022, 27-ea-8-windowsservercore-ltsc2022, 27-ea-jdk-windowsservercore-ltsc2022, 27-ea-windowsservercore-ltsc2022
+SharedTags: 27-ea-8-jdk-windowsservercore, 27-ea-8-windowsservercore, 27-ea-jdk-windowsservercore, 27-ea-windowsservercore, 27-ea-8-jdk, 27-ea-8, 27-ea-jdk, 27-ea
 Directory: 27/windows/windowsservercore-ltsc2022
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 27-ea-7-jdk-nanoserver-ltsc2025, 27-ea-7-nanoserver-ltsc2025, 27-ea-jdk-nanoserver-ltsc2025, 27-ea-nanoserver-ltsc2025
-SharedTags: 27-ea-7-jdk-nanoserver, 27-ea-7-nanoserver, 27-ea-jdk-nanoserver, 27-ea-nanoserver
+Tags: 27-ea-8-jdk-nanoserver-ltsc2025, 27-ea-8-nanoserver-ltsc2025, 27-ea-jdk-nanoserver-ltsc2025, 27-ea-nanoserver-ltsc2025
+SharedTags: 27-ea-8-jdk-nanoserver, 27-ea-8-nanoserver, 27-ea-jdk-nanoserver, 27-ea-nanoserver
 Directory: 27/windows/nanoserver-ltsc2025
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 27-ea-7-jdk-nanoserver-ltsc2022, 27-ea-7-nanoserver-ltsc2022, 27-ea-jdk-nanoserver-ltsc2022, 27-ea-nanoserver-ltsc2022
-SharedTags: 27-ea-7-jdk-nanoserver, 27-ea-7-nanoserver, 27-ea-jdk-nanoserver, 27-ea-nanoserver
+Tags: 27-ea-8-jdk-nanoserver-ltsc2022, 27-ea-8-nanoserver-ltsc2022, 27-ea-jdk-nanoserver-ltsc2022, 27-ea-nanoserver-ltsc2022
+SharedTags: 27-ea-8-jdk-nanoserver, 27-ea-8-nanoserver, 27-ea-jdk-nanoserver, 27-ea-nanoserver
 Directory: 27/windows/nanoserver-ltsc2022
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/5b84a21: Merge pull request https://github.com/docker-library/openjdk/pull/554 from infosiftr/rc-tags
- https://github.com/docker-library/openjdk/commit/4b6d02b: Early access and RC builds don't have a dotted version
- https://github.com/docker-library/openjdk/commit/4ee1b3b: Update 26 to 26-rc; update 27 to 27+ea8
- https://github.com/docker-library/openjdk/commit/a765ee5: Fix windows template to handle rc tags