### PR TITLE
update varnish to 9.0.0

### DIFF
--- a/library/varnish
+++ b/library/varnish
@@ -1,33 +1,9 @@
-# this file was generated using https://github.com/varnish/docker-varnish/blob/9a68f156ac2fa5d6c2d08ebca5cd80fa7f5a4623/populate.sh
+# this file was generated using https://github.com/varnish/docker-varnish/blob/9549601f65e81660417432a6963cdb9a41da3caf/populate.sh
 Maintainers: Guillaume Quintard <guillaume.quintard@gmail.com> (@gquintard)
 GitRepo: https://github.com/varnish/docker-varnish.git
 
-Tags: fresh, 8.0.0, 8, 8.0, latest
+Tags: fresh, 9.0.0, 9, 9.0, latest
 Architectures: amd64, arm64v8
 Directory: fresh/debian
-GitCommit: 9a68f156ac2fa5d6c2d08ebca5cd80fa7f5a4623
-GitFetch: refs/heads/main
-
-Tags: fresh-alpine, 8.0.0-alpine, 8-alpine, 8.0-alpine, alpine
-Architectures: amd64, arm64v8
-Directory: fresh/alpine
-GitCommit: d80cb1ac78089dfa29cb2148c3b3cc5e196757c6
-GitFetch: refs/heads/main
-
-Tags: old, 7.7.3, 7.7
-Architectures: amd64, arm64v8
-Directory: old/debian
-GitCommit: b341feabd8feeafaa2d25d35fdf44eb27a2eaaa1
-GitFetch: refs/heads/main
-
-Tags: old-alpine, 7.7.3-alpine, 7.7-alpine
-Architectures: amd64, arm64v8
-Directory: old/alpine
-GitCommit: 68b666606150f9aa637a23d4358906eb6a409252
-GitFetch: refs/heads/main
-
-Tags: stable, 6.0.16, 6.0
-Architectures: amd64, arm64v8
-Directory: stable/debian
-GitCommit: d41acec41c1251d0b512023abc7fd9cfd4a1490f
+GitCommit: 9549601f65e81660417432a6963cdb9a41da3caf
 GitFetch: refs/heads/main


### PR DESCRIPTION
I've cut out non-debian, non-fresh images as they need a few adjustments to align with the new world order, but I wanted to provide a fresh option quickly.