### PR TITLE
influxdb: release enterprise 3.8.4

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,7 +6,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 39f5e181dbd41a4e9f0f3d10dee6ffbe2c8aa5fc
+GitCommit: 5de5432f19832a6b9eb548ce08d3797f883ed08f
 
 Tags: 1.12, 1.12.2
 Architectures: amd64, arm64v8
@@ -68,6 +68,6 @@ Tags: 3-core, 3.8-core, 3.8.3-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.8-core
 
-Tags: 3-enterprise, 3.8-enterprise, 3.8.3-enterprise, enterprise
+Tags: 3-enterprise, 3.8-enterprise, 3.8.4-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.8-enterprise


### PR DESCRIPTION
This commit bumps influxdb3 enterprise to our latest image, 3.8.4; influxdb3 oss remains at 3.8.3 as nothing has changed.
