### PR TITLE
Update buildpack-deps

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/buildpack-deps/blob/a1e0227454ebf3b856cdf50e4bef4c6fc3bf2ffd/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/buildpack-deps/blob/abbc41715d6f92a6e5137a6a09b59400a6333606/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -108,21 +108,6 @@ Tags: noble, 24.04
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
 GitCommit: 60dc5f9555c521de086b2f5770514faf69ee2cc4
 Directory: ubuntu/noble
-
-Tags: plucky-curl, 25.04-curl
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0
-Directory: ubuntu/plucky/curl
-
-Tags: plucky-scm, 25.04-scm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0
-Directory: ubuntu/plucky/scm
-
-Tags: plucky, 25.04
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: ab3ae04e943ecb240a9691dfa1de219b4a3e32a0
-Directory: ubuntu/plucky
 
 Tags: questing-curl, 25.10-curl
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/buildpack-deps/commit/abbc417: Remove Ubuntu Plucky (EOL)

https://github.com/docker-library/official-images/pull/20863