### PR TITLE
Update openjdk

### DIFF
--- a/library/openjdk
+++ b/library/openjdk
@@ -3,56 +3,7 @@
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/openjdk.git
-GitCommit: a21ff842129d1e42ea67c5c379ce7cc98ed4db2a
-
-Tags: 26-rc-jdk-oraclelinux9, 26-rc-oraclelinux9, 26-rc-jdk-oracle, 26-rc-oracle
-SharedTags: 26-rc-jdk, 26-rc
-Directory: 26/oraclelinux9
-Architectures: amd64, arm64v8
-
-Tags: 26-rc-jdk-oraclelinux8, 26-rc-oraclelinux8
-Directory: 26/oraclelinux8
-Architectures: amd64, arm64v8
-
-Tags: 26-rc-jdk-trixie, 26-rc-trixie
-Directory: 26/trixie
-Architectures: amd64, arm64v8
-
-Tags: 26-rc-jdk-slim-trixie, 26-rc-slim-trixie, 26-rc-jdk-slim, 26-rc-slim
-Directory: 26/slim-trixie
-Architectures: amd64, arm64v8
-
-Tags: 26-rc-jdk-bookworm, 26-rc-bookworm
-Directory: 26/bookworm
-Architectures: amd64, arm64v8
-
-Tags: 26-rc-jdk-slim-bookworm, 26-rc-slim-bookworm
-Directory: 26/slim-bookworm
-Architectures: amd64, arm64v8
-
-Tags: 26-rc-jdk-windowsservercore-ltsc2025, 26-rc-windowsservercore-ltsc2025
-SharedTags: 26-rc-jdk-windowsservercore, 26-rc-windowsservercore, 26-rc-jdk, 26-rc
-Directory: 26/windows/windowsservercore-ltsc2025
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2025
-
-Tags: 26-rc-jdk-windowsservercore-ltsc2022, 26-rc-windowsservercore-ltsc2022
-SharedTags: 26-rc-jdk-windowsservercore, 26-rc-windowsservercore, 26-rc-jdk, 26-rc
-Directory: 26/windows/windowsservercore-ltsc2022
-Architectures: windows-amd64
-Constraints: windowsservercore-ltsc2022
-
-Tags: 26-rc-jdk-nanoserver-ltsc2025, 26-rc-nanoserver-ltsc2025
-SharedTags: 26-rc-jdk-nanoserver, 26-rc-nanoserver
-Directory: 26/windows/nanoserver-ltsc2025
-Architectures: windows-amd64
-Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
-
-Tags: 26-rc-jdk-nanoserver-ltsc2022, 26-rc-nanoserver-ltsc2022
-SharedTags: 26-rc-jdk-nanoserver, 26-rc-nanoserver
-Directory: 26/windows/nanoserver-ltsc2022
-Architectures: windows-amd64
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+GitCommit: 828067798e347ee3ff1acb3c4fdce358c5f0d18b
 
 Tags: 27-ea-13-jdk-oraclelinux9, 27-ea-13-oraclelinux9, 27-ea-jdk-oraclelinux9, 27-ea-oraclelinux9, 27-ea-13-jdk-oracle, 27-ea-13-oracle, 27-ea-jdk-oracle, 27-ea-oracle
 SharedTags: 27-ea-13-jdk, 27-ea-13, 27-ea-jdk, 27-ea


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/openjdk/commit/8280677: Remove 26 (now GA, no longer EA) (https://github.com/docker-library/openjdk/pull/556)