### PR TITLE
[security] Update httpd

### DIFF
--- a/library/httpd
+++ b/library/httpd
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/httpd.git
 
-Tags: 2.4.66, 2.4, 2, latest, 2.4.66-trixie, 2.4-trixie, 2-trixie, trixie
+Tags: 2.4.67, 2.4, 2, latest, 2.4.67-trixie, 2.4-trixie, 2-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8bf24dec3fb94efd3d81ac495bea8247d5115d9
+GitCommit: 80149d966fac4bf538fd5209a793c586c4c7f5f2
 Directory: 2.4
 
-Tags: 2.4.66-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.66-alpine3.23, 2.4-alpine3.23, 2-alpine3.23, alpine3.23
+Tags: 2.4.67-alpine, 2.4-alpine, 2-alpine, alpine, 2.4.67-alpine3.23, 2.4-alpine3.23, 2-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c9c8c54099b541910797a90ca9b406e76966902f
+GitCommit: 80149d966fac4bf538fd5209a793c586c4c7f5f2
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/httpd/commit/80149d9: Update to 2.4.67