### PR TITLE
Fix rabbitmq-tls test for erlang 27.3.4.12

### DIFF
--- a/test/tests/rabbitmq-tls/run.sh
+++ b/test/tests/rabbitmq-tls/run.sh
@@ -17,9 +17,11 @@ RUN set -eux; \
 		-subj '/CN=$cname-CA'; \
 	openssl genrsa -out /certs/private.key 4096; \
 	openssl req -new -key /certs/private.key \
+		-addext "subjectAltName = DNS:$cname" \
 		-out /certs/cert.csr -subj '/CN=$cname'; \
 	openssl x509 -req -in /certs/cert.csr \
 		-CA /certs/ca.crt -CAkey /certs/ca-private.key -CAcreateserial \
+		-copy_extensions copyall \
 		-out /certs/cert.crt -days $(( 365 * 30 )); \
 	openssl verify -CAfile /certs/ca.crt /certs/cert.crt; \
 	cat /certs/cert.crt /certs/private.key > /certs/combined.pem; \


### PR DESCRIPTION
Failing log:
>2026-05-27 22:57:34.541504+00:00 [notice] <0.573.0> TLS server: In state certify received CLIENT ALERT: Fatal - Bad Certificate

The `rabbitmq` images are failing to update to the new erlang version because of erlang incompatibilities.


> Adhere to RFC 9525, and remove support for legacy fallback to check hostname against subject common name
> https://www.erlang.org/patches/OTP-27.3.4.12#incompatibilities

Fix self-signed cert in our test to have the proper `subjectAltName`.