### PR TITLE
update influxdb 1.12 tags to version 1.12.3

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -6,26 +6,26 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj),
              Wayne Warren <wwarren@influxdata.com> (@waynr)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 5de5432f19832a6b9eb548ce08d3797f883ed08f
+GitCommit: 6a18460ea289c2a775395316713fe49bf988ca1c
 
-Tags: 1.12, 1.12.2
+Tags: 1.12, 1.12.3
 Architectures: amd64, arm64v8
 Directory: influxdb/1.12
 
-Tags: 1.12-alpine, 1.12.2-alpine
+Tags: 1.12-alpine, 1.12.3-alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/1.12/alpine
 
-Tags: 1.12-data, 1.12.2-data, data
+Tags: 1.12-data, 1.12.3-data, data
 Directory: influxdb/1.12/data
 
-Tags: 1.12-data-alpine, 1.12.2-data-alpine, data-alpine
+Tags: 1.12-data-alpine, 1.12.3-data-alpine, data-alpine
 Directory: influxdb/1.12/data/alpine
 
-Tags: 1.12-meta, 1.12.2-meta, meta
+Tags: 1.12-meta, 1.12.3-meta, meta
 Directory: influxdb/1.12/meta
 
-Tags: 1.12-meta-alpine, 1.12.2-meta-alpine, meta-alpine
+Tags: 1.12-meta-alpine, 1.12.3-meta-alpine, meta-alpine
 Directory: influxdb/1.12/meta/alpine
 
 Tags: 1.11, 1.11.8


### PR DESCRIPTION
- Update influxdb 1.12 tags to version 1.12.3. 
- Add influxdb 1.12.3 tags.