### PR TITLE
Update ghost

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Austin Burdine <austin@acburdine.me> (@acburdine)
 GitRepo: https://github.com/docker-library/ghost.git
-GitCommit: 949d90ab1cf3a7bcb7b2dd510752679b641689f7
+GitCommit: 1bf8746b7eff6422e5207809743304755e48ff64
 
-Tags: 6.28.0-bookworm, 6.28.0, 6.28-bookworm, 6.28, 6-bookworm, 6, bookworm, latest
+Tags: 6.30.0-bookworm, 6.30.0, 6.30-bookworm, 6.30, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8, s390x
 
-Tags: 6.28.0-alpine3.23, 6.28.0-alpine, 6.28-alpine3.23, 6.28-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.30.0-alpine3.23, 6.30.0-alpine, 6.30-alpine3.23, 6.30-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ghost/commit/1bf8746: Update to 6.30.0, move from yarn to pnpm (https://github.com/docker-library/ghost/pull/467)