### PR TITLE
alpine: security updates 3.22.4, 3.21.7, 3.20.10

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -27,10 +27,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.22.3, 3.22
+Tags: 3.22.4, 3.22
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.22
-GitCommit: c65c121d664a527ec65e1fa4cecc9063fff656da
+GitCommit: ce1b9f141bbd2d604064cae6a3f5309b4a2a40b9
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -40,10 +40,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.21.6, 3.21
+Tags: 3.21.7, 3.21
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.21
-GitCommit: d9ff52957b2fe5361ffeb5d871db8c321e5605d8
+GitCommit: 52e3f9384ecbfe80a2d36bb344e464c0cf7c7507
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -53,10 +53,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.20.9, 3.20
+Tags: 3.20.10, 3.20
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.20
-GitCommit: b3f87708e5052e29737a251b2e9865e182dafe0c
+GitCommit: 0db70ae354ee747109ce0b9a0cfbcd3c907bc822
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
    musl
    - CVE-2026-6042
    - CVE-2026-40200

    openssl
    - CVE-2026-31790
    - CVE-2026-28387
    - CVE-2026-28388
    - CVE-2026-28389
    - CVE-2026-28390
    - CVE-2026-31789

    zlib
    - CVE-2026-22184
    - CVE-2026-27171