### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.10.20260330.0
+Tags: 2023, latest, 2023.11.20260406.2
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: a1c5e01e1a914672143b2c9380c2512850336efa
+amd64-GitCommit: 26c4eb4d3ac161b89e231cd55069dbd17ab5bd5a
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 64f52b97d60679b5defa83b9f34221691b766afb
+arm64v8-GitCommit: 265af682c37e6b3dfbf24ff788a12a77ab980999
 
-Tags: 2, 2.0.20260330.0
+Tags: 2, 2.0.20260406.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: ef0b9fe0e3dd6fd2eb5d54ea531d0c30f4fa7328
+amd64-GitCommit: 6bae5463ede2752fc9149f71bc27a605766c0dab
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: ffc5afe243c69a7089eb81d712300db2dc5a43d1
+arm64v8-GitCommit: 6db48bb1f167b5951f5fa15b287639bfa6824218
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.11.20260406-0.amzn2023
- system-release-2023.11.20260406-0.amzn2023
