### PR TITLE
[oraclelinux] Updating 8, 8-slim and 8-slim-fips for ELSA-2026-3042

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b1a164628accea5dee53fd949bb56a15186ecfe8
+amd64-GitCommit: 21e5582bca3829a6a1746c59a50864fdeed76178
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 960893381665c017147a86386634c8de19e1095f
+arm64v8-GitCommit: 4ae3b33d10a5b9b43dad990343e9a2c657e80f35
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-69419

See the following for details:

ELSA-2026-3042

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
