### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,11 +1,18 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/58af1a21e095e94e24b02350d0dbbc3d7f0a62ba/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/24fb071be01a0e6241fbbabd59a3dd07d31b80f5/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
+# Last Modified: 2026-04-30
+Tags: 16.1.0, 16.1, 16, latest, 16.1.0-trixie, 16.1-trixie, 16-trixie, trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 24fb071be01a0e6241fbbabd59a3dd07d31b80f5
+Directory: 16
+# Docker EOL: 2027-10-30
+
 # Last Modified: 2025-08-08
-Tags: 15.2.0, 15.2, 15, latest, 15.2.0-trixie, 15.2-trixie, 15-trixie, trixie
+Tags: 15.2.0, 15.2, 15, 15.2.0-trixie, 15.2-trixie, 15-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
 GitCommit: 915af5ccbb6b09575e244f280c26925e77172039
 Directory: 15


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/24fb071: update to gcc 16 (https://github.com/docker-library/gcc/pull/116)