### PR TITLE
Redis: follow-up fixes, updated maintainers list

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -1,103 +1,93 @@
-Maintainers: Adam Ben Shmuel <adam.ben-shmuel@redis.com> (@adamiBs),
-             Yossi Gottlieb <yossi@redis.com> (@yossigo),
-             Alexander Dobrzhansky <alexander.dobrzhansky@redis.com> (@adobrzhansky),
-             Max Berkman <max.berkman@redis.com> (@maxb-io),
+Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
              Dagan Sandler <dagan.sandler@redis.com> (@dagansandler),
-             Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh)
+             Petar Shtuchkin <petar.shtuchkin@redis.com> (@Peter-Sh),
+             Kalin Staykov <kalin.staykov@redis.com> (@kalinstaykov),
+             Daria Guy <daria.guy@redis.com> (@dariaguy),
+             Angel Yanev <angel.yanev@redis.com> (@AngelYanev),
+             Hila Barkai <hila.barkai@redis.com> (@hilabarkai),
+             Gonen Goshen <gonen.goshen@redis.com> (@gonen-red)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.8-m03, 8.8-m03-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: fa43b354211879f28d1773ae94e740bd534eb6ef
+GitCommit: 47b5cf675aac356867239fae932a7871768ec020
 GitFetch: refs/tags/v8.8-m03
 Directory: debian
 
 Tags: 8.8-m03-alpine, 8.8-m03-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa43b354211879f28d1773ae94e740bd534eb6ef
+GitCommit: 47b5cf675aac356867239fae932a7871768ec020
 GitFetch: refs/tags/v8.8-m03
 Directory: alpine
 
 Tags: 8.6.3, 8.6, 8, 8.6.3-trixie, 8.6-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 70233d27f12d7df70a1146d9348c6a70c31eebcc
+GitCommit: 0e8b375a38d5b818b5baf23372e395ff8ee99d8e
 GitFetch: refs/tags/v8.6.3
 Directory: debian
 
 Tags: 8.6.3-alpine, 8.6-alpine, 8-alpine, 8.6.3-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 70233d27f12d7df70a1146d9348c6a70c31eebcc
+GitCommit: 0e8b375a38d5b818b5baf23372e395ff8ee99d8e
 GitFetch: refs/tags/v8.6.3
 Directory: alpine
 
 Tags: 8.4.3, 8.4, 8.4.3-trixie, 8.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 78a697e0928dd9ed4ec104a88917dc714bae6e60
+GitCommit: 5d4599c7c6c1a8cce4f7863f960315ba825e3020
 GitFetch: refs/tags/v8.4.3
 Directory: debian
 
 Tags: 8.4.3-alpine, 8.4-alpine, 8.4.3-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 78a697e0928dd9ed4ec104a88917dc714bae6e60
+GitCommit: 5d4599c7c6c1a8cce4f7863f960315ba825e3020
 GitFetch: refs/tags/v8.4.3
 Directory: alpine
 
 Tags: 8.2.6, 8.2, 8.2.6-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ae2372898bd403acf24f8044fd72968cedc3f370
+GitCommit: 8f9c996974573b6031d867a49ec1d46e4e94e9e2
 GitFetch: refs/tags/v8.2.6
 Directory: debian
 
 Tags: 8.2.6-alpine, 8.2-alpine, 8.2.6-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ae2372898bd403acf24f8044fd72968cedc3f370
+GitCommit: 8f9c996974573b6031d867a49ec1d46e4e94e9e2
 GitFetch: refs/tags/v8.2.6
-Directory: alpine
-
-Tags: 8.0.6, 8.0, 8.0.6-bookworm, 8.0-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
-GitFetch: refs/tags/v8.0.6
-Directory: debian
-
-Tags: 8.0.6-alpine, 8.0-alpine, 8.0.6-alpine3.21, 8.0-alpine3.21
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 7f2385183921bba168de2f0444cf455637c044e3
-GitFetch: refs/tags/v8.0.6
 Directory: alpine
 
 Tags: 7.4.9, 7.4, 7, 7.4.9-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: af0c2d7c264cdd38f55bd56a232ef9b94b64feb1
+GitCommit: 2b76f51f4af2f8586e137c49c55bfedb41d6751c
 GitFetch: refs/tags/v7.4.9
 Directory: debian
 
 Tags: 7.4.9-alpine, 7.4-alpine, 7-alpine, 7.4.9-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: af0c2d7c264cdd38f55bd56a232ef9b94b64feb1
+GitCommit: 2b76f51f4af2f8586e137c49c55bfedb41d6751c
 GitFetch: refs/tags/v7.4.9
 Directory: alpine
 
 Tags: 7.2.14, 7.2, 7.2.14-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: ed51d0c7b44b9de72d368adf33ead9736f762406
+GitCommit: 0a362f52c58445de1faf950919711fd1afab319a
 GitFetch: refs/tags/v7.2.14
 Directory: debian
 
 Tags: 7.2.14-alpine, 7.2-alpine, 7.2.14-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ed51d0c7b44b9de72d368adf33ead9736f762406
+GitCommit: 0a362f52c58445de1faf950919711fd1afab319a
 GitFetch: refs/tags/v7.2.14
 Directory: alpine
 
 Tags: 6.2.22, 6.2, 6, 6.2.22-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 27958918ab84259c0506f1fe25a5ed47d248f218
+GitCommit: 2598ca399aad20a20058ba8d043f4ac54207d994
 GitFetch: refs/tags/v6.2.22
 Directory: debian
 
 Tags: 6.2.22-alpine, 6.2-alpine, 6-alpine, 6.2.22-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 27958918ab84259c0506f1fe25a5ed47d248f218
+GitCommit: 2598ca399aad20a20058ba8d043f4ac54207d994
 GitFetch: refs/tags/v6.2.22
 Directory: alpine


### PR DESCRIPTION
Hi Docker team!

This is a follow-up for the recent [security release](https://github.com/docker-library/official-images/pull/21383)

* @yosifkit I put 8.0.x to EOL, so they are no longer in the library file
* @tianon Addressed your comments for the 6.x, 7.x entrypoint (use /bin/sh, eliminate unnecessary `SETPRIV` var)
* Addressed disappeared `REDIS_VERSION` var, reported recently in the [issue](https://github.com/redis/docker-library-redis/issues/518)
* Updated maintainers list to reflect current team members