### PR TITLE
rust: Bump version to 1.96.0

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,48 +5,48 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.95-bullseye, 1.95.0-bullseye, bullseye
+Tags: 1-bullseye, 1.96-bullseye, 1.96.0-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.95-slim-bullseye, 1.95.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.96-slim-bullseye, 1.96.0-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.95-bookworm, 1.95.0-bookworm, bookworm
+Tags: 1-bookworm, 1.96-bookworm, 1.96.0-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.95-slim-bookworm, 1.95.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.96-slim-bookworm, 1.96.0-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.95-trixie, 1.95.0-trixie, trixie, 1, 1.95, 1.95.0, latest
+Tags: 1-trixie, 1.96-trixie, 1.96.0-trixie, trixie, 1, 1.96, 1.96.0, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.95-slim-trixie, 1.95.0-slim-trixie, slim-trixie, 1-slim, 1.95-slim, 1.95.0-slim, slim
+Tags: 1-slim-trixie, 1.96-slim-trixie, 1.96.0-slim-trixie, slim-trixie, 1-slim, 1.96-slim, 1.96.0-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.21, 1.95-alpine3.21, 1.95.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.96-alpine3.21, 1.96.0-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.95-alpine3.22, 1.95.0-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.96-alpine3.22, 1.96.0-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.95-alpine3.23, 1.95.0-alpine3.23, alpine3.23, 1-alpine, 1.95-alpine, 1.95.0-alpine, alpine
+Tags: 1-alpine3.23, 1.96-alpine3.23, 1.96.0-alpine3.23, alpine3.23, 1-alpine, 1.96-alpine, 1.96.0-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: dd106de2954f52f336c3d2c1326ae778c51830f3
+GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
 Directory: stable/alpine3.23
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.96.0
https://blog.rust-lang.org/2026/05/28/Rust-1.96.0/