### PR TITLE
[ros] promote ROS Lyrical to latest

### DIFF
--- a/library/ros
+++ b/library/ros
@@ -34,7 +34,7 @@ Architectures: amd64, arm64v8
 GitCommit: 58af41813ba67f611943c35c551387d652fcdbde
 Directory: ros/jazzy/ubuntu/noble/ros-core
 
-Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy, latest
+Tags: jazzy-ros-base, jazzy-ros-base-noble, jazzy
 Architectures: amd64, arm64v8
 GitCommit: 0038f1c3a11aa0fc573d698b39ab5c204aad5a40
 Directory: ros/jazzy/ubuntu/noble/ros-base
@@ -75,10 +75,10 @@ Directory: ros/kilted/ubuntu/noble/perception
 
 Tags: lyrical-ros-core, lyrical-ros-core-resolute
 Architectures: amd64, arm64v8
-GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
+GitCommit: 54c9478ffafa47e2e65a90a20ebd5412009a35b0
 Directory: ros/lyrical/ubuntu/resolute/ros-core
 
-Tags: lyrical-ros-base, lyrical-ros-base-resolute, lyrical
+Tags: lyrical-ros-base, lyrical-ros-base-resolute, lyrical, latest
 Architectures: amd64, arm64v8
 GitCommit: 0d65786f3d9bb10d55dc28ccd5b87da204240d1a
 Directory: ros/lyrical/ubuntu/resolute/ros-base


### PR DESCRIPTION
The new ROS LTS distribution aka ROS Lyrical is officially out: https://discourse.openrobotics.org/t/ros-2-lyrical-luth-released/55021

This PR updates the dockerfiles to target the main ROS apt repo and move the latest tag to point to lyrical
It also updates how the sources are installed based on feedback from: https://github.com/docker-library/official-images/pull/21417#pullrequestreview-4255672560


Follow-up of https://github.com/docker-library/official-images/pull/21417 and https://github.com/docker-library/official-images/pull/21426

Cross-referencing: https://github.com/osrf/docker_images/pull/882