### PR TITLE
Add official Apache Thrift image

### DIFF
--- a/library/thrift
+++ b/library/thrift
@@ -1,0 +1,30 @@
+# generated via ./generate-stackbrew-library.sh; do not edit directly
+Maintainers: Apache Thrift Developers <dev@thrift.apache.org> (@asfbot),
+             Jens Geyer (@Jens-G),
+             Randy Abernethy (@RandyAbernethy),
+             Duru Can Celasun (@dcelasun)
+GitRepo: https://github.com/apache/thrift.git
+
+Tags: 0.23.0, 0.23, latest, 0.23.0-trixie, 0.23-trixie, trixie
+Architectures: amd64, arm64v8
+GitCommit: 027e3762b09d2174ebe6aa021f2ad1ca0774f07e
+Directory: docker/0.23.0
+File: Dockerfile
+
+Tags: 0.23.0-alpine3.23, 0.23-alpine3.23, alpine3.23, 0.23.0-alpine, 0.23-alpine, alpine
+Architectures: amd64, arm64v8
+GitCommit: 027e3762b09d2174ebe6aa021f2ad1ca0774f07e
+Directory: docker/0.23.0
+File: Dockerfile.alpine
+
+Tags: 0.22.0, 0.22, 0.22.0-trixie, 0.22-trixie
+Architectures: amd64, arm64v8
+GitCommit: 027e3762b09d2174ebe6aa021f2ad1ca0774f07e
+Directory: docker/0.22.0
+File: Dockerfile
+
+Tags: 0.22.0-alpine3.23, 0.22-alpine3.23, 0.22.0-alpine, 0.22-alpine
+Architectures: amd64, arm64v8
+GitCommit: 027e3762b09d2174ebe6aa021f2ad1ca0774f07e
+Directory: docker/0.22.0
+File: Dockerfile.alpine


### PR DESCRIPTION
Apache Thrift "[official](https://github.com/ahawkins/docker-thrift/issues/12)" images has been [deprecated](https://github.com/docker-library/docs/pull/1732) and then [removed](https://github.com/docker-library/official-images/pull/11079) from the repository. This pull request aims to restore them.

In the https://github.com/apache/thrift/pull/3421 we have introduced automation to generate the definitions, and moved dockerfiles to the Thrift monorepo.