### PR TITLE
Odoo: update 17.0-19.0 to release 20260528

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: e2d33388ddecf4c082d491848f62ef28da0a6620
+GitCommit: 7af9c4d6df2d962ea603aca03c630dcc545ca8b1
 
-Tags: 19.0-20260513, 19.0, 19, latest
+Tags: 19.0-20260528, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20260513, 18.0, 18
+Tags: 18.0-20260528, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20260513, 17.0, 17
+Tags: 17.0-20260528, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

Here are the latest updates of Odoo supported versions.

Thanks