### PR TITLE
azul-zulu: add alpine variation

### DIFF
--- a/library/azul-zulu
+++ b/library/azul-zulu
@@ -7,8 +7,24 @@ Maintainers: Azul Devops Team <devops@azul.com> (@azul-publisher),
              Geertjan Wielenga <gwielenga@azul.com> (@geertjanw)
 GitRepo: https://github.com/AzulSystems/azul-zulu-images.git
 GitFetch: refs/heads/main
-GitCommit: 53819781a6977fc2027c49f716184cf4694e1c3c
+GitCommit: 1144a5ee00eb560430eedeac7ad88d3e93e39f44
 
+
+Tags: 8.94-8.0.492-jdk-alpine3.23, 8-alpine3.23, 8-jdk-alpine, 8-jdk-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 8/jdk/alpine
+
+Tags: 8.94-8.0.492-jdk-headless-alpine3.23, 8-headless-alpine, 8-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 8/jdk-headless/alpine
+
+Tags: 8.94-8.0.492-jre-alpine3.23, 8-jre-alpine, 8-jre-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 8/jre/alpine
+
+Tags: 8.94-8.0.492-jre-headless-alpine3.23, 8-jre-headless-alpine, 8-jre-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 8/jre-headless/alpine
 
 Tags: 8.94-8.0.492-jdk-debian13, 8, 8-jdk, 8-jdk-debian, 8-jdk-debian13
 Architectures: amd64, arm64v8
@@ -26,6 +42,22 @@ Tags: 8.94-8.0.492-jre-headless-debian13, 8-jre-headless, 8-jre-headless-debian,
 Architectures: amd64, arm64v8
 Directory: 8/jre-headless/debian
 
+Tags: 11.88-11.0.31-jdk-alpine3.23, 11-alpine3.23, 11-jdk-alpine, 11-jdk-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 11/jdk/alpine
+
+Tags: 11.88-11.0.31-jdk-headless-alpine3.23, 11-headless-alpine, 11-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 11/jdk-headless/alpine
+
+Tags: 11.88-11.0.31-jre-alpine3.23, 11-jre-alpine, 11-jre-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 11/jre/alpine
+
+Tags: 11.88-11.0.31-jre-headless-alpine3.23, 11-jre-headless-alpine, 11-jre-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 11/jre-headless/alpine
+
 Tags: 11.88-11.0.31-jdk-debian13, 11, 11-jdk, 11-jdk-debian, 11-jdk-debian13
 Architectures: amd64, arm64v8
 Directory: 11/jdk/debian
@@ -41,6 +73,22 @@ Directory: 11/jre/debian
 Tags: 11.88-11.0.31-jre-headless-debian13, 11-jre-headless, 11-jre-headless-debian, 11-jre-headless-debian13
 Architectures: amd64, arm64v8
 Directory: 11/jre-headless/debian
+
+Tags: 17.66-17.0.19-jdk-alpine3.23, 17-alpine3.23, 17-jdk-alpine, 17-jdk-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 17/jdk/alpine
+
+Tags: 17.66-17.0.19-jdk-headless-alpine3.23, 17-headless-alpine, 17-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 17/jdk-headless/alpine
+
+Tags: 17.66-17.0.19-jre-alpine3.23, 17-jre-alpine, 17-jre-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 17/jre/alpine
+
+Tags: 17.66-17.0.19-jre-headless-alpine3.23, 17-jre-headless-alpine, 17-jre-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 17/jre-headless/alpine
 
 Tags: 17.66-17.0.19-jdk-debian13, 17, 17-jdk, 17-jdk-debian, 17-jdk-debian13
 Architectures: amd64, arm64v8
@@ -58,6 +106,22 @@ Tags: 17.66-17.0.19-jre-headless-debian13, 17-jre-headless, 17-jre-headless-debi
 Architectures: amd64, arm64v8
 Directory: 17/jre-headless/debian
 
+Tags: 21.50-21.0.11-jdk-alpine3.23, 21-alpine3.23, 21-jdk-alpine, 21-jdk-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 21/jdk/alpine
+
+Tags: 21.50-21.0.11-jdk-headless-alpine3.23, 21-headless-alpine, 21-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 21/jdk-headless/alpine
+
+Tags: 21.50-21.0.11-jre-alpine3.23, 21-jre-alpine, 21-jre-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 21/jre/alpine
+
+Tags: 21.50-21.0.11-jre-headless-alpine3.23, 21-jre-headless-alpine, 21-jre-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 21/jre-headless/alpine
+
 Tags: 21.50-21.0.11-jdk-debian13, 21, 21-jdk, 21-jdk-debian, 21-jdk-debian13
 Architectures: amd64, arm64v8
 Directory: 21/jdk/debian
@@ -74,6 +138,22 @@ Tags: 21.50-21.0.11-jre-headless-debian13, 21-jre-headless, 21-jre-headless-debi
 Architectures: amd64, arm64v8
 Directory: 21/jre-headless/debian
 
+Tags: 25.34-25.0.3-jdk-alpine3.23, 25-alpine3.23, 25-jdk-alpine, 25-jdk-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 25/jdk/alpine
+
+Tags: 25.34-25.0.3-jdk-headless-alpine3.23, 25-headless-alpine, 25-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 25/jdk-headless/alpine
+
+Tags: 25.34-25.0.3-jre-alpine3.23, 25-jre-alpine, 25-jre-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 25/jre/alpine
+
+Tags: 25.34-25.0.3-jre-headless-alpine3.23, 25-jre-headless-alpine, 25-jre-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 25/jre-headless/alpine
+
 Tags: 25.34-25.0.3-jdk-debian13, 25, 25-jdk, 25-jdk-debian, 25-jdk-debian13
 Architectures: amd64, arm64v8
 Directory: 25/jdk/debian
@@ -89,6 +169,22 @@ Directory: 25/jre/debian
 Tags: 25.34-25.0.3-jre-headless-debian13, 25-jre-headless, 25-jre-headless-debian, 25-jre-headless-debian13
 Architectures: amd64, arm64v8
 Directory: 25/jre-headless/debian
+
+Tags: 26.30-26.0.1-jdk-alpine3.23, 26-alpine3.23, 26-jdk-alpine, 26-jdk-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 26/jdk/alpine
+
+Tags: 26.30-26.0.1-jdk-headless-alpine3.23, 26-headless-alpine, 26-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 26/jdk-headless/alpine
+
+Tags: 26.30-26.0.1-jre-alpine3.23, 26-jre-alpine, 26-jre-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 26/jre/alpine
+
+Tags: 26.30-26.0.1-jre-headless-alpine3.23, 26-jre-headless-alpine, 26-jre-headless-alpine3.23
+Architectures: amd64, arm64v8
+Directory: 26/jre-headless/alpine
 
 Tags: 26.30-26.0.1-jdk-debian13, 26, 26-jdk, 26-jdk-debian, 26-jdk-debian13
 Architectures: amd64, arm64v8

--- a/library/azul-zulu
+++ b/library/azul-zulu
@@ -7,7 +7,7 @@ Maintainers: Azul Devops Team <devops@azul.com> (@azul-publisher),
              Geertjan Wielenga <gwielenga@azul.com> (@geertjanw)
 GitRepo: https://github.com/AzulSystems/azul-zulu-images.git
 GitFetch: refs/heads/main
-GitCommit: 1144a5ee00eb560430eedeac7ad88d3e93e39f44
+GitCommit: ffa3090e74d231e01e474b2c527f16dbbf1c427f
 
 
 Tags: 8.94-8.0.492-jdk-alpine3.23, 8-alpine3.23, 8-jdk-alpine, 8-jdk-alpine3.23


### PR DESCRIPTION
Hello, we would like to extend our Azul Zulu image offering with Alpine-based variants, in addition to the existing Debian images. All Alpine Dockerfiles follow the same structure across versions — the only difference between them is the specific Zulu package installed via apk add.