### PR TITLE
archlinux: Release 20260315.0.500537

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260308.0.497099
-GitCommit: 47b54412fa281f44ed3e4a5136ddd4d50f656189
-GitFetch: refs/tags/v20260308.0.497099
+Tags: latest, base, base-20260315.0.500537
+GitCommit: 0fc0a650d90bf036a88bb3cc188e981becce59ab
+GitFetch: refs/tags/v20260315.0.500537
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260308.0.497099
-GitCommit: 47b54412fa281f44ed3e4a5136ddd4d50f656189
-GitFetch: refs/tags/v20260308.0.497099
+Tags: base-devel, base-devel-20260315.0.500537
+GitCommit: 0fc0a650d90bf036a88bb3cc188e981becce59ab
+GitFetch: refs/tags/v20260315.0.500537
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260308.0.497099
-GitCommit: 47b54412fa281f44ed3e4a5136ddd4d50f656189
-GitFetch: refs/tags/v20260308.0.497099
+Tags: multilib-devel, multilib-devel-20260315.0.500537
+GitCommit: 0fc0a650d90bf036a88bb3cc188e981becce59ab
+GitFetch: refs/tags/v20260315.0.500537
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks