### PR TITLE
[oraclelinux] Updating 8 for ELSA-2026-4442 and 9, 9-slim and 9-slim-fips for ELSA-2026-4442 ELSA-2026-4188

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e9faea5d47e34c01ad79f9d7d92f20d1287842be
+amd64-GitCommit: 6a3877aaf3873e5ff0e76c2efe0568af57950fdb
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 964648fa477946a7c3da2ec140c4fbd0c74a6b74
+arm64v8-GitCommit: 4db8fcef68547cd2e6ddfd451b4bc6fa9e57f0d2
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-25749, CVE-2026-25749, CVE-2025-14831, CVE-2025-9820

See the following for details:

ELSA-2026-4188
ELSA-2026-4442

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
