### PR TITLE
Bump traefik to 2.11.47, v3.6.18, and v3.7.2

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,103 +1,103 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.1-windowsservercore-ltsc2025, 3.7.1-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.7.2-windowsservercore-ltsc2025, 3.7.2-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: dab5356146e67356237f08f6e344103ad99ea15c
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.1-windowsservercore-ltsc2022, 3.7.1-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.7.2-windowsservercore-ltsc2022, 3.7.2-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: dab5356146e67356237f08f6e344103ad99ea15c
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.1-nanoserver-ltsc2025, 3.7.1-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.7.2-nanoserver-ltsc2025, 3.7.2-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: dab5356146e67356237f08f6e344103ad99ea15c
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.1-nanoserver-ltsc2022, 3.7.1-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.7.2-nanoserver-ltsc2022, 3.7.2-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: dab5356146e67356237f08f6e344103ad99ea15c
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.1, 3.7.1, v3.7, 3.7, v3, 3, langres, latest
+Tags: v3.7.2, 3.7.2, v3.7, 3.7, v3, 3, langres, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: dab5356146e67356237f08f6e344103ad99ea15c
 Directory: v3.7/alpine
 
-Tags: v3.6.17-windowsservercore-ltsc2025, 3.6.17-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
+Tags: v3.6.18-windowsservercore-ltsc2025, 3.6.18-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.6.17-windowsservercore-ltsc2022, 3.6.17-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
+Tags: v3.6.18-windowsservercore-ltsc2022, 3.6.18-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.17-nanoserver-ltsc2025, 3.6.17-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
+Tags: v3.6.18-nanoserver-ltsc2025, 3.6.18-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.6.17-nanoserver-ltsc2022, 3.6.17-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
+Tags: v3.6.18-nanoserver-ltsc2022, 3.6.18-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.17, 3.6.17, v3.6, 3.6, ramequin
+Tags: v3.6.18, 3.6.18, v3.6, 3.6, v3, 3, ramequin
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/alpine
 
-Tags: v2.11.46-windowsservercore-ltsc2025, 2.11.46-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
+Tags: v2.11.47-windowsservercore-ltsc2025, 2.11.47-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 7036a107271032222fe2002f3945bf9d653ba176
 Directory: v2.11/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v2.11.46-windowsservercore-ltsc2022, 2.11.46-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.47-windowsservercore-ltsc2022, 2.11.47-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 7036a107271032222fe2002f3945bf9d653ba176
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.46-nanoserver-ltsc2025, 2.11.46-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
+Tags: v2.11.47-nanoserver-ltsc2025, 2.11.47-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 7036a107271032222fe2002f3945bf9d653ba176
 Directory: v2.11/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v2.11.46-nanoserver-ltsc2022, 2.11.46-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.47-nanoserver-ltsc2022, 2.11.47-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 7036a107271032222fe2002f3945bf9d653ba176
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.46, 2.11.46, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.47, 2.11.47, v2.11, 2.11, v2, 2, mimolette
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 7036a107271032222fe2002f3945bf9d653ba176
 Directory: v2.11/alpine

--- a/library/traefik
+++ b/library/traefik
@@ -34,35 +34,35 @@ GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: dab5356146e67356237f08f6e344103ad99ea15c
 Directory: v3.7/alpine
 
-Tags: v3.6.18-windowsservercore-ltsc2025, 3.6.18-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
+Tags: v3.6.18-windowsservercore-ltsc2025, 3.6.18-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.6.18-windowsservercore-ltsc2022, 3.6.18-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
+Tags: v3.6.18-windowsservercore-ltsc2022, 3.6.18-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.18-nanoserver-ltsc2025, 3.6.18-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
+Tags: v3.6.18-nanoserver-ltsc2025, 3.6.18-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.6.18-nanoserver-ltsc2022, 3.6.18-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
+Tags: v3.6.18-nanoserver-ltsc2022, 3.6.18-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f355a5becf44eae4fd617745309dae58db6d867a
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.18, 3.6.18, v3.6, 3.6, v3, 3, ramequin
+Tags: v3.6.18, 3.6.18, v3.6, 3.6, ramequin
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
 GitCommit: f355a5becf44eae4fd617745309dae58db6d867a


### PR DESCRIPTION
Hello,

This PR updates Traefik to [v2.11.47](https://github.com/traefik/traefik/releases/tag/v2.11.47), [v3.6.18](https://github.com/traefik/traefik/releases/tag/v3.6.18), [v3.7.2](https://github.com/traefik/traefik/releases/tag/v3.7.2).

/cc @nmengin @mmatur @kevinpollet

Cheers
