### PR TITLE
Update KrakenD to v2.13.3

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.2, 2.13, 2, latest
+Tags: 2.13.3, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 06f5a5d88185e99c9477eb303c7e1445dbb39e5b
-Directory: 2.13.2
+GitCommit: 46254f0398186807f235f0b5728d718a3d644227
+Directory: 2.13.3


### PR DESCRIPTION
This patch release fixes gRPC [CVE-2026-33186](https://www.tenable.com/cve/CVE-2026-33186)