### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.11.20260514.0
+Tags: 2023, latest, 2023.11.20260526.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: db81948fbd2ab68321c5254cde1499eaa928a0d2
+amd64-GitCommit: 7a3381c4ef8fe16ab35a945953866e8e39076c34
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 69f472b801ea2db6c78c09d11ba93b4cbde75a28
+arm64v8-GitCommit: 217905a823d5e51a8c0e7ee8b01aec8ea1011905
 
-Tags: 2, 2.0.20260515.0
+Tags: 2, 2.0.20260526.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 09d9d9ec39dbb97649f224a19e0d45f985274572
+amd64-GitCommit: 0e6504b2ff6c0c49c2397bf7248ca28c35dc3ebe
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: c0c130a6454274566dfb945fd586f7f0597a8aec
+arm64v8-GitCommit: a76034b3fcc66f9f9aa39ad5c4493f10b82d853d
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- nss-sysinit-3.90.0-2.amzn2.0.3
- nss-3.90.0-2.amzn2.0.3
- nss-tools-3.90.0-2.amzn2.0.3
#### Packages addressing CVES:
- nss-sysinit-3.90.0-2.amzn2.0.3, nss-3.90.0-2.amzn2.0.3, nss-tools-3.90.0-2.amzn2.0.3
  - [CVE-2026-6766](https://alas.aws.amazon.com/cve/html/CVE-2026-6766.html)
  - [CVE-2026-6767](https://alas.aws.amazon.com/cve/html/CVE-2026-6767.html)
  - [CVE-2026-6772](https://alas.aws.amazon.com/cve/html/CVE-2026-6772.html)

### Updated Packages for Amazon Linux 2023:
- libsolv-0.7.22-1.amzn2023.0.3
- amazon-linux-repo-cdn-2023.11.20260526-0.amzn2023
- system-release-2023.11.20260526-0.amzn2023
- libcap-2.73-1.amzn2023.0.7
#### Packages addressing CVES:
- libcap-2.73-1.amzn2023.0.7
  - [CVE-2026-27142](https://alas.aws.amazon.com/cve/html/CVE-2026-27142.html)
  - [CVE-2026-33811](https://alas.aws.amazon.com/cve/html/CVE-2026-33811.html)
  - [CVE-2026-33814](https://alas.aws.amazon.com/cve/html/CVE-2026-33814.html)
  - [CVE-2026-39820](https://alas.aws.amazon.com/cve/html/CVE-2026-39820.html)
  - [CVE-2026-39823](https://alas.aws.amazon.com/cve/html/CVE-2026-39823.html)
  - [CVE-2026-42499](https://alas.aws.amazon.com/cve/html/CVE-2026-42499.html)