### PR TITLE
[oraclelinux] Updating 8, 8-slim, 8-slim-fips, 9, 9-slim, 9-slim-fips 10, and 10-slim

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: b846e28be9a048640fa87bc0f4406a50f35a0ee7
+amd64-GitCommit: 9a55bc441bcfc05c2a03cc1987fc0e71f8344716
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: bec4c2a90ca0b39c82bd099b654398c2177153f9
+arm64v8-GitCommit: a36b0c81d2953d8bca635ae450c18e02d9e3446a
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-28417, CVE-2026-28421, CVE-2026-33412, CVE-2026-27135, CVE-2026-28417, CVE-2026-28421, CVE-2026-33412, CVE-2026-27135, CVE-2026-27135, CVE-2026-28417, CVE-2026-28421, CVE-2026-33412, CVE-2026-27135, CVE-2026-27135, CVE-2026-27135

See the following for details:

ELSA-2026-7666
ELSA-2026-7667
ELSA-2026-7668
ELSA-2026-7711

Signed-off-by: Mark Will <mark.will@oracle.com>
