### PR TITLE
[oraclelinux] Updating 9, 9-slim and 9-slim-fips for ELSA-2026-2786

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a11a4b4af1554e204d9a4b90769c2459ee13e855
+amd64-GitCommit: b1a164628accea5dee53fd949bb56a15186ecfe8
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e9b8c36b409b70b46ec58bd05ed21c023eb8b3b9
+arm64v8-GitCommit: 960893381665c017147a86386634c8de19e1095f
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-15281, CVE-2026-0861, CVE-2026-0915

See the following for details:

ELSA-2026-2786

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
