### PR TITLE
Apache CouchDB 3.5.2

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -1,18 +1,18 @@
 # see https://couchdb.apache.org/
 # also the announce@couchdb.apache.org mailing list
 
-Maintainers: Joan Touzet <wohali@apache.org> (@wohali), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
+Maintainers: Ronny Berndt <ronny@apache.org> (@big-r81), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: 4c82ee090d6299c27616f30d93c9622f769431dd
+GitCommit: adcb4f73e8a3c6fb0e901ab88cab50d71f02937a
 
-Tags: latest, 3.5.1, 3.5, 3
-Architectures: amd64, arm64v8, s390x
-Directory: 3.5.1
+Tags: latest, 3.5.2, 3.5, 3
+Architectures: amd64, arm64v8
+Directory: 3.5.2
 
-Tags: 3.5.1-nouveau, 3.5-nouveau, 3-nouveau
-Architectures: amd64, arm64v8, s390x
-Directory: 3.5.1-nouveau
+Tags: 3.5.2-nouveau, 3.5-nouveau, 3-nouveau
+Architectures: amd64, arm64v8
+Directory: 3.5.2-nouveau
 
 Tags: 3.4.3, 3.4
 Architectures: amd64, arm64v8, s390x


### PR DESCRIPTION
Due to an issue with Java 21 installing and running on s390x architecturem we're not releasing an s390x arch flavor for this release. It's just x86_64 and arm. In the future we may return support for it.

Also, replace Joan with Ronny Berndt (our PMC) in maintainers list. Joan has not been active for about 5 years and Ronny made this Docker release and regularly participates in release creation and testing.