### PR TITLE
Redis: Update to 8.8.0

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -8,25 +8,25 @@ Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
              Gonen Goshen <gonen.goshen@redis.com> (@gonen-red)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.8-rc1, 8.8-rc1-trixie
+Tags: 8.8.0, 8.8, 8, 8.8.0-trixie, 8.8-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 565cd595f6faf0b998e61f17035b837d9198c243
-GitFetch: refs/tags/v8.8-rc1
+GitCommit: 40511fc518c300f3b48059daf43c7ac2ef97550b
+GitFetch: refs/tags/v8.8.0
 Directory: debian
 
-Tags: 8.8-rc1-alpine, 8.8-rc1-alpine3.23
+Tags: 8.8.0-alpine, 8.8-alpine, 8-alpine, 8.8.0-alpine3.23, 8.8-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 565cd595f6faf0b998e61f17035b837d9198c243
-GitFetch: refs/tags/v8.8-rc1
+GitCommit: 40511fc518c300f3b48059daf43c7ac2ef97550b
+GitFetch: refs/tags/v8.8.0
 Directory: alpine
 
-Tags: 8.6.3, 8.6, 8, 8.6.3-trixie, 8.6-trixie, 8-trixie, latest, trixie
+Tags: 8.6.3, 8.6, 8.6.3-trixie, 8.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
 GitCommit: 0e8b375a38d5b818b5baf23372e395ff8ee99d8e
 GitFetch: refs/tags/v8.6.3
 Directory: debian
 
-Tags: 8.6.3-alpine, 8.6-alpine, 8-alpine, 8.6.3-alpine3.23, 8.6-alpine3.23, 8-alpine3.23, alpine, alpine3.23
+Tags: 8.6.3-alpine, 8.6-alpine, 8.6.3-alpine3.23, 8.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 0e8b375a38d5b818b5baf23372e395ff8ee99d8e
 GitFetch: refs/tags/v8.6.3


### PR DESCRIPTION
Hi Docker team!

Please review the new version of redis:

Release commit: 40511fc518c300f3b48059daf43c7ac2ef97550b
Release tag: v8.8.0
Compare: https://github.com/redis/docker-library-redis/compare/v8.8.0^1...v8.8.0

Release notes: https://github.com/redis/redis/releases/tag/8.8.0