### PR TITLE
fluentd: drop v1.16 series

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,13 +3,6 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Debian images
-Tags: v1.16.11-debian-1.0, v1.16-debian-1
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitFetch: refs/heads/v1.16
-GitCommit: f1cc6c311f673af8d4d68c7cbe97e5b0831511bc
-Directory: v1.16/debian
-
-# Debian images
 Tags: v1.19.2-debian-1.0, v1.19-debian-1, v1.19.2-1.0, v1.19-1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
 GitCommit: 162a49598542a981bbf73470f0bba815dc4dbf0e


### PR DESCRIPTION
v1.16 was not maintained anymore, so remove them.