### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,72 +14,72 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: fdc3f623fd64fd54af94f2eca500de6a67252725
 Directory: 3.4/alpine
 
-Tags: 3.3.4, 3.3, latest, 3.3.4-trixie, 3.3-trixie, trixie
+Tags: 3.3.5, 3.3, latest, 3.3.5-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 989ae8d4224a68c4648e8534fd222a74db37c8e9
+GitCommit: 6cd3d70d127519eead0e9d43ca58223fb8284680
 Directory: 3.3
 
-Tags: 3.3.4-alpine, 3.3-alpine, alpine, 3.3.4-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.5-alpine, 3.3-alpine, alpine, 3.3.5-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 989ae8d4224a68c4648e8534fd222a74db37c8e9
+GitCommit: 6cd3d70d127519eead0e9d43ca58223fb8284680
 Directory: 3.3/alpine
 
-Tags: 3.2.13, 3.2, lts, 3.2.13-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.14, 3.2, lts, 3.2.14-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 99a94e42356e03c35a698781da8c0c19bfd3e505
+GitCommit: f1255acb427561699534b9a56577b2dfd0c2c68e
 Directory: 3.2
 
-Tags: 3.2.13-alpine, 3.2-alpine, lts-alpine, 3.2.13-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.14-alpine, 3.2-alpine, lts-alpine, 3.2.14-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 99a94e42356e03c35a698781da8c0c19bfd3e505
+GitCommit: f1255acb427561699534b9a56577b2dfd0c2c68e
 Directory: 3.2/alpine
 
-Tags: 3.1.15, 3.1, 3.1.15-trixie, 3.1-trixie
+Tags: 3.1.16, 3.1, 3.1.16-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be08009334efef7924299f7c73a79fa751d501c1
+GitCommit: 8afcf8d85a2f7eceec76d390cb8b0e33592341b6
 Directory: 3.1
 
-Tags: 3.1.15-alpine, 3.1-alpine, 3.1.15-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.16-alpine, 3.1-alpine, 3.1.16-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: be08009334efef7924299f7c73a79fa751d501c1
+GitCommit: 8afcf8d85a2f7eceec76d390cb8b0e33592341b6
 Directory: 3.1/alpine
 
-Tags: 3.0.17, 3.0, 3.0.17-trixie, 3.0-trixie
+Tags: 3.0.18, 3.0, 3.0.18-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 829551699c7dd2422c69df3c8dd1f098bb0c1a3a
+GitCommit: dda3cbe052bafebe01a728f2f0a8fd1cbf7b167b
 Directory: 3.0
 
-Tags: 3.0.17-alpine, 3.0-alpine, 3.0.17-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.18-alpine, 3.0-alpine, 3.0.18-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 829551699c7dd2422c69df3c8dd1f098bb0c1a3a
+GitCommit: dda3cbe052bafebe01a728f2f0a8fd1cbf7b167b
 Directory: 3.0/alpine
 
-Tags: 2.8.18, 2.8, 2.8.18-trixie, 2.8-trixie
+Tags: 2.8.19, 2.8, 2.8.19-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 7edb56c88d34ff20f2c39d8ee812b2cf6ba95d80
 Directory: 2.8
 
-Tags: 2.8.18-alpine, 2.8-alpine, 2.8.18-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.19-alpine, 2.8-alpine, 2.8.19-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: 7edb56c88d34ff20f2c39d8ee812b2cf6ba95d80
 Directory: 2.8/alpine
 
-Tags: 2.6.23, 2.6, 2.6.23-trixie, 2.6-trixie
+Tags: 2.6.24, 2.6, 2.6.24-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: c4b409220de05054e4eebe62796d8f71aa5c8789
 Directory: 2.6
 
-Tags: 2.6.23-alpine, 2.6-alpine, 2.6.23-alpine3.23, 2.6-alpine3.23
+Tags: 2.6.24-alpine, 2.6-alpine, 2.6.24-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: c4b409220de05054e4eebe62796d8f71aa5c8789
 Directory: 2.6/alpine
 
-Tags: 2.4.30, 2.4, 2.4.30-trixie, 2.4-trixie
+Tags: 2.4.31, 2.4, 2.4.31-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: fe191528008021c1b653886a0f62479632c5fddc
 Directory: 2.4
 
-Tags: 2.4.30-alpine, 2.4-alpine, 2.4.30-alpine3.23, 2.4-alpine3.23
+Tags: 2.4.31-alpine, 2.4-alpine, 2.4.31-alpine3.23, 2.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 68b711800e1f0c0ee468db0b73302b4bb61a3761
+GitCommit: fe191528008021c1b653886a0f62479632c5fddc
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/6cd3d70: Update 3.3 to 3.3.5
- https://github.com/docker-library/haproxy/commit/f1255ac: Update 3.2 to 3.2.14
- https://github.com/docker-library/haproxy/commit/8afcf8d: Update 3.1 to 3.1.16
- https://github.com/docker-library/haproxy/commit/dda3cbe: Update 3.0 to 3.0.18
- https://github.com/docker-library/haproxy/commit/7edb56c: Update 2.8 to 2.8.19
- https://github.com/docker-library/haproxy/commit/c4b4092: Update 2.6 to 2.6.24
- https://github.com/docker-library/haproxy/commit/fe19152: Update 2.4 to 2.4.31