### PR TITLE
[oraclelinux] Updating 9 for ELSA-2026-5602

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 18ad8c90a1a89560d2e6b0f0d2b8aca27c9ef99d
+amd64-GitCommit: 478d3ea86d20544e6082a4d6c3dcb77cd7851f59
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: ee6aeb9d11078b5de991d82f8503d51b98981855
+arm64v8-GitCommit: cdd6586144aead057783efaff6d7b28d54a468e2
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-25749

See the following for details:

ELSA-2026-5602

Signed-off-by: Alan Steinberg <alan.steinberg@oracle.com>
