### PR TITLE
Add ParadeDB image

### DIFF
--- a/library/paradedb
+++ b/library/paradedb
@@ -1,0 +1,23 @@
+Maintainers: Isaac Van Doren <isaac@paradedb.com> (@isaacvando),
+             Philippe Noël <phil@paradedb.com> (@philippemnoel),
+             Ming Ying <ming@paradedb.com> (@rebasedming)
+Architectures: amd64, arm64v8
+GitRepo: https://github.com/paradedb/paradedb.git
+GitFetch: refs/heads/main
+GitCommit: d5b3c63b4d325e1aa4b75cee2c4770bf5c18d2ba
+
+Tags: latest, 0.23.4, 0.23.4-pg18, v0.23.4, v0.23.4-pg18, 18-v0.23.4, pg18
+Directory: docker
+File: Dockerfile.official-18
+
+Tags: 0.23.4-pg17, v0.23.4-pg17, 17-v0.23.4, pg17
+Directory: docker
+File: Dockerfile.official-17
+
+Tags: 0.23.4-pg16, v0.23.4-pg16, 16-v0.23.4, pg16
+Directory: docker
+File: Dockerfile.official-16
+
+Tags: 0.23.4-pg15, v0.23.4-pg15, 15-v0.23.4, pg15
+Directory: docker
+File: Dockerfile.official-15

--- a/library/paradedb
+++ b/library/paradedb
@@ -4,20 +4,8 @@ Maintainers: Isaac Van Doren <isaac@paradedb.com> (@isaacvando),
 Architectures: amd64, arm64v8
 GitRepo: https://github.com/paradedb/paradedb.git
 GitFetch: refs/heads/main
-GitCommit: d5b3c63b4d325e1aa4b75cee2c4770bf5c18d2ba
+GitCommit: a5a8228fa1ce7e40d5c3f32d9bf9995e8a278e99
 
-Tags: latest, 0.23.4, 0.23.4-pg18, v0.23.4, v0.23.4-pg18, 18-v0.23.4, pg18
+Tags: latest, 0.25.3, 0.25.3-pg18, v0.25.3, v0.25.3-pg18, 18-v0.25.3, pg18
 Directory: docker
 File: Dockerfile.official-18
-
-Tags: 0.23.4-pg17, v0.23.4-pg17, 17-v0.23.4, pg17
-Directory: docker
-File: Dockerfile.official-17
-
-Tags: 0.23.4-pg16, v0.23.4-pg16, 16-v0.23.4, pg16
-Directory: docker
-File: Dockerfile.official-16
-
-Tags: 0.23.4-pg15, v0.23.4-pg15, 15-v0.23.4, pg15
-Directory: docker
-File: Dockerfile.official-15


### PR DESCRIPTION
Adds [ParadeDB](https://github.com/paradedb/paradedb) as an official image. Thank you for reviewing!

Docs PR: https://github.com/docker-library/docs/pull/2671
