### PR TITLE
Bump Traefik to v2.11.38 and to v3.6.9

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,41 +1,41 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.6.8-windowsservercore-ltsc2022, 3.6.8-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.9-windowsservercore-ltsc2022, 3.6.9-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c55f3ab46832bd745fc4b0367f0ed6256f4427d6
+GitCommit: 75f26cef88c9cfdf907698eef42d027bf569bf1a
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.8-nanoserver-ltsc2022, 3.6.8-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.9-nanoserver-ltsc2022, 3.6.9-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c55f3ab46832bd745fc4b0367f0ed6256f4427d6
+GitCommit: 75f26cef88c9cfdf907698eef42d027bf569bf1a
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.8, 3.6.8, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.9, 3.6.9, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c55f3ab46832bd745fc4b0367f0ed6256f4427d6
+GitCommit: 75f26cef88c9cfdf907698eef42d027bf569bf1a
 Directory: v3.6/alpine
 
-Tags: v2.11.37-windowsservercore-ltsc2022, 2.11.37-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.38-windowsservercore-ltsc2022, 2.11.38-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 296803e3754612a2910e83ba1c4aed2b9414e4ac
+GitCommit: fabf1ab35f387a15d9c271166a9231dc80dccba6
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.37-nanoserver-ltsc2022, 2.11.37-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.38-nanoserver-ltsc2022, 2.11.38-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 296803e3754612a2910e83ba1c4aed2b9414e4ac
+GitCommit: fabf1ab35f387a15d9c271166a9231dc80dccba6
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.37, 2.11.37, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.38, 2.11.38, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 296803e3754612a2910e83ba1c4aed2b9414e4ac
+GitCommit: fabf1ab35f387a15d9c271166a9231dc80dccba6
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.38](https://github.com/traefik/traefik/releases/tag/v2.11.38), and [v3.6.9](https://github.com/traefik/traefik/releases/tag/v3.6.9).

/cc @nmengin @rtribotte  @kevinpollet