### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/docker-library/redmine/blob/a78ef22f57df24fe9e7d4a9b149751a45c87b755/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/redmine/blob/ac72cc35bca8e8d5e5b984829014878808db91a7/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
@@ -43,23 +43,3 @@ Tags: 6.0.9-alpine3.22, 6.0-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: d7dac9b6c9892c971da4dc1b09bf4c90fad8267c
 Directory: 6.0/alpine3.22
-
-Tags: 5.1.12, 5.1, 5, 5.1.12-trixie, 5.1-trixie, 5-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
-Directory: 5.1/trixie
-
-Tags: 5.1.12-bookworm, 5.1-bookworm, 5-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
-Directory: 5.1/bookworm
-
-Tags: 5.1.12-alpine3.23, 5.1-alpine3.23, 5-alpine3.23, 5.1.12-alpine, 5.1-alpine, 5-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
-Directory: 5.1/alpine3.23
-
-Tags: 5.1.12-alpine3.22, 5.1-alpine3.22, 5-alpine3.22
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 78180a845eaec40157e52b5532142698ea9b3ea4
-Directory: 5.1/alpine3.22


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/ac72cc3: Remove 5.1 (Ruby 3.2 EOL) (https://github.com/docker-library/redmine/pull/415)