### PR TITLE
Update docker

### DIFF
--- a/library/docker
+++ b/library/docker
@@ -5,33 +5,33 @@ Maintainers: Tianon Gravi <tianon@dockerproject.org> (@tianon),
 GitRepo: https://github.com/docker-library/docker.git
 Builder: buildkit
 
-Tags: 29.5.2-cli, 29.5-cli, 29-cli, cli, 29.5.2-cli-alpine3.23
+Tags: 29.5.3-cli, 29.5-cli, 29-cli, cli, 29.5.3-cli-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: bc9e03bd1093d09d4aa4c3d74ca0a1d42acdc3e8
+GitCommit: f3c8a6a2fa4b39191a6911a6d1a674d9c8d3e312
 Directory: 29/cli
 
-Tags: 29.5.2-dind, 29.5-dind, 29-dind, dind, 29.5.2-dind-alpine3.23, 29.5.2, 29.5, 29, latest, 29.5.2-alpine3.23
+Tags: 29.5.3-dind, 29.5-dind, 29-dind, dind, 29.5.3-dind-alpine3.23, 29.5.3, 29.5, 29, latest, 29.5.3-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8
-GitCommit: bc9e03bd1093d09d4aa4c3d74ca0a1d42acdc3e8
+GitCommit: f3c8a6a2fa4b39191a6911a6d1a674d9c8d3e312
 Directory: 29/dind
 
-Tags: 29.5.2-dind-rootless, 29.5-dind-rootless, 29-dind-rootless, dind-rootless
+Tags: 29.5.3-dind-rootless, 29.5-dind-rootless, 29-dind-rootless, dind-rootless
 Architectures: amd64, arm64v8
-GitCommit: bc9e03bd1093d09d4aa4c3d74ca0a1d42acdc3e8
+GitCommit: f3c8a6a2fa4b39191a6911a6d1a674d9c8d3e312
 Directory: 29/dind-rootless
 
-Tags: 29.5.2-windowsservercore-ltsc2025, 29.5-windowsservercore-ltsc2025, 29-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 29.5.2-windowsservercore, 29.5-windowsservercore, 29-windowsservercore, windowsservercore
+Tags: 29.5.3-windowsservercore-ltsc2025, 29.5-windowsservercore-ltsc2025, 29-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 29.5.3-windowsservercore, 29.5-windowsservercore, 29-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: bc9e03bd1093d09d4aa4c3d74ca0a1d42acdc3e8
+GitCommit: f3c8a6a2fa4b39191a6911a6d1a674d9c8d3e312
 Directory: 29/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 Builder: classic
 
-Tags: 29.5.2-windowsservercore-ltsc2022, 29.5-windowsservercore-ltsc2022, 29-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 29.5.2-windowsservercore, 29.5-windowsservercore, 29-windowsservercore, windowsservercore
+Tags: 29.5.3-windowsservercore-ltsc2022, 29.5-windowsservercore-ltsc2022, 29-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 29.5.3-windowsservercore, 29.5-windowsservercore, 29-windowsservercore, windowsservercore
 Architectures: windows-amd64
-GitCommit: bc9e03bd1093d09d4aa4c3d74ca0a1d42acdc3e8
+GitCommit: f3c8a6a2fa4b39191a6911a6d1a674d9c8d3e312
 Directory: 29/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 Builder: classic


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/docker/commit/f3c8a6a: Update 29 to 29.5.3



LOL; thought I’d open a PR to update the docker image similar to how previous PRs were done, but guess that’s not possible if I do it directly from the docker-library-bot branch? https://github.com/docker-library/official-images/compare/master...docker-library-bot:official-images:docker

<img width="477" height="65" alt="Screenshot 2026-06-04 at 12 31 58" src="https://github.com/user-attachments/assets/5dc139c7-0f2c-447a-b028-c7ea668fa446" />
