### PR TITLE
Updated nginx mainline to 1.31.1, nginx stable to 1.30.2.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,72 +3,72 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.31.0, mainline, 1, 1.31, latest, 1.31.0-trixie, mainline-trixie, 1-trixie, 1.31-trixie, trixie
+Tags: 1.31.1, mainline, 1, 1.31, latest, 1.31.1-trixie, mainline-trixie, 1-trixie, 1.31-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/debian
 
-Tags: 1.31.0-perl, mainline-perl, 1-perl, 1.31-perl, perl, 1.31.0-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.31-trixie-perl, trixie-perl
+Tags: 1.31.1-perl, mainline-perl, 1-perl, 1.31-perl, perl, 1.31.1-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.31-trixie-perl, trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/debian-perl
 
-Tags: 1.31.0-otel, mainline-otel, 1-otel, 1.31-otel, otel, 1.31.0-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.31-trixie-otel, trixie-otel
+Tags: 1.31.1-otel, mainline-otel, 1-otel, 1.31-otel, otel, 1.31.1-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.31-trixie-otel, trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/debian-otel
 
-Tags: 1.31.0-alpine, mainline-alpine, 1-alpine, 1.31-alpine, alpine, 1.31.0-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.31-alpine3.23, alpine3.23
+Tags: 1.31.1-alpine, mainline-alpine, 1-alpine, 1.31-alpine, alpine, 1.31.1-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.31-alpine3.23, alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/alpine
 
-Tags: 1.31.0-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.31-alpine-perl, alpine-perl, 1.31.0-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.31-alpine3.23-perl, alpine3.23-perl
+Tags: 1.31.1-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.31-alpine-perl, alpine-perl, 1.31.1-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.31-alpine3.23-perl, alpine3.23-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/alpine-perl
 
-Tags: 1.31.0-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.31-alpine-slim, alpine-slim, 1.31.0-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.31-alpine3.23-slim, alpine3.23-slim
+Tags: 1.31.1-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.31-alpine-slim, alpine-slim, 1.31.1-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.31-alpine3.23-slim, alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/alpine-slim
 
-Tags: 1.31.0-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.31-alpine-otel, alpine-otel, 1.31.0-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.31-alpine3.23-otel, alpine3.23-otel
+Tags: 1.31.1-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.31-alpine-otel, alpine-otel, 1.31.1-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.31-alpine3.23-otel, alpine3.23-otel
 Architectures: amd64, arm64v8
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: mainline/alpine-otel
 
-Tags: 1.30.1, stable, 1.30, 1.30.1-trixie, stable-trixie, 1.30-trixie
+Tags: 1.30.2, stable, 1.30, 1.30.2-trixie, stable-trixie, 1.30-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/debian
 
-Tags: 1.30.1-perl, stable-perl, 1.30-perl, 1.30.1-trixie-perl, stable-trixie-perl, 1.30-trixie-perl
+Tags: 1.30.2-perl, stable-perl, 1.30-perl, 1.30.2-trixie-perl, stable-trixie-perl, 1.30-trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/debian-perl
 
-Tags: 1.30.1-otel, stable-otel, 1.30-otel, 1.30.1-trixie-otel, stable-trixie-otel, 1.30-trixie-otel
+Tags: 1.30.2-otel, stable-otel, 1.30-otel, 1.30.2-trixie-otel, stable-trixie-otel, 1.30-trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/debian-otel
 
-Tags: 1.30.1-alpine, stable-alpine, 1.30-alpine, 1.30.1-alpine3.23, stable-alpine3.23, 1.30-alpine3.23
+Tags: 1.30.2-alpine, stable-alpine, 1.30-alpine, 1.30.2-alpine3.23, stable-alpine3.23, 1.30-alpine3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/alpine
 
-Tags: 1.30.1-alpine-perl, stable-alpine-perl, 1.30-alpine-perl, 1.30.1-alpine3.23-perl, stable-alpine3.23-perl, 1.30-alpine3.23-perl
+Tags: 1.30.2-alpine-perl, stable-alpine-perl, 1.30-alpine-perl, 1.30.2-alpine3.23-perl, stable-alpine3.23-perl, 1.30-alpine3.23-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/alpine-perl
 
-Tags: 1.30.1-alpine-slim, stable-alpine-slim, 1.30-alpine-slim, 1.30.1-alpine3.23-slim, stable-alpine3.23-slim, 1.30-alpine3.23-slim
+Tags: 1.30.2-alpine-slim, stable-alpine-slim, 1.30-alpine-slim, 1.30.2-alpine3.23-slim, stable-alpine3.23-slim, 1.30-alpine3.23-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/alpine-slim
 
-Tags: 1.30.1-alpine-otel, stable-alpine-otel, 1.30-alpine-otel, 1.30.1-alpine3.23-otel, stable-alpine3.23-otel, 1.30-alpine3.23-otel
+Tags: 1.30.2-alpine-otel, stable-alpine-otel, 1.30-alpine-otel, 1.30.2-alpine3.23-otel, stable-alpine3.23-otel, 1.30-alpine3.23-otel
 Architectures: amd64, arm64v8
-GitCommit: d19b67749e7f9087801ae9f7275eec343753eed8
+GitCommit: 3375edc7170bc7b7da708c1c658706eb5355e099
 Directory: stable/alpine-otel


### PR DESCRIPTION
Nginx updated to address CVE-2026-9256