### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,62 +4,62 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 6.1.1, 6.1, 6, latest, 6.1.1-trixie, 6.1-trixie, 6-trixie, trixie
+Tags: 6.1.2, 6.1, 6, latest, 6.1.2-trixie, 6.1-trixie, 6-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
+GitCommit: a7cc730bbb670118816f63a5db76f71326b97aea
 Directory: 6.1/trixie
 
-Tags: 6.1.1-bookworm, 6.1-bookworm, 6-bookworm, bookworm
+Tags: 6.1.2-bookworm, 6.1-bookworm, 6-bookworm, bookworm
 Architectures: amd64, arm64v8
-GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
+GitCommit: a7cc730bbb670118816f63a5db76f71326b97aea
 Directory: 6.1/bookworm
 
-Tags: 6.1.1-alpine3.23, 6.1-alpine3.23, 6-alpine3.23, alpine3.23, 6.1.1-alpine, 6.1-alpine, 6-alpine, alpine
+Tags: 6.1.2-alpine3.23, 6.1-alpine3.23, 6-alpine3.23, alpine3.23, 6.1.2-alpine, 6.1-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
+GitCommit: a7cc730bbb670118816f63a5db76f71326b97aea
 Directory: 6.1/alpine3.23
 
-Tags: 6.1.1-alpine3.22, 6.1-alpine3.22, 6-alpine3.22, alpine3.22
+Tags: 6.1.2-alpine3.22, 6.1-alpine3.22, 6-alpine3.22, alpine3.22
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3230e2b4d5cb3ff26b2a9fe016ff7f6727bfd485
+GitCommit: a7cc730bbb670118816f63a5db76f71326b97aea
 Directory: 6.1/alpine3.22
 
-Tags: 6.0.8, 6.0, 6.0.8-trixie, 6.0-trixie
+Tags: 6.0.9, 6.0, 6.0.9-trixie, 6.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
+GitCommit: d7dac9b6c9892c971da4dc1b09bf4c90fad8267c
 Directory: 6.0/trixie
 
-Tags: 6.0.8-bookworm, 6.0-bookworm
+Tags: 6.0.9-bookworm, 6.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
+GitCommit: d7dac9b6c9892c971da4dc1b09bf4c90fad8267c
 Directory: 6.0/bookworm
 
-Tags: 6.0.8-alpine3.23, 6.0-alpine3.23, 6.0.8-alpine, 6.0-alpine
+Tags: 6.0.9-alpine3.23, 6.0-alpine3.23, 6.0.9-alpine, 6.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
+GitCommit: d7dac9b6c9892c971da4dc1b09bf4c90fad8267c
 Directory: 6.0/alpine3.23
 
-Tags: 6.0.8-alpine3.22, 6.0-alpine3.22
+Tags: 6.0.9-alpine3.22, 6.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f216e86f5049c2f7b2c2c276c80dbcbad6b09b80
+GitCommit: d7dac9b6c9892c971da4dc1b09bf4c90fad8267c
 Directory: 6.0/alpine3.22
 
-Tags: 5.1.11, 5.1, 5, 5.1.11-trixie, 5.1-trixie, 5-trixie
+Tags: 5.1.12, 5.1, 5, 5.1.12-trixie, 5.1-trixie, 5-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
+GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
 Directory: 5.1/trixie
 
-Tags: 5.1.11-bookworm, 5.1-bookworm, 5-bookworm
+Tags: 5.1.12-bookworm, 5.1-bookworm, 5-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
+GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
 Directory: 5.1/bookworm
 
-Tags: 5.1.11-alpine3.23, 5.1-alpine3.23, 5-alpine3.23, 5.1.11-alpine, 5.1-alpine, 5-alpine
+Tags: 5.1.12-alpine3.23, 5.1-alpine3.23, 5-alpine3.23, 5.1.12-alpine, 5.1-alpine, 5-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
+GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
 Directory: 5.1/alpine3.23
 
-Tags: 5.1.11-alpine3.22, 5.1-alpine3.22, 5-alpine3.22
+Tags: 5.1.12-alpine3.22, 5.1-alpine3.22, 5-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9526f1d90613fe28167fd025ec0e42344a97e745
+GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
 Directory: 5.1/alpine3.22


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/a7cc730: Update 6.1 to 6.1.2
- https://github.com/docker-library/redmine/commit/d7dac9b: Update 6.0 to 6.0.9
- https://github.com/docker-library/redmine/commit/78180a8: Update 5.1 to 5.1.12