### PR TITLE
Updated stable alpine-slim hashes for nginx

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -30,7 +30,7 @@ Directory: mainline/alpine-perl
 
 Tags: 1.29.5-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.29-alpine-slim, alpine-slim, 1.29.5-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.29-alpine3.23-slim, alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
+GitCommit: e2ce6fac3776b07c746ec4e0d26ab07cb45c3cec
 Directory: mainline/alpine-slim
 
 Tags: 1.29.5-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.29-alpine-otel, alpine-otel, 1.29.5-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.29-alpine3.23-otel, alpine3.23-otel
@@ -65,7 +65,7 @@ Directory: stable/alpine-perl
 
 Tags: 1.28.2-alpine-slim, stable-alpine-slim, 1.28-alpine-slim, 1.28.2-alpine3.23-slim, stable-alpine3.23-slim, 1.28-alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: ffe72978e08c5b0dacecd604e528f6d0741a9ae5
+GitCommit: e2ce6fac3776b07c746ec4e0d26ab07cb45c3cec
 Directory: stable/alpine-slim
 
 Tags: 1.28.2-alpine-otel, stable-alpine-otel, 1.28-alpine-otel, 1.28.2-alpine3.23-otel, stable-alpine3.23-otel, 1.28-alpine3.23-otel


### PR DESCRIPTION
Incorporates changes making sure nginx.org repo is used when building stable images.

W/o the changes due to a recent nginx version bump in Alpine upstream, wrong binaries could be pulled, as caught by CI.