### PR TITLE
Update Eclipse Temurin tags and Git commits to 8u492-b09

### DIFF
--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -7,138 +7,138 @@ GitFetch: refs/heads/main
 Builder: buildkit
 
 #------------------------------v8 images---------------------------------
-Tags: 8u482-b08-jdk-alpine-3.23, 8-jdk-alpine-3.23, 8-alpine-3.23, 8u482-b08-jdk-alpine, 8-jdk-alpine, 8-alpine
+Tags: 8u492-b09-jdk-alpine-3.23, 8-jdk-alpine-3.23, 8-alpine-3.23, 8u492-b09-jdk-alpine, 8-jdk-alpine, 8-alpine
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/alpine/3.23
 
-Tags: 8u482-b08-jdk-alpine-3.22, 8-jdk-alpine-3.22, 8-alpine-3.22
+Tags: 8u492-b09-jdk-alpine-3.22, 8-jdk-alpine-3.22, 8-alpine-3.22
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/alpine/3.22
 
-Tags: 8u482-b08-jdk-alpine-3.21, 8-jdk-alpine-3.21, 8-alpine-3.21
+Tags: 8u492-b09-jdk-alpine-3.21, 8-jdk-alpine-3.21, 8-alpine-3.21
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8u482-b08-jdk-noble, 8-jdk-noble, 8-noble
-SharedTags: 8u482-b08-jdk, 8-jdk, 8
+Tags: 8u492-b09-jdk-noble, 8-jdk-noble, 8-noble
+SharedTags: 8u492-b09-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/ubuntu/noble
 
-Tags: 8u482-b08-jdk-jammy, 8-jdk-jammy, 8-jammy
+Tags: 8u492-b09-jdk-jammy, 8-jdk-jammy, 8-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/ubuntu/jammy
 
-Tags: 8u482-b08-jdk-ubi10-minimal, 8-jdk-ubi10-minimal, 8-ubi10-minimal
+Tags: 8u492-b09-jdk-ubi10-minimal, 8-jdk-ubi10-minimal, 8-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/ubi/ubi10-minimal
 
-Tags: 8u482-b08-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
+Tags: 8u492-b09-jdk-ubi9-minimal, 8-jdk-ubi9-minimal, 8-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/ubi/ubi9-minimal
 
-Tags: 8u482-b08-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
-SharedTags: 8u482-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u482-b08-jdk, 8-jdk, 8
+Tags: 8u492-b09-jdk-windowsservercore-ltsc2022, 8-jdk-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022
+SharedTags: 8u492-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u492-b09-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u482-b08-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
-SharedTags: 8u482-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u492-b09-jdk-nanoserver-ltsc2022, 8-jdk-nanoserver-ltsc2022, 8-nanoserver-ltsc2022
+SharedTags: 8u492-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u482-b08-jdk-windowsservercore-ltsc2025, 8-jdk-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025
-SharedTags: 8u482-b08-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u482-b08-jdk, 8-jdk, 8
+Tags: 8u492-b09-jdk-windowsservercore-ltsc2025, 8-jdk-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025
+SharedTags: 8u492-b09-jdk-windowsservercore, 8-jdk-windowsservercore, 8-windowsservercore, 8u492-b09-jdk, 8-jdk, 8
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8u482-b08-jdk-nanoserver-ltsc2025, 8-jdk-nanoserver-ltsc2025, 8-nanoserver-ltsc2025
-SharedTags: 8u482-b08-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
+Tags: 8u492-b09-jdk-nanoserver-ltsc2025, 8-jdk-nanoserver-ltsc2025, 8-nanoserver-ltsc2025
+SharedTags: 8u492-b09-jdk-nanoserver, 8-jdk-nanoserver, 8-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 8u482-b08-jre-alpine-3.23, 8-jre-alpine-3.23, 8u482-b08-jre-alpine, 8-jre-alpine
+Tags: 8u492-b09-jre-alpine-3.23, 8-jre-alpine-3.23, 8u492-b09-jre-alpine, 8-jre-alpine
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/alpine/3.23
 
-Tags: 8u482-b08-jre-alpine-3.22, 8-jre-alpine-3.22
+Tags: 8u492-b09-jre-alpine-3.22, 8-jre-alpine-3.22
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/alpine/3.22
 
-Tags: 8u482-b08-jre-alpine-3.21, 8-jre-alpine-3.21
+Tags: 8u492-b09-jre-alpine-3.21, 8-jre-alpine-3.21
 Architectures: amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/alpine/3.21
 
-Tags: 8u482-b08-jre-noble, 8-jre-noble
-SharedTags: 8u482-b08-jre, 8-jre
+Tags: 8u492-b09-jre-noble, 8-jre-noble
+SharedTags: 8u492-b09-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/ubuntu/noble
 
-Tags: 8u482-b08-jre-jammy, 8-jre-jammy
+Tags: 8u492-b09-jre-jammy, 8-jre-jammy
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/ubuntu/jammy
 
-Tags: 8u482-b08-jre-ubi10-minimal, 8-jre-ubi10-minimal
+Tags: 8u492-b09-jre-ubi10-minimal, 8-jre-ubi10-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/ubi/ubi10-minimal
 
-Tags: 8u482-b08-jre-ubi9-minimal, 8-jre-ubi9-minimal
+Tags: 8u492-b09-jre-ubi9-minimal, 8-jre-ubi9-minimal
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/ubi/ubi9-minimal
 
-Tags: 8u482-b08-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
-SharedTags: 8u482-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u482-b08-jre, 8-jre
+Tags: 8u492-b09-jre-windowsservercore-ltsc2022, 8-jre-windowsservercore-ltsc2022
+SharedTags: 8u492-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u492-b09-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8u482-b08-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
-SharedTags: 8u482-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u492-b09-jre-nanoserver-ltsc2022, 8-jre-nanoserver-ltsc2022
+SharedTags: 8u492-b09-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8u482-b08-jre-windowsservercore-ltsc2025, 8-jre-windowsservercore-ltsc2025
-SharedTags: 8u482-b08-jre-windowsservercore, 8-jre-windowsservercore, 8u482-b08-jre, 8-jre
+Tags: 8u492-b09-jre-windowsservercore-ltsc2025, 8-jre-windowsservercore-ltsc2025
+SharedTags: 8u492-b09-jre-windowsservercore, 8-jre-windowsservercore, 8u492-b09-jre, 8-jre
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8u482-b08-jre-nanoserver-ltsc2025, 8-jre-nanoserver-ltsc2025
-SharedTags: 8u482-b08-jre-nanoserver, 8-jre-nanoserver
+Tags: 8u492-b09-jre-nanoserver-ltsc2025, 8-jre-nanoserver-ltsc2025
+SharedTags: 8u492-b09-jre-nanoserver, 8-jre-nanoserver
 Architectures: windows-amd64
-GitCommit: a475d69551c1fa735bb4bd1570b7c908691525b2
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -22,6 +22,12 @@ Architectures: amd64
 GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/alpine/3.21
 
+Tags: 8u492-b09-jdk-resolute, 8-jdk-resolute, 8-resolute
+SharedTags: 8u492-b09-jdk, 8-jdk, 8
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
+Directory: 8/jdk/ubuntu/resolute
+
 Tags: 8u492-b09-jdk-noble, 8-jdk-noble, 8-noble
 SharedTags: 8u492-b09-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
@@ -89,6 +95,12 @@ Tags: 8u492-b09-jre-alpine-3.21, 8-jre-alpine-3.21
 Architectures: amd64
 GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/alpine/3.21
+
+Tags: 8u492-b09-jre-resolute, 8-jre-resolute
+SharedTags: 8u492-b09-jre, 8-jre
+Architectures: amd64, arm32v7, arm64v8, ppc64le
+GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
+Directory: 8/jre/ubuntu/resolute
 
 Tags: 8u492-b09-jre-noble, 8-jre-noble
 SharedTags: 8u492-b09-jre, 8-jre

--- a/library/eclipse-temurin
+++ b/library/eclipse-temurin
@@ -29,7 +29,6 @@ GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/ubuntu/resolute
 
 Tags: 8u492-b09-jdk-noble, 8-jdk-noble, 8-noble
-SharedTags: 8u492-b09-jdk, 8-jdk, 8
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jdk/ubuntu/noble
@@ -103,7 +102,6 @@ GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/ubuntu/resolute
 
 Tags: 8u492-b09-jre-noble, 8-jre-noble
-SharedTags: 8u492-b09-jre, 8-jre
 Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: b7f53fd8790240285938420a53067c9fb5da82df
 Directory: 8/jre/ubuntu/noble


### PR DESCRIPTION
Update April 2026 updates for JDK versions 8