### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev12, 3.4-dev, 3.4-dev12-trixie, 3.4-dev-trixie
+Tags: 3.4-dev13, 3.4-dev, 3.4-dev13-trixie, 3.4-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4f7ea0e84098ff1d6d8919c9634d4b4c0148aa53
+GitCommit: 84f01de702284cb90dea787566228fca766c4dfa
 Directory: 3.4
 
-Tags: 3.4-dev12-alpine, 3.4-dev-alpine, 3.4-dev12-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4-dev13-alpine, 3.4-dev-alpine, 3.4-dev13-alpine3.23, 3.4-dev-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 4f7ea0e84098ff1d6d8919c9634d4b4c0148aa53
+GitCommit: 84f01de702284cb90dea787566228fca766c4dfa
 Directory: 3.4/alpine
 
 Tags: 3.3.10, 3.3, latest, 3.3.10-trixie, 3.3-trixie, trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/84f01de: Update 3.4 to 3.4-dev13