### PR TITLE
Update rabbitmq

### DIFF
--- a/library/rabbitmq
+++ b/library/rabbitmq
@@ -7,7 +7,7 @@ Builder: buildkit
 
 Tags: 4.3.1, 4.3, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: e3cc5d9699fb35e5e9e6549c58066e58d60479c2
+GitCommit: e72c658a466b6eee4c381396f5a6e01e9dea733f
 Directory: 4.3/ubuntu
 
 Tags: 4.3.1-management, 4.3-management, 4-management, management
@@ -17,7 +17,7 @@ Directory: 4.3/ubuntu/management
 
 Tags: 4.3.1-alpine, 4.3-alpine, 4-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: e3cc5d9699fb35e5e9e6549c58066e58d60479c2
+GitCommit: e72c658a466b6eee4c381396f5a6e01e9dea733f
 Directory: 4.3/alpine
 
 Tags: 4.3.1-management-alpine, 4.3-management-alpine, 4-management-alpine, management-alpine
@@ -27,7 +27,7 @@ Directory: 4.3/alpine/management
 
 Tags: 4.2.7, 4.2
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: bd150c0d31d2feb2c96041d63b8f916cb4c27685
+GitCommit: 6c9428b8f6c1026b1fa9910adceec59301f34d76
 Directory: 4.2/ubuntu
 
 Tags: 4.2.7-management, 4.2-management
@@ -37,7 +37,7 @@ Directory: 4.2/ubuntu/management
 
 Tags: 4.2.7-alpine, 4.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: bd150c0d31d2feb2c96041d63b8f916cb4c27685
+GitCommit: 6c9428b8f6c1026b1fa9910adceec59301f34d76
 Directory: 4.2/alpine
 
 Tags: 4.2.7-management-alpine, 4.2-management-alpine
@@ -47,7 +47,7 @@ Directory: 4.2/alpine/management
 
 Tags: 4.1.8, 4.1
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: eaa545eb536d9f019d72d1d6a5f0e364878a4fd9
+GitCommit: 0cef4ca4c4d996a43ca7aefc1b1fb81f88f02bbd
 Directory: 4.1/ubuntu
 
 Tags: 4.1.8-management, 4.1-management
@@ -57,7 +57,7 @@ Directory: 4.1/ubuntu/management
 
 Tags: 4.1.8-alpine, 4.1-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: eaa545eb536d9f019d72d1d6a5f0e364878a4fd9
+GitCommit: 0cef4ca4c4d996a43ca7aefc1b1fb81f88f02bbd
 Directory: 4.1/alpine
 
 Tags: 4.1.8-management-alpine, 4.1-management-alpine
@@ -67,7 +67,7 @@ Directory: 4.1/alpine/management
 
 Tags: 4.0.9, 4.0
 Architectures: amd64, arm32v7, arm64v8, ppc64le, riscv64, s390x
-GitCommit: d85835d549a1c0248bb59b2f1ff2622deb463a72
+GitCommit: 45fd8b549f23e4cb00f7784ff68cd69da1a9570d
 Directory: 4.0/ubuntu
 
 Tags: 4.0.9-management, 4.0-management
@@ -77,7 +77,7 @@ Directory: 4.0/ubuntu/management
 
 Tags: 4.0.9-alpine, 4.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d85835d549a1c0248bb59b2f1ff2622deb463a72
+GitCommit: 45fd8b549f23e4cb00f7784ff68cd69da1a9570d
 Directory: 4.0/alpine
 
 Tags: 4.0.9-management-alpine, 4.0-management-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/rabbitmq/commit/e72c658: Update 4.3 to otp 27.3.4.12
- https://github.com/docker-library/rabbitmq/commit/6c9428b: Update 4.2 to otp 27.3.4.12
- https://github.com/docker-library/rabbitmq/commit/0cef4ca: Update 4.1 to otp 27.3.4.12
- https://github.com/docker-library/rabbitmq/commit/45fd8b5: Update 4.0 to otp 27.3.4.12

Users may see issues if they have TLS certificates that aren't RFC 9525 compliant (https://www.erlang.org/patches/OTP-27.3.4.12#incompatibilities). TL;DR: use `subjectAltName` and not just common name (`CN`). See also https://github.com/docker-library/official-images/pull/21556.