### PR TITLE
Update KrakenD to v2.13.1

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.0, 2.13, 2, latest
+Tags: 2.13.1, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: c49830a6157382db1498bd9d12f53b2fb9b3567d
-Directory: 2.13.0
+GitCommit: 740c6d87249e2d0331ffe3f9e37054e5d939f850
+Directory: 2.13.1


### PR DESCRIPTION
## KrakenD CE v2.13.1
Recommended upgrade of the Circuit Breaker component

* Upgraded Circuit Breaker component addressing an undisclosed CVE

**Note**: the KrakenD Github organization was renamed from `krakendio` to `krakend`. The download URLs have been tweaked to the new name to avoid a redirection