### PR TITLE
[oraclelinux] Updating 8 for ELSA-2026-8352 and 9 for ELSA-2026-8352 ELSA-2026-8259

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9a55bc441bcfc05c2a03cc1987fc0e71f8344716
+amd64-GitCommit: 9062dbbd9878a3d0433c0c95e80be57c175ba003
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a36b0c81d2953d8bca635ae450c18e02d9e3446a
+arm64v8-GitCommit: f53dd58988b4dce38ec51be315fde17ffa5bacbe
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-1519, CVE-2026-1519, CVE-2026-28417, CVE-2026-28421, CVE-2026-33412

See the following for details:

ELSA-2026-8259
ELSA-2026-8352

Signed-off-by: Mark Will <mark.will@oracle.com>
