### PR TITLE
Bump Traefik to v2.11.43, v3.6.14, and to v3.7.0-rc.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,103 +1,103 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.0-rc.1-windowsservercore-ltsc2025, 3.7.0-rc.1-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025
+Tags: v3.7.0-rc.2-windowsservercore-ltsc2025, 3.7.0-rc.2-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fa4b5d2b759a7bec51cf561dbd222c29f5c51a46
+GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.0-rc.1-windowsservercore-ltsc2022, 3.7.0-rc.1-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022
+Tags: v3.7.0-rc.2-windowsservercore-ltsc2022, 3.7.0-rc.2-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fa4b5d2b759a7bec51cf561dbd222c29f5c51a46
+GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.0-rc.1-nanoserver-ltsc2025, 3.7.0-rc.1-nanoserver-ltsc2025, langres-nanoserver-ltsc2025
+Tags: v3.7.0-rc.2-nanoserver-ltsc2025, 3.7.0-rc.2-nanoserver-ltsc2025, langres-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fa4b5d2b759a7bec51cf561dbd222c29f5c51a46
+GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.0-rc.1-nanoserver-ltsc2022, 3.7.0-rc.1-nanoserver-ltsc2022, langres-nanoserver-ltsc2022
+Tags: v3.7.0-rc.2-nanoserver-ltsc2022, 3.7.0-rc.2-nanoserver-ltsc2022, langres-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fa4b5d2b759a7bec51cf561dbd222c29f5c51a46
+GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.0-rc.1, 3.7.0-rc.1, langres
+Tags: v3.7.0-rc.2, 3.7.0-rc.2, langres
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: fa4b5d2b759a7bec51cf561dbd222c29f5c51a46
+GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
 Directory: v3.7/alpine
 
-Tags: v3.6.13-windowsservercore-ltsc2025, 3.6.13-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.6.14-windowsservercore-ltsc2025, 3.6.14-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c8d68e4423f058006c8b6c84b63edd70bc6dd904
+GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
 Directory: v3.6/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.6.13-windowsservercore-ltsc2022, 3.6.13-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.14-windowsservercore-ltsc2022, 3.6.14-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c8d68e4423f058006c8b6c84b63edd70bc6dd904
+GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.13-nanoserver-ltsc2025, 3.6.13-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.6.14-nanoserver-ltsc2025, 3.6.14-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c8d68e4423f058006c8b6c84b63edd70bc6dd904
+GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
 Directory: v3.6/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.6.13-nanoserver-ltsc2022, 3.6.13-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.14-nanoserver-ltsc2022, 3.6.14-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c8d68e4423f058006c8b6c84b63edd70bc6dd904
+GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.13, 3.6.13, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.14, 3.6.14, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: c8d68e4423f058006c8b6c84b63edd70bc6dd904
+GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
 Directory: v3.6/alpine
 
-Tags: v2.11.42-windowsservercore-ltsc2025, 2.11.42-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
+Tags: v2.11.43-windowsservercore-ltsc2025, 2.11.43-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cf1e3a50fa929794de1e7318428c0d00402dcbf6
+GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
 Directory: v2.11/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v2.11.42-windowsservercore-ltsc2022, 2.11.42-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.43-windowsservercore-ltsc2022, 2.11.43-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cf1e3a50fa929794de1e7318428c0d00402dcbf6
+GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.42-nanoserver-ltsc2025, 2.11.42-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
+Tags: v2.11.43-nanoserver-ltsc2025, 2.11.43-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cf1e3a50fa929794de1e7318428c0d00402dcbf6
+GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
 Directory: v2.11/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v2.11.42-nanoserver-ltsc2022, 2.11.42-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.43-nanoserver-ltsc2022, 2.11.43-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cf1e3a50fa929794de1e7318428c0d00402dcbf6
+GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.42, 2.11.42, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.43, 2.11.43, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: cf1e3a50fa929794de1e7318428c0d00402dcbf6
+GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
 Directory: v2.11/alpine


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.43](https://github.com/traefik/traefik/releases/tag/v2.11.43), [v3.6.14](https://github.com/traefik/traefik/releases/tag/v3.6.14), [v3.7.0-rc.2](https://github.com/traefik/traefik/releases/tag/v3.7.0-rc.2).

/cc @nmengin @kevinpollet  @rtribotte

Cheers