### PR TITLE
[oraclelinux] Updating 10 and 10-slim for ELSA-2026-5063 ELBA-2026-4902 and 8, 8-slim and 8-slim-fips for ELSA-2026-4772 ELBA-2026-4902 and 9, 9-slim and 9-slim-fips for ELBA-2026-4902  ELSA-2026-4772  ELSA-2026-5080

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1080dc132d40f0d7e272ba29bda04f7e74c689c5
+amd64-GitCommit: 18ad8c90a1a89560d2e6b0f0d2b8aca27c9ef99d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4055848700f3c8c3cba39bbc53ab30f8b430df17
+arm64v8-GitCommit: ee6aeb9d11078b5de991d82f8503d51b98981855
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-4111, CVE-2025-15281, CVE-2026-0915, CVE-2026-0915, CVE-2026-4111, tzdata 2026a

See the following for details:

ELBA-2026-4902
ELSA-2026-4772
ELSA-2026-5063
ELSA-2026-5080

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
