### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 6.9.1-php8.2-apache, 6.9-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.9.1-php8.2, 6.9-php8.2, 6-php8.2, php8.2
+Tags: 6.9.2-php8.2-apache, 6.9-php8.2-apache, 6-php8.2-apache, php8.2-apache, 6.9.2-php8.2, 6.9-php8.2, 6-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.2/apache
 
-Tags: 6.9.1-php8.2-fpm, 6.9-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
+Tags: 6.9.2-php8.2-fpm, 6.9-php8.2-fpm, 6-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.2/fpm
 
-Tags: 6.9.1-php8.2-fpm-alpine, 6.9-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 6.9.2-php8.2-fpm-alpine, 6.9-php8.2-fpm-alpine, 6-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 6.9.1-apache, 6.9-apache, 6-apache, apache, 6.9.1, 6.9, 6, latest, 6.9.1-php8.3-apache, 6.9-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.9.1-php8.3, 6.9-php8.3, 6-php8.3, php8.3
+Tags: 6.9.2-apache, 6.9-apache, 6-apache, apache, 6.9.2, 6.9, 6, latest, 6.9.2-php8.3-apache, 6.9-php8.3-apache, 6-php8.3-apache, php8.3-apache, 6.9.2-php8.3, 6.9-php8.3, 6-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.3/apache
 
-Tags: 6.9.1-fpm, 6.9-fpm, 6-fpm, fpm, 6.9.1-php8.3-fpm, 6.9-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
+Tags: 6.9.2-fpm, 6.9-fpm, 6-fpm, fpm, 6.9.2-php8.3-fpm, 6.9-php8.3-fpm, 6-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.3/fpm
 
-Tags: 6.9.1-fpm-alpine, 6.9-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.9.1-php8.3-fpm-alpine, 6.9-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 6.9.2-fpm-alpine, 6.9-fpm-alpine, 6-fpm-alpine, fpm-alpine, 6.9.2-php8.3-fpm-alpine, 6.9-php8.3-fpm-alpine, 6-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.3/fpm-alpine
 
-Tags: 6.9.1-php8.4-apache, 6.9-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.9.1-php8.4, 6.9-php8.4, 6-php8.4, php8.4
+Tags: 6.9.2-php8.4-apache, 6.9-php8.4-apache, 6-php8.4-apache, php8.4-apache, 6.9.2-php8.4, 6.9-php8.4, 6-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.4/apache
 
-Tags: 6.9.1-php8.4-fpm, 6.9-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
+Tags: 6.9.2-php8.4-fpm, 6.9-php8.4-fpm, 6-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.4/fpm
 
-Tags: 6.9.1-php8.4-fpm-alpine, 6.9-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
+Tags: 6.9.2-php8.4-fpm-alpine, 6.9-php8.4-fpm-alpine, 6-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.4/fpm-alpine
 
-Tags: 6.9.1-php8.5-apache, 6.9-php8.5-apache, 6-php8.5-apache, php8.5-apache, 6.9.1-php8.5, 6.9-php8.5, 6-php8.5, php8.5
+Tags: 6.9.2-php8.5-apache, 6.9-php8.5-apache, 6-php8.5-apache, php8.5-apache, 6.9.2-php8.5, 6.9-php8.5, 6-php8.5, php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.5/apache
 
-Tags: 6.9.1-php8.5-fpm, 6.9-php8.5-fpm, 6-php8.5-fpm, php8.5-fpm
+Tags: 6.9.2-php8.5-fpm, 6.9-php8.5-fpm, 6-php8.5-fpm, php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e9f9f56f29897fffad5a6b895beaecd93a11833c
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.5/fpm
 
-Tags: 6.9.1-php8.5-fpm-alpine, 6.9-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.5-fpm-alpine
+Tags: 6.9.2-php8.5-fpm-alpine, 6.9-php8.5-fpm-alpine, 6-php8.5-fpm-alpine, php8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4eb711d9183e4e0e60df209be1fb41e5389a573d
+GitCommit: 8b1111857eab28c35e7ddb5029db67896770a86c
 Directory: latest/php8.5/fpm-alpine
 
 Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/8b11118: Update latest to 6.9.2