### PR TITLE
[nats] Releases v2.12.5, v2.11.14

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,47 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 4ca878fe674ab167c067c326960baca5396005ee
+GitCommit: d2540cc8734b095c223372c5fda2ec4d069a1978
 GitFetch: refs/heads/main
 
-Tags: 2.12.4-alpine3.22, 2.12-alpine3.22, 2-alpine3.22, alpine3.22, 2.12.4-alpine, 2.12-alpine, 2-alpine, alpine
+Tags: 2.12.5-alpine3.22, 2.12-alpine3.22, 2-alpine3.22, alpine3.22, 2.12.5-alpine, 2.12-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/alpine3.22
 
-Tags: 2.12.4-scratch, 2.12-scratch, 2-scratch, scratch, 2.12.4-linux, 2.12-linux, 2-linux, linux
-SharedTags: 2.12.4, 2.12, 2, latest
+Tags: 2.12.5-scratch, 2.12-scratch, 2-scratch, scratch, 2.12.5-linux, 2.12-linux, 2-linux, linux
+SharedTags: 2.12.5, 2.12, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/scratch
 
-Tags: 2.12.4-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.12.4-windowsservercore, 2.12-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.12.5-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.12.5-windowsservercore, 2.12-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.12.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.12.4-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.12.4-nanoserver, 2.12-nanoserver, 2-nanoserver, nanoserver, 2.12.4, 2.12, 2, latest
+Tags: 2.12.5-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.12.5-nanoserver, 2.12-nanoserver, 2-nanoserver, nanoserver, 2.12.5, 2.12, 2, latest
 Architectures: windows-amd64
 Directory: 2.12.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.11.12-alpine3.22, 2.11-alpine3.22, 2.11.12-alpine, 2.11-alpine
+Tags: 2.11.14-alpine3.22, 2.11-alpine3.22, 2.11.14-alpine, 2.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/alpine3.22
 
-Tags: 2.11.12-scratch, 2.11-scratch, 2.11.12-linux, 2.11-linux
-SharedTags: 2.11.12, 2.11
+Tags: 2.11.14-scratch, 2.11-scratch, 2.11.14-linux, 2.11-linux
+SharedTags: 2.11.14, 2.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.12-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
-SharedTags: 2.11.12-windowsservercore, 2.11-windowsservercore
+Tags: 2.11.14-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
+SharedTags: 2.11.14-windowsservercore, 2.11-windowsservercore
 Architectures: windows-amd64
 Directory: 2.11.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.12-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
-SharedTags: 2.11.12-nanoserver, 2.11-nanoserver, 2.11.12, 2.11
+Tags: 2.11.14-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
+SharedTags: 2.11.14-nanoserver, 2.11-nanoserver, 2.11.14, 2.11
 Architectures: windows-amd64
 Directory: 2.11.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Release notes here:

- https://github.com/nats-io/nats-server/releases/tag/v2.12.5
- https://github.com/nats-io/nats-server/releases/tag/v2.11.14