### PR TITLE
[SECURITY] Redis seurity fixes in 6.x, 7.x and 8.x series

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -18,40 +18,40 @@ GitCommit: fa43b354211879f28d1773ae94e740bd534eb6ef
 GitFetch: refs/tags/v8.8-m03
 Directory: alpine
 
-Tags: 8.6.2, 8.6, 8, 8.6.2-trixie, 8.6-trixie, 8-trixie, latest, trixie
+Tags: 8.6.3, 8.6, 8, 8.6.3-trixie, 8.6-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 8c81e2a44cae9258294718d767ce594e5cbbf20e
-GitFetch: refs/tags/v8.6.2
+GitCommit: 70233d27f12d7df70a1146d9348c6a70c31eebcc
+GitFetch: refs/tags/v8.6.3
 Directory: debian
 
-Tags: 8.6.2-alpine, 8.6-alpine, 8-alpine, 8.6.2-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
+Tags: 8.6.3-alpine, 8.6-alpine, 8-alpine, 8.6.3-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8c81e2a44cae9258294718d767ce594e5cbbf20e
-GitFetch: refs/tags/v8.6.2
+GitCommit: 70233d27f12d7df70a1146d9348c6a70c31eebcc
+GitFetch: refs/tags/v8.6.3
 Directory: alpine
 
-Tags: 8.4.2, 8.4, 8.4.2-trixie, 8.4-trixie
+Tags: 8.4.3, 8.4, 8.4.3-trixie, 8.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: f57c53203ef603901bd75cbee76f1f5a5d56d8fa
-GitFetch: refs/tags/v8.4.2
+GitCommit: 78a697e0928dd9ed4ec104a88917dc714bae6e60
+GitFetch: refs/tags/v8.4.3
 Directory: debian
 
-Tags: 8.4.2-alpine, 8.4-alpine, 8.4.2-alpine3.22, 8.4-alpine3.22
+Tags: 8.4.3-alpine, 8.4-alpine, 8.4.3-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f57c53203ef603901bd75cbee76f1f5a5d56d8fa
-GitFetch: refs/tags/v8.4.2
+GitCommit: 78a697e0928dd9ed4ec104a88917dc714bae6e60
+GitFetch: refs/tags/v8.4.3
 Directory: alpine
 
-Tags: 8.2.5, 8.2, 8.2.5-bookworm, 8.2-bookworm
+Tags: 8.2.6, 8.2, 8.2.6-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d42260abdb8f76db20151682a71e0e154a8147f3
-GitFetch: refs/tags/v8.2.5
+GitCommit: ae2372898bd403acf24f8044fd72968cedc3f370
+GitFetch: refs/tags/v8.2.6
 Directory: debian
 
-Tags: 8.2.5-alpine, 8.2-alpine, 8.2.5-alpine3.22, 8.2-alpine3.22
+Tags: 8.2.6-alpine, 8.2-alpine, 8.2.6-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d42260abdb8f76db20151682a71e0e154a8147f3
-GitFetch: refs/tags/v8.2.5
+GitCommit: ae2372898bd403acf24f8044fd72968cedc3f370
+GitFetch: refs/tags/v8.2.6
 Directory: alpine
 
 Tags: 8.0.6, 8.0, 8.0.6-bookworm, 8.0-bookworm
@@ -66,32 +66,38 @@ GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
 GitFetch: refs/tags/v8.0.6
 Directory: alpine
 
-Tags: 7.4.8, 7.4, 7, 7.4.8-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.9, 7.4, 7, 7.4.9-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.4/debian
+GitCommit: af0c2d7c264cdd38f55bd56a232ef9b94b64feb1
+GitFetch: refs/tags/v7.4.9
+Directory: debian
 
-Tags: 7.4.8-alpine, 7.4-alpine, 7-alpine, 7.4.8-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.9-alpine, 7.4-alpine, 7-alpine, 7.4.9-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.4/alpine
+GitCommit: af0c2d7c264cdd38f55bd56a232ef9b94b64feb1
+GitFetch: refs/tags/v7.4.9
+Directory: alpine
 
-Tags: 7.2.13, 7.2, 7.2.13-bookworm, 7.2-bookworm
+Tags: 7.2.14, 7.2, 7.2.14-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.2/debian
+GitCommit: ed51d0c7b44b9de72d368adf33ead9736f762406
+GitFetch: refs/tags/v7.2.14
+Directory: debian
 
-Tags: 7.2.13-alpine, 7.2-alpine, 7.2.13-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.14-alpine, 7.2-alpine, 7.2.14-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9d9b74b729d555ef784db63c1941b73d1c47a6f9
-Directory: 7.2/alpine
+GitCommit: ed51d0c7b44b9de72d368adf33ead9736f762406
+GitFetch: refs/tags/v7.2.14
+Directory: alpine
 
-Tags: 6.2.21, 6.2, 6, 6.2.21-bookworm, 6.2-bookworm, 6-bookworm
+Tags: 6.2.22, 6.2, 6, 6.2.22-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
-Directory: 6.2/debian
+GitCommit: 27958918ab84259c0506f1fe25a5ed47d248f218
+GitFetch: refs/tags/v6.2.22
+Directory: debian
 
-Tags: 6.2.21-alpine, 6.2-alpine, 6-alpine, 6.2.21-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
+Tags: 6.2.22-alpine, 6.2-alpine, 6-alpine, 6.2.22-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d42d7aec93b1c54dd46f37a66a92f62478456039
-Directory: 6.2/alpine
+GitCommit: 27958918ab84259c0506f1fe25a5ed47d248f218
+GitFetch: refs/tags/v6.2.22
+Directory: alpine


### PR DESCRIPTION
Hi Docker team!

Please update Redis to the newest versions that include security fixes. Various CVEs are addressed in Redis and its modules, including RCE vulnerabilities.

https://github.com/redis/redis/releases/tag/6.2.22
https://github.com/redis/redis/releases/tag/7.2.14
https://github.com/redis/redis/releases/tag/7.4.9
https://github.com/redis/redis/releases/tag/8.2.6
https://github.com/redis/redis/releases/tag/8.4.3
https://github.com/redis/redis/releases/tag/8.6.3

Note: For the 6.x and 7.x series, specifically for Docker:
* We are using the new repository layout, which is branch/tag-based, as it is for 8.x.
* `gosu` has been replaced with `setpriv` in the entrypoint.
