### PR TITLE
Odoo: update 17.0-19.0 to release 20260513

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 7b39d976b8d5a0ad59bcf39642a27e6c9062b35b
+GitCommit: e2d33388ddecf4c082d491848f62ef28da0a6620
 
-Tags: 19.0-20260504, 19.0, 19, latest
+Tags: 19.0-20260513, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20260504, 18.0, 18
+Tags: 18.0-20260513, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20260504, 17.0, 17
+Tags: 17.0-20260513, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

This PR also include changes odoo/docker@65242a59b2ff482184382a4f051625bdf5f7a822 in order to:
- support postgresql env variables
- `wait-for-psql.py` can now read odoo configuration file and thus remove the need to pass configuration on cli arguments