### PR TITLE
[nats] Release v2.14.0

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: e6bf552cc60f59021c14158a86e014f8bd8997f9
+GitCommit: 1f357727beebab29147240e66ede94df14b33d44
 GitFetch: refs/heads/main
 
-Tags: 2.12.8-alpine3.22, 2.12-alpine3.22, 2-alpine3.22, alpine3.22, 2.12.8-alpine, 2.12-alpine, 2-alpine, alpine
+Tags: 2.14.0-alpine3.22, 2.14-alpine3.22, 2-alpine3.22, alpine3.22, 2.14.0-alpine, 2.14-alpine, 2-alpine, alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
+Directory: 2.14.x/alpine3.22
+
+Tags: 2.14.0-scratch, 2.14-scratch, 2-scratch, scratch, 2.14.0-linux, 2.14-linux, 2-linux, linux
+SharedTags: 2.14.0, 2.14, 2, latest
+Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
+Directory: 2.14.x/scratch
+
+Tags: 2.14.0-windowsservercore-ltsc2022, 2.14-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.14.0-windowsservercore, 2.14-windowsservercore, 2-windowsservercore, windowsservercore
+Architectures: windows-amd64
+Directory: 2.14.x/windowsservercore-ltsc2022
+Constraints: windowsservercore-ltsc2022
+
+Tags: 2.14.0-nanoserver-ltsc2022, 2.14-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.14.0-nanoserver, 2.14-nanoserver, 2-nanoserver, nanoserver, 2.14.0, 2.14, 2, latest
+Architectures: windows-amd64
+Directory: 2.14.x/nanoserver-ltsc2022
+Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
+
+Tags: 2.12.8-alpine3.22, 2.12-alpine3.22, 2.12.8-alpine, 2.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/alpine3.22
 
-Tags: 2.12.8-scratch, 2.12-scratch, 2-scratch, scratch, 2.12.8-linux, 2.12-linux, 2-linux, linux
-SharedTags: 2.12.8, 2.12, 2, latest
+Tags: 2.12.8-scratch, 2.12-scratch, 2.12.8-linux, 2.12-linux
+SharedTags: 2.12.8, 2.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/scratch
 
-Tags: 2.12.8-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.12.8-windowsservercore, 2.12-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.12.8-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022
+SharedTags: 2.12.8-windowsservercore, 2.12-windowsservercore
 Architectures: windows-amd64
 Directory: 2.12.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.12.8-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.12.8-nanoserver, 2.12-nanoserver, 2-nanoserver, nanoserver, 2.12.8, 2.12, 2, latest
+Tags: 2.12.8-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022
+SharedTags: 2.12.8-nanoserver, 2.12-nanoserver, 2.12.8, 2.12
 Architectures: windows-amd64
 Directory: 2.12.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Release info: https://github.com/nats-io/nats-server/releases/tag/v2.14.0