### PR TITLE
update influxdb 1.12 to 1.12.4

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -5,26 +5,26 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 5f348c414cdf357a6d3916f0ffe49c5f42bb7576
+GitCommit: ca349af15bb3dbe666a26fa0acf7e19b32ac74ec
 
-Tags: 1.12, 1.12.3
+Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
 Directory: influxdb/1.12
 
-Tags: 1.12-alpine, 1.12.3-alpine
+Tags: 1.12-alpine, 1.12.4-alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/1.12/alpine
 
-Tags: 1.12-data, 1.12.3-data, data
+Tags: 1.12-data, 1.12.4-data, data
 Directory: influxdb/1.12/data
 
-Tags: 1.12-data-alpine, 1.12.3-data-alpine, data-alpine
+Tags: 1.12-data-alpine, 1.12.4-data-alpine, data-alpine
 Directory: influxdb/1.12/data/alpine
 
-Tags: 1.12-meta, 1.12.3-meta, meta
+Tags: 1.12-meta, 1.12.4-meta, meta
 Directory: influxdb/1.12/meta
 
-Tags: 1.12-meta-alpine, 1.12.3-meta-alpine, meta-alpine
+Tags: 1.12-meta-alpine, 1.12.4-meta-alpine, meta-alpine
 Directory: influxdb/1.12/meta/alpine
 
 Tags: 1.11, 1.11.8


### PR DESCRIPTION
- Update influxdb 1.12 tags to 1.12.4.
- Fix some curl commands to use `-fsSLO` instead of `-fssLO`
- Fix 1.12-data-alpine to use INFLUXDB_PR in INFLUXDB_PV. This does not have any impact on the images currently being built.