### PR TITLE
Release SonarQube Server 2025.1.8 and 2025.4.7

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -50,44 +50,44 @@ Directory: commercial-editions/datacenter/search
 GitCommit: 21dbae3d7df8f96e641955104c459a18ad50c396
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2025.4.6-developer, 2025.4-developer, 2025.4-lta-developer
+Tags: 2025.4.7-developer, 2025.4-developer, 2025.4-lta-developer
 Directory: commercial-editions/developer
-GitCommit: e493ac520eba893f488a4980e6edb99128f08abb
+GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.6-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
+Tags: 2025.4.7-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: e493ac520eba893f488a4980e6edb99128f08abb
+GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.6-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
+Tags: 2025.4.7-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: e493ac520eba893f488a4980e6edb99128f08abb
+GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.6-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
+Tags: 2025.4.7-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: e493ac520eba893f488a4980e6edb99128f08abb
+GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.1.7-developer, 2025.1-developer, 2025-lta-developer
+Tags: 2025.1.8-developer, 2025.1-developer, 2025-lta-developer
 Directory: commercial-editions/developer
-GitCommit: 81ba255ef68dcc154df0a5d1cb022419d8cfba77
+GitCommit: 24038659701d0a53c0f494d57f09c4da67274020
 GitFetch: refs/heads/release/2025.1
 
-Tags: 2025.1.7-enterprise, 2025.1-enterprise, 2025-lta-enterprise
+Tags: 2025.1.8-enterprise, 2025.1-enterprise, 2025-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 81ba255ef68dcc154df0a5d1cb022419d8cfba77
+GitCommit: 24038659701d0a53c0f494d57f09c4da67274020
 GitFetch: refs/heads/release/2025.1
 
-Tags: 2025.1.7-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app
+Tags: 2025.1.8-datacenter-app, 2025.1-datacenter-app, 2025-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 81ba255ef68dcc154df0a5d1cb022419d8cfba77
+GitCommit: 24038659701d0a53c0f494d57f09c4da67274020
 GitFetch: refs/heads/release/2025.1
 
-Tags: 2025.1.7-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search
+Tags: 2025.1.8-datacenter-search, 2025.1-datacenter-search, 2025-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 81ba255ef68dcc154df0a5d1cb022419d8cfba77
+GitCommit: 24038659701d0a53c0f494d57f09c4da67274020
 GitFetch: refs/heads/release/2025.1
 
 Tags: 26.5.0.122743-community, community, latest


### PR DESCRIPTION
Dear team,

we would to release the following two patches: 2025.1.8 and 2025.4.7.

Could you please review?

Thanks!