### PR TITLE
Update amazoncorretto for 2026 Q1 release

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,7 +15,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: d16498c662b9676715ac207de2dcd674358e8b2d
+GitCommit: 13002864817aec6fb82f8ed7081d067082891263
 
 Tags: 8, 8u482, 8u482-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u482-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update GitCommit in amazoncorretto to support new 2026 Q1 release.