### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,108 +6,108 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.26.2-trixie, 1.26-trixie, 1-trixie, trixie
-SharedTags: 1.26.2, 1.26, 1, latest
+Tags: 1.26.3-trixie, 1.26-trixie, 1-trixie, trixie
+SharedTags: 1.26.3, 1.26, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/trixie
 
-Tags: 1.26.2-bookworm, 1.26-bookworm, 1-bookworm, bookworm
+Tags: 1.26.3-bookworm, 1.26-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/bookworm
 
-Tags: 1.26.2-alpine3.23, 1.26-alpine3.23, 1-alpine3.23, alpine3.23, 1.26.2-alpine, 1.26-alpine, 1-alpine, alpine
+Tags: 1.26.3-alpine3.23, 1.26-alpine3.23, 1-alpine3.23, alpine3.23, 1.26.3-alpine, 1.26-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/alpine3.23
 
-Tags: 1.26.2-alpine3.22, 1.26-alpine3.22, 1-alpine3.22, alpine3.22
+Tags: 1.26.3-alpine3.22, 1.26-alpine3.22, 1-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/alpine3.22
 
-Tags: 1.26.2-windowsservercore-ltsc2025, 1.26-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 1.26.2-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.2, 1.26, 1, latest
+Tags: 1.26.3-windowsservercore-ltsc2025, 1.26-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.26.3-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.3, 1.26, 1, latest
 Architectures: windows-amd64
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.26.2-windowsservercore-ltsc2022, 1.26-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.26.2-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.2, 1.26, 1, latest
+Tags: 1.26.3-windowsservercore-ltsc2022, 1.26-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.26.3-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.3, 1.26, 1, latest
 Architectures: windows-amd64
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.26.2-nanoserver-ltsc2025, 1.26-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 1.26.2-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.26.3-nanoserver-ltsc2025, 1.26-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 1.26.3-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.26.2-nanoserver-ltsc2022, 1.26-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.26.2-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.26.3-nanoserver-ltsc2022, 1.26-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.26.3-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: f5af4bcde335960d1ecb2ce7e8693c88e5f0f5ec
+GitCommit: 1740b669ce4a1d3962efa071979a503dc72ac601
 Directory: 1.26/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.25.9-trixie, 1.25-trixie
-SharedTags: 1.25.9, 1.25
+Tags: 1.25.10-trixie, 1.25-trixie
+SharedTags: 1.25.10, 1.25
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/trixie
 
-Tags: 1.25.9-bookworm, 1.25-bookworm
+Tags: 1.25.10-bookworm, 1.25-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/bookworm
 
-Tags: 1.25.9-alpine3.23, 1.25-alpine3.23, 1.25.9-alpine, 1.25-alpine
+Tags: 1.25.10-alpine3.23, 1.25-alpine3.23, 1.25.10-alpine, 1.25-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/alpine3.23
 
-Tags: 1.25.9-alpine3.22, 1.25-alpine3.22
+Tags: 1.25.10-alpine3.22, 1.25-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/alpine3.22
 
-Tags: 1.25.9-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025
-SharedTags: 1.25.9-windowsservercore, 1.25-windowsservercore, 1.25.9, 1.25
+Tags: 1.25.10-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025
+SharedTags: 1.25.10-windowsservercore, 1.25-windowsservercore, 1.25.10, 1.25
 Architectures: windows-amd64
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.25.9-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022
-SharedTags: 1.25.9-windowsservercore, 1.25-windowsservercore, 1.25.9, 1.25
+Tags: 1.25.10-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022
+SharedTags: 1.25.10-windowsservercore, 1.25-windowsservercore, 1.25.10, 1.25
 Architectures: windows-amd64
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.25.9-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025
-SharedTags: 1.25.9-nanoserver, 1.25-nanoserver
+Tags: 1.25.10-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025
+SharedTags: 1.25.10-nanoserver, 1.25-nanoserver
 Architectures: windows-amd64
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.25.9-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022
-SharedTags: 1.25.9-nanoserver, 1.25-nanoserver
+Tags: 1.25.10-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022
+SharedTags: 1.25.10-nanoserver, 1.25-nanoserver
 Architectures: windows-amd64
-GitCommit: 005ca4128e45b46125d25893e48691cfed2918a7
+GitCommit: 078e0ff62fd3ac83e3dd666125efcf09884b9321
 Directory: 1.25/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/1740b66: Update 1.26 to 1.26.3
- https://github.com/docker-library/golang/commit/078e0ff: Update 1.25 to 1.25.10

https://groups.google.com/g/golang-announce/c/qcCIEXso47M/m/2bOHLAuTBQAJ