### PR TITLE
archlinux: Release 20260215.0.490969

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260208.0.488728
-GitCommit: d3f5b0812a7b45490f9ab5298edceacda1c0fd93
-GitFetch: refs/tags/v20260208.0.488728
+Tags: latest, base, base-20260215.0.490969
+GitCommit: 4d96f7165bd7477c8145ddd38a5182b0f961b5f7
+GitFetch: refs/tags/v20260215.0.490969
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260208.0.488728
-GitCommit: d3f5b0812a7b45490f9ab5298edceacda1c0fd93
-GitFetch: refs/tags/v20260208.0.488728
+Tags: base-devel, base-devel-20260215.0.490969
+GitCommit: 4d96f7165bd7477c8145ddd38a5182b0f961b5f7
+GitFetch: refs/tags/v20260215.0.490969
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260208.0.488728
-GitCommit: d3f5b0812a7b45490f9ab5298edceacda1c0fd93
-GitFetch: refs/tags/v20260208.0.488728
+Tags: multilib-devel, multilib-devel-20260215.0.490969
+GitCommit: 4d96f7165bd7477c8145ddd38a5182b0f961b5f7
+GitFetch: refs/tags/v20260215.0.490969
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks