### PR TITLE
Update Storm version to 2.8.8

### DIFF
--- a/library/storm
+++ b/library/storm
@@ -4,10 +4,10 @@ Maintainers: The Apache Storm Project <dev@storm.apache.org> (@asfbot),
 GitRepo: https://github.com/apache/storm-docker.git
 Architectures: amd64, arm64v8
 
-Tags: 2.8.7-jre17, 2.8-jre17, 2.8.7, 2.8, latest
-GitCommit: 625f431e16c92c9c76a6271326c920f844d487ab
-Directory: 2.8.7
+Tags: 2.8.8-jre17, 2.8-jre17, 2.8.8, 2.8, latest
+GitCommit: 177a1534bf910c2271845f4eaedef7c040559fbc
+Directory: 2.8.8
 
-Tags: 2.8.7-jre21, 2.8-jre21
-GitCommit: 625f431e16c92c9c76a6271326c920f844d487ab
-Directory: 2.8.7-jre21
+Tags: 2.8.8-jre21, 2.8-jre21
+GitCommit: 177a1534bf910c2271845f4eaedef7c040559fbc
+Directory: 2.8.8-jre21


### PR DESCRIPTION
Following up on the updated docker files on storm-docker:

https://github.com/apache/storm-docker/commit/177a1534bf910c2271845f4eaedef7c040559fbc