### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev8, 3.4-dev, 3.4-dev8-trixie, 3.4-dev-trixie
+Tags: 3.4-dev9, 3.4-dev, 3.4-dev9-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 48ef04c1facaa18977bfe01a80c8788d1a43ec88
+GitCommit: 89c2946e37515558790ce0536a5dc23447534712
 Directory: 3.4
 
-Tags: 3.4-dev8-alpine, 3.4-dev-alpine, 3.4-dev8-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev9-alpine, 3.4-dev-alpine, 3.4-dev9-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 48ef04c1facaa18977bfe01a80c8788d1a43ec88
+GitCommit: 89c2946e37515558790ce0536a5dc23447534712
 Directory: 3.4/alpine
 
 Tags: 3.3.6, 3.3, latest, 3.3.6-trixie, 3.3-trixie, trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/89c2946: Update 3.4 to 3.4-dev9