### PR TITLE
rust: Update rustup to 1.29.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -7,51 +7,51 @@ GitRepo: https://github.com/rust-lang/docker-rust.git
 
 Tags: 1-bullseye, 1.94-bullseye, 1.94.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/bullseye
 
 Tags: 1-slim-bullseye, 1.94-slim-bullseye, 1.94.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/bullseye/slim
 
 Tags: 1-bookworm, 1.94-bookworm, 1.94.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/bookworm
 
 Tags: 1-slim-bookworm, 1.94-slim-bookworm, 1.94.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/bookworm/slim
 
 Tags: 1-trixie, 1.94-trixie, 1.94.0-trixie, trixie, 1, 1.94, 1.94.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/trixie
 
 Tags: 1-slim-trixie, 1.94-slim-trixie, 1.94.0-slim-trixie, slim-trixie, 1-slim, 1.94-slim, 1.94.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/trixie/slim
 
 Tags: 1-alpine3.20, 1.94-alpine3.20, 1.94.0-alpine3.20, alpine3.20
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/alpine3.20
 
 Tags: 1-alpine3.21, 1.94-alpine3.21, 1.94.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/alpine3.21
 
 Tags: 1-alpine3.22, 1.94-alpine3.22, 1.94.0-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/alpine3.22
 
 Tags: 1-alpine3.23, 1.94-alpine3.23, 1.94.0-alpine3.23, alpine3.23, 1-alpine, 1.94-alpine, 1.94.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 6a9e575ded855748996e92e5b5557d5192f16e21
+GitCommit: 4132ed1e071f80134ef880bbac42ebc430e946ea
 Directory: stable/alpine3.23
 


### PR DESCRIPTION
https://blog.rust-lang.org/2026/03/12/Rustup-1.29.0/
https://github.com/rust-lang/docker-rust/pull/268