### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,54 +4,54 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev4, 3.4-dev, 3.4-dev4-trixie, 3.4-dev-trixie
+Tags: 3.4-dev5, 3.4-dev, 3.4-dev5-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c2c23e09052bb6680ed9f812493a2ae1c93375fd
+GitCommit: 37110246de5be54be8073266fb7c78cd9c734007
 Directory: 3.4
 
-Tags: 3.4-dev4-alpine, 3.4-dev-alpine, 3.4-dev4-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev5-alpine, 3.4-dev-alpine, 3.4-dev5-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c2c23e09052bb6680ed9f812493a2ae1c93375fd
+GitCommit: 37110246de5be54be8073266fb7c78cd9c734007
 Directory: 3.4/alpine
 
-Tags: 3.3.3, 3.3, latest, 3.3.3-trixie, 3.3-trixie, trixie
+Tags: 3.3.4, 3.3, latest, 3.3.4-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3673c64e349585c71434dd8391cbbb86314b10a7
+GitCommit: 989ae8d4224a68c4648e8534fd222a74db37c8e9
 Directory: 3.3
 
-Tags: 3.3.3-alpine, 3.3-alpine, alpine, 3.3.3-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.4-alpine, 3.3-alpine, alpine, 3.3.4-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3673c64e349585c71434dd8391cbbb86314b10a7
+GitCommit: 989ae8d4224a68c4648e8534fd222a74db37c8e9
 Directory: 3.3/alpine
 
-Tags: 3.2.12, 3.2, lts, 3.2.12-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.13, 3.2, lts, 3.2.13-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a911c4d9764e7a369eee4a6d03f97d5aabb58d26
+GitCommit: 99a94e42356e03c35a698781da8c0c19bfd3e505
 Directory: 3.2
 
-Tags: 3.2.12-alpine, 3.2-alpine, lts-alpine, 3.2.12-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.13-alpine, 3.2-alpine, lts-alpine, 3.2.13-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a911c4d9764e7a369eee4a6d03f97d5aabb58d26
+GitCommit: 99a94e42356e03c35a698781da8c0c19bfd3e505
 Directory: 3.2/alpine
 
-Tags: 3.1.14, 3.1, 3.1.14-trixie, 3.1-trixie
+Tags: 3.1.15, 3.1, 3.1.15-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5404a22c963e815aac92a616b4ddf4423bc7fd3f
+GitCommit: be08009334efef7924299f7c73a79fa751d501c1
 Directory: 3.1
 
-Tags: 3.1.14-alpine, 3.1-alpine, 3.1.14-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.15-alpine, 3.1-alpine, 3.1.15-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5404a22c963e815aac92a616b4ddf4423bc7fd3f
+GitCommit: be08009334efef7924299f7c73a79fa751d501c1
 Directory: 3.1/alpine
 
-Tags: 3.0.16, 3.0, 3.0.16-trixie, 3.0-trixie
+Tags: 3.0.17, 3.0, 3.0.17-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fbc20658be6d68d4565301a1546d7c0fc2aa088d
+GitCommit: 829551699c7dd2422c69df3c8dd1f098bb0c1a3a
 Directory: 3.0
 
-Tags: 3.0.16-alpine, 3.0-alpine, 3.0.16-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.17-alpine, 3.0-alpine, 3.0.17-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fbc20658be6d68d4565301a1546d7c0fc2aa088d
+GitCommit: 829551699c7dd2422c69df3c8dd1f098bb0c1a3a
 Directory: 3.0/alpine
 
 Tags: 2.8.18, 2.8, 2.8.18-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3711024: Update 3.4 to 3.4-dev5
- https://github.com/docker-library/haproxy/commit/989ae8d: Update 3.3 to 3.3.4
- https://github.com/docker-library/haproxy/commit/99a94e4: Update 3.2 to 3.2.13
- https://github.com/docker-library/haproxy/commit/be08009: Update 3.1 to 3.1.15
- https://github.com/docker-library/haproxy/commit/8295516: Update 3.0 to 3.0.17