### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -5,24 +5,24 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/rabbitmq.git
 Builder: buildkit
 
-Tags: 4.2.4, 4.2, 4, latest
+Tags: 4.2.5, 4.2, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: 5e5785f95bc1bc8b452d1b45a6b8aea729919b43
+GitCommit: fa6cb7beb484121f1fb2561eb7db576510adcf3b
 Directory: 4.2/ubuntu
 
-Tags: 4.2.4-management, 4.2-management, 4-management, management
+Tags: 4.2.5-management, 4.2-management, 4-management, management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: b63bf0887a34745935e0ee9185a649edab000545
+GitCommit: fa6cb7beb484121f1fb2561eb7db576510adcf3b
 Directory: 4.2/ubuntu/management
 
-Tags: 4.2.4-alpine, 4.2-alpine, 4-alpine, alpine
+Tags: 4.2.5-alpine, 4.2-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5e5785f95bc1bc8b452d1b45a6b8aea729919b43
+GitCommit: fa6cb7beb484121f1fb2561eb7db576510adcf3b
 Directory: 4.2/alpine
 
-Tags: 4.2.4-management-alpine, 4.2-management-alpine, 4-management-alpine, management-alpine
+Tags: 4.2.5-management-alpine, 4.2-management-alpine, 4-management-alpine, management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b63bf0887a34745935e0ee9185a649edab000545
+GitCommit: fa6cb7beb484121f1fb2561eb7db576510adcf3b
 Directory: 4.2/alpine/management
 
 Tags: 4.1.8, 4.1
@@ -32,7 +32,7 @@ Directory: 4.1/ubuntu
 
 Tags: 4.1.8-management, 4.1-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: e2e3e5a2a791351719f640debb0912e72857778e
+GitCommit: c0b2a8cb4422106392c7c15a13b0f9b074bfe3b7
 Directory: 4.1/ubuntu/management
 
 Tags: 4.1.8-alpine, 4.1-alpine
@@ -42,7 +42,7 @@ Directory: 4.1/alpine
 
 Tags: 4.1.8-management-alpine, 4.1-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e2e3e5a2a791351719f640debb0912e72857778e
+GitCommit: c0b2a8cb4422106392c7c15a13b0f9b074bfe3b7
 Directory: 4.1/alpine/management
 
 Tags: 4.0.9, 4.0
@@ -52,7 +52,7 @@ Directory: 4.0/ubuntu
 
 Tags: 4.0.9-management, 4.0-management
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: e97a4e1df92f520d5d7c6d89c2e17091471045ef
+GitCommit: d7706d74fc0ad345b9e9f52257caabdd0049596a
 Directory: 4.0/ubuntu/management
 
 Tags: 4.0.9-alpine, 4.0-alpine
@@ -62,5 +62,5 @@ Directory: 4.0/alpine
 
 Tags: 4.0.9-management-alpine, 4.0-management-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e97a4e1df92f520d5d7c6d89c2e17091471045ef
+GitCommit: d7706d74fc0ad345b9e9f52257caabdd0049596a
 Directory: 4.0/alpine/management


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/fa6cb7b: Update 4.2 to 4.2.5, rabbitmqadmin 2.28.0
- https://github.com/docker-library/rabbitmq/commit/c0b2a8c: Update 4.1 to rabbitmqadmin 2.28.0
- https://github.com/docker-library/rabbitmq/commit/d7706d7: Update 4.0 to rabbitmqadmin 2.28.0