### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.10.20260216.1
+Tags: 2023, latest, 2023.10.20260302.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 77b0f4905ce77c6b36669123051adc4947ea9a9b
+amd64-GitCommit: 067442068b2c915e7af7b61c6a58cf0cf422e470
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 286c81a5b2d310277670ccfd5710834be988e4b4
+arm64v8-GitCommit: f98d788e7b60d3eae932e1f69c5c1284a75269e5
 
-Tags: 2, 2.0.20260216.0
+Tags: 2, 2.0.20260302.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 7f2f8130f23dd0653adfd7cb1e1beea193ba1c7b
+amd64-GitCommit: 9925759ad43f2e78e58edf31f16dac11a51bee64
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 656448bbe47c348eab4535557ebd23f50eacc809
+arm64v8-GitCommit: 44b55b829fc1004c4da08cd9c2dd7e215921226f
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- python-libs-2.7.18-1.amzn2.0.16
- libxml2-2.9.1-6.amzn2.5.24
- python-2.7.18-1.amzn2.0.16

Updated Packages for Amazon Linux 2023:
- libxml2-2.10.4-1.amzn2023.0.18
- expat-2.6.3-1.amzn2023.0.4
- coreutils-single-8.32-30.amzn2023.0.5
- openssl-fips-provider-latest-3.2.2-1.amzn2023.0.5
- libcurl-minimal-8.17.0-1.amzn2023.0.1
- gnupg2-minimal-2.3.7-1.amzn2023.0.7
- publicsuffix-list-dafsa-20260116-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.10.20260302-0.amzn2023
- system-release-2023.10.20260302-0.amzn2023
- zlib-1.2.11-33.amzn2023.0.6
- openssl-libs-3.2.2-1.amzn2023.0.5
- curl-minimal-8.17.0-1.amzn2023.0.1