### PR TITLE
archlinux: Release 20260531.0.538839

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260524.0.535079
-GitCommit: 6da13b7e86acf01fc4617205e1c01c786baae76a
-GitFetch: refs/tags/v20260524.0.535079
+Tags: latest, base, base-20260531.0.538839
+GitCommit: 0d8cb552d1fbe1f38d5850ba2a351d8e811de8c7
+GitFetch: refs/tags/v20260531.0.538839
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260524.0.535079
-GitCommit: 6da13b7e86acf01fc4617205e1c01c786baae76a
-GitFetch: refs/tags/v20260524.0.535079
+Tags: base-devel, base-devel-20260531.0.538839
+GitCommit: 0d8cb552d1fbe1f38d5850ba2a351d8e811de8c7
+GitFetch: refs/tags/v20260531.0.538839
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260524.0.535079
-GitCommit: 6da13b7e86acf01fc4617205e1c01c786baae76a
-GitFetch: refs/tags/v20260524.0.535079
+Tags: multilib-devel, multilib-devel-20260531.0.538839
+GitCommit: 0d8cb552d1fbe1f38d5850ba2a351d8e811de8c7
+GitFetch: refs/tags/v20260531.0.538839
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks