### PR TITLE
Update oraclelinux for 10, 9, and 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 439e38f796f3c1e436209503c9de70879df5ab2e
+amd64-GitCommit: 27bb1c161e081bbe67b1cc20f095f28a99a5d9f3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 704ed33c89510452b60624024f9ffeb74af7b89b
+arm64v8-GitCommit: 6f673a8e74df27b70ee18b1f83b2ee7c60fe92ce
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-11389](https://linux.oracle.com/errata/ELSA-2026-11389.html)

### Oracle Linux 9
- [ELSA-2026-11510](https://linux.oracle.com/errata/ELSA-2026-11510.html)

### Oracle Linux 8
- [ELSA-2026-11509](https://linux.oracle.com/errata/ELSA-2026-11509.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
