### PR TITLE
Update KrakenD to v2.13.6

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.5, 2.13, 2, latest
+Tags: 2.13.6, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 8c2abb57d14f937815fc3b87ef8c7d1e2cfee430
-Directory: 2.13.5
+GitCommit: 55a0b89b95073e736db2a1b3786eef68d0814b7e
+Directory: 2.13.6


### PR DESCRIPTION
  # Security CVEs - May 2026

  Source: Go Security Team announcements

  ---

  ## golang.org/x/net — fix: v0.55.0

  | CVE | Description | Link |
  |-----|-------------|------|
  | CVE-2026-42506 | `html`: XSS via incorrect handling of namespaced elements in foreign content | https://go.dev/issue/79571 |
  | CVE-2026-39821 | `x/net/idna`: privilege escalation — incorrectly accepts ASCII-only Punycode-encoded labels | https://go.dev/issue/78760 |
  | CVE-2026-42502 | `html`: XSS via incorrect handling of HTML elements in foreign content | https://go.dev/issue/79572 |
  | CVE-2026-25680 | `html`: DoS via cubic complexity algorithm during HTML tree construction | https://go.dev/issue/79573 |
  | CVE-2026-25681 | `html`: XSS via incorrect handling of character references in DOCTYPE nodes | https://go.dev/issue/79574 |
  | CVE-2026-27136 | `html`: XSS via duplicate attributes causing mis-parsing | https://go.dev/issue/79575 |

  ---

  ## golang.org/x/crypto — fix: v0.52.0

  | CVE | Description | Link |
  |-----|-------------|------|
  | CVE-2026-46598 | `ssh/agent`: client panic on pathological inputs (malformed ed25519 wire bytes) | https://go.dev/issue/79596 |
  | CVE-2026-46597 | `ssh`: byte arithmetic underflow in AES-GCM packet decoder → server-side panic | https://go.dev/issue/79561 |
  | CVE-2026-39828 | `ssh`: bypass of certificate restrictions via PartialSuccessError with non-nil Permissions | https://go.dev/issue/79562 |
  | CVE-2026-39835 | `ssh`: server panic during CheckHostKey/Authenticate when CertChecker has no authority callbacks | https://go.dev/issue/79563 |
  | CVE-2026-39833 | `ssh/agent`: ConfirmBeforeUse constraint silently not enforced in in-memory keyring | https://go.dev/issue/79436 |
  | CVE-2026-39832 | `ssh/agent`: destination constraints silently dropped when forwarding keys to remote agent | https://go.dev/issue/79435 |
  | CVE-2026-39827 | `ssh`: memory leak via repeatedly rejected channels → server DoS (authenticated client) | https://go.dev/issue/35127 |
  | CVE-2026-39830 | `ssh`: server deadlock via unsolicited global request responses filling internal buffer | https://go.dev/issue/79564 |
  | CVE-2026-39829 | `ssh`: DoS via pathological RSA/DSA key parameters — exploitable pre-authentication | https://go.dev/issue/79565 |
  | CVE-2026-39831 | `ssh`: bypass of FIDO/U2F physical interaction requirement (User Presence flag not checked) | https://go.dev/issue/79566 |
  | CVE-2026-39834 | `ssh`: infinite loop on channel writes >4GB due to integer overflow in payload size | https://go.dev/issue/79567 |
  | CVE-2026-42508 | `ssh/knownhosts`: auth bypass — @revoked status not checked on CA SignatureKey | https://go.dev/issue/79568 |
  | CVE-2026-46595 | `ssh`: VerifiedPublicKeyCallback skips source-address validation when other callback types are used | https://go.dev/issue/79570 |

  ---

  ## golang.org/x/sys — fix: v0.45.0

  | CVE | Description | Link |
  |-----|-------------|------|
  | CVE-2026-39824 | `windows`: integer overflow in NewNTUnicodeString returns truncated string instead of error | https://go.dev/issue/78916 |
