### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.11.20260427.1
+Tags: 2023, latest, 2023.11.20260505.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 07914df2a0c0a0400099702f3757a73912bb8b3f
+amd64-GitCommit: 1f96416595206d3ef5555209e7d29581a4093c0a
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 6c7d0cae051dbf23b1aabc2da0d113586294caab
+arm64v8-GitCommit: 1d65cb214a505e3d82ddc313179427658653c088
 
-Tags: 2, 2.0.20260427.1
+Tags: 2, 2.0.20260504.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: abf1f4f168e01e30ab085c6e0264ec95ba3282a6
+amd64-GitCommit: bf1cf55dbc6ff6c957e29cf0bf92c7830fbfada1
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 208df4f8ca7540238a8c92840d354efbadac343d
+arm64v8-GitCommit: 4420f10f28143cfa76414d95929f490f6b48e413
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
#### Packages addressing CVES:

### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.11.20260505-0.amzn2023
- system-release-2023.11.20260505-0.amzn2023
#### Packages addressing CVES: