### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -16,14 +16,14 @@ GitCommit: 7fcf7198cf8be286bae76a4b587ac206af3e7cd8
 Directory: 8.4
 File: Dockerfile.oracle
 
-Tags: 8.0.45, 8.0, 8.0.45-oraclelinux9, 8.0-oraclelinux9, 8.0.45-oracle, 8.0-oracle
+Tags: 8.0.46, 8.0, 8.0.46-oraclelinux9, 8.0-oraclelinux9, 8.0.46-oracle, 8.0-oracle
 Architectures: amd64, arm64v8
-GitCommit: 7a8f81aad11e871baf1dbc755dbff1652e13cba5
+GitCommit: 7cf11d5360282effadb347353d5f82339506b106
 Directory: 8.0
 File: Dockerfile.oracle
 
-Tags: 8.0.45-bookworm, 8.0-bookworm, 8.0.45-debian, 8.0-debian
+Tags: 8.0.46-bookworm, 8.0-bookworm, 8.0.46-debian, 8.0-debian
 Architectures: amd64
-GitCommit: 7a8f81aad11e871baf1dbc755dbff1652e13cba5
+GitCommit: 7cf11d5360282effadb347353d5f82339506b106
 Directory: 8.0
 File: Dockerfile.debian


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/7cf11d5: Update 8.0 to 8.0.46, debian 8.0.46-1debian12, oracle 8.0.46-1.el9, mysql-shell 8.0.46-1.el9

According to https://dev.mysql.com/doc/relnotes/mysql/8.0/en/, this is the last release of `8.0.x`
> As of April 2026, with version 8.0.46, MySQL 8.0 reaches End of Life (EoL). MySQL 8.0 users are encouraged to upgrade to the latest MySQL 8.4 LTS or MySQL Innovation release.
