### PR TITLE
MariaDB Server Releases Maintenance 2026 Q2

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/65483980c6c0034361a604ca1e2a048c48da08c6/generate-stackbrew-library.sh
+# this file is generated via https://github.com/MariaDB/mariadb-docker/blob/fb3ac619f14c36ac5111f6eef644268ca47ed2d0/generate-stackbrew-library.sh
 
 Maintainers: Daniel Black <daniel@mariadb.org> (@grooverdan),
              Daniel Bartholomew <dbart@mariadb.com> (@dbart),
@@ -8,60 +8,60 @@ Builder: buildkit
 
 Tags: 12.3.1-ubi10-rc, 12.3-ubi10-rc, 12.3.1-ubi-rc, 12.3-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+GitCommit: 769f60ce827e3465281d184080727f3f13f3f61e
 Directory: 12.3-ubi
 
 Tags: 12.3.1-noble-rc, 12.3-noble-rc, 12.3.1-rc, 12.3-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3fbf86c7b9301bcb6b0dc0f4f478800ee458224f
+GitCommit: a681c62cf8d84fc614e648776992733cdca60983
 Directory: 12.3
 
 Tags: 12.2.2-ubi10, 12.2-ubi10, 12-ubi10, 12.2.2-ubi, 12.2-ubi, 12-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+GitCommit: 604617ddd4d241538390b0bb97bf4cd92e5f4c6f
 Directory: 12.2-ubi
 
 Tags: 12.2.2-noble, 12.2-noble, 12-noble, noble, 12.2.2, 12.2, 12, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 3fbf86c7b9301bcb6b0dc0f4f478800ee458224f
+GitCommit: 604617ddd4d241538390b0bb97bf4cd92e5f4c6f
 Directory: 12.2
 
-Tags: 11.8.6-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.6-ubi, 11.8-ubi, 11-ubi, lts-ubi
+Tags: 11.8.7-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.7-ubi, 11.8-ubi, 11-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 11.8-ubi
 
-Tags: 11.8.6-noble, 11.8-noble, 11-noble, lts-noble, 11.8.6, 11.8, 11, lts
+Tags: 11.8.7-noble, 11.8-noble, 11-noble, lts-noble, 11.8.7, 11.8, 11, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 11.8
 
-Tags: 11.4.10-ubi9, 11.4-ubi9, 11.4.10-ubi, 11.4-ubi
+Tags: 11.4.11-ubi9, 11.4-ubi9, 11.4.11-ubi, 11.4-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 11.4-ubi
 
-Tags: 11.4.10-noble, 11.4-noble, 11.4.10, 11.4
+Tags: 11.4.11-noble, 11.4-noble, 11.4.11, 11.4
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 11.4
 
-Tags: 10.11.16-ubi9, 10.11-ubi9, 10-ubi9, 10.11.16-ubi, 10.11-ubi, 10-ubi
+Tags: 10.11.17-ubi9, 10.11-ubi9, 10-ubi9, 10.11.17-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 10.11-ubi
 
-Tags: 10.11.16-jammy, 10.11-jammy, 10-jammy, 10.11.16, 10.11, 10
+Tags: 10.11.17-jammy, 10.11-jammy, 10-jammy, 10.11.17, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 10.11
 
-Tags: 10.6.25-ubi9, 10.6-ubi9, 10.6.25-ubi, 10.6-ubi
+Tags: 10.6.26-ubi9, 10.6-ubi9, 10.6.26-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: fff6ab37913bbbe25bfc6c6ea6f095e4ad7a039c
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 10.6-ubi
 
-Tags: 10.6.25-jammy, 10.6-jammy, 10.6.25, 10.6
+Tags: 10.6.26-jammy, 10.6-jammy, 10.6.26, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 66972bc2e0c6fd33dcd5d98de0653c5696a1166e
+GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
 Directory: 10.6


### PR DESCRIPTION
Update the library file to reflect the latest releases of MariaDB Server: 11.8.7, 11.4.11, 10.11.17, 10.6.26.