### PR TITLE
Bump Traefik to v2.11.44, v3.6.15, and v3.7.0-rc.3

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -68,36 +68,36 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
 Directory: v3.6/alpine
 
-Tags: v2.11.43-windowsservercore-ltsc2025, 2.11.43-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
+Tags: v2.11.44-windowsservercore-ltsc2025, 2.11.44-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
+GitCommit: ca941add1a0a60bf0bf344b21fc6012b5536043f
 Directory: v2.11/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v2.11.43-windowsservercore-ltsc2022, 2.11.43-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.44-windowsservercore-ltsc2022, 2.11.44-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
+GitCommit: ca941add1a0a60bf0bf344b21fc6012b5536043f
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.43-nanoserver-ltsc2025, 2.11.43-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
+Tags: v2.11.44-nanoserver-ltsc2025, 2.11.44-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
+GitCommit: ca941add1a0a60bf0bf344b21fc6012b5536043f
 Directory: v2.11/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v2.11.43-nanoserver-ltsc2022, 2.11.43-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.44-nanoserver-ltsc2022, 2.11.44-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
+GitCommit: ca941add1a0a60bf0bf344b21fc6012b5536043f
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.43, 2.11.43, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.44, 2.11.44, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f598a3c7e01a61e5166acecab49afca24e989708
+GitCommit: ca941add1a0a60bf0bf344b21fc6012b5536043f
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -1,37 +1,37 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.0-rc.2-windowsservercore-ltsc2025, 3.7.0-rc.2-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025
+Tags: v3.7.0-rc.3-windowsservercore-ltsc2025, 3.7.0-rc.3-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
+GitCommit: 780a3f803a43b0280e0848ae0be6647fe29c0989
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.0-rc.2-windowsservercore-ltsc2022, 3.7.0-rc.2-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022
+Tags: v3.7.0-rc.3-windowsservercore-ltsc2022, 3.7.0-rc.3-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
+GitCommit: 780a3f803a43b0280e0848ae0be6647fe29c0989
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.0-rc.2-nanoserver-ltsc2025, 3.7.0-rc.2-nanoserver-ltsc2025, langres-nanoserver-ltsc2025
+Tags: v3.7.0-rc.3-nanoserver-ltsc2025, 3.7.0-rc.3-nanoserver-ltsc2025, langres-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
+GitCommit: 780a3f803a43b0280e0848ae0be6647fe29c0989
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.0-rc.2-nanoserver-ltsc2022, 3.7.0-rc.2-nanoserver-ltsc2022, langres-nanoserver-ltsc2022
+Tags: v3.7.0-rc.3-nanoserver-ltsc2022, 3.7.0-rc.3-nanoserver-ltsc2022, langres-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
+GitCommit: 780a3f803a43b0280e0848ae0be6647fe29c0989
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.0-rc.2, 3.7.0-rc.2, langres
+Tags: v3.7.0-rc.3, 3.7.0-rc.3, langres
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
+GitCommit: 780a3f803a43b0280e0848ae0be6647fe29c0989
 Directory: v3.7/alpine
 
 Tags: v3.6.15-windowsservercore-ltsc2025, 3.6.15-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025, windowsservercore-ltsc2025

--- a/library/traefik
+++ b/library/traefik
@@ -34,38 +34,38 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: 0c9d3bf601fd68726dabe7a89208212f4e9433c9
 Directory: v3.7/alpine
 
-Tags: v3.6.14-windowsservercore-ltsc2025, 3.6.14-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.6.15-windowsservercore-ltsc2025, 3.6.15-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
+GitCommit: 0b13d4cab486f54c38504dba7eec341be362d4dc
 Directory: v3.6/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.6.14-windowsservercore-ltsc2022, 3.6.14-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.6.15-windowsservercore-ltsc2022, 3.6.15-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
+GitCommit: 0b13d4cab486f54c38504dba7eec341be362d4dc
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.14-nanoserver-ltsc2025, 3.6.14-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.6.15-nanoserver-ltsc2025, 3.6.15-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
+GitCommit: 0b13d4cab486f54c38504dba7eec341be362d4dc
 Directory: v3.6/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.6.14-nanoserver-ltsc2022, 3.6.14-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.6.15-nanoserver-ltsc2022, 3.6.15-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
+GitCommit: 0b13d4cab486f54c38504dba7eec341be362d4dc
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.14, 3.6.14, v3.6, 3.6, v3, 3, ramequin, latest
+Tags: v3.6.15, 3.6.15, v3.6, 3.6, v3, 3, ramequin, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 0b565f82fb3c8f74f9b8ec7ebbb1e7f374b79cc7
+GitCommit: 0b13d4cab486f54c38504dba7eec341be362d4dc
 Directory: v3.6/alpine
 
 Tags: v2.11.44-windowsservercore-ltsc2025, 2.11.44-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.44](https://github.com/traefik/traefik/releases/tag/v2.11.44), [v3.6.15](https://github.com/traefik/traefik/releases/tag/v3.6.15), [v3.7.0-rc.3](https://github.com/traefik/traefik/releases/tag/v3.7.0-rc.3).

/cc @nmengin @mmatur @rtribotte

Cheers