### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,44 +14,44 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: fdc3f623fd64fd54af94f2eca500de6a67252725
 Directory: 3.4/alpine
 
-Tags: 3.3.5, 3.3, latest, 3.3.5-trixie, 3.3-trixie, trixie
+Tags: 3.3.6, 3.3, latest, 3.3.6-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6cd3d70d127519eead0e9d43ca58223fb8284680
+GitCommit: 873e28d796e2467fcea0f46b5904ef3380f1cc0b
 Directory: 3.3
 
-Tags: 3.3.5-alpine, 3.3-alpine, alpine, 3.3.5-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.6-alpine, 3.3-alpine, alpine, 3.3.6-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6cd3d70d127519eead0e9d43ca58223fb8284680
+GitCommit: 873e28d796e2467fcea0f46b5904ef3380f1cc0b
 Directory: 3.3/alpine
 
-Tags: 3.2.14, 3.2, lts, 3.2.14-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.15, 3.2, lts, 3.2.15-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f1255acb427561699534b9a56577b2dfd0c2c68e
+GitCommit: 55b3ead0f618eb7bab5a52ac0b1d86d3fbe7ebfb
 Directory: 3.2
 
-Tags: 3.2.14-alpine, 3.2-alpine, lts-alpine, 3.2.14-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.15-alpine, 3.2-alpine, lts-alpine, 3.2.15-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f1255acb427561699534b9a56577b2dfd0c2c68e
+GitCommit: 55b3ead0f618eb7bab5a52ac0b1d86d3fbe7ebfb
 Directory: 3.2/alpine
 
-Tags: 3.1.16, 3.1, 3.1.16-trixie, 3.1-trixie
+Tags: 3.1.17, 3.1, 3.1.17-trixie, 3.1-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8afcf8d85a2f7eceec76d390cb8b0e33592341b6
+GitCommit: 8c6a4cd92c42227f540ddc039162f4b75672f372
 Directory: 3.1
 
-Tags: 3.1.16-alpine, 3.1-alpine, 3.1.16-alpine3.23, 3.1-alpine3.23
+Tags: 3.1.17-alpine, 3.1-alpine, 3.1.17-alpine3.23, 3.1-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8afcf8d85a2f7eceec76d390cb8b0e33592341b6
+GitCommit: 8c6a4cd92c42227f540ddc039162f4b75672f372
 Directory: 3.1/alpine
 
-Tags: 3.0.18, 3.0, 3.0.18-trixie, 3.0-trixie
+Tags: 3.0.19, 3.0, 3.0.19-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dda3cbe052bafebe01a728f2f0a8fd1cbf7b167b
+GitCommit: 88a6be733ab3aa1db3eb72aaf37ad92c64b51ae5
 Directory: 3.0
 
-Tags: 3.0.18-alpine, 3.0-alpine, 3.0.18-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.19-alpine, 3.0-alpine, 3.0.19-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: dda3cbe052bafebe01a728f2f0a8fd1cbf7b167b
+GitCommit: 88a6be733ab3aa1db3eb72aaf37ad92c64b51ae5
 Directory: 3.0/alpine
 
 Tags: 2.8.19, 2.8, 2.8.19-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/88a6be7: Update 3.0 to 3.0.19
- https://github.com/docker-library/haproxy/commit/873e28d: Update 3.3 to 3.3.6
- https://github.com/docker-library/haproxy/commit/55b3ead: Update 3.2 to 3.2.15
- https://github.com/docker-library/haproxy/commit/8c6a4cd: Update 3.1 to 3.1.17