### PR TITLE
Bump Traefik to v3.7.3, v3.6.19, v2.11.48

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,103 +1,103 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.1-windowsservercore-ltsc2025, 3.7.1-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.7.3-windowsservercore-ltsc2025, 3.7.3-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: 79cb1fff5b99096b3865e3abe22c1505de7c7da2
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.1-windowsservercore-ltsc2022, 3.7.1-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.7.3-windowsservercore-ltsc2022, 3.7.3-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: 79cb1fff5b99096b3865e3abe22c1505de7c7da2
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.1-nanoserver-ltsc2025, 3.7.1-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.7.3-nanoserver-ltsc2025, 3.7.3-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: 79cb1fff5b99096b3865e3abe22c1505de7c7da2
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.1-nanoserver-ltsc2022, 3.7.1-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.7.3-nanoserver-ltsc2022, 3.7.3-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: 79cb1fff5b99096b3865e3abe22c1505de7c7da2
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.1, 3.7.1, v3.7, 3.7, v3, 3, langres, latest
+Tags: v3.7.3, 3.7.3, v3.7, 3.7, langres, v3, 3, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 005971c99323d650d04d29cea460d3c7a1e5e5ac
+GitCommit: 79cb1fff5b99096b3865e3abe22c1505de7c7da2
 Directory: v3.7/alpine
 
-Tags: v3.6.17-windowsservercore-ltsc2025, 3.6.17-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
+Tags: v3.6.19-windowsservercore-ltsc2025, 3.6.19-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: 01e37ad12f228725e6c4b53152a337c9484380c1
 Directory: v3.6/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.6.17-windowsservercore-ltsc2022, 3.6.17-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
+Tags: v3.6.19-windowsservercore-ltsc2022, 3.6.19-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: 01e37ad12f228725e6c4b53152a337c9484380c1
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.17-nanoserver-ltsc2025, 3.6.17-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
+Tags: v3.6.19-nanoserver-ltsc2025, 3.6.19-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: 01e37ad12f228725e6c4b53152a337c9484380c1
 Directory: v3.6/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.6.17-nanoserver-ltsc2022, 3.6.17-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
+Tags: v3.6.19-nanoserver-ltsc2022, 3.6.19-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: 01e37ad12f228725e6c4b53152a337c9484380c1
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.17, 3.6.17, v3.6, 3.6, ramequin
+Tags: v3.6.19, 3.6.19, v3.6, 3.6, ramequin
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: dda5c39d72ed12e911c3131e22d1734becc120d4
+GitCommit: 01e37ad12f228725e6c4b53152a337c9484380c1
 Directory: v3.6/alpine
 
-Tags: v2.11.46-windowsservercore-ltsc2025, 2.11.46-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025
+Tags: v2.11.48-windowsservercore-ltsc2025, 2.11.48-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 6ccc8d8036e8f1a462476fdd59a8522b81a8e00a
 Directory: v2.11/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v2.11.46-windowsservercore-ltsc2022, 2.11.46-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022
+Tags: v2.11.48-windowsservercore-ltsc2022, 2.11.48-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 6ccc8d8036e8f1a462476fdd59a8522b81a8e00a
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.46-nanoserver-ltsc2025, 2.11.46-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025
+Tags: v2.11.48-nanoserver-ltsc2025, 2.11.48-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 6ccc8d8036e8f1a462476fdd59a8522b81a8e00a
 Directory: v2.11/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v2.11.46-nanoserver-ltsc2022, 2.11.46-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022
+Tags: v2.11.48-nanoserver-ltsc2022, 2.11.48-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 6ccc8d8036e8f1a462476fdd59a8522b81a8e00a
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.46, 2.11.46, v2.11, 2.11, v2, 2, mimolette
+Tags: v2.11.48, 2.11.48, v2.11, 2.11, mimolette, v2, 2
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: f7f433c743f4c25fff2c829bc22a2d4b1eddbf7d
+GitCommit: 6ccc8d8036e8f1a462476fdd59a8522b81a8e00a
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to:
- [v3.7.3](https://github.com/traefik/traefik/releases/tag/v3.7.3)
- [v3.6.19](https://github.com/traefik/traefik/releases/tag/v3.6.19)
- [v2.11.48](https://github.com/traefik/traefik/releases/tag/v2.11.48)

/cc @mmatur @kevinpollet

Cheers
