### PR TITLE
Support SapMachine 26 and desupport SapMachine 11

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,62 +1,142 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Arno Zeller <sapmachine@sap.com> (@ArnoZeller)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: latest, ubuntu, jdk, jdk-ubuntu, lts, lts-ubuntu, 25, 25-ubuntu, 25.0.2, 25.0.2-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.2-jdk, 25.0.2-jdk-ubuntu, lts-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.2-ubuntu-noble, 25.0.2-ubuntu-24.04, 25.0.2-jdk-ubuntu-noble, 25.0.2-jdk-ubuntu-24.04
+Tags: latest, ubuntu, jdk, jdk-ubuntu, 26, 26-ubuntu, 26-jdk, 26-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 26-ubuntu-noble, 26-ubuntu-24.04, 26-jdk-ubuntu-noble, 26-jdk-ubuntu-24.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/24_04/jdk
+
+Tags: jdk-headless, jdk-headless-ubuntu, 26-jdk-headless, 26-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 26-jdk-headless-ubuntu-noble, 26-jdk-headless-ubuntu-24.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/24_04/jdk-headless
+
+Tags: jre, jre-ubuntu, 26-jre, 26-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 26-jre-ubuntu-noble, 26-jre-ubuntu-24.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/24_04/jre
+
+Tags: jre-headless, jre-headless-ubuntu, 26-jre-headless, 26-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 26-jre-headless-ubuntu-noble, 26-jre-headless-ubuntu-24.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/24_04/jre-headless
+
+Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 26-ubuntu-jammy, 26-ubuntu-22.04, 26-jdk-ubuntu-jammy, 26-jdk-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/22_04/jdk
+
+Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 26-jdk-headless-ubuntu-jammy, 26-jdk-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/22_04/jdk-headless
+
+Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 26-jre-ubuntu-jammy, 26-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/22_04/jre
+
+Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 26-jre-headless-ubuntu-jammy, 26-jre-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/ubuntu/22_04/jre-headless
+
+Tags: alpine, jdk-alpine, 26-alpine, 26-jdk-alpine, alpine-3.23, jdk-alpine-3.23, 26-alpine-3.23, 26-jdk-alpine-3.23
+Architectures: amd64
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/alpine/3_23/jdk
+
+Tags: jre-alpine, 26-jre-alpine, jre-alpine-3.23, 26-jre-alpine-3.23
+Architectures: amd64
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/alpine/3_23/jre
+
+Tags: alpine-3.22, jdk-alpine-3.22, 26-alpine-3.22, 26-jdk-alpine-3.22
+Architectures: amd64
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/alpine/3_22/jdk
+
+Tags: jre-alpine-3.22, 26-jre-alpine-3.22
+Architectures: amd64
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/alpine/3_22/jre
+
+Tags: alpine-3.21, jdk-alpine-3.21, 26-alpine-3.21, 26-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/alpine/3_21/jdk
+
+Tags: jre-alpine-3.21, 26-jre-alpine-3.21
+Architectures: amd64
+GitCommit: 545bf09c44a881eebd1369138e33b79970825254
+Directory: dockerfiles/26/alpine/3_21/jre
+
+Tags: lts, lts-ubuntu, 25, 25-ubuntu, 25.0.2, 25.0.2-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.2-jdk, 25.0.2-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.2-ubuntu-noble, 25.0.2-ubuntu-24.04, 25.0.2-jdk-ubuntu-noble, 25.0.2-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jdk
 
-Tags: jdk-headless, jdk-headless-ubuntu, 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.2-jdk-headless, 25.0.2-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.2-jdk-headless-ubuntu-noble, 25.0.2-jdk-headless-ubuntu-24.04
+Tags: 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.2-jdk-headless, 25.0.2-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.2-jdk-headless-ubuntu-noble, 25.0.2-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jdk-headless
 
-Tags: jre, jre-ubuntu, 25-jre, 25-jre-ubuntu, 25.0.2-jre, 25.0.2-jre-ubuntu, lts-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.2-jre-ubuntu-noble, 25.0.2-jre-ubuntu-24.04
+Tags: 25-jre, 25-jre-ubuntu, 25.0.2-jre, 25.0.2-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.2-jre-ubuntu-noble, 25.0.2-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jre
 
-Tags: jre-headless, jre-headless-ubuntu, 25-jre-headless, 25-jre-headless-ubuntu, 25.0.2-jre-headless, 25.0.2-jre-headless-ubuntu, lts-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.2-jre-headless-ubuntu-noble, 25.0.2-jre-headless-ubuntu-24.04
+Tags: 25-jre-headless, 25-jre-headless-ubuntu, 25.0.2-jre-headless, 25.0.2-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.2-jre-headless-ubuntu-noble, 25.0.2-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/24_04/jre-headless
 
-Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.2-ubuntu-jammy, 25.0.2-ubuntu-22.04, 25.0.2-jdk-ubuntu-jammy, 25.0.2-jdk-ubuntu-22.04
+Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.2-ubuntu-jammy, 25.0.2-ubuntu-22.04, 25.0.2-jdk-ubuntu-jammy, 25.0.2-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jdk
 
-Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.2-jdk-headless-ubuntu-jammy, 25.0.2-jdk-headless-ubuntu-22.04
+Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.2-jdk-headless-ubuntu-jammy, 25.0.2-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jdk-headless
 
-Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.2-jre-ubuntu-jammy, 25.0.2-jre-ubuntu-22.04
+Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.2-jre-ubuntu-jammy, 25.0.2-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jre
 
-Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.2-jre-headless-ubuntu-jammy, 25.0.2-jre-headless-ubuntu-22.04
+Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.2-jre-headless-ubuntu-jammy, 25.0.2-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/ubuntu/22_04/jre-headless
 
-Tags: alpine, jdk-alpine, lts-alpine, 25-alpine, 25.0.2-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.2-jdk-alpine, alpine-3.22, jdk-alpine-3.22, lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.2-alpine-3.22, 25.0.2-jdk-alpine-3.22
+Tags: lts-alpine, 25-alpine, 25.0.2-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.2-jdk-alpine, lts-alpine-3.23, lts-jdk-alpine-3.23, 25-alpine-3.23, 25-jdk-alpine-3.23, 25.0.2-alpine-3.23, 25.0.2-jdk-alpine-3.23
+Architectures: amd64
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
+Directory: dockerfiles/25/alpine/3_23/jdk
+
+Tags: lts-jre-alpine, 25-jre-alpine, 25.0.2-jre-alpine, lts-jre-alpine-3.23, 25-jre-alpine-3.23, 25.0.2-jre-alpine-3.23
+Architectures: amd64
+GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
+Directory: dockerfiles/25/alpine/3_23/jre
+
+Tags: lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.2-alpine-3.22, 25.0.2-jdk-alpine-3.22
 Architectures: amd64
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_22/jdk
 
-Tags: jre-alpine, lts-jre-alpine, 25-jre-alpine, 25.0.2-jre-alpine, jre-alpine-3.22, lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.2-jre-alpine-3.22
+Tags: lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.2-jre-alpine-3.22
 Architectures: amd64
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_22/jre
 
-Tags: alpine-3.21, jdk-alpine-3.21, lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.2-alpine-3.21, 25.0.2-jdk-alpine-3.21
+Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.2-alpine-3.21, 25.0.2-jdk-alpine-3.21
 Architectures: amd64
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_21/jdk
 
-Tags: jre-alpine-3.21, lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.2-jre-alpine-3.21
+Tags: lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.2-jre-alpine-3.21
 Architectures: amd64
 GitCommit: 0616770611ff2295ec1f1a2ef2ac7c4c26c964b5
 Directory: dockerfiles/25/alpine/3_21/jre
@@ -101,12 +181,22 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: 31b8a284b8237cd9afea30116c07160f3c689832
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
-Tags: 21-alpine, 21.0.10.0.1-alpine, 21-jdk-alpine, 21.0.10.0.1-jdk-alpine, 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.10.0.1-alpine-3.22, 21.0.10.0.1-jdk-alpine-3.22
+Tags: 21-alpine, 21.0.10.0.1-alpine, 21-jdk-alpine, 21.0.10.0.1-jdk-alpine, 21-alpine-3.23, 21-jdk-alpine-3.23, 21.0.10.0.1-alpine-3.23, 21.0.10.0.1-jdk-alpine-3.23
+Architectures: amd64
+GitCommit: 31b8a284b8237cd9afea30116c07160f3c689832
+Directory: dockerfiles/21/alpine/3_23/jdk
+
+Tags: 21-jre-alpine, 21.0.10.0.1-jre-alpine, 21-jre-alpine-3.23, 21.0.10.0.1-jre-alpine-3.23
+Architectures: amd64
+GitCommit: 31b8a284b8237cd9afea30116c07160f3c689832
+Directory: dockerfiles/21/alpine/3_23/jre
+
+Tags: 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.10.0.1-alpine-3.22, 21.0.10.0.1-jdk-alpine-3.22
 Architectures: amd64
 GitCommit: 31b8a284b8237cd9afea30116c07160f3c689832
 Directory: dockerfiles/21/alpine/3_22/jdk
 
-Tags: 21-jre-alpine, 21.0.10.0.1-jre-alpine, 21-jre-alpine-3.22, 21.0.10.0.1-jre-alpine-3.22
+Tags: 21-jre-alpine-3.22, 21.0.10.0.1-jre-alpine-3.22
 Architectures: amd64
 GitCommit: 31b8a284b8237cd9afea30116c07160f3c689832
 Directory: dockerfiles/21/alpine/3_22/jre
@@ -161,12 +251,22 @@ Architectures: amd64, arm64v8, ppc64le
 GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
-Tags: 17-alpine, 17.0.18-alpine, 17-jdk-alpine, 17.0.18-jdk-alpine, 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.18-alpine-3.22, 17.0.18-jdk-alpine-3.22
+Tags: 17-alpine, 17.0.18-alpine, 17-jdk-alpine, 17.0.18-jdk-alpine, 17-alpine-3.23, 17-jdk-alpine-3.23, 17.0.18-alpine-3.23, 17.0.18-jdk-alpine-3.23
+Architectures: amd64
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
+Directory: dockerfiles/17/alpine/3_23/jdk
+
+Tags: 17-jre-alpine, 17.0.18-jre-alpine, 17-jre-alpine-3.23, 17.0.18-jre-alpine-3.23
+Architectures: amd64
+GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
+Directory: dockerfiles/17/alpine/3_23/jre
+
+Tags: 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.18-alpine-3.22, 17.0.18-jdk-alpine-3.22
 Architectures: amd64
 GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_22/jdk
 
-Tags: 17-jre-alpine, 17.0.18-jre-alpine, 17-jre-alpine-3.22, 17.0.18-jre-alpine-3.22
+Tags: 17-jre-alpine-3.22, 17.0.18-jre-alpine-3.22
 Architectures: amd64
 GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_22/jre
@@ -180,43 +280,3 @@ Tags: 17-jre-alpine-3.21, 17.0.18-jre-alpine-3.21
 Architectures: amd64
 GitCommit: c20ee65bae0d54c94024bef202527ca1107149e8
 Directory: dockerfiles/17/alpine/3_21/jre
-
-Tags: 11, 11-ubuntu, 11.0.30, 11.0.30-ubuntu, 11-jdk, 11-jdk-ubuntu, 11.0.30-jdk, 11.0.30-jdk-ubuntu, 11-ubuntu-noble, 11-ubuntu-24.04, 11-jdk-ubuntu-noble, 11-jdk-ubuntu-24.04, 11.0.30-ubuntu-noble, 11.0.30-ubuntu-24.04, 11.0.30-jdk-ubuntu-noble, 11.0.30-jdk-ubuntu-24.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/24_04/jdk
-
-Tags: 11-jdk-headless, 11-jdk-headless-ubuntu, 11.0.30-jdk-headless, 11.0.30-jdk-headless-ubuntu, 11-jdk-headless-ubuntu-noble, 11-jdk-headless-ubuntu-24.04, 11.0.30-jdk-headless-ubuntu-noble, 11.0.30-jdk-headless-ubuntu-24.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/24_04/jdk-headless
-
-Tags: 11-jre, 11-jre-ubuntu, 11.0.30-jre, 11.0.30-jre-ubuntu, 11-jre-ubuntu-noble, 11-jre-ubuntu-24.04, 11.0.30-jre-ubuntu-noble, 11.0.30-jre-ubuntu-24.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/24_04/jre
-
-Tags: 11-jre-headless, 11-jre-headless-ubuntu, 11.0.30-jre-headless, 11.0.30-jre-headless-ubuntu, 11-jre-headless-ubuntu-noble, 11-jre-headless-ubuntu-24.04, 11.0.30-jre-headless-ubuntu-noble, 11.0.30-jre-headless-ubuntu-24.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/24_04/jre-headless
-
-Tags: 11-ubuntu-jammy, 11-ubuntu-22.04, 11-jdk-ubuntu-jammy, 11-jdk-ubuntu-22.04, 11.0.30-ubuntu-jammy, 11.0.30-ubuntu-22.04, 11.0.30-jdk-ubuntu-jammy, 11.0.30-jdk-ubuntu-22.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/22_04/jdk
-
-Tags: 11-jdk-headless-ubuntu-jammy, 11-jdk-headless-ubuntu-22.04, 11.0.30-jdk-headless-ubuntu-jammy, 11.0.30-jdk-headless-ubuntu-22.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/22_04/jdk-headless
-
-Tags: 11-jre-ubuntu-jammy, 11-jre-ubuntu-22.04, 11.0.30-jre-ubuntu-jammy, 11.0.30-jre-ubuntu-22.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/22_04/jre
-
-Tags: 11-jre-headless-ubuntu-jammy, 11-jre-headless-ubuntu-22.04, 11.0.30-jre-headless-ubuntu-jammy, 11.0.30-jre-headless-ubuntu-22.04
-Architectures: amd64
-GitCommit: 8164390bf31d1a07b0dd072263a7b204dab1d415
-Directory: dockerfiles/11/ubuntu/22_04/jre-headless


### PR DESCRIPTION
New release of SapMachine 26. SapMachine 11 goes out of support.