### PR TITLE
[Friendica] New Version 2026.05

### DIFF
--- a/library/friendica
+++ b/library/friendica
@@ -4,47 +4,47 @@ Maintainers: Friendica <info@friendi.ca> (@friendica), Philipp Holzer <admin@phi
 GitRepo: https://github.com/friendica/docker.git
 GitFetch: refs/heads/stable
 
-Tags: 2026.01-apache, apache, stable-apache, 2026.01, latest, stable
+Tags: 2026.01-apache, 2026.01
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 10607f3b885ca311dcb5c24f57c731ff1857ab14
 Directory: 2026.01/apache
 
-Tags: 2026.01-fpm, fpm, stable-fpm
+Tags: 2026.01-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 10607f3b885ca311dcb5c24f57c731ff1857ab14
 Directory: 2026.01/fpm
 
-Tags: 2026.01-fpm-alpine, fpm-alpine, stable-fpm-alpine
+Tags: 2026.01-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 10607f3b885ca311dcb5c24f57c731ff1857ab14
 Directory: 2026.01/fpm-alpine
 
-Tags: 2026.04-dev-apache, dev-apache, 2026.04-dev, dev
+Tags: 2026.05-apache, apache, stable-apache, 2026.05, latest, stable
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 384247e95a9abf4f26f0bdbccbfc26fdaf0b7d16
-Directory: 2026.04-dev/apache
+GitCommit: b70aa03e49e3c408971417d4d72d1995f857f37a
+Directory: 2026.05/apache
 
-Tags: 2026.04-dev-fpm, dev-fpm
+Tags: 2026.05-fpm, fpm, stable-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 384247e95a9abf4f26f0bdbccbfc26fdaf0b7d16
-Directory: 2026.04-dev/fpm
+GitCommit: b70aa03e49e3c408971417d4d72d1995f857f37a
+Directory: 2026.05/fpm
 
-Tags: 2026.04-dev-fpm-alpine, dev-fpm-alpine
+Tags: 2026.05-fpm-alpine, fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 384247e95a9abf4f26f0bdbccbfc26fdaf0b7d16
-Directory: 2026.04-dev/fpm-alpine
+GitCommit: b70aa03e49e3c408971417d4d72d1995f857f37a
+Directory: 2026.05/fpm-alpine
 
-Tags: 2026.04-rc-apache, rc-apache, 2026.04-rc, rc
+Tags: 2026.08-dev-apache, dev-apache, 2026.08-dev, dev
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 384247e95a9abf4f26f0bdbccbfc26fdaf0b7d16
-Directory: 2026.04-rc/apache
+GitCommit: dcbc3166d05ca444fa9cdc70247c6e40930a7fce
+Directory: 2026.08-dev/apache
 
-Tags: 2026.04-rc-fpm, rc-fpm
+Tags: 2026.08-dev-fpm, dev-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 384247e95a9abf4f26f0bdbccbfc26fdaf0b7d16
-Directory: 2026.04-rc/fpm
+GitCommit: dcbc3166d05ca444fa9cdc70247c6e40930a7fce
+Directory: 2026.08-dev/fpm
 
-Tags: 2026.04-rc-fpm-alpine, rc-fpm-alpine
+Tags: 2026.08-dev-fpm-alpine, dev-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 384247e95a9abf4f26f0bdbccbfc26fdaf0b7d16
-Directory: 2026.04-rc/fpm-alpine
+GitCommit: dcbc3166d05ca444fa9cdc70247c6e40930a7fce
+Directory: 2026.08-dev/fpm-alpine


### PR DESCRIPTION
The new version 2026.05 of Friendica.
For details see [release notes](https://github.com/friendica/friendica/releases/tag/2026.05-1).