### PR TITLE
Bump Traefik to v3.7.5, v3.6.21, v2.11.50

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,103 +1,103 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.4-windowsservercore-ltsc2025, 3.7.4-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.7.5-windowsservercore-ltsc2025, 3.7.5-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a2003ee1d14afe94d0e35a2e8f5a4b6bf4c47b1d
+GitCommit: 5f3401da91ad5ced550efd53983695bf45765176
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.4-windowsservercore-ltsc2022, 3.7.4-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.7.5-windowsservercore-ltsc2022, 3.7.5-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a2003ee1d14afe94d0e35a2e8f5a4b6bf4c47b1d
+GitCommit: 5f3401da91ad5ced550efd53983695bf45765176
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.4-nanoserver-ltsc2025, 3.7.4-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.7.5-nanoserver-ltsc2025, 3.7.5-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a2003ee1d14afe94d0e35a2e8f5a4b6bf4c47b1d
+GitCommit: 5f3401da91ad5ced550efd53983695bf45765176
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.4-nanoserver-ltsc2022, 3.7.4-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.7.5-nanoserver-ltsc2022, 3.7.5-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a2003ee1d14afe94d0e35a2e8f5a4b6bf4c47b1d
+GitCommit: 5f3401da91ad5ced550efd53983695bf45765176
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.4, 3.7.4, v3.7, 3.7, langres, v3, 3, latest
+Tags: v3.7.5, 3.7.5, v3.7, 3.7, langres, v3, 3, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: a2003ee1d14afe94d0e35a2e8f5a4b6bf4c47b1d
+GitCommit: 5f3401da91ad5ced550efd53983695bf45765176
 Directory: v3.7/alpine
 
-Tags: v3.6.20-windowsservercore-ltsc2025, 3.6.20-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
+Tags: v3.6.21-windowsservercore-ltsc2025, 3.6.21-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 16579e1b53aa3b07183b5feb79ed0a4b0ef060ab
+GitCommit: 63000f87a98158eaf640ae282ca026f5e43d0923
 Directory: v3.6/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.6.20-windowsservercore-ltsc2022, 3.6.20-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
+Tags: v3.6.21-windowsservercore-ltsc2022, 3.6.21-windowsservercore-ltsc2022, v3.6-windowsservercore-ltsc2022, 3.6-windowsservercore-ltsc2022, ramequin-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 16579e1b53aa3b07183b5feb79ed0a4b0ef060ab
+GitCommit: 63000f87a98158eaf640ae282ca026f5e43d0923
 Directory: v3.6/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.6.20-nanoserver-ltsc2025, 3.6.20-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
+Tags: v3.6.21-nanoserver-ltsc2025, 3.6.21-nanoserver-ltsc2025, v3.6-nanoserver-ltsc2025, 3.6-nanoserver-ltsc2025, ramequin-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 16579e1b53aa3b07183b5feb79ed0a4b0ef060ab
+GitCommit: 63000f87a98158eaf640ae282ca026f5e43d0923
 Directory: v3.6/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.6.20-nanoserver-ltsc2022, 3.6.20-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
+Tags: v3.6.21-nanoserver-ltsc2022, 3.6.21-nanoserver-ltsc2022, v3.6-nanoserver-ltsc2022, 3.6-nanoserver-ltsc2022, ramequin-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 16579e1b53aa3b07183b5feb79ed0a4b0ef060ab
+GitCommit: 63000f87a98158eaf640ae282ca026f5e43d0923
 Directory: v3.6/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.6.20, 3.6.20, v3.6, 3.6, ramequin
+Tags: v3.6.21, 3.6.21, v3.6, 3.6, ramequin
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 16579e1b53aa3b07183b5feb79ed0a4b0ef060ab
+GitCommit: 63000f87a98158eaf640ae282ca026f5e43d0923
 Directory: v3.6/alpine
 
-Tags: v2.11.49-windowsservercore-ltsc2025, 2.11.49-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025
+Tags: v2.11.50-windowsservercore-ltsc2025, 2.11.50-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: edb31b48b1546cd8a2023e7a780717c345f56b0a
+GitCommit: 2c28299e3b792dab738c83005ef3847545a9ef88
 Directory: v2.11/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v2.11.49-windowsservercore-ltsc2022, 2.11.49-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
+Tags: v2.11.50-windowsservercore-ltsc2022, 2.11.50-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: edb31b48b1546cd8a2023e7a780717c345f56b0a
+GitCommit: 2c28299e3b792dab738c83005ef3847545a9ef88
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.49-nanoserver-ltsc2025, 2.11.49-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025
+Tags: v2.11.50-nanoserver-ltsc2025, 2.11.50-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: edb31b48b1546cd8a2023e7a780717c345f56b0a
+GitCommit: 2c28299e3b792dab738c83005ef3847545a9ef88
 Directory: v2.11/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v2.11.49-nanoserver-ltsc2022, 2.11.49-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
+Tags: v2.11.50-nanoserver-ltsc2022, 2.11.50-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: edb31b48b1546cd8a2023e7a780717c345f56b0a
+GitCommit: 2c28299e3b792dab738c83005ef3847545a9ef88
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.49, 2.11.49, v2.11, 2.11, mimolette, v2, 2
+Tags: v2.11.50, 2.11.50, v2.11, 2.11, mimolette, v2, 2
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: edb31b48b1546cd8a2023e7a780717c345f56b0a
+GitCommit: 2c28299e3b792dab738c83005ef3847545a9ef88
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to:
- [v3.7.5](https://github.com/traefik/traefik/releases/tag/v3.7.5)
- [v3.6.21](https://github.com/traefik/traefik/releases/tag/v3.6.21)
- [v2.11.50](https://github.com/traefik/traefik/releases/tag/v2.11.50)

/cc @kevinpollet @mmatur @rtribotte

Cheers
