### PR TITLE
Update KrakenD to v2.13.7

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.6, 2.13, 2, latest
+Tags: 2.13.7, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 55a0b89b95073e736db2a1b3786eef68d0814b7e
-Directory: 2.13.6
+GitCommit: 6384c602acef16436efffd7a6acc296b38ce5ecf
+Directory: 2.13.7


### PR DESCRIPTION
## Changes

Upgraded Go to 1.25.11, addressing several CVEs with disclosed descriptions:

* [CVE-2026-42504](https://go.dev/issue/79217) `mime`: quadratic complexity in WordDecoder.DecodeHeader
* [CVE-2026-42507](https://go.dev/issue/79346) `net/textproto`: arbitrary input are included in errors without any escaping
* [CVE-2026-27145](https://go.dev/issue/79694) `crypto/x509`: split candidate hostname only once