### PR TITLE
caddy: v2.11.1 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,130 +1,68 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/f760f9dcc0e12d0729e26c968be313dc59ba584f/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/1dc09bb684f72bde5259ea55eae3297f69c86637/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
-Tags: 2.11.0-beta.2-alpine, 2.11-alpine
-SharedTags: 2.11.0-beta.2, 2.11
+Tags: 2.11.1-alpine, 2.11-alpine, 2-alpine, alpine
+SharedTags: 2.11.1, 2.11, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/alpine
-GitCommit: 272e3f8bf40120000fbd9deb4a9003892a8e7c5e
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.11.0-beta.2-builder-alpine, 2.11-builder-alpine
-SharedTags: 2.11.0-beta.2-builder, 2.11-builder
+Tags: 2.11.1-builder-alpine, 2.11-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.11.1-builder, 2.11-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/builder
-GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.11.0-beta.2-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
-SharedTags: 2.11.0-beta.2-windowsservercore, 2.11-windowsservercore, 2.11.0-beta.2, 2.11
+Tags: 2.11.1-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.11.1-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore, 2.11.1, 2.11, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows/ltsc2022
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.2-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025
-SharedTags: 2.11.0-beta.2-windowsservercore, 2.11-windowsservercore, 2.11.0-beta.2, 2.11
+Tags: 2.11.1-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 2.11.1-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore, 2.11.1, 2.11, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows/ltsc2025
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 2.11.0-beta.2-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
-SharedTags: 2.11.0-beta.2-nanoserver, 2.11-nanoserver
+Tags: 2.11.1-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.11.1-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2022
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.2-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025
-SharedTags: 2.11.0-beta.2-nanoserver, 2.11-nanoserver
+Tags: 2.11.1-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 2.11.1-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2025
-GitCommit: f760f9dcc0e12d0729e26c968be313dc59ba584f
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 2.11.0-beta.2-builder-windowsservercore-ltsc2022, 2.11-builder-windowsservercore-ltsc2022
-SharedTags: 2.11.0-beta.2-builder, 2.11-builder
+Tags: 2.11.1-builder-windowsservercore-ltsc2022, 2.11-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.11.1-builder, 2.11-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2022
-GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.0-beta.2-builder-windowsservercore-ltsc2025, 2.11-builder-windowsservercore-ltsc2025
-SharedTags: 2.11.0-beta.2-builder, 2.11-builder
+Tags: 2.11.1-builder-windowsservercore-ltsc2025, 2.11-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
+SharedTags: 2.11.1-builder, 2.11-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2025
-GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2025
-
-Tags: 2.10.2-alpine, 2.10-alpine, 2-alpine, alpine
-SharedTags: 2.10.2, 2.10, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/alpine
-GitCommit: 272e3f8bf40120000fbd9deb4a9003892a8e7c5e
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
-
-Tags: 2.10.2-builder-alpine, 2.10-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/builder
-GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
-Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
-
-Tags: 2.10.2-windowsservercore-ltsc2022, 2.10-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.10.2-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.2, 2.10, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows/ltsc2022
-GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 2.10.2-windowsservercore-ltsc2025, 2.10-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 2.10.2-windowsservercore, 2.10-windowsservercore, 2-windowsservercore, windowsservercore, 2.10.2, 2.10, 2, latest
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows/ltsc2025
-GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2025
-
-Tags: 2.10.2-nanoserver-ltsc2022, 2.10-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.10.2-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows-nanoserver/ltsc2022
-GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
-Architectures: windows-amd64
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
-Tags: 2.10.2-nanoserver-ltsc2025, 2.10-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 2.10.2-nanoserver, 2.10-nanoserver, 2-nanoserver, nanoserver
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows-nanoserver/ltsc2025
-GitCommit: cb53459d74f53359cd4abecf2fcda1a20c101eab
-Architectures: windows-amd64
-Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
-
-Tags: 2.10.2-builder-windowsservercore-ltsc2022, 2.10-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows-builder/ltsc2022
-GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 2.10.2-builder-windowsservercore-ltsc2025, 2.10-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
-SharedTags: 2.10.2-builder, 2.10-builder, 2-builder, builder
-GitRepo: https://github.com/caddyserver/caddy-docker.git
-Directory: 2.10/windows-builder/ltsc2025
-GitCommit: 300a68ffcad36145ac11498abbd3b90a69be6aca
+GitCommit: 1dc09bb684f72bde5259ea55eae3297f69c86637
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.11.1