### PR TITLE
Official Convertigo 8.4.2 and 8.3.13 releases!

### DIFF
--- a/library/convertigo
+++ b/library/convertigo
@@ -1,7 +1,13 @@
 Maintainers: Nicolas Albert <nicolasa@convertigo.com> (@nicolas-albert), Olivier Picciotto <olivier.picciotto@convertigo.com> (@opicciotto)
 GitRepo: https://github.com/convertigo/convertigo
-GitCommit: fb6f00cdd5842fffb22271230507789e4c565fa4
+GitCommit: e858e10da3fcec033c75fdfeca963613e0504ebb
 
-Tags: 8.4.1, 8.4, latest
+Tags: 8.4.2, 8.4, latest
+Architectures: amd64, arm64v8
+Directory: docker/default
+
+Tags: 8.3.13, 8.3
+GitFetch: refs/tags/8.3.13
+GitCommit: b2d70389f013d3ccb4e50e4388f2a0603015768f
 Architectures: amd64, arm64v8
 Directory: docker/default


### PR DESCRIPTION
Exceptional double release, should change to one release for the next `8.4.3`.
I hope this is a valid syntax.

Thx!