### PR TITLE
Update oraclelinux-slim for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: df4cd906fdc8fccecd30201dbaa9a5a7b034ccb0
+amd64-GitCommit: 0218ab4ba2f820b1b978dcc5a76435040397a472
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 5c2b177b18647d70a4f06e9cc37f22062a097381
+arm64v8-GitCommit: 1793f77944bb75a34575d594c6ce680a4e6cbba0
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-16799](https://linux.oracle.com/errata/ELSA-2026-16799.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
