### PR TITLE
[oraclelinux] Updating 8, 9, and 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 439e38f796f3c1e436209503c9de70879df5ab2e
+amd64-GitCommit: 7f0983c6c969ef963d3dd1a86457aed8f2a76605
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 704ed33c89510452b60624024f9ffeb74af7b89b
+arm64v8-GitCommit: d26f369c6da53bbbf3129a6e55f7a5e97025e480
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This update incorporates fixes for CVE-2026-4786, CVE-2026-6100, CVE-2026-4786, CVE-2026-6100, CVE-2025-9714, CVE-2026-4786, CVE-2026-6100, CVE-2026-4786, CVE-2026-6100, CVE-2025-9714, CVE-2026-4786, CVE-2026-6100

See the following for details:

ELSA-2026-10711
ELSA-2026-10949
ELSA-2026-11077
ELSA-2026-11349

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
