### PR TITLE
Update for Corretto releases: 8.492.09.1, 11.0.31.11.1, 17.0.19.10.1, 21.0.11.10.1, 25.0.3.9.1, 26.0.1.8.1

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,7 +15,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: e4e1a57d43309b7e8856887cddeaac7e4802f8a8
+GitCommit: 5a0fa371106fd28791331fcf7364a46feadc4d58
 
 Tags: 8, 8u492, 8u492-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u492-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8

--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,228 +15,228 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: 08df98dad1cbed8f8f0f227c10b7b7a3d8c1a57e
+GitCommit: e4e1a57d43309b7e8856887cddeaac7e4802f8a8
 
-Tags: 8, 8u482, 8u482-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u482-al2-generic, 8-al2-generic-jdk, latest
+Tags: 8, 8u492, 8u492-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u492-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2-generic
 
-Tags: 8-al2023, 8u482-al2023, 8-al2023-jdk
+Tags: 8-al2023, 8u492-al2023, 8-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2023-jre, 8u482-al2023-jre
+Tags: 8-al2023-jre, 8u492-al2023-jre
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2-native-jre, 8u482-al2-native-jre
+Tags: 8-al2-native-jre, 8u492-al2-native-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2
 
-Tags: 8-al2-native-jdk, 8u482-al2-native-jdk
+Tags: 8-al2-native-jdk, 8u492-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.20, 8u482-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
+Tags: 8-alpine3.20, 8u492-alpine3.20, 8-alpine3.20-full, 8-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.20
 
-Tags: 8-alpine3.20-jre, 8u482-alpine3.20-jre
+Tags: 8-alpine3.20-jre, 8u492-alpine3.20-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.20
 
-Tags: 8-alpine3.21, 8u482-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
+Tags: 8-alpine3.21, 8u492-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8-alpine3.21-jre, 8u482-alpine3.21-jre
+Tags: 8-alpine3.21-jre, 8u492-alpine3.21-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.21
 
-Tags: 8-alpine3.22, 8u482-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk
+Tags: 8-alpine3.22, 8u492-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.22
 
-Tags: 8-alpine3.22-jre, 8u482-alpine3.22-jre
+Tags: 8-alpine3.22-jre, 8u492-alpine3.22-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.22
 
-Tags: 8-alpine3.23, 8u482-alpine3.23, 8-alpine3.23-full, 8-alpine3.23-jdk, 8-alpine, 8u482-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.23, 8u492-alpine3.23, 8-alpine3.23-full, 8-alpine3.23-jdk, 8-alpine, 8u492-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.23
 
-Tags: 8-alpine3.23-jre, 8u482-alpine3.23-jre, 8-alpine-jre, 8u482-alpine-jre
+Tags: 8-alpine3.23-jre, 8u492-alpine3.23-jre, 8-alpine-jre, 8u492-alpine-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.23
 
-Tags: 11, 11.0.30, 11.0.30-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.30-al2-generic, 11-al2-generic-jdk
+Tags: 11, 11.0.31, 11.0.31-al2, 11-al2-full, 11-al2-jdk, 11-al2-generic, 11.0.31-al2-generic, 11-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2-generic
 
-Tags: 11-al2023, 11.0.30-al2023, 11-al2023-jdk
+Tags: 11-al2023, 11.0.31-al2023, 11-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2023
 
-Tags: 11-al2023-headless, 11.0.30-al2023-headless
+Tags: 11-al2023-headless, 11.0.31-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2023
 
-Tags: 11-al2023-headful, 11.0.30-al2023-headful
+Tags: 11-al2023-headful, 11.0.31-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 11/headful/al2023
 
-Tags: 11-al2-native-headless, 11.0.30-al2-native-headless
+Tags: 11-al2-native-headless, 11.0.31-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 11/headless/al2
 
-Tags: 11-al2-native-jdk, 11.0.30-al2-native-jdk
+Tags: 11-al2-native-jdk, 11.0.31-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/al2
 
-Tags: 11-alpine3.20, 11.0.30-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
+Tags: 11-alpine3.20, 11.0.31-alpine3.20, 11-alpine3.20-full, 11-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.20
 
-Tags: 11-alpine3.21, 11.0.30-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
+Tags: 11-alpine3.21, 11.0.31-alpine3.21, 11-alpine3.21-full, 11-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.21
 
-Tags: 11-alpine3.22, 11.0.30-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk
+Tags: 11-alpine3.22, 11.0.31-alpine3.22, 11-alpine3.22-full, 11-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.22
 
-Tags: 11-alpine3.23, 11.0.30-alpine3.23, 11-alpine3.23-full, 11-alpine3.23-jdk, 11-alpine, 11.0.30-alpine, 11-alpine-full, 11-alpine-jdk
+Tags: 11-alpine3.23, 11.0.31-alpine3.23, 11-alpine3.23-full, 11-alpine3.23-jdk, 11-alpine, 11.0.31-alpine, 11-alpine-full, 11-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine/3.23
 
-Tags: 17, 17.0.18, 17.0.18-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.18-al2-generic, 17-al2-generic-jdk
+Tags: 17, 17.0.19, 17.0.19-al2, 17-al2-full, 17-al2-jdk, 17-al2-generic, 17.0.19-al2-generic, 17-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2-generic
 
-Tags: 17-al2023, 17.0.18-al2023, 17-al2023-jdk
+Tags: 17-al2023, 17.0.19-al2023, 17-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2023
 
-Tags: 17-al2023-headless, 17.0.18-al2023-headless
+Tags: 17-al2023-headless, 17.0.19-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2023
 
-Tags: 17-al2023-headful, 17.0.18-al2023-headful
+Tags: 17-al2023-headful, 17.0.19-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2023
 
-Tags: 17-al2-native-headless, 17.0.18-al2-native-headless
+Tags: 17-al2-native-headless, 17.0.19-al2-native-headless
 Architectures: amd64, arm64v8
 Directory: 17/headless/al2
 
-Tags: 17-al2-native-headful, 17.0.18-al2-native-headful
+Tags: 17-al2-native-headful, 17.0.19-al2-native-headful
 Architectures: amd64, arm64v8
 Directory: 17/headful/al2
 
-Tags: 17-al2-native-jdk, 17.0.18-al2-native-jdk
+Tags: 17-al2-native-jdk, 17.0.19-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/al2
 
-Tags: 17-alpine3.20, 17.0.18-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
+Tags: 17-alpine3.20, 17.0.19-alpine3.20, 17-alpine3.20-full, 17-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.20
 
-Tags: 17-alpine3.21, 17.0.18-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
+Tags: 17-alpine3.21, 17.0.19-alpine3.21, 17-alpine3.21-full, 17-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.21
 
-Tags: 17-alpine3.22, 17.0.18-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk
+Tags: 17-alpine3.22, 17.0.19-alpine3.22, 17-alpine3.22-full, 17-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.22
 
-Tags: 17-alpine3.23, 17.0.18-alpine3.23, 17-alpine3.23-full, 17-alpine3.23-jdk, 17-alpine, 17.0.18-alpine, 17-alpine-full, 17-alpine-jdk
+Tags: 17-alpine3.23, 17.0.19-alpine3.23, 17-alpine3.23-full, 17-alpine3.23-jdk, 17-alpine, 17.0.19-alpine, 17-alpine-full, 17-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 17/jdk/alpine/3.23
 
-Tags: 21, 21.0.10, 21.0.10-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.10-al2-generic, 21-al2-generic-jdk
+Tags: 21, 21.0.11, 21.0.11-al2, 21-al2-full, 21-al2-jdk, 21-al2-generic, 21.0.11-al2-generic, 21-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2-generic
 
-Tags: 21-al2023, 21.0.10-al2023, 21-al2023-jdk
+Tags: 21-al2023, 21.0.11-al2023, 21-al2023-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/al2023
 
-Tags: 21-al2023-headless, 21.0.10-al2023-headless
+Tags: 21-al2023-headless, 21.0.11-al2023-headless
 Architectures: amd64, arm64v8
 Directory: 21/headless/al2023
 
-Tags: 21-al2023-headful, 21.0.10-al2023-headful
+Tags: 21-al2023-headful, 21.0.11-al2023-headful
 Architectures: amd64, arm64v8
 Directory: 21/headful/al2023
 
-Tags: 21-alpine3.20, 21.0.10-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
+Tags: 21-alpine3.20, 21.0.11-alpine3.20, 21-alpine3.20-full, 21-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.20
 
-Tags: 21-alpine3.21, 21.0.10-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
+Tags: 21-alpine3.21, 21.0.11-alpine3.21, 21-alpine3.21-full, 21-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.21
 
-Tags: 21-alpine3.22, 21.0.10-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk
+Tags: 21-alpine3.22, 21.0.11-alpine3.22, 21-alpine3.22-full, 21-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.22
 
-Tags: 21-alpine3.23, 21.0.10-alpine3.23, 21-alpine3.23-full, 21-alpine3.23-jdk, 21-alpine, 21.0.10-alpine, 21-alpine-full, 21-alpine-jdk
+Tags: 21-alpine3.23, 21.0.11-alpine3.23, 21-alpine3.23-full, 21-alpine3.23-jdk, 21-alpine, 21.0.11-alpine, 21-alpine-full, 21-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine/3.23
 
-Tags: 25-al2023, 25.0.2-al2023, 25-al2023-jdk, 25, 25-jdk, 25.0.2
+Tags: 25-al2023, 25.0.3-al2023, 25-al2023-jdk, 25, 25-jdk, 25.0.3
 Architectures: amd64, arm64v8
 Directory: 25/jdk/al2023
 
-Tags: 25-al2023-headless, 25.0.2-al2023-headless, 25-headless
+Tags: 25-al2023-headless, 25.0.3-al2023-headless, 25-headless
 Architectures: amd64, arm64v8
 Directory: 25/headless/al2023
 
-Tags: 25-al2023-headful, 25.0.2-al2023-headful, 25-headful
+Tags: 25-al2023-headful, 25.0.3-al2023-headful, 25-headful
 Architectures: amd64, arm64v8
 Directory: 25/headful/al2023
 
-Tags: 25-alpine3.20, 25.0.2-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
+Tags: 25-alpine3.20, 25.0.3-alpine3.20, 25-alpine3.20-full, 25-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.20
 
-Tags: 25-alpine3.21, 25.0.2-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
+Tags: 25-alpine3.21, 25.0.3-alpine3.21, 25-alpine3.21-full, 25-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.21
 
-Tags: 25-alpine3.22, 25.0.2-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk
+Tags: 25-alpine3.22, 25.0.3-alpine3.22, 25-alpine3.22-full, 25-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.22
 
-Tags: 25-alpine3.23, 25.0.2-alpine3.23, 25-alpine3.23-full, 25-alpine3.23-jdk, 25-alpine, 25.0.2-alpine, 25-alpine-full, 25-alpine-jdk
+Tags: 25-alpine3.23, 25.0.3-alpine3.23, 25-alpine3.23-full, 25-alpine3.23-jdk, 25-alpine, 25.0.3-alpine, 25-alpine-full, 25-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine/3.23
 
-Tags: 26-al2023, 26.0.0-al2023, 26-al2023-jdk, 26, 26-jdk, 26.0.0
+Tags: 26-al2023, 26.0.1-al2023, 26-al2023-jdk, 26, 26-jdk, 26.0.1
 Architectures: amd64, arm64v8
 Directory: 26/jdk/al2023
 
-Tags: 26-al2023-headless, 26.0.0-al2023-headless, 26-headless
+Tags: 26-al2023-headless, 26.0.1-al2023-headless, 26-headless
 Architectures: amd64, arm64v8
 Directory: 26/headless/al2023
 
-Tags: 26-al2023-headful, 26.0.0-al2023-headful, 26-headful
+Tags: 26-al2023-headful, 26.0.1-al2023-headful, 26-headful
 Architectures: amd64, arm64v8
 Directory: 26/headful/al2023
 
-Tags: 26-alpine3.20, 26.0.0-alpine3.20, 26-alpine3.20-full, 26-alpine3.20-jdk
+Tags: 26-alpine3.20, 26.0.1-alpine3.20, 26-alpine3.20-full, 26-alpine3.20-jdk
 Architectures: amd64, arm64v8
 Directory: 26/jdk/alpine/3.20
 
-Tags: 26-alpine3.21, 26.0.0-alpine3.21, 26-alpine3.21-full, 26-alpine3.21-jdk
+Tags: 26-alpine3.21, 26.0.1-alpine3.21, 26-alpine3.21-full, 26-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 26/jdk/alpine/3.21
 
-Tags: 26-alpine3.22, 26.0.0-alpine3.22, 26-alpine3.22-full, 26-alpine3.22-jdk
+Tags: 26-alpine3.22, 26.0.1-alpine3.22, 26-alpine3.22-full, 26-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 26/jdk/alpine/3.22
 
-Tags: 26-alpine3.23, 26.0.0-alpine3.23, 26-alpine3.23-full, 26-alpine3.23-jdk, 26-alpine, 26.0.0-alpine, 26-alpine-full, 26-alpine-jdk
+Tags: 26-alpine3.23, 26.0.1-alpine3.23, 26-alpine3.23-full, 26-alpine3.23-jdk, 26-alpine, 26.0.1-alpine, 26-alpine-full, 26-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 26/jdk/alpine/3.23


### PR DESCRIPTION
Update amazoncorretto for latest release. For more details, see the following:
* [corretto/corretto-docker repo](https://github.com/corretto/corretto-docker/commit/main)
* [corretto/corretto-8 release](https://github.com/corretto/corretto-8/releases/tag/8.492.09.1)
* [corretto/corretto-11 release](https://github.com/corretto/corretto-11/releases/tag/11.0.31.11.1)
* [corretto/corretto-17 release](https://github.com/corretto/corretto-17/releases/tag/17.0.19.10.1)
* [corretto/corretto-21 release](https://github.com/corretto/corretto-21/releases/tag/21.0.11.10.1)
* [corretto/corretto-25 release](https://github.com/corretto/corretto-25/releases/tag/25.0.3.9.1)
* [corretto/corretto-26 release](https://github.com/corretto/corretto-26/releases/tag/26.0.1.8.1)