### PR TITLE
Bump Traefik to v2.11.40 and to v3.6.10

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,41 +1,41 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.6.9-windowsservercore-ltsc2022, 3.6.9-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.10-windowsservercore-ltsc2022, 3.6.10-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 75f26cef88c9cfdf907698eef42d027bf569bf1a
+GitCommit: a85566765999287df65055c129bf330d40e68d37
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.9-nanoserver-ltsc2022, 3.6.9-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.10-nanoserver-ltsc2022, 3.6.10-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 75f26cef88c9cfdf907698eef42d027bf569bf1a
+GitCommit: a85566765999287df65055c129bf330d40e68d37
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.9, 3.6.9, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.10, 3.6.10, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 75f26cef88c9cfdf907698eef42d027bf569bf1a
+GitCommit: a85566765999287df65055c129bf330d40e68d37
 Directory: v3.6/alpine
 
-Tags: v2.11.38-windowsservercore-ltsc2022, 2.11.38-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.40-windowsservercore-ltsc2022, 2.11.40-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fabf1ab35f387a15d9c271166a9231dc80dccba6
+GitCommit: 3cad1b7774f9b975ef9f885c8fa8714b06ad0e00
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.38-nanoserver-ltsc2022, 2.11.38-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.40-nanoserver-ltsc2022, 2.11.40-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fabf1ab35f387a15d9c271166a9231dc80dccba6
+GitCommit: 3cad1b7774f9b975ef9f885c8fa8714b06ad0e00
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.38, 2.11.38, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.40, 2.11.40, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fabf1ab35f387a15d9c271166a9231dc80dccba6
+GitCommit: 3cad1b7774f9b975ef9f885c8fa8714b06ad0e00
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.40](https://github.com/traefik/traefik/releases/tag/v2.11.40), and [v3.6.10](https://github.com/traefik/traefik/releases/tag/v3.6.10).

/cc @nmengin @rtribotte  @kevinpollet