### PR TITLE
archlinux: Release 20260301.0.494762

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260222.0.493200
-GitCommit: 93d30073990300a1b508f7001c4c107bccbad1ba
-GitFetch: refs/tags/v20260222.0.493200
+Tags: latest, base, base-20260301.0.494762
+GitCommit: 8a52dcc7d49d37b356892e9d20fa68d89dff503a
+GitFetch: refs/tags/v20260301.0.494762
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260222.0.493200
-GitCommit: 93d30073990300a1b508f7001c4c107bccbad1ba
-GitFetch: refs/tags/v20260222.0.493200
+Tags: base-devel, base-devel-20260301.0.494762
+GitCommit: 8a52dcc7d49d37b356892e9d20fa68d89dff503a
+GitFetch: refs/tags/v20260301.0.494762
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260222.0.493200
-GitCommit: 93d30073990300a1b508f7001c4c107bccbad1ba
-GitFetch: refs/tags/v20260222.0.493200
+Tags: multilib-devel, multilib-devel-20260301.0.494762
+GitCommit: 8a52dcc7d49d37b356892e9d20fa68d89dff503a
+GitFetch: refs/tags/v20260301.0.494762
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks