### PR TITLE
[security] Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -4,144 +4,74 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 8.5.6RC3-cli-trixie, 8.5-rc-cli-trixie, 8.5.6RC3-trixie, 8.5-rc-trixie, 8.5.6RC3-cli, 8.5-rc-cli, 8.5.6RC3, 8.5-rc
+Tags: 8.5.6-cli-trixie, 8.5-cli-trixie, 8-cli-trixie, cli-trixie, 8.5.6-trixie, 8.5-trixie, 8-trixie, trixie, 8.5.6-cli, 8.5-cli, 8-cli, cli, 8.5.6, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/trixie/cli
-
-Tags: 8.5.6RC3-apache-trixie, 8.5-rc-apache-trixie, 8.5.6RC3-apache, 8.5-rc-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/trixie/apache
-
-Tags: 8.5.6RC3-fpm-trixie, 8.5-rc-fpm-trixie, 8.5.6RC3-fpm, 8.5-rc-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/trixie/fpm
-
-Tags: 8.5.6RC3-zts-trixie, 8.5-rc-zts-trixie, 8.5.6RC3-zts, 8.5-rc-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/trixie/zts
-
-Tags: 8.5.6RC3-cli-bookworm, 8.5-rc-cli-bookworm, 8.5.6RC3-bookworm, 8.5-rc-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/bookworm/cli
-
-Tags: 8.5.6RC3-apache-bookworm, 8.5-rc-apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/bookworm/apache
-
-Tags: 8.5.6RC3-fpm-bookworm, 8.5-rc-fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/bookworm/fpm
-
-Tags: 8.5.6RC3-zts-bookworm, 8.5-rc-zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/bookworm/zts
-
-Tags: 8.5.6RC3-cli-alpine3.23, 8.5-rc-cli-alpine3.23, 8.5.6RC3-alpine3.23, 8.5-rc-alpine3.23, 8.5.6RC3-cli-alpine, 8.5-rc-cli-alpine, 8.5.6RC3-alpine, 8.5-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/alpine3.23/cli
-
-Tags: 8.5.6RC3-fpm-alpine3.23, 8.5-rc-fpm-alpine3.23, 8.5.6RC3-fpm-alpine, 8.5-rc-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/alpine3.23/fpm
-
-Tags: 8.5.6RC3-zts-alpine3.23, 8.5-rc-zts-alpine3.23, 8.5.6RC3-zts-alpine, 8.5-rc-zts-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/alpine3.23/zts
-
-Tags: 8.5.6RC3-cli-alpine3.22, 8.5-rc-cli-alpine3.22, 8.5.6RC3-alpine3.22, 8.5-rc-alpine3.22
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/alpine3.22/cli
-
-Tags: 8.5.6RC3-fpm-alpine3.22, 8.5-rc-fpm-alpine3.22
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/alpine3.22/fpm
-
-Tags: 8.5.6RC3-zts-alpine3.22, 8.5-rc-zts-alpine3.22
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 437b5df0733b7cacedd00d05ce25abefeaecb6ae
-Directory: 8.5-rc/alpine3.22/zts
-
-Tags: 8.5.5-cli-trixie, 8.5-cli-trixie, 8-cli-trixie, cli-trixie, 8.5.5-trixie, 8.5-trixie, 8-trixie, trixie, 8.5.5-cli, 8.5-cli, 8-cli, cli, 8.5.5, 8.5, 8, latest
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/trixie/cli
 
-Tags: 8.5.5-apache-trixie, 8.5-apache-trixie, 8-apache-trixie, apache-trixie, 8.5.5-apache, 8.5-apache, 8-apache, apache
+Tags: 8.5.6-apache-trixie, 8.5-apache-trixie, 8-apache-trixie, apache-trixie, 8.5.6-apache, 8.5-apache, 8-apache, apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/trixie/apache
 
-Tags: 8.5.5-fpm-trixie, 8.5-fpm-trixie, 8-fpm-trixie, fpm-trixie, 8.5.5-fpm, 8.5-fpm, 8-fpm, fpm
+Tags: 8.5.6-fpm-trixie, 8.5-fpm-trixie, 8-fpm-trixie, fpm-trixie, 8.5.6-fpm, 8.5-fpm, 8-fpm, fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/trixie/fpm
 
-Tags: 8.5.5-zts-trixie, 8.5-zts-trixie, 8-zts-trixie, zts-trixie, 8.5.5-zts, 8.5-zts, 8-zts, zts
+Tags: 8.5.6-zts-trixie, 8.5-zts-trixie, 8-zts-trixie, zts-trixie, 8.5.6-zts, 8.5-zts, 8-zts, zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/trixie/zts
 
-Tags: 8.5.5-cli-bookworm, 8.5-cli-bookworm, 8-cli-bookworm, cli-bookworm, 8.5.5-bookworm, 8.5-bookworm, 8-bookworm, bookworm
+Tags: 8.5.6-cli-bookworm, 8.5-cli-bookworm, 8-cli-bookworm, cli-bookworm, 8.5.6-bookworm, 8.5-bookworm, 8-bookworm, bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/bookworm/cli
 
-Tags: 8.5.5-apache-bookworm, 8.5-apache-bookworm, 8-apache-bookworm, apache-bookworm
+Tags: 8.5.6-apache-bookworm, 8.5-apache-bookworm, 8-apache-bookworm, apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/bookworm/apache
 
-Tags: 8.5.5-fpm-bookworm, 8.5-fpm-bookworm, 8-fpm-bookworm, fpm-bookworm
+Tags: 8.5.6-fpm-bookworm, 8.5-fpm-bookworm, 8-fpm-bookworm, fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/bookworm/fpm
 
-Tags: 8.5.5-zts-bookworm, 8.5-zts-bookworm, 8-zts-bookworm, zts-bookworm
+Tags: 8.5.6-zts-bookworm, 8.5-zts-bookworm, 8-zts-bookworm, zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/bookworm/zts
 
-Tags: 8.5.5-cli-alpine3.23, 8.5-cli-alpine3.23, 8-cli-alpine3.23, cli-alpine3.23, 8.5.5-alpine3.23, 8.5-alpine3.23, 8-alpine3.23, alpine3.23, 8.5.5-cli-alpine, 8.5-cli-alpine, 8-cli-alpine, cli-alpine, 8.5.5-alpine, 8.5-alpine, 8-alpine, alpine
+Tags: 8.5.6-cli-alpine3.23, 8.5-cli-alpine3.23, 8-cli-alpine3.23, cli-alpine3.23, 8.5.6-alpine3.23, 8.5-alpine3.23, 8-alpine3.23, alpine3.23, 8.5.6-cli-alpine, 8.5-cli-alpine, 8-cli-alpine, cli-alpine, 8.5.6-alpine, 8.5-alpine, 8-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/alpine3.23/cli
 
-Tags: 8.5.5-fpm-alpine3.23, 8.5-fpm-alpine3.23, 8-fpm-alpine3.23, fpm-alpine3.23, 8.5.5-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
+Tags: 8.5.6-fpm-alpine3.23, 8.5-fpm-alpine3.23, 8-fpm-alpine3.23, fpm-alpine3.23, 8.5.6-fpm-alpine, 8.5-fpm-alpine, 8-fpm-alpine, fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/alpine3.23/fpm
 
-Tags: 8.5.5-zts-alpine3.23, 8.5-zts-alpine3.23, 8-zts-alpine3.23, zts-alpine3.23, 8.5.5-zts-alpine, 8.5-zts-alpine, 8-zts-alpine, zts-alpine
+Tags: 8.5.6-zts-alpine3.23, 8.5-zts-alpine3.23, 8-zts-alpine3.23, zts-alpine3.23, 8.5.6-zts-alpine, 8.5-zts-alpine, 8-zts-alpine, zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/alpine3.23/zts
 
-Tags: 8.5.5-cli-alpine3.22, 8.5-cli-alpine3.22, 8-cli-alpine3.22, cli-alpine3.22, 8.5.5-alpine3.22, 8.5-alpine3.22, 8-alpine3.22, alpine3.22
+Tags: 8.5.6-cli-alpine3.22, 8.5-cli-alpine3.22, 8-cli-alpine3.22, cli-alpine3.22, 8.5.6-alpine3.22, 8.5-alpine3.22, 8-alpine3.22, alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/alpine3.22/cli
 
-Tags: 8.5.5-fpm-alpine3.22, 8.5-fpm-alpine3.22, 8-fpm-alpine3.22, fpm-alpine3.22
+Tags: 8.5.6-fpm-alpine3.22, 8.5-fpm-alpine3.22, 8-fpm-alpine3.22, fpm-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/alpine3.22/fpm
 
-Tags: 8.5.5-zts-alpine3.22, 8.5-zts-alpine3.22, 8-zts-alpine3.22, zts-alpine3.22
+Tags: 8.5.6-zts-alpine3.22, 8.5-zts-alpine3.22, 8-zts-alpine3.22, zts-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992f68ff3c761d3c8702d7de77b47ce980d4d1aa
+GitCommit: 12b0add14b1227eb156f145fc4ad6310e81459d8
 Directory: 8.5/alpine3.22/zts
 
 Tags: 8.4.21-cli-trixie, 8.4-cli-trixie, 8.4.21-trixie, 8.4-trixie, 8.4.21-cli, 8.4-cli, 8.4.21, 8.4


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/12b0add1: Update to 8.5.6 (security)

Follow-up to https://github.com/docker-library/official-images/pull/21404