### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-3477

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 21e5582bca3829a6a1746c59a50864fdeed76178
+amd64-GitCommit: c5ea29f1689b87cba665b65f9216aab4f4cc26d4
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4ae3b33d10a5b9b43dad990343e9a2c657e80f35
+arm64v8-GitCommit: bd2e7bbff0cf56fbd21c086de3076a019605d92f
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-14831, CVE-2025-9820

See the following for details:

ELSA-2026-3477

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
