### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -34,16 +34,6 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b57e412d30f52c897198c13d671cf878fac24983
 Directory: 3.2/alpine
 
-Tags: 3.1.17, 3.1, 3.1.17-trixie, 3.1-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1c7f3b7b59c41a9455c687e7458c7b68469a6700
-Directory: 3.1
-
-Tags: 3.1.17-alpine, 3.1-alpine, 3.1.17-alpine3.23, 3.1-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1c7f3b7b59c41a9455c687e7458c7b68469a6700
-Directory: 3.1/alpine
-
 Tags: 3.0.20, 3.0, 3.0.20-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: ba7a086441d1655ba5000ee589b5b6645ee0b6e0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/733387f: Merge pull request https://github.com/docker-library/haproxy/pull/258 from infosiftr/3.1-eol
- https://github.com/docker-library/haproxy/commit/23e975a: Remove EOL 3.1