### PR TITLE
Release SonarQube Server 2026.3.0

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -4,30 +4,31 @@ Maintainers: Carmine Vassallo <carmine.vassallo@sonarsource.com> (@carminevassal
 	Jimil Desai <jimil.desai@sonarsource.com> (@jimil09),
 	Julien Lancelot <julien.lancelot@sonarsource.com> (@julienlancelot),
 	Lukasz Jarocki <lukasz.jarocki@sonarsource.com> (@lukasz-jarocki-sonarsource),
-	Matteo Mara <matteo.mara@sonarsource.com> (@matteo-mara-sonarsource)
+	Matteo Mara <matteo.mara@sonarsource.com> (@matteo-mara-sonarsource),
+	Navya Teja Otturu <navya.otturu@sonarsource.com> (@navyatejaotturu-sonarsource)
 GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2026.2.1-developer, 2026.2-developer, developer
+Tags: 2026.3.0-developer, 2026.3-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 46da64077d8567ace61a27c3e7c178b1f5511d05
-GitFetch: refs/heads/release/2026.2
+GitCommit: 405238a0ac06edb7b6a3a6658552e296e5f87bfe
+GitFetch: refs/heads/master
 
-Tags: 2026.2.1-enterprise, 2026.2-enterprise, enterprise
+Tags: 2026.3.0-enterprise, 2026.3-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 46da64077d8567ace61a27c3e7c178b1f5511d05
-GitFetch: refs/heads/release/2026.2
+GitCommit: 405238a0ac06edb7b6a3a6658552e296e5f87bfe
+GitFetch: refs/heads/master
 
-Tags: 2026.2.1-datacenter-app, 2026.2-datacenter-app, datacenter-app
+Tags: 2026.3.0-datacenter-app, 2026.3-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 46da64077d8567ace61a27c3e7c178b1f5511d05
-GitFetch: refs/heads/release/2026.2
+GitCommit: 405238a0ac06edb7b6a3a6658552e296e5f87bfe
+GitFetch: refs/heads/master
 
-Tags: 2026.2.1-datacenter-search, 2026.2-datacenter-search, datacenter-search
+Tags: 2026.3.0-datacenter-search, 2026.3-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 46da64077d8567ace61a27c3e7c178b1f5511d05
-GitFetch: refs/heads/release/2026.2
+GitCommit: 405238a0ac06edb7b6a3a6658552e296e5f87bfe
+GitFetch: refs/heads/master
 
 Tags: 2026.1.2-developer, 2026.1-developer, 2026-lta-developer
 Directory: commercial-editions/developer


### PR DESCRIPTION
Dear team,

We would like to release SonarQube Server version 2026.3.0

Please review and approve the proposed changes.

Thank you!