### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/32ed6b6c9363239c5acccfcf89bf401e07fc33c3/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/c7624fc5c725ca94aedd0d570c3978a16fc8da35/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 32ed6b6c9363239c5acccfcf89bf401e07fc33c3
+GitCommit: c7624fc5c725ca94aedd0d570c3978a16fc8da35
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 557f024d4e247f4fa6e086640e7982333b29f04e
+amd64-GitCommit: c1375496373e76f680b1ef5f713500e98921a45c
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 3edda89aee2cb45463eb3e4858b0d0b55b28b0cd
+arm32v5-GitCommit: ca40c0d2d0d41236d15489a29866c186f86eef50
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 262f1f8fc3fd7ae038d0abee2908193c1f8ed7fd
+arm32v6-GitCommit: 788d997fb9961f32cc3148af0e8eaa1966e54fb1
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: 6dde356a78739c0bf7e2fcd3c84a194431bdd73b
+arm32v7-GitCommit: b9b6bc9e93104819ef6b50a4de1c3677f5f9d416
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 86823563177e12460ad3e122103a3ee14691807d
+arm64v8-GitCommit: b6ab7c14ba46700181395f420545aee1ab297934
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: b637faa0f5db2890dab7f4b93495ee1c7d951b08
+i386-GitCommit: 30feda7759d9d42f55d7c7daf1d2241d7eb36524
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: ec0723d76b735e22d7b8070f928ab6de1cc8a17a
+ppc64le-GitCommit: 3dbe0834ac3fa8142a54ea6c676ef4f9581a7bc3
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: e43482cb6af1ec3c0e58945046222805ad069d5b
+riscv64-GitCommit: 5e7e6f8960e72260400505fc5b6d547bb0e4223b
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: d76495a831258bec4d30c217b742399a4a793bfc
+s390x-GitCommit: f83ddfed5a43316725b4ff637d76e8f895ae22e3
 
 Tags: 1.37.0-glibc, 1.37-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/c7624fc: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/0143ee1: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/1732194: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/c7c4cdf: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/1fa93a7: Merge pull request https://github.com/docker-library/busybox/pull/244 from infosiftr/buildroot-2025.11.3
- https://github.com/docker-library/busybox/commit/47d8865: Update metadata for amd64 and i386
- https://github.com/docker-library/busybox/commit/9106ef5: Update buildroot to 2025.11.3
- https://github.com/docker-library/busybox/commit/1a27720: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/dd323e7: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/00c385f: Update metadata for i386
- https://github.com/docker-library/busybox/commit/e4a61f5: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/a34149e: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/2357da4: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/080eda6: Update metadata for amd64