### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/64903e30a3bd3556c0974aa7b41da4f24f97b803/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/32ed6b6c9363239c5acccfcf89bf401e07fc33c3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 64903e30a3bd3556c0974aa7b41da4f24f97b803
+GitCommit: 32ed6b6c9363239c5acccfcf89bf401e07fc33c3
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9b4d4be67b9f2a68ddbd9975a6779bd5bdfe60fa
+amd64-GitCommit: 557f024d4e247f4fa6e086640e7982333b29f04e
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: fb7dd97d590a07d2e69650f8dc7aa5a23ab55589
+arm32v5-GitCommit: 3edda89aee2cb45463eb3e4858b0d0b55b28b0cd
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: e4def65e99453b20d5cb5a90b2029fe38825c3e3
+arm32v6-GitCommit: 262f1f8fc3fd7ae038d0abee2908193c1f8ed7fd
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: f9c0ba5920a85dbcb7a575880f0eb0c8a74e7309
+arm32v7-GitCommit: 6dde356a78739c0bf7e2fcd3c84a194431bdd73b
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d4b4fb07165bc3ee219eebc530b27c56dd28eba0
+arm64v8-GitCommit: 86823563177e12460ad3e122103a3ee14691807d
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: da1b602f27a56ff20e8e5e1ec23d5e44f5e47586
+i386-GitCommit: b637faa0f5db2890dab7f4b93495ee1c7d951b08
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 403811e3da78b5ad4d8356f99d78e9b4e1997a60
+ppc64le-GitCommit: ec0723d76b735e22d7b8070f928ab6de1cc8a17a
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: b6d7978dcbd904ceb4aaa4c88224550d008ab274
+riscv64-GitCommit: e43482cb6af1ec3c0e58945046222805ad069d5b
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: e2eb9d29e6467c31535f5fba9521b7b08238b933
+s390x-GitCommit: d76495a831258bec4d30c217b742399a4a793bfc
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/32ed6b6: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/f876a64: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/756806d: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/b596c0e: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/451d2e0: Merge pull request https://github.com/docker-library/busybox/pull/243 from infosiftr/buildroot-2025.11.2
- https://github.com/docker-library/busybox/commit/0e103ab: Update metadata for amd64 and i386
- https://github.com/docker-library/busybox/commit/4451db9: Update buildroot to 2025.11.2