### PR TITLE
Update for Corretto release 8.492.09.2

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,7 +15,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: 5a0fa371106fd28791331fcf7364a46feadc4d58
+GitCommit: 507853cc5f7441f7f37f4c0999f790e2f322d670
 
 Tags: 8, 8u492, 8u492-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u492-al2-generic, 8-al2-generic-jdk, latest
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update amazoncorretto for latest release. For more details, see the following:
* [corretto/corretto-docker repo](https://github.com/corretto/corretto-docker/commit/main)
* [corretto/corretto-8 release](https://github.com/corretto/corretto-8/releases/tag/8.492.09.2)