### PR TITLE
Update oraclelinux for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0a35a7ed9d154a59658f23e2b16c114bde6a219b
+amd64-GitCommit: 147ade51134f526c2ed0343eb3dcb41b28c4c660
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: babb60b88c3f2667be37336e70a40f9b7f61008c
+arm64v8-GitCommit: 4c0c0fed832ec7dabd40b23c93cd819239748d45
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-13285](https://linux.oracle.com/errata/ELSA-2026-13285.html)
- [ELSA-2026-13383](https://linux.oracle.com/errata/ELSA-2026-13383.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
