### PR TITLE
Updated swipl devel to 10.1.6

### DIFF
--- a/library/swipl
+++ b/library/swipl
@@ -1,11 +1,11 @@
 Maintainers: Jan Wielemaker <jan@swi-prolog.org> (@JanWielemaker),
              Dave Curylo <dave@curylo.org> (@ninjarobot)
 GitRepo: https://github.com/SWI-Prolog/docker-swipl.git
-GitCommit: 85408a2856d774e9a96ae4ea29d5a44fe35198b4
+GitCommit: cb916a7490ac3cdcad77f876e977c7d08d3335e9
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: latest, 10.1.5
-Directory: 10.1.5/bookworm
+Tags: latest, 10.1.6
+Directory: 10.1.6/trixie
 
 Tags: stable, 10.0.2
 Directory: 10.0.2/bookworm


### PR DESCRIPTION
      - Updated base to debian:trixie
      - Updated runtime dependency packages
      - Added libutf8proc to the dependencies
      - Updated versions of prosqlite, hdt and rserve-client
