### PR TITLE
Release Neo4j 2026.05.0

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -4,45 +4,25 @@ Maintainers: Jenny Owen <jenny.owen@neo4j.com> (@jennyowen),
              Nedeljko Cvejic <nedeljko.cvejic@neo4j.com> (@nedeljko-cvejic)
 GitRepo: https://github.com/neo4j/docker-neo4j-publish.git
 
-Tags: 2026.04.0-community-trixie, 2026.04-community-trixie, 2026-community-trixie, 2026.04.0-community, 2026.04-community, 2026-community, 2026.04.0-trixie, 2026.04-trixie, 2026-trixie, 2026.04.0, 2026.04, 2026, community-trixie, community, trixie, latest
+Tags: 2026.05.0-community-trixie, 2026.05-community-trixie, 2026-community-trixie, 2026.05.0-community, 2026.05-community, 2026-community, 2026.05.0-trixie, 2026.05-trixie, 2026-trixie, 2026.05.0, 2026.05, 2026, community-trixie, community, trixie, latest
 Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/trixie/community
+GitCommit: 5ed41341182f1c0850f027e399b2d9278c00bb07
+Directory: 2026.05.0/trixie/community
 
-Tags: 2026.04.0-enterprise-trixie, 2026.04-enterprise-trixie, 2026-enterprise-trixie, 2026.04.0-enterprise, 2026.04-enterprise, 2026-enterprise, enterprise-trixie, enterprise
+Tags: 2026.05.0-enterprise-trixie, 2026.05-enterprise-trixie, 2026-enterprise-trixie, 2026.05.0-enterprise, 2026.05-enterprise, 2026-enterprise, enterprise-trixie, enterprise
 Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/trixie/enterprise
+GitCommit: 5ed41341182f1c0850f027e399b2d9278c00bb07
+Directory: 2026.05.0/trixie/enterprise
 
-Tags: 2026.04.0-community-ubi10, 2026.04-community-ubi10, 2026-community-ubi10, 2026.04.0-ubi10, 2026.04-ubi10, 2026-ubi10, community-ubi10, ubi10
+Tags: 2026.05.0-community-ubi10, 2026.05-community-ubi10, 2026-community-ubi10, 2026.05.0-ubi10, 2026.05-ubi10, 2026-ubi10, community-ubi10, ubi10
 Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/ubi10/community
+GitCommit: 5ed41341182f1c0850f027e399b2d9278c00bb07
+Directory: 2026.05.0/ubi10/community
 
-Tags: 2026.04.0-enterprise-ubi10, 2026.04-enterprise-ubi10, 2026-enterprise-ubi10, enterprise-ubi10
+Tags: 2026.05.0-enterprise-ubi10, 2026.05-enterprise-ubi10, 2026-enterprise-ubi10, enterprise-ubi10
 Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/ubi10/enterprise
-
-Tags: 2026.04.0-community-bullseye, 2026.04-community-bullseye, 2026-community-bullseye, 2026.04.0-bullseye, 2026.04-bullseye, 2026-bullseye, community-bullseye, bullseye
-Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/bullseye/community
-
-Tags: 2026.04.0-enterprise-bullseye, 2026.04-enterprise-bullseye, 2026-enterprise-bullseye, enterprise-bullseye
-Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/bullseye/enterprise
-
-Tags: 2026.04.0-community-ubi9, 2026.04-community-ubi9, 2026-community-ubi9, 2026.04.0-ubi9, 2026.04-ubi9, 2026-ubi9, community-ubi9, ubi9
-Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/ubi9/community
-
-Tags: 2026.04.0-enterprise-ubi9, 2026.04-enterprise-ubi9, 2026-enterprise-ubi9, enterprise-ubi9
-Architectures: amd64, arm64v8
-GitCommit: ae06064fb16112cbf1fd11ed327240dfc27d3d5c
-Directory: 2026.04.0/ubi9/enterprise
+GitCommit: 5ed41341182f1c0850f027e399b2d9278c00bb07
+Directory: 2026.05.0/ubi10/enterprise
 
 
 


### PR DESCRIPTION
Update the calver line from 2026.04.0 to 2026.05.0 (docker-neo4j-publish 5ed41341182f1c0850f027e399b2d9278c00bb07).

2026.05.0 ships only the trixie and ubi10 variants; the bullseye and ubi9 variants are no longer produced and have been removed.