### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.41, 1.6, 1, latest, 1.6.41-trixie, 1.6-trixie, 1-trixie, trixie
+Tags: 1.6.42, 1.6, 1, latest, 1.6.42-trixie, 1.6-trixie, 1-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cba550f257148ea0ee5a63a52404a228e0f08fe8
+GitCommit: ac84e05c54a4a00b15f252331e568f342de2c4c3
 Directory: 1/debian
 
-Tags: 1.6.41-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.41-alpine3.23, 1.6-alpine3.23, 1-alpine3.23, alpine3.23
+Tags: 1.6.42-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.42-alpine3.23, 1.6-alpine3.23, 1-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cba550f257148ea0ee5a63a52404a228e0f08fe8
+GitCommit: ac84e05c54a4a00b15f252331e568f342de2c4c3
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/ac84e05: Update 1 to 1.6.42