### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev6, 3.4-dev, 3.4-dev6-trixie, 3.4-dev-trixie
+Tags: 3.4-dev7, 3.4-dev, 3.4-dev7-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fdc3f623fd64fd54af94f2eca500de6a67252725
+GitCommit: 1182ee9d1257d789b5a38b38920e7b836316b549
 Directory: 3.4
 
-Tags: 3.4-dev6-alpine, 3.4-dev-alpine, 3.4-dev6-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev7-alpine, 3.4-dev-alpine, 3.4-dev7-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fdc3f623fd64fd54af94f2eca500de6a67252725
+GitCommit: 1182ee9d1257d789b5a38b38920e7b836316b549
 Directory: 3.4/alpine
 
 Tags: 3.3.6, 3.3, latest, 3.3.6-trixie, 3.3-trixie, trixie
@@ -54,24 +54,24 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 88a6be733ab3aa1db3eb72aaf37ad92c64b51ae5
 Directory: 3.0/alpine
 
-Tags: 2.8.19, 2.8, 2.8.19-trixie, 2.8-trixie
+Tags: 2.8.20, 2.8, 2.8.20-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7edb56c88d34ff20f2c39d8ee812b2cf6ba95d80
+GitCommit: b18416a08cc0589fc14004eb86f3e8696ec0731b
 Directory: 2.8
 
-Tags: 2.8.19-alpine, 2.8-alpine, 2.8.19-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.20-alpine, 2.8-alpine, 2.8.20-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7edb56c88d34ff20f2c39d8ee812b2cf6ba95d80
+GitCommit: b18416a08cc0589fc14004eb86f3e8696ec0731b
 Directory: 2.8/alpine
 
-Tags: 2.6.24, 2.6, 2.6.24-trixie, 2.6-trixie
+Tags: 2.6.25, 2.6, 2.6.25-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c4b409220de05054e4eebe62796d8f71aa5c8789
+GitCommit: 4b9e56f8a15defd4fe110a9077cd0495e8447b54
 Directory: 2.6
 
-Tags: 2.6.24-alpine, 2.6-alpine, 2.6.24-alpine3.23, 2.6-alpine3.23
+Tags: 2.6.25-alpine, 2.6-alpine, 2.6.25-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c4b409220de05054e4eebe62796d8f71aa5c8789
+GitCommit: 4b9e56f8a15defd4fe110a9077cd0495e8447b54
 Directory: 2.6/alpine
 
 Tags: 2.4.31, 2.4, 2.4.31-trixie, 2.4-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b18416a: Update 2.8 to 2.8.20
- https://github.com/docker-library/haproxy/commit/4b9e56f: Update 2.6 to 2.6.25
- https://github.com/docker-library/haproxy/commit/1182ee9: Update 3.4 to 3.4-dev7