### PR TITLE
azul-zulu: add almalinux variation

### DIFF
--- a/library/azul-zulu
+++ b/library/azul-zulu
@@ -7,8 +7,24 @@ Maintainers: Azul Devops Team <devops@azul.com> (@azul-publisher),
              Geertjan Wielenga <gwielenga@azul.com> (@geertjanw)
 GitRepo: https://github.com/AzulSystems/azul-zulu-images.git
 GitFetch: refs/heads/main
-GitCommit: ffa3090e74d231e01e474b2c527f16dbbf1c427f
+GitCommit: eaa5481239a895ec585325e02be86f4720582abe
 
+
+Tags: 8.94-8.0.492-jdk-almalinux10, 8-almalinux10, 8-jdk-almalinux, 8-jdk-almalinux10
+Architectures: amd64, arm64v8
+Directory: 8/jdk/almalinux
+
+Tags: 8.94-8.0.492-jdk-headless-almalinux10, 8-headless-almalinux, 8-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 8/jdk-headless/almalinux
+
+Tags: 8.94-8.0.492-jre-almalinux10, 8-jre-almalinux, 8-jre-almalinux10
+Architectures: amd64, arm64v8
+Directory: 8/jre/almalinux
+
+Tags: 8.94-8.0.492-jre-headless-almalinux10, 8-jre-headless-almalinux, 8-jre-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 8/jre-headless/almalinux
 
 Tags: 8.94-8.0.492-jdk-alpine3.23, 8-alpine3.23, 8-jdk-alpine, 8-jdk-alpine3.23
 Architectures: amd64, arm64v8
@@ -42,6 +58,22 @@ Tags: 8.94-8.0.492-jre-headless-debian13, 8-jre-headless, 8-jre-headless-debian,
 Architectures: amd64, arm64v8
 Directory: 8/jre-headless/debian
 
+Tags: 11.88-11.0.31-jdk-almalinux10, 11-almalinux10, 11-jdk-almalinux, 11-jdk-almalinux10
+Architectures: amd64, arm64v8
+Directory: 11/jdk/almalinux
+
+Tags: 11.88-11.0.31-jdk-headless-almalinux10, 11-headless-almalinux, 11-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 11/jdk-headless/almalinux
+
+Tags: 11.88-11.0.31-jre-almalinux10, 11-jre-almalinux, 11-jre-almalinux10
+Architectures: amd64, arm64v8
+Directory: 11/jre/almalinux
+
+Tags: 11.88-11.0.31-jre-headless-almalinux10, 11-jre-headless-almalinux, 11-jre-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 11/jre-headless/almalinux
+
 Tags: 11.88-11.0.31-jdk-alpine3.23, 11-alpine3.23, 11-jdk-alpine, 11-jdk-alpine3.23
 Architectures: amd64, arm64v8
 Directory: 11/jdk/alpine
@@ -73,6 +105,22 @@ Directory: 11/jre/debian
 Tags: 11.88-11.0.31-jre-headless-debian13, 11-jre-headless, 11-jre-headless-debian, 11-jre-headless-debian13
 Architectures: amd64, arm64v8
 Directory: 11/jre-headless/debian
+
+Tags: 17.66-17.0.19-jdk-almalinux10, 17-almalinux10, 17-jdk-almalinux, 17-jdk-almalinux10
+Architectures: amd64, arm64v8
+Directory: 17/jdk/almalinux
+
+Tags: 17.66-17.0.19-jdk-headless-almalinux10, 17-headless-almalinux, 17-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 17/jdk-headless/almalinux
+
+Tags: 17.66-17.0.19-jre-almalinux10, 17-jre-almalinux, 17-jre-almalinux10
+Architectures: amd64, arm64v8
+Directory: 17/jre/almalinux
+
+Tags: 17.66-17.0.19-jre-headless-almalinux10, 17-jre-headless-almalinux, 17-jre-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 17/jre-headless/almalinux
 
 Tags: 17.66-17.0.19-jdk-alpine3.23, 17-alpine3.23, 17-jdk-alpine, 17-jdk-alpine3.23
 Architectures: amd64, arm64v8
@@ -106,6 +154,22 @@ Tags: 17.66-17.0.19-jre-headless-debian13, 17-jre-headless, 17-jre-headless-debi
 Architectures: amd64, arm64v8
 Directory: 17/jre-headless/debian
 
+Tags: 21.50-21.0.11-jdk-almalinux10, 21-almalinux10, 21-jdk-almalinux, 21-jdk-almalinux10
+Architectures: amd64, arm64v8
+Directory: 21/jdk/almalinux
+
+Tags: 21.50-21.0.11-jdk-headless-almalinux10, 21-headless-almalinux, 21-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 21/jdk-headless/almalinux
+
+Tags: 21.50-21.0.11-jre-almalinux10, 21-jre-almalinux, 21-jre-almalinux10
+Architectures: amd64, arm64v8
+Directory: 21/jre/almalinux
+
+Tags: 21.50-21.0.11-jre-headless-almalinux10, 21-jre-headless-almalinux, 21-jre-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 21/jre-headless/almalinux
+
 Tags: 21.50-21.0.11-jdk-alpine3.23, 21-alpine3.23, 21-jdk-alpine, 21-jdk-alpine3.23
 Architectures: amd64, arm64v8
 Directory: 21/jdk/alpine
@@ -138,6 +202,22 @@ Tags: 21.50-21.0.11-jre-headless-debian13, 21-jre-headless, 21-jre-headless-debi
 Architectures: amd64, arm64v8
 Directory: 21/jre-headless/debian
 
+Tags: 25.34-25.0.3-jdk-almalinux10, 25-almalinux10, 25-jdk-almalinux, 25-jdk-almalinux10
+Architectures: amd64, arm64v8
+Directory: 25/jdk/almalinux
+
+Tags: 25.34-25.0.3-jdk-headless-almalinux10, 25-headless-almalinux, 25-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 25/jdk-headless/almalinux
+
+Tags: 25.34-25.0.3-jre-almalinux10, 25-jre-almalinux, 25-jre-almalinux10
+Architectures: amd64, arm64v8
+Directory: 25/jre/almalinux
+
+Tags: 25.34-25.0.3-jre-headless-almalinux10, 25-jre-headless-almalinux, 25-jre-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 25/jre-headless/almalinux
+
 Tags: 25.34-25.0.3-jdk-alpine3.23, 25-alpine3.23, 25-jdk-alpine, 25-jdk-alpine3.23
 Architectures: amd64, arm64v8
 Directory: 25/jdk/alpine
@@ -169,6 +249,22 @@ Directory: 25/jre/debian
 Tags: 25.34-25.0.3-jre-headless-debian13, 25-jre-headless, 25-jre-headless-debian, 25-jre-headless-debian13
 Architectures: amd64, arm64v8
 Directory: 25/jre-headless/debian
+
+Tags: 26.30-26.0.1-jdk-almalinux10, 26-almalinux10, 26-jdk-almalinux, 26-jdk-almalinux10
+Architectures: amd64, arm64v8
+Directory: 26/jdk/almalinux
+
+Tags: 26.30-26.0.1-jdk-headless-almalinux10, 26-headless-almalinux, 26-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 26/jdk-headless/almalinux
+
+Tags: 26.30-26.0.1-jre-almalinux10, 26-jre-almalinux, 26-jre-almalinux10
+Architectures: amd64, arm64v8
+Directory: 26/jre/almalinux
+
+Tags: 26.30-26.0.1-jre-headless-almalinux10, 26-jre-headless-almalinux, 26-jre-headless-almalinux10
+Architectures: amd64, arm64v8
+Directory: 26/jre-headless/almalinux
 
 Tags: 26.30-26.0.1-jdk-alpine3.23, 26-alpine3.23, 26-jdk-alpine, 26-jdk-alpine3.23
 Architectures: amd64, arm64v8

--- a/library/azul-zulu
+++ b/library/azul-zulu
@@ -7,7 +7,7 @@ Maintainers: Azul Devops Team <devops@azul.com> (@azul-publisher),
              Geertjan Wielenga <gwielenga@azul.com> (@geertjanw)
 GitRepo: https://github.com/AzulSystems/azul-zulu-images.git
 GitFetch: refs/heads/main
-GitCommit: eaa5481239a895ec585325e02be86f4720582abe
+GitCommit: c3c5ad0d77beee6063b4e1496fe32f417af274ed
 
 
 Tags: 8.94-8.0.492-jdk-almalinux10, 8-almalinux10, 8-jdk-almalinux, 8-jdk-almalinux10


### PR DESCRIPTION
Hello, we would like to extend our Azul Zulu image offering with Almalinux-based variants, in addition to the existing Alpine, Debian images. All Almalinux Dockerfiles follow the same structure across versions.