### PR TITLE
Add Traefik v3.7.0-ea.1

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,5 +1,25 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
+Tags: v3.7.0-ea.1-windowsservercore-ltsc2022, 3.7.0-ea.1-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 01d8d8ba9f04026f77b424ddf13d98ab6ddc5777
+Directory: v3.7/windows/servercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: v3.7.0-ea.1-nanoserver-ltsc2022, 3.7.0-ea.1-nanoserver-ltsc2022, langres-nanoserver-ltsc2022
+Architectures: windows-amd64
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 01d8d8ba9f04026f77b424ddf13d98ab6ddc5777
+Directory: v3.7/windows/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: v3.7.0-ea.1, 3.7.0-ea.1, langres
+Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
+GitRepo: https://github.com/traefik/traefik-library-image.git
+GitCommit: 01d8d8ba9f04026f77b424ddf13d98ab6ddc5777
+Directory: v3.7/alpine
+
 Tags: v3.6.10-windowsservercore-ltsc2022, 3.6.10-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v3.7.0-ea.1](https://github.com/traefik/traefik/releases/tag/v3.7.0-ea.1).

/cc @nmengin @rtribotte  @kevinpollet