### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -1,35 +1,35 @@
-# this file is generated via https://github.com/docker-library/haproxy/blob/875a6dd82a46bc6474b8fa10003655f6103e7c67/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/haproxy/blob/33360bb6d4861fa584137c1faa6f537eb085252b/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4-dev14, 3.4-dev, 3.4-dev14-trixie, 3.4-dev-trixie
+Tags: 3.4.0, 3.4, latest, lts, 3.4.0-trixie, 3.4-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f266f1913bccd22f65e6d064d2eccc6d57305510
+GitCommit: d38caa309841e22343e5e689ba738b6ea4f74aca
 Directory: 3.4
 
-Tags: 3.4-dev14-alpine, 3.4-dev-alpine, 3.4-dev14-alpine3.23, 3.4-dev-alpine3.23
+Tags: 3.4.0-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.0-alpine3.23, 3.4-alpine3.23, alpine3.23, lts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f266f1913bccd22f65e6d064d2eccc6d57305510
+GitCommit: d38caa309841e22343e5e689ba738b6ea4f74aca
 Directory: 3.4/alpine
 
-Tags: 3.3.10, 3.3, latest, 3.3.10-trixie, 3.3-trixie, trixie
+Tags: 3.3.10, 3.3, 3.3.10-trixie, 3.3-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
 Directory: 3.3
 
-Tags: 3.3.10-alpine, 3.3-alpine, alpine, 3.3.10-alpine3.23, 3.3-alpine3.23, alpine3.23
+Tags: 3.3.10-alpine, 3.3-alpine, 3.3.10-alpine3.23, 3.3-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
 Directory: 3.3/alpine
 
-Tags: 3.2.19, 3.2, lts, 3.2.19-trixie, 3.2-trixie, lts-trixie
+Tags: 3.2.19, 3.2, 3.2.19-trixie, 3.2-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
 Directory: 3.2
 
-Tags: 3.2.19-alpine, 3.2-alpine, lts-alpine, 3.2.19-alpine3.23, 3.2-alpine3.23, lts-alpine3.23
+Tags: 3.2.19-alpine, 3.2-alpine, 3.2.19-alpine3.23, 3.2-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
 Directory: 3.2/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/33360bb: Update "latest" and "lts" aliases (3.4 GA)
- https://github.com/docker-library/haproxy/commit/d38caa3: Update 3.4 to 3.4.0