### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,62 +14,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 7d33179cd9c08558f30c84fc74681e7d0ffe8fbf
 Directory: 3.4/alpine
 
-Tags: 3.3.7, 3.3, latest, 3.3.7-trixie, 3.3-trixie, trixie
+Tags: 3.3.8, 3.3, latest, 3.3.8-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: db045c9904935169caa24265ad62910207e275f4
+GitCommit: c1eede16f73f78ceeea990356719a5ee26496022
 Directory: 3.3
 
-Tags: 3.3.7-alpine, 3.3-alpine, alpine, 3.3.7-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.8-alpine, 3.3-alpine, alpine, 3.3.8-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: db045c9904935169caa24265ad62910207e275f4
+GitCommit: c1eede16f73f78ceeea990356719a5ee26496022
 Directory: 3.3/alpine
 
-Tags: 3.2.16, 3.2, lts, 3.2.16-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.17, 3.2, lts, 3.2.17-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b57e412d30f52c897198c13d671cf878fac24983
+GitCommit: 79f88364eb54bf6b57a3afd4f3231119d1eddde2
 Directory: 3.2
 
-Tags: 3.2.16-alpine, 3.2-alpine, lts-alpine, 3.2.16-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.17-alpine, 3.2-alpine, lts-alpine, 3.2.17-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b57e412d30f52c897198c13d671cf878fac24983
+GitCommit: 79f88364eb54bf6b57a3afd4f3231119d1eddde2
 Directory: 3.2/alpine
 
-Tags: 3.0.20, 3.0, 3.0.20-trixie, 3.0-trixie
+Tags: 3.0.21, 3.0, 3.0.21-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ba7a086441d1655ba5000ee589b5b6645ee0b6e0
+GitCommit: 292ea12efbd500119d068331c8386eb395b9e28d
 Directory: 3.0
 
-Tags: 3.0.20-alpine, 3.0-alpine, 3.0.20-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.21-alpine, 3.0-alpine, 3.0.21-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ba7a086441d1655ba5000ee589b5b6645ee0b6e0
+GitCommit: 292ea12efbd500119d068331c8386eb395b9e28d
 Directory: 3.0/alpine
 
-Tags: 2.8.21, 2.8, 2.8.21-trixie, 2.8-trixie
+Tags: 2.8.22, 2.8, 2.8.22-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 08afb7723867aa1fb48fad0d3ef479521cd76eed
+GitCommit: 2ea30c3a0cfd0cb0680ce8c6f565c25d95a9bc9d
 Directory: 2.8
 
-Tags: 2.8.21-alpine, 2.8-alpine, 2.8.21-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.22-alpine, 2.8-alpine, 2.8.22-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 08afb7723867aa1fb48fad0d3ef479521cd76eed
+GitCommit: 2ea30c3a0cfd0cb0680ce8c6f565c25d95a9bc9d
 Directory: 2.8/alpine
 
-Tags: 2.6.26, 2.6, 2.6.26-trixie, 2.6-trixie
+Tags: 2.6.27, 2.6, 2.6.27-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 64392b241fbc288e8250bd89d421a60e6f7f42fa
+GitCommit: f85c43ab484729db3360a8e5070c2e2ae6272cdc
 Directory: 2.6
 
-Tags: 2.6.26-alpine, 2.6-alpine, 2.6.26-alpine3.23, 2.6-alpine3.23
+Tags: 2.6.27-alpine, 2.6-alpine, 2.6.27-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 64392b241fbc288e8250bd89d421a60e6f7f42fa
+GitCommit: f85c43ab484729db3360a8e5070c2e2ae6272cdc
 Directory: 2.6/alpine
 
-Tags: 2.4.32, 2.4, 2.4.32-trixie, 2.4-trixie
+Tags: 2.4.33, 2.4, 2.4.33-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6024b8b38f842e045e18d2bd820a183a760d07d8
+GitCommit: 4d807a76a0c4817a8b72205c4b101635d9103074
 Directory: 2.4
 
-Tags: 2.4.32-alpine, 2.4-alpine, 2.4.32-alpine3.23, 2.4-alpine3.23
+Tags: 2.4.33-alpine, 2.4-alpine, 2.4.33-alpine3.23, 2.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6024b8b38f842e045e18d2bd820a183a760d07d8
+GitCommit: 4d807a76a0c4817a8b72205c4b101635d9103074
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c1eede1: Update 3.3 to 3.3.8
- https://github.com/docker-library/haproxy/commit/79f8836: Update 3.2 to 3.2.17
- https://github.com/docker-library/haproxy/commit/292ea12: Update 3.0 to 3.0.21
- https://github.com/docker-library/haproxy/commit/2ea30c3: Update 2.8 to 2.8.22
- https://github.com/docker-library/haproxy/commit/f85c43a: Update 2.6 to 2.6.27
- https://github.com/docker-library/haproxy/commit/4d807a7: Update 2.4 to 2.4.33