### PR TITLE
Update KrakenD to v2.13.2

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.1, 2.13, 2, latest
+Tags: 2.13.2, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 740c6d87249e2d0331ffe3f9e37054e5d939f850
-Directory: 2.13.1
+GitCommit: 06f5a5d88185e99c9477eb303c7e1445dbb39e5b
+Directory: 2.13.2


### PR DESCRIPTION
Upgraded Go to 1.25.8 addressing several CVEs with disclosed descriptions:
* [CVE-2026-27142](https://go.dev/issue/77954) `html/template`: URLs in meta content attribute actions are not escaped (false positive)
* [CVE-2026-25679](https://go.dev/issue/77578) `net/url`: reject IPv6 literal not at start of host
* [CVE-2026-27139](https://go.dev/issue/77827) `os`: FileInfo can escape from a Root

Upgraded `telemetry/opentelemetry` component to address [CVE-2026-24051](https://nvd.nist.gov/vuln/detail/CVE-2026-24051)