### PR TITLE
Update oraclelinux-slim for 10, 9, and 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 147ade51134f526c2ed0343eb3dcb41b28c4c660
+amd64-GitCommit: df4cd906fdc8fccecd30201dbaa9a5a7b034ccb0
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4c0c0fed832ec7dabd40b23c93cd819239748d45
+arm64v8-GitCommit: 5c2b177b18647d70a4f06e9cc37f22062a097381
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-15969](https://linux.oracle.com/errata/ELSA-2026-15969.html)

### Oracle Linux 9
- [ELSA-2026-15971](https://linux.oracle.com/errata/ELSA-2026-15971.html)

### Oracle Linux 8
- [ELSA-2026-15953](https://linux.oracle.com/errata/ELSA-2026-15953.html)

Signed-off-by: Mark Will <mark.will@oracle.com>
