### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev9, 3.4-dev, 3.4-dev9-trixie, 3.4-dev-trixie
+Tags: 3.4-dev10, 3.4-dev, 3.4-dev10-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 48aae50abc6e098165ffbf195db869ba8cdf6c08
+GitCommit: 7d33179cd9c08558f30c84fc74681e7d0ffe8fbf
 Directory: 3.4
 
-Tags: 3.4-dev9-alpine, 3.4-dev-alpine, 3.4-dev9-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev10-alpine, 3.4-dev-alpine, 3.4-dev10-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 48aae50abc6e098165ffbf195db869ba8cdf6c08
+GitCommit: 7d33179cd9c08558f30c84fc74681e7d0ffe8fbf
 Directory: 3.4/alpine
 
 Tags: 3.3.7, 3.3, latest, 3.3.7-trixie, 3.3-trixie, trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/7d33179: Update 3.4 to 3.4-dev10