### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,9 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.7, 5.0, 5, latest, 5.0.7-bookworm, 5.0-bookworm, 5-bookworm, bookworm
+Tags: 5.0.8, 5.0, 5, latest, 5.0.8-bookworm, 5.0-bookworm, 5-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: cedb7139e880263c5b5257b37c3bff05440f9e18
+GitCommit: 7b9da8f4f58f48af79feb0fc2f7a1e2c639965f1
 Directory: 5.0
 
 Tags: 4.1.11, 4.1, 4, 4.1.11-bookworm, 4.1-bookworm, 4-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/7b9da8f: Update 5.0 to 5.0.8