### PR TITLE
[oraclelinux] Updating 10 for ELSA-2026-4713 ELSA-2026-4715

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6a3877aaf3873e5ff0e76c2efe0568af57950fdb
+amd64-GitCommit: 1080dc132d40f0d7e272ba29bda04f7e74c689c5
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4db8fcef68547cd2e6ddfd451b4bc6fa9e57f0d2
+arm64v8-GitCommit: 4055848700f3c8c3cba39bbc53ab30f8b430df17
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2025-15366, CVE-2025-15367, CVE-2026-0865, CVE-2026-1299, CVE-2026-25749

See the following for details:

ELSA-2026-4713
ELSA-2026-4715

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
