### PR TITLE
archlinux: Release 20260419.0.517065

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260412.0.513370
-GitCommit: d7cf6ad776df5104c05e6085089f0e7fbd4b2fef
-GitFetch: refs/tags/v20260412.0.513370
+Tags: latest, base, base-20260419.0.517065
+GitCommit: 25354c172306956092edf933ad385f23975ebedd
+GitFetch: refs/tags/v20260419.0.517065
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260412.0.513370
-GitCommit: d7cf6ad776df5104c05e6085089f0e7fbd4b2fef
-GitFetch: refs/tags/v20260412.0.513370
+Tags: base-devel, base-devel-20260419.0.517065
+GitCommit: 25354c172306956092edf933ad385f23975ebedd
+GitFetch: refs/tags/v20260419.0.517065
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260412.0.513370
-GitCommit: d7cf6ad776df5104c05e6085089f0e7fbd4b2fef
-GitFetch: refs/tags/v20260412.0.513370
+Tags: multilib-devel, multilib-devel-20260419.0.517065
+GitCommit: 25354c172306956092edf933ad385f23975ebedd
+GitFetch: refs/tags/v20260419.0.517065
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks