### PR TITLE
Update r-base to 4.6.0 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.5.3, latest
+Tags: 4.6.0, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: afc9cbb503ca0b68fa8c513a8088d3b378e8bed9
-Directory: r-base/4.5.3
+GitCommit: 353d611b3ee5457b645f322f819eda32255a03ac
+Directory: r-base/4.6.0
 


### PR DESCRIPTION
Standard update to the new R release made by upstream this morning, and using the Debian (unstable) package prepared earlier today as well.

No changes in the container setup or build besides the upgrade from R 4.5.3 to R 4.6.0, and with the commit in our repo correctly including referenced directory 4.6.0 as well as latest (with identical Dockerfiles).