### PR TITLE
[oraclelinux] Updating 9 for ELSA-2026-4168

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c5ea29f1689b87cba665b65f9216aab4f4cc26d4
+amd64-GitCommit: e9faea5d47e34c01ad79f9d7d92f20d1287842be
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: bd2e7bbff0cf56fbd21c086de3076a019605d92f
+arm64v8-GitCommit: 964648fa477946a7c3da2ec140c4fbd0c74a6b74
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-15366, CVE-2025-15367, CVE-2026-1299

See the following for details:

ELSA-2026-4168

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
