### PR TITLE
[ros] add ROS Lyrical beta images

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -68,6 +68,28 @@ Directory: ros/kilted/ubuntu/noble/perception
 
 
 ################################################################################
+# Release: lyrical
+
+########################################
+# Distro: ubuntu:resolute
+
+Tags: lyrical-ros-core, lyrical-ros-core-resolute
+Architectures: amd64, arm64v8
+GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+Directory: ros/lyrical/ubuntu/resolute/ros-core
+
+Tags: lyrical-ros-base, lyrical-ros-base-resolute, lyrical
+Architectures: amd64, arm64v8
+GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+Directory: ros/lyrical/ubuntu/resolute/ros-base
+
+Tags: lyrical-perception, lyrical-perception-resolute
+Architectures: amd64, arm64v8
+GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+Directory: ros/lyrical/ubuntu/resolute/perception
+
+
+################################################################################
 # Release: rolling
 
 ########################################


### PR DESCRIPTION
This PR is to create a first version of the docker images for the ROS Lyrical release (the next LTS version of ROS)

The official release will take place on May 23rd at which point a new PR updating the Dockerfiles and the latest tag will be made

Cross-referencing:
https://github.com/osrf/docker_images/pull/877
https://discourse.openrobotics.org/t/lyrical-luth-test-and-tutorial-party-instructions/54427