### PR TITLE
Update nextcloud

### DIFF
--- a/library/nextcloud
+++ b/library/nextcloud
@@ -5,30 +5,45 @@ GitRepo: https://github.com/nextcloud/docker.git
 
 Tags: 31.0.14-apache, 31.0-apache, 31-apache, 31.0.14, 31.0, 31
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a548962b17b1708dd84dc0561b522f47ca480e16
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
 Directory: 31/apache
 
 Tags: 31.0.14-fpm, 31.0-fpm, 31-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a548962b17b1708dd84dc0561b522f47ca480e16
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
 Directory: 31/fpm
 
 Tags: 31.0.14-fpm-alpine, 31.0-fpm-alpine, 31-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a548962b17b1708dd84dc0561b522f47ca480e16
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
 Directory: 31/fpm-alpine
 
-Tags: 32.0.6-apache, 32.0-apache, 32-apache, apache, stable-apache, production-apache, 32.0.6, 32.0, 32, latest, stable, production
+Tags: 32.0.6-apache, 32.0-apache, 32-apache, 32.0.6, 32.0, 32
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a548962b17b1708dd84dc0561b522f47ca480e16
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
 Directory: 32/apache
 
-Tags: 32.0.6-fpm, 32.0-fpm, 32-fpm, fpm, stable-fpm, production-fpm
+Tags: 32.0.6-fpm, 32.0-fpm, 32-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a548962b17b1708dd84dc0561b522f47ca480e16
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
 Directory: 32/fpm
 
-Tags: 32.0.6-fpm-alpine, 32.0-fpm-alpine, 32-fpm-alpine, fpm-alpine, stable-fpm-alpine, production-fpm-alpine
+Tags: 32.0.6-fpm-alpine, 32.0-fpm-alpine, 32-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: a548962b17b1708dd84dc0561b522f47ca480e16
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
 Directory: 32/fpm-alpine
+
+Tags: 33.0.0-apache, 33.0-apache, 33-apache, apache, stable-apache, production-apache, 33.0.0, 33.0, 33, latest, stable, production
+Architectures: amd64, arm33v5, arm33v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
+Directory: 33/apache
+
+Tags: 33.0.0-fpm, 33.0-fpm, 33-fpm, fpm, stable-fpm, production-fpm
+Architectures: amd64, arm33v5, arm33v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
+Directory: 33/fpm
+
+Tags: 33.0.0-fpm-alpine, 33.0-fpm-alpine, 33-fpm-alpine, fpm-alpine, stable-fpm-alpine, production-fpm-alpine
+Architectures: amd64, arm33v6, arm33v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 145c97aed6dc421dfe55aecb759c0afe8a604c9e
+Directory: 33/fpm-alpine


### PR DESCRIPTION
A new stable version of nextcloud has been available since February 18. I have updated the version and GitCommit. I wasn't sure whether version 31 should be deleted, as it is no longer supported, if I understand correctly.