### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.10.20260202.2
+Tags: 2023, latest, 2023.10.20260216.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 5bf38a1e9fac9d7056dd38e74b2e1c1d32e55ae8
+amd64-GitCommit: 77b0f4905ce77c6b36669123051adc4947ea9a9b
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: e4ef08ff4b154dfa4c1ccc37c3b2ff9514cb1e87
+arm64v8-GitCommit: 286c81a5b2d310277670ccfd5710834be988e4b4
 
-Tags: 2, 2.0.20260202.2
+Tags: 2, 2.0.20260216.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 663d9bf516bbd3ffdcc80818093e5143ea771b93
+amd64-GitCommit: 7f2f8130f23dd0653adfd7cb1e1beea193ba1c7b
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 6597466bee690a6bdbf980e5b96091e7e244cd40
+arm64v8-GitCommit: 656448bbe47c348eab4535557ebd23f50eacc809
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- libcurl-8.3.0-1.amzn2.0.12
- expat-2.1.0-15.amzn2.0.6
- openssl-libs-1.0.2k-24.amzn2.0.17
- curl-8.3.0-1.amzn2.0.12
#### Packages addressing CVES:
- libcurl-8.3.0-1.amzn2.0.12, curl-8.3.0-1.amzn2.0.12
  - [CVE-2025-10966](https://alas.aws.amazon.com/cve/html/CVE-2025-10966.html)
  - [CVE-2025-14017](https://alas.aws.amazon.com/cve/html/CVE-2025-14017.html)
  - [CVE-2025-14524](https://alas.aws.amazon.com/cve/html/CVE-2025-14524.html)
  - [CVE-2025-14819](https://alas.aws.amazon.com/cve/html/CVE-2025-14819.html)
  - [CVE-2025-15079](https://alas.aws.amazon.com/cve/html/CVE-2025-15079.html)
  - [CVE-2025-15224](https://alas.aws.amazon.com/cve/html/CVE-2025-15224.html)
- expat-2.1.0-15.amzn2.0.6
  - [CVE-2026-25210](https://alas.aws.amazon.com/cve/html/CVE-2026-25210.html)
- openssl-libs-1.0.2k-24.amzn2.0.17
  - [CVE-2025-68160](https://alas.aws.amazon.com/cve/html/CVE-2025-68160.html)
  - [CVE-2025-69420](https://alas.aws.amazon.com/cve/html/CVE-2025-69420.html)
  - [CVE-2025-69421](https://alas.aws.amazon.com/cve/html/CVE-2025-69421.html)
  - [CVE-2026-22796](https://alas.aws.amazon.com/cve/html/CVE-2026-22796.html)

### Updated Packages for Amazon Linux 2023:
- expat-2.6.3-1.amzn2023.0.4
- coreutils-single-8.32-30.amzn2023.0.5
- openssl-fips-provider-latest-3.2.2-1.amzn2023.0.5
- libcurl-minimal-8.17.0-1.amzn2023.0.1
- gnupg2-minimal-2.3.7-1.amzn2023.0.7
- publicsuffix-list-dafsa-20260116-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.10.20260216-0.amzn2023
- system-release-2023.10.20260216-0.amzn2023
- zlib-1.2.11-33.amzn2023.0.6
- openssl-libs-3.2.2-1.amzn2023.0.5
- curl-minimal-8.17.0-1.amzn2023.0.1
#### Packages addressing CVES:
- expat-2.6.3-1.amzn2023.0.4
  - [CVE-2026-25210](https://alas.aws.amazon.com/cve/html/CVE-2026-25210.html)
- openssl-fips-provider-latest-3.2.2-1.amzn2023.0.5, openssl-libs-3.2.2-1.amzn2023.0.5
  - [CVE-2025-15468](https://alas.aws.amazon.com/cve/html/CVE-2025-15468.html)
  - [CVE-2025-66199](https://alas.aws.amazon.com/cve/html/CVE-2025-66199.html)
  - [CVE-2025-68160](https://alas.aws.amazon.com/cve/html/CVE-2025-68160.html)
  - [CVE-2025-69418](https://alas.aws.amazon.com/cve/html/CVE-2025-69418.html)
  - [CVE-2025-69419](https://alas.aws.amazon.com/cve/html/CVE-2025-69419.html)
  - [CVE-2025-69420](https://alas.aws.amazon.com/cve/html/CVE-2025-69420.html)
  - [CVE-2025-69421](https://alas.aws.amazon.com/cve/html/CVE-2025-69421.html)
  - [CVE-2026-22795](https://alas.aws.amazon.com/cve/html/CVE-2026-22795.html)
  - [CVE-2026-22796](https://alas.aws.amazon.com/cve/html/CVE-2026-22796.html)
- libcurl-minimal-8.17.0-1.amzn2023.0.1, curl-minimal-8.17.0-1.amzn2023.0.1
  - [CVE-2025-13034](https://alas.aws.amazon.com/cve/html/CVE-2025-13034.html)
  - [CVE-2025-14017](https://alas.aws.amazon.com/cve/html/CVE-2025-14017.html)
  - [CVE-2025-14524](https://alas.aws.amazon.com/cve/html/CVE-2025-14524.html)
  - [CVE-2025-14819](https://alas.aws.amazon.com/cve/html/CVE-2025-14819.html)
  - [CVE-2025-15079](https://alas.aws.amazon.com/cve/html/CVE-2025-15079.html)
  - [CVE-2025-15224](https://alas.aws.amazon.com/cve/html/CVE-2025-15224.html)
- gnupg2-minimal-2.3.7-1.amzn2023.0.7
  - [CVE-2026-24882](https://alas.aws.amazon.com/cve/html/CVE-2026-24882.html)