### PR TITLE
arangodb 3.12.8

### DIFF
--- a/library/arangodb
+++ b/library/arangodb
@@ -2,7 +2,7 @@ Maintainers: Frank Celler <info@arangodb.com> (@fceller), Wilfried Goesgens <w.g
 GitRepo: https://github.com/arangodb/arangodb-docker
 GitFetch: refs/heads/official
 
-Tags: 3.12, 3.12.7, 3.12.7.2, latest
+Tags: 3.12, 3.12.8, latest
 Architectures: amd64, arm64v8
-GitCommit: e066520e4660de822967cb7e7fc3f1447d224585
-Directory: alpine/3.12.7.2
+GitCommit: 30ea7cc3dc73075d9b9f0c5295fd65e33803f197
+Directory: alpine/3.12.8


### PR DESCRIPTION
Updated ArangoDB 3.12 to 3.12.8.