### PR TITLE
alpine: security update 3.23.4

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.23.3, 3.23, 3, latest
+Tags: 3.23.4, 3.23, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.23
-GitCommit: a037d70ba44f91b00dff940019d29a28f7ba1265
+GitCommit: c68e08480b8fb053591ade7dbaffa2ea67db2f56
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
musl
- CVE-2026-6042
- CVE-2026-40200

openssl
- CVE-2026-31790
- CVE-2026-28387
- CVE-2026-28388
- CVE-2026-28389
- CVE-2026-28390
- CVE-2026-31789

zlib
- CVE-2026-22184
- CVE-2026-27171