### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -84,62 +84,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.5/alpine
 
-Tags: beta-7.0-beta1-php8.2-apache, beta-7.0-php8.2-apache, beta-7-php8.2-apache, beta-php8.2-apache, beta-7.0-beta1-php8.2, beta-7.0-php8.2, beta-7-php8.2, beta-php8.2
+Tags: beta-7.0-beta2-php8.2-apache, beta-7.0-php8.2-apache, beta-7-php8.2-apache, beta-php8.2-apache, beta-7.0-beta2-php8.2, beta-7.0-php8.2, beta-7-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.2/apache
 
-Tags: beta-7.0-beta1-php8.2-fpm, beta-7.0-php8.2-fpm, beta-7-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-7.0-beta2-php8.2-fpm, beta-7.0-php8.2-fpm, beta-7-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.2/fpm
 
-Tags: beta-7.0-beta1-php8.2-fpm-alpine, beta-7.0-php8.2-fpm-alpine, beta-7-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-7.0-beta2-php8.2-fpm-alpine, beta-7.0-php8.2-fpm-alpine, beta-7-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.2/fpm-alpine
 
-Tags: beta-7.0-beta1-apache, beta-7.0-apache, beta-7-apache, beta-apache, beta-7.0-beta1, beta-7.0, beta-7, beta, beta-7.0-beta1-php8.3-apache, beta-7.0-php8.3-apache, beta-7-php8.3-apache, beta-php8.3-apache, beta-7.0-beta1-php8.3, beta-7.0-php8.3, beta-7-php8.3, beta-php8.3
+Tags: beta-7.0-beta2-apache, beta-7.0-apache, beta-7-apache, beta-apache, beta-7.0-beta2, beta-7.0, beta-7, beta, beta-7.0-beta2-php8.3-apache, beta-7.0-php8.3-apache, beta-7-php8.3-apache, beta-php8.3-apache, beta-7.0-beta2-php8.3, beta-7.0-php8.3, beta-7-php8.3, beta-php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.3/apache
 
-Tags: beta-7.0-beta1-fpm, beta-7.0-fpm, beta-7-fpm, beta-fpm, beta-7.0-beta1-php8.3-fpm, beta-7.0-php8.3-fpm, beta-7-php8.3-fpm, beta-php8.3-fpm
+Tags: beta-7.0-beta2-fpm, beta-7.0-fpm, beta-7-fpm, beta-fpm, beta-7.0-beta2-php8.3-fpm, beta-7.0-php8.3-fpm, beta-7-php8.3-fpm, beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.3/fpm
 
-Tags: beta-7.0-beta1-fpm-alpine, beta-7.0-fpm-alpine, beta-7-fpm-alpine, beta-fpm-alpine, beta-7.0-beta1-php8.3-fpm-alpine, beta-7.0-php8.3-fpm-alpine, beta-7-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Tags: beta-7.0-beta2-fpm-alpine, beta-7.0-fpm-alpine, beta-7-fpm-alpine, beta-fpm-alpine, beta-7.0-beta2-php8.3-fpm-alpine, beta-7.0-php8.3-fpm-alpine, beta-7-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.3/fpm-alpine
 
-Tags: beta-7.0-beta1-php8.4-apache, beta-7.0-php8.4-apache, beta-7-php8.4-apache, beta-php8.4-apache, beta-7.0-beta1-php8.4, beta-7.0-php8.4, beta-7-php8.4, beta-php8.4
+Tags: beta-7.0-beta2-php8.4-apache, beta-7.0-php8.4-apache, beta-7-php8.4-apache, beta-php8.4-apache, beta-7.0-beta2-php8.4, beta-7.0-php8.4, beta-7-php8.4, beta-php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.4/apache
 
-Tags: beta-7.0-beta1-php8.4-fpm, beta-7.0-php8.4-fpm, beta-7-php8.4-fpm, beta-php8.4-fpm
+Tags: beta-7.0-beta2-php8.4-fpm, beta-7.0-php8.4-fpm, beta-7-php8.4-fpm, beta-php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.4/fpm
 
-Tags: beta-7.0-beta1-php8.4-fpm-alpine, beta-7.0-php8.4-fpm-alpine, beta-7-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
+Tags: beta-7.0-beta2-php8.4-fpm-alpine, beta-7.0-php8.4-fpm-alpine, beta-7-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.4/fpm-alpine
 
-Tags: beta-7.0-beta1-php8.5-apache, beta-7.0-php8.5-apache, beta-7-php8.5-apache, beta-php8.5-apache, beta-7.0-beta1-php8.5, beta-7.0-php8.5, beta-7-php8.5, beta-php8.5
+Tags: beta-7.0-beta2-php8.5-apache, beta-7.0-php8.5-apache, beta-7-php8.5-apache, beta-php8.5-apache, beta-7.0-beta2-php8.5, beta-7.0-php8.5, beta-7-php8.5, beta-php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.5/apache
 
-Tags: beta-7.0-beta1-php8.5-fpm, beta-7.0-php8.5-fpm, beta-7-php8.5-fpm, beta-php8.5-fpm
+Tags: beta-7.0-beta2-php8.5-fpm, beta-7.0-php8.5-fpm, beta-7-php8.5-fpm, beta-php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.5/fpm
 
-Tags: beta-7.0-beta1-php8.5-fpm-alpine, beta-7.0-php8.5-fpm-alpine, beta-7-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
+Tags: beta-7.0-beta2-php8.5-fpm-alpine, beta-7.0-php8.5-fpm-alpine, beta-7-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3973605600c47b1ccb8b93921ace0604d8e67d8c
+GitCommit: ec762da1bc2c364b24c8240cec359e6f5eae96f2
 Directory: beta/php8.5/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/ec762da: Update beta to 7.0-beta2