### PR TITLE
[ros] apply suggestions from 21417

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -9,7 +9,7 @@ GitRepo: https://github.com/osrf/docker_images.git
 
 Tags: humble-ros-core, humble-ros-core-jammy
 Architectures: amd64, arm64v8
-GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
+GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/humble/ubuntu/jammy/ros-core
 
 Tags: humble-ros-base, humble-ros-base-jammy, humble
@@ -31,7 +31,7 @@ Directory: ros/humble/ubuntu/jammy/perception
 
 Tags: jazzy-ros-core, jazzy-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
+GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
 Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
@@ -53,7 +53,7 @@ Directory: ros/jazzy/ubuntu/noble/perception
 
 Tags: kilted-ros-core, kilted-ros-core-noble
 Architectures: amd64, arm64v8
-GitCommit: eb5634cf92ba079897e44fb7541d3b78aa6cf717
+GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/kilted/ubuntu/noble/ros-core
 
 Tags: kilted-ros-base, kilted-ros-base-noble, kilted


### PR DESCRIPTION
fail early on deb download
use binary format for sha check

Based on: https://github.com/docker-library/official-images/pull/21417#pullrequestreview-4255672560

Cross-referencing: https://github.com/osrf/docker_images/pull/880