### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev5, 3.4-dev, 3.4-dev5-trixie, 3.4-dev-trixie
+Tags: 3.4-dev6, 3.4-dev, 3.4-dev6-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 37110246de5be54be8073266fb7c78cd9c734007
+GitCommit: fdc3f623fd64fd54af94f2eca500de6a67252725
 Directory: 3.4
 
-Tags: 3.4-dev5-alpine, 3.4-dev-alpine, 3.4-dev5-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev6-alpine, 3.4-dev-alpine, 3.4-dev6-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 37110246de5be54be8073266fb7c78cd9c734007
+GitCommit: fdc3f623fd64fd54af94f2eca500de6a67252725
 Directory: 3.4/alpine
 
 Tags: 3.3.4, 3.3, latest, 3.3.4-trixie, 3.3-trixie, trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/fdc3f62: Update 3.4 to 3.4-dev6