### PR TITLE
Update KrakenD to v2.13.5

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.4, 2.13, 2, latest
+Tags: 2.13.5, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 5df24cd2a74b03bb1869bf55395aa96e5b3b0553
-Directory: 2.13.4
+GitCommit: 8c2abb57d14f937815fc3b87ef8c7d1e2cfee430
+Directory: 2.13.5


### PR DESCRIPTION
## KrakenD  CE v2.13.5
* Upgraded OTLP HTTP exporters addressing [CVE-2026-39882](https://nvd.nist.gov/vuln/detail/CVE-2026-39882).
* Upgraded Prometheus dependency addressing [CVE-2026-42154](https://nvd.nist.gov/vuln/detail/CVE-2026-42154), [CVE-2026-42151](https://nvd.nist.gov/vuln/detail/CVE-2026-42151) and [CVE-2026-40179](https://nvd.nist.gov/vuln/detail/CVE-2026-40179).
* Upgraded Go to 1.25.10, addressing several CVEs with disclosed descriptions
            - [CVE-2026-42501](https://go.dev/issue/79070) `cmd/go`: malicious module proxy can bypass checksum database (false positive)
            - [CVE-2026-39819](https://go.dev/issue/78584) `cmd/go`: "go bug" follows symlinks in predictable temporary filenames (false positive)
            - [CVE-2026-39817](https://go.dev/issue/78778) `cmd/go`: "go tool pack" does not sanitize output paths (false positive)
            - [CVE-2026-39825](https://go.dev/issue/78948) `net/http/httputil`: ReverseProxy forwards queries with more than urlmaxqueryparams parameters
            - [CVE-2026-39836](https://go.dev/issue/79006) `net`: panic in Dial and LookupPort when handling NUL byte on Windows (false positive)
            - [CVE-2026-33811](https://go.dev/issue/78803) `net`: crash when handling long CNAME response
            - [CVE-2026-42499](https://go.dev/issue/78987) `net/mail`: quadratic string concatenation in consumePhrase (false positive)
            - [CVE-2026-39820](https://go.dev/issue/78566) `net/mail`: quadratic string concatentation in consumeComment (false positive)
            - [CVE-2026-33814](https://go.dev/issue/78476) `net/http`: infinite loop in HTTP/2 transport when given bad SETTINGS_MAX_FRAME_SIZE
            - [CVE-2026-39826](https://go.dev/issue/78981) `html/template`: escaper bypass leads to XSS (false positive)
            - [CVE-2026-39823](https://go.dev/issue/78913) `html/template`: bypass of meta content URL escaping causes XSS (false positive)