### PR TITLE
[oraclelinux] Updating 10 and 10-slim; 9, 9-slim and 9-slim-fips; 8, 8-slim and 8-slim-fips

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9062dbbd9878a3d0433c0c95e80be57c175ba003
+amd64-GitCommit: 439e38f796f3c1e436209503c9de70879df5ab2e
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f53dd58988b4dce38ec51be315fde17ffa5bacbe
+arm64v8-GitCommit: 704ed33c89510452b60624024f9ffeb74af7b89b
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-4424, CVE-2026-4424, CVE-2026-4424, CVE-2026-5121, CVE-2026-4424, CVE-2026-4424, CVE-2026-5121, CVE-2026-4424, CVE-2026-5121

See the following for details:

ELSA-2026-8492
ELSA-2026-8510
ELSA-2026-8534

Signed-off-by: Mark Will <mark.will@oracle.com>
