### PR TITLE
[oraclelinux] Updating 10, 9, and 8 for ELSAs

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: dc537bd14decd4e16b7a3c6c7c74b38dc22767e2
+amd64-GitCommit: b846e28be9a048640fa87bc0f4406a50f35a0ee7
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6c80bd7078de50cd091d4bf89fb7811f2cf431f8
+arm64v8-GitCommit: bec4c2a90ca0b39c82bd099b654398c2177153f9
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-3497, CVE-2026-4519, CVE-2026-3497, CVE-2026-4519, CVE-2026-3497, CVE-2026-4519, CVE-2026-28417, CVE-2026-28421, CVE-2026-33412, CVE-2026-3497, CVE-2026-4519, CVE-2026-3497, CVE-2026-4519, CVE-2026-28417, CVE-2026-28421, CVE-2026-33412, CVE-2026-3497, CVE-2026-4519

See the following for details:

ELSA-2026-6256
ELSA-2026-6461
ELSA-2026-6462
ELSA-2026-6463
ELSA-2026-6473
ELSA-2026-6766
ELSA-2026-6915

Signed-off-by: Mark Will <mark.will@oracle.com>
