### PR TITLE
MariaDB 2026q2 corrective release 10.6 -> 11.8

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -8,60 +8,60 @@ Builder: buildkit
 
 Tags: 12.3.1-ubi10-rc, 12.3-ubi10-rc, 12.3.1-ubi-rc, 12.3-ubi-rc
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 769f60ce827e3465281d184080727f3f13f3f61e
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 12.3-ubi
 
 Tags: 12.3.1-noble-rc, 12.3-noble-rc, 12.3.1-rc, 12.3-rc
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: a681c62cf8d84fc614e648776992733cdca60983
+GitCommit: 1b6429ba3544e134715c15f8c56cc6f665f827c9
 Directory: 12.3
 
 Tags: 12.2.2-ubi10, 12.2-ubi10, 12-ubi10, 12.2.2-ubi, 12.2-ubi, 12-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 604617ddd4d241538390b0bb97bf4cd92e5f4c6f
+GitCommit: 1b6429ba3544e134715c15f8c56cc6f665f827c9
 Directory: 12.2-ubi
 
 Tags: 12.2.2-noble, 12.2-noble, 12-noble, noble, 12.2.2, 12.2, 12, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 604617ddd4d241538390b0bb97bf4cd92e5f4c6f
+GitCommit: 1b6429ba3544e134715c15f8c56cc6f665f827c9
 Directory: 12.2
 
-Tags: 11.8.7-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.7-ubi, 11.8-ubi, 11-ubi, lts-ubi
+Tags: 11.8.8-ubi9, 11.8-ubi9, 11-ubi9, lts-ubi9, 11.8.8-ubi, 11.8-ubi, 11-ubi, lts-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 11.8-ubi
 
-Tags: 11.8.7-noble, 11.8-noble, 11-noble, lts-noble, 11.8.7, 11.8, 11, lts
+Tags: 11.8.8-noble, 11.8-noble, 11-noble, lts-noble, 11.8.8, 11.8, 11, lts
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 11.8
 
-Tags: 11.4.11-ubi9, 11.4-ubi9, 11.4.11-ubi, 11.4-ubi
+Tags: 11.4.12-ubi9, 11.4-ubi9, 11.4.12-ubi, 11.4-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 11.4-ubi
 
-Tags: 11.4.11-noble, 11.4-noble, 11.4.11, 11.4
+Tags: 11.4.12-noble, 11.4-noble, 11.4.12, 11.4
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 11.4
 
-Tags: 10.11.17-ubi9, 10.11-ubi9, 10-ubi9, 10.11.17-ubi, 10.11-ubi, 10-ubi
+Tags: 10.11.18-ubi9, 10.11-ubi9, 10-ubi9, 10.11.18-ubi, 10.11-ubi, 10-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 10.11-ubi
 
-Tags: 10.11.17-jammy, 10.11-jammy, 10-jammy, 10.11.17, 10.11, 10
+Tags: 10.11.18-jammy, 10.11-jammy, 10-jammy, 10.11.18, 10.11, 10
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 10.11
 
-Tags: 10.6.26-ubi9, 10.6-ubi9, 10.6.26-ubi, 10.6-ubi
+Tags: 10.6.27-ubi9, 10.6-ubi9, 10.6.27-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 10.6-ubi
 
-Tags: 10.6.26-jammy, 10.6-jammy, 10.6.26, 10.6
+Tags: 10.6.27-jammy, 10.6-jammy, 10.6.27, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: cfc6a068e6d6418b22e3f0e498c243c2279a118a
+GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 10.6


### PR DESCRIPTION
Also remove environment variables of passwords and host from the mariadbd execution based on blog by Mats Kindahl

https://dbmsdrops.kindahl.net/2026/05/22/dont-put-secrets-in-your-postgresql-environment-variables/