### PR TITLE
archlinux: Release 20260426.0.520785

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,23 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260419.0.517065
-GitCommit: 25354c172306956092edf933ad385f23975ebedd
-GitFetch: refs/tags/v20260419.0.517065
+Tags: latest, base, base-20260426.0.520785
+GitCommit: 2c315ee0bfb72104b4754026f53daa9761dd9c1e
+GitFetch: refs/tags/v20260426.0.520785
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260419.0.517065
-GitCommit: 25354c172306956092edf933ad385f23975ebedd
-GitFetch: refs/tags/v20260419.0.517065
+Tags: base-devel, base-devel-20260426.0.520785
+GitCommit: 2c315ee0bfb72104b4754026f53daa9761dd9c1e
+GitFetch: refs/tags/v20260426.0.520785
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260419.0.517065
-GitCommit: 25354c172306956092edf933ad385f23975ebedd
-GitFetch: refs/tags/v20260419.0.517065
+Tags: multilib-devel, multilib-devel-20260426.0.520785
+GitCommit: 2c315ee0bfb72104b4754026f53daa9761dd9c1e
+GitFetch: refs/tags/v20260426.0.520785
 File: Dockerfile.multilib-devel
+
+Tags: repro, repro-20260426.0.520785
+GitCommit: 2c315ee0bfb72104b4754026f53daa9761dd9c1e
+GitFetch: refs/tags/v20260426.0.520785
+File: Dockerfile.repro
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks