### PR TITLE
archlinux: Release 20260510.0.525573

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260503.0.523481
-GitCommit: 89b8bd477ecb2ad67f5069083b8255162a26cf7d
-GitFetch: refs/tags/v20260503.0.523481
+Tags: latest, base, base-20260510.0.525573
+GitCommit: 7d5201d50afe35c661e430a479f65802f84721d0
+GitFetch: refs/tags/v20260510.0.525573
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260503.0.523481
-GitCommit: 89b8bd477ecb2ad67f5069083b8255162a26cf7d
-GitFetch: refs/tags/v20260503.0.523481
+Tags: base-devel, base-devel-20260510.0.525573
+GitCommit: 7d5201d50afe35c661e430a479f65802f84721d0
+GitFetch: refs/tags/v20260510.0.525573
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260503.0.523481
-GitCommit: 89b8bd477ecb2ad67f5069083b8255162a26cf7d
-GitFetch: refs/tags/v20260503.0.523481
+Tags: multilib-devel, multilib-devel-20260510.0.525573
+GitCommit: 7d5201d50afe35c661e430a479f65802f84721d0
+GitFetch: refs/tags/v20260510.0.525573
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks