### PR TITLE
feat: Release influxdb v2.9.1

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 74f0633592894e9245520b947e1b89ccfaa14ced
+GitCommit: f1dffdff9bf0143540251f64464a4c0391c0af19
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -54,11 +54,11 @@ Tags: 2.8-alpine, 2.8.0-alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.8/alpine
 
-Tags: 2, 2.9, 2.9.0, latest
+Tags: 2, 2.9, 2.9.1, latest
 Architectures: amd64, arm64v8
 Directory: influxdb/2.9
 
-Tags: 2-alpine, 2.9-alpine, 2.9.0-alpine, alpine
+Tags: 2-alpine, 2.9-alpine, 2.9.1-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.9/alpine
 


### PR DESCRIPTION
We recently found a bug impacting all compaction in version 2.9.0. This commit updates the latest version of influxdb 2.9 to use 2.9.1. This minor patch resolves the following issues: https://github.com/influxdata/influxdata-docker/issues/874 & https://github.com/influxdata/influxdb/issues/27409

Closes https://github.com/docker-library/official-images/pull/21427