### PR TITLE
rust: Bump Rust version to 1.94.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,53 +5,53 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.93-bullseye, 1.93.1-bullseye, bullseye
+Tags: 1-bullseye, 1.94-bullseye, 1.94.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.93-slim-bullseye, 1.93.1-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.94-slim-bullseye, 1.94.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.93-bookworm, 1.93.1-bookworm, bookworm
+Tags: 1-bookworm, 1.94-bookworm, 1.94.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.93-slim-bookworm, 1.93.1-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.94-slim-bookworm, 1.94.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.93-trixie, 1.93.1-trixie, trixie, 1, 1.93, 1.93.1, latest
+Tags: 1-trixie, 1.94-trixie, 1.94.0-trixie, trixie, 1, 1.94, 1.94.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.93-slim-trixie, 1.93.1-slim-trixie, slim-trixie, 1-slim, 1.93-slim, 1.93.1-slim, slim
+Tags: 1-slim-trixie, 1.94-slim-trixie, 1.94.0-slim-trixie, slim-trixie, 1-slim, 1.94-slim, 1.94.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.20, 1.93-alpine3.20, 1.93.1-alpine3.20, alpine3.20
+Tags: 1-alpine3.20, 1.94-alpine3.20, 1.94.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/alpine3.20
 
-Tags: 1-alpine3.21, 1.93-alpine3.21, 1.93.1-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.94-alpine3.21, 1.94.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.93-alpine3.22, 1.93.1-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.94-alpine3.22, 1.94.0-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.93-alpine3.23, 1.93.1-alpine3.23, alpine3.23, 1-alpine, 1.93-alpine, 1.93.1-alpine, alpine
+Tags: 1-alpine3.23, 1.94-alpine3.23, 1.94.0-alpine3.23, alpine3.23, 1-alpine, 1.94-alpine, 1.94.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a67145c24ae0a04790c9d7b5289beb103e35e95e
+GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
 Directory: stable/alpine3.23
 


### PR DESCRIPTION
https://blog.rust-lang.org/2026/03/05/Rust-1.94.0/
https://github.com/rust-lang/rust/releases/tag/1.94.0