### PR TITLE
Update Spark 4.1 from 4.1.1 to 4.1.2

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -6,45 +6,45 @@ Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark),
              Yikun Jiang (@Yikun)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 4.1.1-scala2.13-java21-python3-ubuntu, 4.1.1-java21-python3, 4.1.1-java21, python3, latest
+Tags: 4.1.2-scala2.13-java21-python3-ubuntu, 4.1.2-java21-python3, python3, latest
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java21-python3-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java21-python3-ubuntu
 
-Tags: 4.1.1-scala2.13-java21-r-ubuntu, 4.1.1-java21-r
+Tags: 4.1.2-scala2.13-java21-r-ubuntu, 4.1.2-java21-r, 4.1.2-r
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java21-r-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java21-r-ubuntu
 
-Tags: 4.1.1-scala2.13-java21-ubuntu, 4.1.1-java21-scala
+Tags: 4.1.2-scala2.13-java21-ubuntu, 4.1.2-java21-scala
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java21-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java21-ubuntu
 
-Tags: 4.1.1-scala2.13-java21-python3-r-ubuntu
+Tags: 4.1.2-scala2.13-java21-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java21-python3-r-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java21-python3-r-ubuntu
 
-Tags: 4.1.1-scala2.13-java17-python3-ubuntu, 4.1.1-python3, 4.1.1, python3-java17
+Tags: 4.1.2-scala2.13-java17-python3-ubuntu, 4.1.2-java17, 4.1.2-python3, 4.1.2, python3-java17
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java17-python3-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java17-python3-ubuntu
 
-Tags: 4.1.1-scala2.13-java17-r-ubuntu, 4.1.1-r, r
+Tags: 4.1.2-scala2.13-java17-r-ubuntu, 4.1.2-java17-r, r-java17, r
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java17-r-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java17-r-ubuntu
 
-Tags: 4.1.1-scala2.13-java17-ubuntu, 4.1.1-scala, scala
+Tags: 4.1.2-scala2.13-java17-ubuntu, 4.1.2-scala-java17, scala-java17, 4.1.2-scala, scala
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java17-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java17-ubuntu
 
-Tags: 4.1.1-scala2.13-java17-python3-r-ubuntu
+Tags: 4.1.2-scala2.13-java17-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: b0876281ebd5ef739bf6103a5980b8a38cd957eb
-Directory: ./4.1.1/scala2.13-java17-python3-r-ubuntu
+GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
+Directory: ./4.1.2/scala2.13-java17-python3-r-ubuntu
 
 Tags: 4.0.2-scala2.13-java21-python3-ubuntu, 4.0.2-java21-python3, 4.0.2-java21
 Architectures: amd64, arm64v8

--- a/library/spark
+++ b/library/spark
@@ -6,12 +6,12 @@ Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark),
              Yikun Jiang (@Yikun)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 4.1.2-scala2.13-java21-python3-ubuntu, 4.1.2-java21-python3, python3, latest
+Tags: 4.1.2-scala2.13-java21-python3-ubuntu, 4.1.2-java21-python3, 4.1.2-java21, python3, latest
 Architectures: amd64, arm64v8
 GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
 Directory: ./4.1.2/scala2.13-java21-python3-ubuntu
 
-Tags: 4.1.2-scala2.13-java21-r-ubuntu, 4.1.2-java21-r, 4.1.2-r
+Tags: 4.1.2-scala2.13-java21-r-ubuntu, 4.1.2-java21-r
 Architectures: amd64, arm64v8
 GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
 Directory: ./4.1.2/scala2.13-java21-r-ubuntu
@@ -31,7 +31,7 @@ Architectures: amd64, arm64v8
 GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
 Directory: ./4.1.2/scala2.13-java17-python3-ubuntu
 
-Tags: 4.1.2-scala2.13-java17-r-ubuntu, 4.1.2-java17-r, r-java17, r
+Tags: 4.1.2-scala2.13-java17-r-ubuntu, 4.1.2-java17-r, 4.1.2-r, r-java17, r
 Architectures: amd64, arm64v8
 GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
 Directory: ./4.1.2/scala2.13-java17-r-ubuntu


### PR DESCRIPTION
This PR proposes to update Spark 4.1 to its latest 4.1.2 and adds missing tags from [spark-docker](https://github.com/apache/spark-docker/pull/117/changes#diff-2b39d33506bc7a34cef4b9ebf4cf8b1e3a5532f2131ceb37011b94261cec5f8c).

Please note that some tags conflict between `spark-docker` and `docker-library/official-images` (see details in inline comments), in those cases I kept the `docker-library/official-images` ones.