### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,62 +14,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 761288e860aa894892275688c3b99d73e61e7d54
 Directory: 3.4/alpine
 
-Tags: 3.3.9, 3.3, latest, 3.3.9-trixie, 3.3-trixie, trixie
+Tags: 3.3.10, 3.3, latest, 3.3.10-trixie, 3.3-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e7b2d58dc43c85f9a0479c7c3d88950c10cc4f7
+GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
 Directory: 3.3
 
-Tags: 3.3.9-alpine, 3.3-alpine, alpine, 3.3.9-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.10-alpine, 3.3-alpine, alpine, 3.3.10-alpine3.23, 3.3-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e7b2d58dc43c85f9a0479c7c3d88950c10cc4f7
+GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
 Directory: 3.3/alpine
 
-Tags: 3.2.18, 3.2, lts, 3.2.18-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.19, 3.2, lts, 3.2.19-trixie, 3.2-trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 076e607d7e92ce2da6a3402f4056deeb0273d098
+GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
 Directory: 3.2
 
-Tags: 3.2.18-alpine, 3.2-alpine, lts-alpine, 3.2.18-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.19-alpine, 3.2-alpine, lts-alpine, 3.2.19-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 076e607d7e92ce2da6a3402f4056deeb0273d098
+GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
 Directory: 3.2/alpine
 
-Tags: 3.0.22, 3.0, 3.0.22-trixie, 3.0-trixie
+Tags: 3.0.23, 3.0, 3.0.23-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 61958a8c3347db441a9a1a38669bf769be45f6c6
+GitCommit: 1fe6009a5f5b568ddac086d99a7d23809ea7f036
 Directory: 3.0
 
-Tags: 3.0.22-alpine, 3.0-alpine, 3.0.22-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.23-alpine, 3.0-alpine, 3.0.23-alpine3.23, 3.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 61958a8c3347db441a9a1a38669bf769be45f6c6
+GitCommit: 1fe6009a5f5b568ddac086d99a7d23809ea7f036
 Directory: 3.0/alpine
 
-Tags: 2.8.23, 2.8, 2.8.23-trixie, 2.8-trixie
+Tags: 2.8.24, 2.8, 2.8.24-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 98a5338407357a6c9f34ea80e453b76382e7e9b7
+GitCommit: 288da6fb5e44d5fadc572917b3c2bcad8811875c
 Directory: 2.8
 
-Tags: 2.8.23-alpine, 2.8-alpine, 2.8.23-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.24-alpine, 2.8-alpine, 2.8.24-alpine3.23, 2.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 98a5338407357a6c9f34ea80e453b76382e7e9b7
+GitCommit: 288da6fb5e44d5fadc572917b3c2bcad8811875c
 Directory: 2.8/alpine
 
-Tags: 2.6.28, 2.6, 2.6.28-trixie, 2.6-trixie
+Tags: 2.6.29, 2.6, 2.6.29-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 261594ae62a427a48d0a8f926ef62c51ec5a96b4
+GitCommit: 669c5af611989a3396923ae0b655b0ca644f8a86
 Directory: 2.6
 
-Tags: 2.6.28-alpine, 2.6-alpine, 2.6.28-alpine3.23, 2.6-alpine3.23
+Tags: 2.6.29-alpine, 2.6-alpine, 2.6.29-alpine3.23, 2.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 261594ae62a427a48d0a8f926ef62c51ec5a96b4
+GitCommit: 669c5af611989a3396923ae0b655b0ca644f8a86
 Directory: 2.6/alpine
 
-Tags: 2.4.34, 2.4, 2.4.34-trixie, 2.4-trixie
+Tags: 2.4.35, 2.4, 2.4.35-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 940062eb8b33568ae18a56a8625699d92cb6f8a2
+GitCommit: 6eda5ce996d9ffb3f7a6ed352dd7f61580100a26
 Directory: 2.4
 
-Tags: 2.4.34-alpine, 2.4-alpine, 2.4.34-alpine3.23, 2.4-alpine3.23
+Tags: 2.4.35-alpine, 2.4-alpine, 2.4.35-alpine3.23, 2.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 940062eb8b33568ae18a56a8625699d92cb6f8a2
+GitCommit: 6eda5ce996d9ffb3f7a6ed352dd7f61580100a26
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/37598dc: Update 3.3 to 3.3.10
- https://github.com/docker-library/haproxy/commit/acd08ed: Update 3.2 to 3.2.19
- https://github.com/docker-library/haproxy/commit/1fe6009: Update 3.0 to 3.0.23
- https://github.com/docker-library/haproxy/commit/288da6f: Update 2.8 to 2.8.24
- https://github.com/docker-library/haproxy/commit/669c5af: Update 2.6 to 2.6.29
- https://github.com/docker-library/haproxy/commit/6eda5ce: Update 2.4 to 2.4.35