### PR TITLE
archlinux: Release 20260322.0.504324

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260315.0.500537
-GitCommit: 0fc0a650d90bf036a88bb3cc188e981becce59ab
-GitFetch: refs/tags/v20260315.0.500537
+Tags: latest, base, base-20260322.0.504324
+GitCommit: 7f3f466a536e84ca5640932ef409b433c9d38eaf
+GitFetch: refs/tags/v20260322.0.504324
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260315.0.500537
-GitCommit: 0fc0a650d90bf036a88bb3cc188e981becce59ab
-GitFetch: refs/tags/v20260315.0.500537
+Tags: base-devel, base-devel-20260322.0.504324
+GitCommit: 7f3f466a536e84ca5640932ef409b433c9d38eaf
+GitFetch: refs/tags/v20260322.0.504324
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260315.0.500537
-GitCommit: 0fc0a650d90bf036a88bb3cc188e981becce59ab
-GitFetch: refs/tags/v20260315.0.500537
+Tags: multilib-devel, multilib-devel-20260322.0.504324
+GitCommit: 7f3f466a536e84ca5640932ef409b433c9d38eaf
+GitFetch: refs/tags/v20260322.0.504324
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks