### PR TITLE
MariaDB 12.3 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/8eaa6638a5bcb18849a6cd1b6ee55620d624a861/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/65483980c6c0034361a604ca1e2a048c48da08c6/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
@@ -6,9 +6,19 @@ Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
 GitRepo: https://github.com/MariaDB/mariadb-docker.git
 Builder: buildkit
 
+Tags: 12.3.1-ubi10-rc, 12.3-ubi10-rc, 12.3.1-ubi-rc, 12.3-ubi-rc
+Architectures: amd64, arm64v8, s390x, ppc64le
+GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+Directory: 12.3-ubi
+
+Tags: 12.3.1-noble-rc, 12.3-noble-rc, 12.3.1-rc, 12.3-rc
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 3fbf86c7b9301bcb6b0dc0f4f478800ee458224f
+Directory: 12.3
+
 Tags: 12.2.2-ubi10, 12.2-ubi10, 12-ubi10, 12.2.2-ubi, 12.2-ubi, 12-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 3fbf86c7b9301bcb6b0dc0f4f478800ee458224f
+GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
 Directory: 12.2-ubi
 
 Tags: 12.2.2-noble, 12.2-noble, 12-noble, noble, 12.2.2, 12.2, 12, latest
@@ -16,19 +26,9 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 3fbf86c7b9301bcb6b0dc0f4f478800ee458224f
 Directory: 12.2
 
-Tags: 12.1.2-ubi10, 12.1-ubi10, 12.1.2-ubi, 12.1-ubi
-Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: b6c0c786de44bb9651d687daa9561d0643bb3d2e
-Directory: 12.1-ubi
-
-Tags: 12.1.2-noble, 12.1-noble, 12.1.2, 12.1
-Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 4ef487565005c1acf62dcfaa87110a39262b8150
-Directory: 12.1
-
 Tags: 11.8.6-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.6-ubi, 11.8-ubi, 11-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
 Directory: 11.8-ubi
 
 Tags: 11.8.6-noble, 11.8-noble, 11-noble, lts-noble, 11.8.6, 11.8, 11, lts
@@ -38,7 +38,7 @@ Directory: 11.8
 
 Tags: 11.4.10-ubi9, 11.4-ubi9, 11.4.10-ubi, 11.4-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
 Directory: 11.4-ubi
 
 Tags: 11.4.10-noble, 11.4-noble, 11.4.10, 11.4
@@ -48,7 +48,7 @@ Directory: 11.4
 
 Tags: 10.11.16-ubi9, 10.11-ubi9, 10-ubi9, 10.11.16-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
 Directory: 10.11-ubi
 
 Tags: 10.11.16-jammy, 10.11-jammy, 10-jammy, 10.11.16, 10.11, 10
@@ -58,7 +58,7 @@ Directory: 10.11
 
 Tags: 10.6.25-ubi9, 10.6-ubi9, 10.6.25-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
 Directory: 10.6-ubi
 
 Tags: 10.6.25-jammy, 10.6-jammy, 10.6.25, 10.6


### PR DESCRIPTION
In a sudden move galera isn't there. No idea
who this will impact. So "going with upstream".

Minor clean up of things as the 12.3 docker-entrypoint-initdb.d had tar and gzip requirements that where being
met by galera sst dependences. Made these consistant for all.