### PR TITLE
Update Joomla!

### DIFF
--- a/library/joomla
+++ b/library/joomla
@@ -4,47 +4,62 @@ Maintainers: Llewellyn van der Merwe <llewellyn.van-der-merwe@community.joomla.o
              Harald Leithner <harald.leithner@community.joomla.org> (@HLeithner)
 GitRepo: https://github.com/joomla-docker/docker-joomla.git
 
-Tags: 6.0.2, 6.0, 6, latest, 6.0.2-apache, 6.0-apache, 6-apache, apache, 6.0.2-php8.3, 6.0-php8.3, 6-php8.3, php8.3, 6.0.2-php8.3-apache, 6.0-php8.3-apache, 6-php8.3-apache, php8.3-apache
+Tags: 6.0.3-php8.3-apache, 6.0-php8.3-apache, 6-php8.3-apache, php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 6.0/php8.3/apache
 
-Tags: 6.0.2-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.0.3-php8.3-fpm-alpine, 6.0-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 6.0/php8.3/fpm-alpine
 
-Tags: 6.0.2-php8.3-fpm, 6.0-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.0.3-php8.3-fpm, 6.0-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 6.0/php8.3/fpm
 
-Tags: 5.4.2-php8.2-apache, 5.4-php8.2-apache, 5-php8.2-apache
+Tags: 6.0.3, 6.0, 6, latest, 6.0.3-apache, 6.0-apache, 6-apache, apache, 6.0.3-php8.4, 6.0-php8.4, 6-php8.4, php8.4, 6.0.3-php8.4-apache, 6.0-php8.4-apache, 6-php8.4-apache, php8.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
+Directory: 6.0/php8.4/apache
+
+Tags: 6.0.3-php8.4-fpm-alpine, 6.0-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
+Directory: 6.0/php8.4/fpm-alpine
+
+Tags: 6.0.3-php8.4-fpm, 6.0-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
+Directory: 6.0/php8.4/fpm
+
+Tags: 5.4.3-php8.2-apache, 5.4-php8.2-apache, 5-php8.2-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 5.4/php8.2/apache
 
-Tags: 5.4.2-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5-php8.2-fpm-alpine
+Tags: 5.4.3-php8.2-fpm-alpine, 5.4-php8.2-fpm-alpine, 5-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 5.4/php8.2/fpm-alpine
 
-Tags: 5.4.2-php8.2-fpm, 5.4-php8.2-fpm, 5-php8.2-fpm
+Tags: 5.4.3-php8.2-fpm, 5.4-php8.2-fpm, 5-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 5.4/php8.2/fpm
 
-Tags: 5.4.2, 5.4, 5, 5.4.2-apache, 5.4-apache, 5-apache, 5.4.2-php8.3, 5.4-php8.3, 5-php8.3, 5.4.2-php8.3-apache, 5.4-php8.3-apache, 5-php8.3-apache
+Tags: 5.4.3, 5.4, 5, 5.4.3-apache, 5.4-apache, 5-apache, 5.4.3-php8.3, 5.4-php8.3, 5-php8.3, 5.4.3-php8.3-apache, 5.4-php8.3-apache, 5-php8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 5.4/php8.3/apache
 
-Tags: 5.4.2-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5-php8.3-fpm-alpine
+Tags: 5.4.3-php8.3-fpm-alpine, 5.4-php8.3-fpm-alpine, 5-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 5.4/php8.3/fpm-alpine
 
-Tags: 5.4.2-php8.3-fpm, 5.4-php8.3-fpm, 5-php8.3-fpm
+Tags: 5.4.3-php8.3-fpm, 5.4-php8.3-fpm, 5-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8993ee2ff3a2e2b87b5d854d91c9a618647ddcfd
+GitCommit: 3f4f203e035f1175c40cfea25e0db404ba3baa6b
 Directory: 5.4/php8.3/fpm


### PR DESCRIPTION
Changes:

- joomla-docker/docker-joomla@3f4f203: Update Joomla 6.0.2 to 6.0.3 and Joomla 5.4.2 to 5.4.3
                                                                                adds PHP 8.4 to Joomla 6
                                                                                 bump the pecl extensions versions respectively