### PR TITLE
eclipse-temurin: Update tags and Git commits for multiple images

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -310,7 +310,7 @@ Directory: 17/jdk/alpine/3.21
 
 Tags: 17.0.19_10-jdk-resolute, 17-jdk-resolute, 17-resolute
 SharedTags: 17.0.19_10-jdk, 17-jdk, 17
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/ubuntu/resolute
 
@@ -383,7 +383,7 @@ Directory: 17/jre/alpine/3.21
 
 Tags: 17.0.19_10-jre-resolute, 17-jre-resolute
 SharedTags: 17.0.19_10-jre, 17-jre
-Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/ubuntu/resolute
 
@@ -458,7 +458,7 @@ Directory: 21/jdk/alpine/3.21
 
 Tags: 21.0.11_10-jdk-resolute, 21-jdk-resolute, 21-resolute
 SharedTags: 21.0.11_10-jdk, 21-jdk, 21
-Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/ubuntu/resolute
 
@@ -531,7 +531,7 @@ Directory: 21/jre/alpine/3.21
 
 Tags: 21.0.11_10-jre-resolute, 21-jre-resolute
 SharedTags: 21.0.11_10-jre, 21-jre
-Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/ubuntu/resolute
 
@@ -606,7 +606,7 @@ Directory: 25/jdk/alpine/3.21
 
 Tags: 25.0.3_9-jdk-resolute, 25-jdk-resolute, 25-resolute
 SharedTags: 25.0.3_9-jdk, 25-jdk, 25, latest
-Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 25/jdk/ubuntu/resolute
 
@@ -674,7 +674,7 @@ Directory: 25/jre/alpine/3.21
 
 Tags: 25.0.3_9-jre-resolute, 25-jre-resolute
 SharedTags: 25.0.3_9-jre, 25-jre
-Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 25/jre/ubuntu/resolute
 

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -160,8 +160,13 @@ Architectures: amd64
 GitCommit: d16e9c8fa81e491677d171f7cb80cd8f19d7c499
 Directory: 11/jdk/alpine/3.21
 
-Tags: 11.0.31_11-jdk-noble, 11-jdk-noble, 11-noble
+Tags: 11.0.31_11-jdk-resolute, 11-jdk-resolute, 11-resolute
 SharedTags: 11.0.31_11-jdk, 11-jdk, 11
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 11/jdk/ubuntu/resolute
+
+Tags: 11.0.31_11-jdk-noble, 11-jdk-noble, 11-noble
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d16e9c8fa81e491677d171f7cb80cd8f19d7c499
 Directory: 11/jdk/ubuntu/noble
@@ -228,8 +233,13 @@ Architectures: amd64
 GitCommit: d16e9c8fa81e491677d171f7cb80cd8f19d7c499
 Directory: 11/jre/alpine/3.21
 
-Tags: 11.0.31_11-jre-noble, 11-jre-noble
+Tags: 11.0.31_11-jre-resolute, 11-jre-resolute
 SharedTags: 11.0.31_11-jre, 11-jre
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 11/jre/ubuntu/resolute
+
+Tags: 11.0.31_11-jre-noble, 11-jre-noble
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: d16e9c8fa81e491677d171f7cb80cd8f19d7c499
 Directory: 11/jre/ubuntu/noble
@@ -283,276 +293,296 @@ Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
 
 #------------------------------v17 images---------------------------------
-Tags: 17.0.18_8-jdk-alpine-3.23, 17-jdk-alpine-3.23, 17-alpine-3.23, 17.0.18_8-jdk-alpine, 17-jdk-alpine, 17-alpine
+Tags: 17.0.19_10-jdk-alpine-3.23, 17-jdk-alpine-3.23, 17-alpine-3.23, 17.0.19_10-jdk-alpine, 17-jdk-alpine, 17-alpine
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/alpine/3.23
 
-Tags: 17.0.18_8-jdk-alpine-3.22, 17-jdk-alpine-3.22, 17-alpine-3.22
+Tags: 17.0.19_10-jdk-alpine-3.22, 17-jdk-alpine-3.22, 17-alpine-3.22
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/alpine/3.22
 
-Tags: 17.0.18_8-jdk-alpine-3.21, 17-jdk-alpine-3.21, 17-alpine-3.21
+Tags: 17.0.19_10-jdk-alpine-3.21, 17-jdk-alpine-3.21, 17-alpine-3.21
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/alpine/3.21
 
-Tags: 17.0.18_8-jdk-noble, 17-jdk-noble, 17-noble
-SharedTags: 17.0.18_8-jdk, 17-jdk, 17
+Tags: 17.0.19_10-jdk-resolute, 17-jdk-resolute, 17-resolute
+SharedTags: 17.0.19_10-jdk, 17-jdk, 17
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 17/jdk/ubuntu/resolute
+
+Tags: 17.0.19_10-jdk-noble, 17-jdk-noble, 17-noble
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/ubuntu/noble
 
-Tags: 17.0.18_8-jdk-jammy, 17-jdk-jammy, 17-jammy
+Tags: 17.0.19_10-jdk-jammy, 17-jdk-jammy, 17-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/ubuntu/jammy
 
-Tags: 17.0.18_8-jdk-ubi10-minimal, 17-jdk-ubi10-minimal, 17-ubi10-minimal
+Tags: 17.0.19_10-jdk-ubi10-minimal, 17-jdk-ubi10-minimal, 17-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/ubi/ubi10-minimal
 
-Tags: 17.0.18_8-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
+Tags: 17.0.19_10-jdk-ubi9-minimal, 17-jdk-ubi9-minimal, 17-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/ubi/ubi9-minimal
 
-Tags: 17.0.18_8-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
-SharedTags: 17.0.18_8-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.18_8-jdk, 17-jdk, 17
+Tags: 17.0.19_10-jdk-windowsservercore-ltsc2022, 17-jdk-windowsservercore-ltsc2022, 17-windowsservercore-ltsc2022
+SharedTags: 17.0.19_10-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.19_10-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.18_8-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
-SharedTags: 17.0.18_8-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.19_10-jdk-nanoserver-ltsc2022, 17-jdk-nanoserver-ltsc2022, 17-nanoserver-ltsc2022
+SharedTags: 17.0.19_10-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.18_8-jdk-windowsservercore-ltsc2025, 17-jdk-windowsservercore-ltsc2025, 17-windowsservercore-ltsc2025
-SharedTags: 17.0.18_8-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.18_8-jdk, 17-jdk, 17
+Tags: 17.0.19_10-jdk-windowsservercore-ltsc2025, 17-jdk-windowsservercore-ltsc2025, 17-windowsservercore-ltsc2025
+SharedTags: 17.0.19_10-jdk-windowsservercore, 17-jdk-windowsservercore, 17-windowsservercore, 17.0.19_10-jdk, 17-jdk, 17
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 17.0.18_8-jdk-nanoserver-ltsc2025, 17-jdk-nanoserver-ltsc2025, 17-nanoserver-ltsc2025
-SharedTags: 17.0.18_8-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
+Tags: 17.0.19_10-jdk-nanoserver-ltsc2025, 17-jdk-nanoserver-ltsc2025, 17-nanoserver-ltsc2025
+SharedTags: 17.0.19_10-jdk-nanoserver, 17-jdk-nanoserver, 17-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 17.0.18_8-jre-alpine-3.23, 17-jre-alpine-3.23, 17.0.18_8-jre-alpine, 17-jre-alpine
+Tags: 17.0.19_10-jre-alpine-3.23, 17-jre-alpine-3.23, 17.0.19_10-jre-alpine, 17-jre-alpine
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/alpine/3.23
 
-Tags: 17.0.18_8-jre-alpine-3.22, 17-jre-alpine-3.22
+Tags: 17.0.19_10-jre-alpine-3.22, 17-jre-alpine-3.22
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/alpine/3.22
 
-Tags: 17.0.18_8-jre-alpine-3.21, 17-jre-alpine-3.21
+Tags: 17.0.19_10-jre-alpine-3.21, 17-jre-alpine-3.21
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/alpine/3.21
 
-Tags: 17.0.18_8-jre-noble, 17-jre-noble
-SharedTags: 17.0.18_8-jre, 17-jre
+Tags: 17.0.19_10-jre-resolute, 17-jre-resolute
+SharedTags: 17.0.19_10-jre, 17-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 17/jre/ubuntu/resolute
+
+Tags: 17.0.19_10-jre-noble, 17-jre-noble
+Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/ubuntu/noble
 
-Tags: 17.0.18_8-jre-jammy, 17-jre-jammy
+Tags: 17.0.19_10-jre-jammy, 17-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/ubuntu/jammy
 
-Tags: 17.0.18_8-jre-ubi10-minimal, 17-jre-ubi10-minimal
+Tags: 17.0.19_10-jre-ubi10-minimal, 17-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/ubi/ubi10-minimal
 
-Tags: 17.0.18_8-jre-ubi9-minimal, 17-jre-ubi9-minimal
+Tags: 17.0.19_10-jre-ubi9-minimal, 17-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/ubi/ubi9-minimal
 
-Tags: 17.0.18_8-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
-SharedTags: 17.0.18_8-jre-windowsservercore, 17-jre-windowsservercore, 17.0.18_8-jre, 17-jre
+Tags: 17.0.19_10-jre-windowsservercore-ltsc2022, 17-jre-windowsservercore-ltsc2022
+SharedTags: 17.0.19_10-jre-windowsservercore, 17-jre-windowsservercore, 17.0.19_10-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 17.0.18_8-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
-SharedTags: 17.0.18_8-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.19_10-jre-nanoserver-ltsc2022, 17-jre-nanoserver-ltsc2022
+SharedTags: 17.0.19_10-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 17.0.18_8-jre-windowsservercore-ltsc2025, 17-jre-windowsservercore-ltsc2025
-SharedTags: 17.0.18_8-jre-windowsservercore, 17-jre-windowsservercore, 17.0.18_8-jre, 17-jre
+Tags: 17.0.19_10-jre-windowsservercore-ltsc2025, 17-jre-windowsservercore-ltsc2025
+SharedTags: 17.0.19_10-jre-windowsservercore, 17-jre-windowsservercore, 17.0.19_10-jre, 17-jre
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 17.0.18_8-jre-nanoserver-ltsc2025, 17-jre-nanoserver-ltsc2025
-SharedTags: 17.0.18_8-jre-nanoserver, 17-jre-nanoserver
+Tags: 17.0.19_10-jre-nanoserver-ltsc2025, 17-jre-nanoserver-ltsc2025
+SharedTags: 17.0.19_10-jre-nanoserver, 17-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 17/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
 
 #------------------------------v21 images---------------------------------
-Tags: 21.0.10_7-jdk-alpine-3.23, 21-jdk-alpine-3.23, 21-alpine-3.23, 21.0.10_7-jdk-alpine, 21-jdk-alpine, 21-alpine
+Tags: 21.0.11_10-jdk-alpine-3.23, 21-jdk-alpine-3.23, 21-alpine-3.23, 21.0.11_10-jdk-alpine, 21-jdk-alpine, 21-alpine
 Architectures: amd64, arm64v8
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/alpine/3.23
 
-Tags: 21.0.10_7-jdk-alpine-3.22, 21-jdk-alpine-3.22, 21-alpine-3.22
+Tags: 21.0.11_10-jdk-alpine-3.22, 21-jdk-alpine-3.22, 21-alpine-3.22
 Architectures: amd64, arm64v8
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/alpine/3.22
 
-Tags: 21.0.10_7-jdk-alpine-3.21, 21-jdk-alpine-3.21, 21-alpine-3.21
+Tags: 21.0.11_10-jdk-alpine-3.21, 21-jdk-alpine-3.21, 21-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/alpine/3.21
 
-Tags: 21.0.10_7-jdk-noble, 21-jdk-noble, 21-noble
-SharedTags: 21.0.10_7-jdk, 21-jdk, 21
+Tags: 21.0.11_10-jdk-resolute, 21-jdk-resolute, 21-resolute
+SharedTags: 21.0.11_10-jdk, 21-jdk, 21
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 21/jdk/ubuntu/resolute
+
+Tags: 21.0.11_10-jdk-noble, 21-jdk-noble, 21-noble
+Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/ubuntu/noble
 
-Tags: 21.0.10_7-jdk-jammy, 21-jdk-jammy, 21-jammy
+Tags: 21.0.11_10-jdk-jammy, 21-jdk-jammy, 21-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/ubuntu/jammy
 
-Tags: 21.0.10_7-jdk-ubi10-minimal, 21-jdk-ubi10-minimal, 21-ubi10-minimal
+Tags: 21.0.11_10-jdk-ubi10-minimal, 21-jdk-ubi10-minimal, 21-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/ubi/ubi10-minimal
 
-Tags: 21.0.10_7-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
+Tags: 21.0.11_10-jdk-ubi9-minimal, 21-jdk-ubi9-minimal, 21-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/ubi/ubi9-minimal
 
-Tags: 21.0.10_7-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
-SharedTags: 21.0.10_7-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.10_7-jdk, 21-jdk, 21
+Tags: 21.0.11_10-jdk-windowsservercore-ltsc2022, 21-jdk-windowsservercore-ltsc2022, 21-windowsservercore-ltsc2022
+SharedTags: 21.0.11_10-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.11_10-jdk, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.10_7-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
-SharedTags: 21.0.10_7-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.11_10-jdk-nanoserver-ltsc2022, 21-jdk-nanoserver-ltsc2022, 21-nanoserver-ltsc2022
+SharedTags: 21.0.11_10-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.10_7-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
-SharedTags: 21.0.10_7-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.10_7-jdk, 21-jdk, 21
+Tags: 21.0.11_10-jdk-windowsservercore-ltsc2025, 21-jdk-windowsservercore-ltsc2025, 21-windowsservercore-ltsc2025
+SharedTags: 21.0.11_10-jdk-windowsservercore, 21-jdk-windowsservercore, 21-windowsservercore, 21.0.11_10-jdk, 21-jdk, 21
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 21.0.10_7-jdk-nanoserver-ltsc2025, 21-jdk-nanoserver-ltsc2025, 21-nanoserver-ltsc2025
-SharedTags: 21.0.10_7-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
+Tags: 21.0.11_10-jdk-nanoserver-ltsc2025, 21-jdk-nanoserver-ltsc2025, 21-nanoserver-ltsc2025
+SharedTags: 21.0.11_10-jdk-nanoserver, 21-jdk-nanoserver, 21-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 21.0.10_7-jre-alpine-3.23, 21-jre-alpine-3.23, 21.0.10_7-jre-alpine, 21-jre-alpine
+Tags: 21.0.11_10-jre-alpine-3.23, 21-jre-alpine-3.23, 21.0.11_10-jre-alpine, 21-jre-alpine
 Architectures: amd64, arm64v8
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/alpine/3.23
 
-Tags: 21.0.10_7-jre-alpine-3.22, 21-jre-alpine-3.22
+Tags: 21.0.11_10-jre-alpine-3.22, 21-jre-alpine-3.22
 Architectures: amd64, arm64v8
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/alpine/3.22
 
-Tags: 21.0.10_7-jre-alpine-3.21, 21-jre-alpine-3.21
+Tags: 21.0.11_10-jre-alpine-3.21, 21-jre-alpine-3.21
 Architectures: amd64, arm64v8
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/alpine/3.21
 
-Tags: 21.0.10_7-jre-noble, 21-jre-noble
-SharedTags: 21.0.10_7-jre, 21-jre
+Tags: 21.0.11_10-jre-resolute, 21-jre-resolute
+SharedTags: 21.0.11_10-jre, 21-jre
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 21/jre/ubuntu/resolute
+
+Tags: 21.0.11_10-jre-noble, 21-jre-noble
+Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/ubuntu/noble
 
-Tags: 21.0.10_7-jre-jammy, 21-jre-jammy
+Tags: 21.0.11_10-jre-jammy, 21-jre-jammy
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/ubuntu/jammy
 
-Tags: 21.0.10_7-jre-ubi10-minimal, 21-jre-ubi10-minimal
+Tags: 21.0.11_10-jre-ubi10-minimal, 21-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/ubi/ubi10-minimal
 
-Tags: 21.0.10_7-jre-ubi9-minimal, 21-jre-ubi9-minimal
+Tags: 21.0.11_10-jre-ubi9-minimal, 21-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/ubi/ubi9-minimal
 
-Tags: 21.0.10_7-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
-SharedTags: 21.0.10_7-jre-windowsservercore, 21-jre-windowsservercore, 21.0.10_7-jre, 21-jre
+Tags: 21.0.11_10-jre-windowsservercore-ltsc2022, 21-jre-windowsservercore-ltsc2022
+SharedTags: 21.0.11_10-jre-windowsservercore, 21-jre-windowsservercore, 21.0.11_10-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 21.0.10_7-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
-SharedTags: 21.0.10_7-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.11_10-jre-nanoserver-ltsc2022, 21-jre-nanoserver-ltsc2022
+SharedTags: 21.0.11_10-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 21.0.10_7-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
-SharedTags: 21.0.10_7-jre-windowsservercore, 21-jre-windowsservercore, 21.0.10_7-jre, 21-jre
+Tags: 21.0.11_10-jre-windowsservercore-ltsc2025, 21-jre-windowsservercore-ltsc2025
+SharedTags: 21.0.11_10-jre-windowsservercore, 21-jre-windowsservercore, 21.0.11_10-jre, 21-jre
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 21.0.10_7-jre-nanoserver-ltsc2025, 21-jre-nanoserver-ltsc2025
-SharedTags: 21.0.10_7-jre-nanoserver, 21-jre-nanoserver
+Tags: 21.0.11_10-jre-nanoserver-ltsc2025, 21-jre-nanoserver-ltsc2025
+SharedTags: 21.0.11_10-jre-nanoserver, 21-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
 Directory: 21/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
@@ -574,8 +604,13 @@ Architectures: amd64, arm64v8
 GitCommit: f39414c99e9d615874425d0937d692fed533dfb2
 Directory: 25/jdk/alpine/3.21
 
-Tags: 25.0.3_9-jdk-noble, 25-jdk-noble, 25-noble
+Tags: 25.0.3_9-jdk-resolute, 25-jdk-resolute, 25-resolute
 SharedTags: 25.0.3_9-jdk, 25-jdk, 25, latest
+Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 25/jdk/ubuntu/resolute
+
+Tags: 25.0.3_9-jdk-noble, 25-jdk-noble, 25-noble
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
 GitCommit: f39414c99e9d615874425d0937d692fed533dfb2
 Directory: 25/jdk/ubuntu/noble
@@ -637,8 +672,13 @@ Architectures: amd64, arm64v8
 GitCommit: f39414c99e9d615874425d0937d692fed533dfb2
 Directory: 25/jre/alpine/3.21
 
-Tags: 25.0.3_9-jre-noble, 25-jre-noble
+Tags: 25.0.3_9-jre-resolute, 25-jre-resolute
 SharedTags: 25.0.3_9-jre, 25-jre
+Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
+GitCommit: df6138afaf1b564116e895b0acd51d70e11cd996
+Directory: 25/jre/ubuntu/resolute
+
+Tags: 25.0.3_9-jre-noble, 25-jre-noble
 Architectures: amd64, arm64v8, ppc64le, riscv64, s390x
 GitCommit: f39414c99e9d615874425d0937d692fed533dfb2
 Directory: 25/jre/ubuntu/noble


### PR DESCRIPTION
Noting that Ubuntu Resolute becomes the default "latest" distro now that it's GA.