### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,62 +14,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 7d33179cd9c08558f30c84fc74681e7d0ffe8fbf
 Directory: 3.4/alpine
 
-Tags: 3.3.8, 3.3, latest, 3.3.8-trixie, 3.3-trixie, trixie
+Tags: 3.3.9, 3.3, latest, 3.3.9-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c1eede16f73f78ceeea990356719a5ee26496022
+GitCommit: 3e7b2d58dc43c85f9a0479c7c3d88950c10cc4f7
 Directory: 3.3
 
-Tags: 3.3.8-alpine, 3.3-alpine, alpine, 3.3.8-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.9-alpine, 3.3-alpine, alpine, 3.3.9-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c1eede16f73f78ceeea990356719a5ee26496022
+GitCommit: 3e7b2d58dc43c85f9a0479c7c3d88950c10cc4f7
 Directory: 3.3/alpine
 
-Tags: 3.2.17, 3.2, lts, 3.2.17-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.18, 3.2, lts, 3.2.18-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 79f88364eb54bf6b57a3afd4f3231119d1eddde2
+GitCommit: 076e607d7e92ce2da6a3402f4056deeb0273d098
 Directory: 3.2
 
-Tags: 3.2.17-alpine, 3.2-alpine, lts-alpine, 3.2.17-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.18-alpine, 3.2-alpine, lts-alpine, 3.2.18-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 79f88364eb54bf6b57a3afd4f3231119d1eddde2
+GitCommit: 076e607d7e92ce2da6a3402f4056deeb0273d098
 Directory: 3.2/alpine
 
-Tags: 3.0.21, 3.0, 3.0.21-trixie, 3.0-trixie
+Tags: 3.0.22, 3.0, 3.0.22-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 292ea12efbd500119d068331c8386eb395b9e28d
+GitCommit: 61958a8c3347db441a9a1a38669bf769be45f6c6
 Directory: 3.0
 
-Tags: 3.0.21-alpine, 3.0-alpine, 3.0.21-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.22-alpine, 3.0-alpine, 3.0.22-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 292ea12efbd500119d068331c8386eb395b9e28d
+GitCommit: 61958a8c3347db441a9a1a38669bf769be45f6c6
 Directory: 3.0/alpine
 
-Tags: 2.8.22, 2.8, 2.8.22-trixie, 2.8-trixie
+Tags: 2.8.23, 2.8, 2.8.23-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ea30c3a0cfd0cb0680ce8c6f565c25d95a9bc9d
+GitCommit: 98a5338407357a6c9f34ea80e453b76382e7e9b7
 Directory: 2.8
 
-Tags: 2.8.22-alpine, 2.8-alpine, 2.8.22-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.23-alpine, 2.8-alpine, 2.8.23-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ea30c3a0cfd0cb0680ce8c6f565c25d95a9bc9d
+GitCommit: 98a5338407357a6c9f34ea80e453b76382e7e9b7
 Directory: 2.8/alpine
 
-Tags: 2.6.27, 2.6, 2.6.27-trixie, 2.6-trixie
+Tags: 2.6.28, 2.6, 2.6.28-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f85c43ab484729db3360a8e5070c2e2ae6272cdc
+GitCommit: 261594ae62a427a48d0a8f926ef62c51ec5a96b4
 Directory: 2.6
 
-Tags: 2.6.27-alpine, 2.6-alpine, 2.6.27-alpine3.23, 2.6-alpine3.23
+Tags: 2.6.28-alpine, 2.6-alpine, 2.6.28-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f85c43ab484729db3360a8e5070c2e2ae6272cdc
+GitCommit: 261594ae62a427a48d0a8f926ef62c51ec5a96b4
 Directory: 2.6/alpine
 
-Tags: 2.4.33, 2.4, 2.4.33-trixie, 2.4-trixie
+Tags: 2.4.34, 2.4, 2.4.34-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4d807a76a0c4817a8b72205c4b101635d9103074
+GitCommit: 940062eb8b33568ae18a56a8625699d92cb6f8a2
 Directory: 2.4
 
-Tags: 2.4.33-alpine, 2.4-alpine, 2.4.33-alpine3.23, 2.4-alpine3.23
+Tags: 2.4.34-alpine, 2.4-alpine, 2.4.34-alpine3.23, 2.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4d807a76a0c4817a8b72205c4b101635d9103074
+GitCommit: 940062eb8b33568ae18a56a8625699d92cb6f8a2
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/3e7b2d5: Update 3.3 to 3.3.9
- https://github.com/docker-library/haproxy/commit/076e607: Update 3.2 to 3.2.18
- https://github.com/docker-library/haproxy/commit/61958a8: Update 3.0 to 3.0.22
- https://github.com/docker-library/haproxy/commit/98a5338: Update 2.8 to 2.8.23
- https://github.com/docker-library/haproxy/commit/261594a: Update 2.6 to 2.6.28
- https://github.com/docker-library/haproxy/commit/940062e: Update 2.4 to 2.4.34