### PR TITLE
Redis: Update to 8.6.2

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,16 +6,16 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.6.1, 8.6, 8, 8.6.1-trixie, 8.6-trixie, 8-trixie, latest, trixie
+Tags: 8.6.2, 8.6, 8, 8.6.2-trixie, 8.6-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 772020f24a0acb30ffaa6647f3c79a7f3932225d
-GitFetch: refs/tags/v8.6.1
+GitCommit: 8c81e2a44cae9258294718d767ce594e5cbbf20e
+GitFetch: refs/tags/v8.6.2
 Directory: debian
 
-Tags: 8.6.1-alpine, 8.6-alpine, 8-alpine, 8.6.1-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
+Tags: 8.6.2-alpine, 8.6-alpine, 8-alpine, 8.6.2-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 772020f24a0acb30ffaa6647f3c79a7f3932225d
-GitFetch: refs/tags/v8.6.1
+GitCommit: 8c81e2a44cae9258294718d767ce594e5cbbf20e
+GitFetch: refs/tags/v8.6.2
 Directory: alpine
 
 Tags: 8.4.2, 8.4, 8.4.2-trixie, 8.4-trixie


### PR DESCRIPTION
Hi Docker Team!

Please update Redis to 8.6.2, this is maintenance release.

Release notes: https://github.com/redis/redis/releases/tag/8.6.2