### PR TITLE
Update oraclelinux for 10 and 9

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: e97846c0bf05a3042d6c09e7eabcbad11e3e9b39
+amd64-GitCommit: 0a35a7ed9d154a59658f23e2b16c114bde6a219b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4b939cacf413894462ef9e211f708e8d8c7d1d9e
+arm64v8-GitCommit: babb60b88c3f2667be37336e70a40f9b7f61008c
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-13380](https://linux.oracle.com/errata/ELSA-2026-13380.html)
- [ELSA-2026-13651](https://linux.oracle.com/errata/ELSA-2026-13651.html)

### Oracle Linux 9
- [ELSA-2026-13381](https://linux.oracle.com/errata/ELSA-2026-13381.html)
- [ELSA-2026-13677](https://linux.oracle.com/errata/ELSA-2026-13677.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
