### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.11.20260413.0
+Tags: 2023, latest, 2023.11.20260427.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: ecae640162289581b4a99c9f9e2856e51a2f037f
+amd64-GitCommit: 07914df2a0c0a0400099702f3757a73912bb8b3f
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 3e56d63d1beaefab178d94571d0053f451a9a917
+arm64v8-GitCommit: 6c7d0cae051dbf23b1aabc2da0d113586294caab
 
-Tags: 2, 2.0.20260413.0
+Tags: 2, 2.0.20260427.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: cf751c605649af6c36fa50c86045267b2b938558
+amd64-GitCommit: abf1f4f168e01e30ab085c6e0264ec95ba3282a6
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: c99e7a43a5345517f4400796e8ea97ff38d6d69e
+arm64v8-GitCommit: 208df4f8ca7540238a8c92840d354efbadac343d
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- glibc-common-2.26-64.amzn2.0.6
- glibc-2.26-64.amzn2.0.6
- openssl-libs-1.0.2k-24.amzn2.0.20
- vim-data-9.0.2153-1.amzn2.0.5
- vim-minimal-9.0.2153-1.amzn2.0.5
- glibc-minimal-langpack-2.26-64.amzn2.0.6
- libcrypt-2.26-64.amzn2.0.6
- glibc-langpack-en-2.26-64.amzn2.0.6

Updated Packages for Amazon Linux 2023:
- glibc-minimal-langpack-2.34-231.amzn2023.0.4
- glibc-2.34-231.amzn2023.0.4
- python3-libs-3.9.25-1.amzn2023.0.5
- gnupg2-minimal-2.3.7-1.amzn2023.0.8
- amazon-linux-repo-cdn-2023.11.20260427-1.amzn2023
- system-release-2023.11.20260427-1.amzn2023
- glibc-common-2.34-231.amzn2023.0.4
- python3-pip-wheel-21.3.1-2.amzn2023.0.17
- python3-3.9.25-1.amzn2023.0.5