### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.26.0-trixie, 1.26-trixie, 1-trixie, trixie
-SharedTags: 1.26.0, 1.26, 1, latest
+Tags: 1.26.1-trixie, 1.26-trixie, 1-trixie, trixie
+SharedTags: 1.26.1, 1.26, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/trixie
 
-Tags: 1.26.0-bookworm, 1.26-bookworm, 1-bookworm, bookworm
+Tags: 1.26.1-bookworm, 1.26-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/bookworm
 
-Tags: 1.26.0-alpine3.23, 1.26-alpine3.23, 1-alpine3.23, alpine3.23, 1.26.0-alpine, 1.26-alpine, 1-alpine, alpine
+Tags: 1.26.1-alpine3.23, 1.26-alpine3.23, 1-alpine3.23, alpine3.23, 1.26.1-alpine, 1.26-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/alpine3.23
 
-Tags: 1.26.0-alpine3.22, 1.26-alpine3.22, 1-alpine3.22, alpine3.22
+Tags: 1.26.1-alpine3.22, 1.26-alpine3.22, 1-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/alpine3.22
 
-Tags: 1.26.0-windowsservercore-ltsc2025, 1.26-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 1.26.0-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.0, 1.26, 1, latest
+Tags: 1.26.1-windowsservercore-ltsc2025, 1.26-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.26.1-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.1, 1.26, 1, latest
 Architectures: windows-amd64
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.26.0-windowsservercore-ltsc2022, 1.26-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.26.0-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.0, 1.26, 1, latest
+Tags: 1.26.1-windowsservercore-ltsc2022, 1.26-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.26.1-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.1, 1.26, 1, latest
 Architectures: windows-amd64
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.26.0-nanoserver-ltsc2025, 1.26-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 1.26.0-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.26.1-nanoserver-ltsc2025, 1.26-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 1.26.1-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.26.0-nanoserver-ltsc2022, 1.26-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.26.0-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.26.1-nanoserver-ltsc2022, 1.26-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.26.1-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 0a8424b32f5bbc6cdb2bd80efdf1c363083b5d5c
+GitCommit: c8592aafabc63c68da0ef207f1b35c0548a7114a
 Directory: 1.26/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.25.7-trixie, 1.25-trixie
-SharedTags: 1.25.7, 1.25
+Tags: 1.25.8-trixie, 1.25-trixie
+SharedTags: 1.25.8, 1.25
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/trixie
 
-Tags: 1.25.7-bookworm, 1.25-bookworm
+Tags: 1.25.8-bookworm, 1.25-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/bookworm
 
-Tags: 1.25.7-alpine3.23, 1.25-alpine3.23, 1.25.7-alpine, 1.25-alpine
+Tags: 1.25.8-alpine3.23, 1.25-alpine3.23, 1.25.8-alpine, 1.25-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/alpine3.23
 
-Tags: 1.25.7-alpine3.22, 1.25-alpine3.22
+Tags: 1.25.8-alpine3.22, 1.25-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/alpine3.22
 
-Tags: 1.25.7-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025
-SharedTags: 1.25.7-windowsservercore, 1.25-windowsservercore, 1.25.7, 1.25
+Tags: 1.25.8-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025
+SharedTags: 1.25.8-windowsservercore, 1.25-windowsservercore, 1.25.8, 1.25
 Architectures: windows-amd64
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.25.7-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022
-SharedTags: 1.25.7-windowsservercore, 1.25-windowsservercore, 1.25.7, 1.25
+Tags: 1.25.8-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022
+SharedTags: 1.25.8-windowsservercore, 1.25-windowsservercore, 1.25.8, 1.25
 Architectures: windows-amd64
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.25.7-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025
-SharedTags: 1.25.7-nanoserver, 1.25-nanoserver
+Tags: 1.25.8-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025
+SharedTags: 1.25.8-nanoserver, 1.25-nanoserver
 Architectures: windows-amd64
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.25.7-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022
-SharedTags: 1.25.7-nanoserver, 1.25-nanoserver
+Tags: 1.25.8-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022
+SharedTags: 1.25.8-nanoserver, 1.25-nanoserver
 Architectures: windows-amd64
-GitCommit: 9d9f1862167ddcd870be07d6113f0d69589356a7
+GitCommit: f51096b5761d066ba6ead35d44179731a09c48e2
 Directory: 1.25/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/c8592aa: Update 1.26 to 1.26.1
- https://github.com/docker-library/golang/commit/f51096b: Update 1.25 to 1.25.8