### PR TITLE
Redis: new release 8.8-m03

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -6,6 +6,18 @@ Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
              Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
+Tags: 8.8-m03, 8.8-m03-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+GitCommit: fa43b354211879f28d1773ae94e740bd534eb6ef
+GitFetch: refs/tags/v8.8-m03
+Directory: debian
+
+Tags: 8.8-m03-alpine, 8.8-m03-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: fa43b354211879f28d1773ae94e740bd534eb6ef
+GitFetch: refs/tags/v8.8-m03
+Directory: alpine
+
 Tags: 8.6.2, 8.6, 8, 8.6.2-trixie, 8.6-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
 GitCommit: 8c81e2a44cae9258294718d767ce594e5cbbf20e


### PR DESCRIPTION
Hi docker team!

Please consider adding new 8.8-m03 milestone Redis release.

The changelog is here: https://github.com/redis/redis/releases/tag/8.8-m03

