### PR TITLE
[nats] Release v2.12.8, v2.11.17

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,47 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 030935a2771a1de30456f3c5b16c1366e37e6448
+GitCommit: e6bf552cc60f59021c14158a86e014f8bd8997f9
 GitFetch: refs/heads/main
 
-Tags: 2.12.7-alpine3.22, 2.12-alpine3.22, 2-alpine3.22, alpine3.22, 2.12.7-alpine, 2.12-alpine, 2-alpine, alpine
+Tags: 2.12.8-alpine3.22, 2.12-alpine3.22, 2-alpine3.22, alpine3.22, 2.12.8-alpine, 2.12-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/alpine3.22
 
-Tags: 2.12.7-scratch, 2.12-scratch, 2-scratch, scratch, 2.12.7-linux, 2.12-linux, 2-linux, linux
-SharedTags: 2.12.7, 2.12, 2, latest
+Tags: 2.12.8-scratch, 2.12-scratch, 2-scratch, scratch, 2.12.8-linux, 2.12-linux, 2-linux, linux
+SharedTags: 2.12.8, 2.12, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/scratch
 
-Tags: 2.12.7-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.12.7-windowsservercore, 2.12-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.12.8-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.12.8-windowsservercore, 2.12-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.12.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.12.7-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.12.7-nanoserver, 2.12-nanoserver, 2-nanoserver, nanoserver, 2.12.7, 2.12, 2, latest
+Tags: 2.12.8-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.12.8-nanoserver, 2.12-nanoserver, 2-nanoserver, nanoserver, 2.12.8, 2.12, 2, latest
 Architectures: windows-amd64
 Directory: 2.12.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.11.16-alpine3.22, 2.11-alpine3.22, 2.11.16-alpine, 2.11-alpine
+Tags: 2.11.17-alpine3.22, 2.11-alpine3.22, 2.11.17-alpine, 2.11-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/alpine3.22
 
-Tags: 2.11.16-scratch, 2.11-scratch, 2.11.16-linux, 2.11-linux
-SharedTags: 2.11.16, 2.11
+Tags: 2.11.17-scratch, 2.11-scratch, 2.11.17-linux, 2.11-linux
+SharedTags: 2.11.17, 2.11
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.11.x/scratch
 
-Tags: 2.11.16-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
-SharedTags: 2.11.16-windowsservercore, 2.11-windowsservercore
+Tags: 2.11.17-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022
+SharedTags: 2.11.17-windowsservercore, 2.11-windowsservercore
 Architectures: windows-amd64
 Directory: 2.11.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.16-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
-SharedTags: 2.11.16-nanoserver, 2.11-nanoserver, 2.11.16, 2.11
+Tags: 2.11.17-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022
+SharedTags: 2.11.17-nanoserver, 2.11-nanoserver, 2.11.17, 2.11
 Architectures: windows-amd64
 Directory: 2.11.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Release notes:

- https://github.com/nats-io/nats-server/releases/tag/v2.12.8
- https://github.com/nats-io/nats-server/releases/tag/v2.11.17