### PR TITLE
Release SonarQube Server 2026.2.0, 2026.1.1, and 2025.4.5

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -9,44 +9,64 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2026.1.0-developer, 2026.1-developer, developer, 2026-lta-developer
+Tags: 2026.2.0-developer, 2026.2-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 3536fb9581da63de5294fa8b249ec9a74c5cd0b0
-GitFetch: refs/heads/release/2026.1
+GitCommit: 3ccc76d6a8a16b6402a16ba3e0b26e43c825d4d8
+GitFetch: refs/heads/master
 
-Tags: 2026.1.0-enterprise, 2026.1-enterprise, enterprise, 2026-lta-enterprise
+Tags: 2026.2.0-enterprise, 2026.2-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 3536fb9581da63de5294fa8b249ec9a74c5cd0b0
-GitFetch: refs/heads/release/2026.1
+GitCommit: 3ccc76d6a8a16b6402a16ba3e0b26e43c825d4d8
+GitFetch: refs/heads/master
 
-Tags: 2026.1.0-datacenter-app, 2026.1-datacenter-app, datacenter-app, 2026-lta-datacenter-app
+Tags: 2026.2.0-datacenter-app, 2026.2-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 3536fb9581da63de5294fa8b249ec9a74c5cd0b0
-GitFetch: refs/heads/release/2026.1
+GitCommit: 3ccc76d6a8a16b6402a16ba3e0b26e43c825d4d8
+GitFetch: refs/heads/master
 
-Tags: 2026.1.0-datacenter-search, 2026.1-datacenter-search, datacenter-search, 2026-lta-datacenter-search
+Tags: 2026.2.0-datacenter-search, 2026.2-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 3536fb9581da63de5294fa8b249ec9a74c5cd0b0
-GitFetch: refs/heads/release/2026.1
+GitCommit: 3ccc76d6a8a16b6402a16ba3e0b26e43c825d4d8
+GitFetch: refs/heads/master
 
-Tags: 2025.4.4-developer, 2025.4-developer, 2025.4-lta-developer
+Tags: 2026.1.1-developer, 2026.1-developer, 2026-lta-developer
 Directory: commercial-editions/developer
-GitCommit: b366d18634f02e45e6dc4d28151db6704b0630c8
-GitFetch: refs/heads/release/2025.4
+GitCommit: 8c0a0d739faad86652bf34aca90147d9c9ce8b19
+GitFetch: refs/heads/release/2026.1
 
-Tags: 2025.4.4-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
+Tags: 2026.1.1-enterprise, 2026.1-enterprise, 2026-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: b366d18634f02e45e6dc4d28151db6704b0630c8
-GitFetch: refs/heads/release/2025.4
+GitCommit: 8c0a0d739faad86652bf34aca90147d9c9ce8b19
+GitFetch: refs/heads/release/2026.1
 
-Tags: 2025.4.4-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
+Tags: 2026.1.1-datacenter-app, 2026.1-datacenter-app, 2026-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: b366d18634f02e45e6dc4d28151db6704b0630c8
+GitCommit: 8c0a0d739faad86652bf34aca90147d9c9ce8b19
+GitFetch: refs/heads/release/2026.1
+
+Tags: 2026.1.1-datacenter-search, 2026.1-datacenter-search, 2026-lta-datacenter-search
+Directory: commercial-editions/datacenter/search
+GitCommit: 8c0a0d739faad86652bf34aca90147d9c9ce8b19
+GitFetch: refs/heads/release/2026.1
+
+Tags: 2025.4.5-developer, 2025.4-developer, 2025.4-lta-developer
+Directory: commercial-editions/developer
+GitCommit: 468f913df52ab9dc6f2f9e78f91ab6cbc70a9a5c
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.4-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
+Tags: 2025.4.5-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
+Directory: commercial-editions/enterprise
+GitCommit: 468f913df52ab9dc6f2f9e78f91ab6cbc70a9a5c
+GitFetch: refs/heads/release/2025.4
+
+Tags: 2025.4.5-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
+Directory: commercial-editions/datacenter/app
+GitCommit: 468f913df52ab9dc6f2f9e78f91ab6cbc70a9a5c
+GitFetch: refs/heads/release/2025.4
+
+Tags: 2025.4.5-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: b366d18634f02e45e6dc4d28151db6704b0630c8
+GitCommit: 468f913df52ab9dc6f2f9e78f91ab6cbc70a9a5c
 GitFetch: refs/heads/release/2025.4
 
 Tags: 2025.1.6-developer, 2025.1-developer, 2025-lta-developer


### PR DESCRIPTION
Dear team,

We would like to release SonarQube Server versions 2026.2.0, 2026.1.1, and 2025.4.5.

Please review and approve the proposed changes.
