### PR TITLE
caddy: v2.11.3 release

### DIFF
--- a/library/caddy
+++ b/library/caddy
@@ -1,68 +1,68 @@
 # this file is generated with gomplate:
 # template: https://github.com/caddyserver/caddy-docker/blob/e05f66898af9a0a694af637db2724f91d9d82ed7/stackbrew.tmpl
-# config context: https://github.com/caddyserver/caddy-docker/blob/03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b/stackbrew-config.yaml
+# config context: https://github.com/caddyserver/caddy-docker/blob/7b04f0b70155465249dcc940c5c6ceaf39863ab0/stackbrew-config.yaml
 Maintainers: Dave Henderson (@hairyhenderson),
              Francis Lavoie (@francislavoie)
 
-Tags: 2.11.2-alpine, 2.11-alpine, 2-alpine, alpine
-SharedTags: 2.11.2, 2.11, 2, latest
+Tags: 2.11.3-alpine, 2.11-alpine, 2-alpine, alpine
+SharedTags: 2.11.3, 2.11, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/alpine
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.11.2-builder-alpine, 2.11-builder-alpine, 2-builder-alpine, builder-alpine
-SharedTags: 2.11.2-builder, 2.11-builder, 2-builder, builder
+Tags: 2.11.3-builder-alpine, 2.11-builder-alpine, 2-builder-alpine, builder-alpine
+SharedTags: 2.11.3-builder, 2.11-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/builder
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: amd64, arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x
 
-Tags: 2.11.2-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.11.2-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore, 2.11.2, 2.11, 2, latest
+Tags: 2.11.3-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.11.3-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore, 2.11.3, 2.11, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows/ltsc2022
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.2-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 2.11.2-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore, 2.11.2, 2.11, 2, latest
+Tags: 2.11.3-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 2.11.3-windowsservercore, 2.11-windowsservercore, 2-windowsservercore, windowsservercore, 2.11.3, 2.11, 2, latest
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows/ltsc2025
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 
-Tags: 2.11.2-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.11.2-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver
+Tags: 2.11.3-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.11.3-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2022
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.11.2-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 2.11.2-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver
+Tags: 2.11.3-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 2.11.3-nanoserver, 2.11-nanoserver, 2-nanoserver, nanoserver
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-nanoserver/ltsc2025
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: windows-amd64
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 2.11.2-builder-windowsservercore-ltsc2022, 2.11-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
-SharedTags: 2.11.2-builder, 2.11-builder, 2-builder, builder
+Tags: 2.11.3-builder-windowsservercore-ltsc2022, 2.11-builder-windowsservercore-ltsc2022, 2-builder-windowsservercore-ltsc2022, builder-windowsservercore-ltsc2022
+SharedTags: 2.11.3-builder, 2.11-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2022
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.11.2-builder-windowsservercore-ltsc2025, 2.11-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
-SharedTags: 2.11.2-builder, 2.11-builder, 2-builder, builder
+Tags: 2.11.3-builder-windowsservercore-ltsc2025, 2.11-builder-windowsservercore-ltsc2025, 2-builder-windowsservercore-ltsc2025, builder-windowsservercore-ltsc2025
+SharedTags: 2.11.3-builder, 2.11-builder, 2-builder, builder
 GitRepo: https://github.com/caddyserver/caddy-docker.git
 Directory: 2.11/windows-builder/ltsc2025
-GitCommit: 03d78cdcd835a384ab5567ea2a5ffa022ce3ec3b
+GitCommit: 7b04f0b70155465249dcc940c5c6ceaf39863ab0
 Architectures: windows-amd64
 Constraints: windowsservercore-ltsc2025
 


### PR DESCRIPTION
https://github.com/caddyserver/caddy/releases/tag/v2.11.3

https://github.com/caddyserver/caddy-docker/pull/457