### PR TITLE
Update TeamSpeak Server to 3.13.8

### DIFF
--- a/library/teamspeak
+++ b/library/teamspeak
@@ -2,6 +2,6 @@ Maintainers: Hubert Nöbauer <hubert.noebauer@teamspeak.com> (@HuppiN),
              Achim Klittich <achim.klittich@teamspeak.com> (@achimklittich)
 GitRepo: https://github.com/TeamSpeak-Systems/teamspeak-linux-docker-images
 
-Tags: 3.13, 3.13.7, latest
-GitCommit: e17fc2b955883f6ee1334d43a05208a7276d81d2
+Tags: 3.13, 3.13.8, latest
+GitCommit: e03f9a91761c389d42568b7c0cdee63e77d38fb0
 Directory: alpine


### PR DESCRIPTION
Update TeamSpeak Server to 3.13.8, including fixes for vulnerabilities scheduled for public disclosure today.