### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -9,9 +9,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: d38caa309841e22343e5e689ba738b6ea4f74aca
 Directory: 3.4
 
-Tags: 3.4.0-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.0-alpine3.23, 3.4-alpine3.23, alpine3.23, lts-alpine3.23
+Tags: 3.4.0-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.0-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d38caa309841e22343e5e689ba738b6ea4f74aca
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 3.4/alpine
 
 Tags: 3.3.10, 3.3, 3.3.10-trixie, 3.3-trixie
@@ -19,9 +19,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
 Directory: 3.3
 
-Tags: 3.3.10-alpine, 3.3-alpine, 3.3.10-alpine3.23, 3.3-alpine3.23
+Tags: 3.3.10-alpine, 3.3-alpine, 3.3.10-alpine3.24, 3.3-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 3.3/alpine
 
 Tags: 3.2.19, 3.2, 3.2.19-trixie, 3.2-trixie
@@ -29,9 +29,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
 Directory: 3.2
 
-Tags: 3.2.19-alpine, 3.2-alpine, 3.2.19-alpine3.23, 3.2-alpine3.23
+Tags: 3.2.19-alpine, 3.2-alpine, 3.2.19-alpine3.24, 3.2-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 3.2/alpine
 
 Tags: 3.0.23, 3.0, 3.0.23-trixie, 3.0-trixie
@@ -39,9 +39,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 1fe6009a5f5b568ddac086d99a7d23809ea7f036
 Directory: 3.0
 
-Tags: 3.0.23-alpine, 3.0-alpine, 3.0.23-alpine3.23, 3.0-alpine3.23
+Tags: 3.0.23-alpine, 3.0-alpine, 3.0.23-alpine3.24, 3.0-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1fe6009a5f5b568ddac086d99a7d23809ea7f036
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 3.0/alpine
 
 Tags: 2.8.24, 2.8, 2.8.24-trixie, 2.8-trixie
@@ -49,9 +49,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 288da6fb5e44d5fadc572917b3c2bcad8811875c
 Directory: 2.8
 
-Tags: 2.8.24-alpine, 2.8-alpine, 2.8.24-alpine3.23, 2.8-alpine3.23
+Tags: 2.8.24-alpine, 2.8-alpine, 2.8.24-alpine3.24, 2.8-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 288da6fb5e44d5fadc572917b3c2bcad8811875c
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 2.8/alpine
 
 Tags: 2.6.29, 2.6, 2.6.29-trixie, 2.6-trixie
@@ -59,9 +59,9 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 669c5af611989a3396923ae0b655b0ca644f8a86
 Directory: 2.6
 
-Tags: 2.6.29-alpine, 2.6-alpine, 2.6.29-alpine3.23, 2.6-alpine3.23
+Tags: 2.6.29-alpine, 2.6-alpine, 2.6.29-alpine3.24, 2.6-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 669c5af611989a3396923ae0b655b0ca644f8a86
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 2.6/alpine
 
 Tags: 2.4.35, 2.4, 2.4.35-trixie, 2.4-trixie
@@ -69,7 +69,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 6eda5ce996d9ffb3f7a6ed352dd7f61580100a26
 Directory: 2.4
 
-Tags: 2.4.35-alpine, 2.4-alpine, 2.4.35-alpine3.23, 2.4-alpine3.23
+Tags: 2.4.35-alpine, 2.4-alpine, 2.4.35-alpine3.24, 2.4-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6eda5ce996d9ffb3f7a6ed352dd7f61580100a26
+GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/18ff1c7: Merge pull request https://github.com/docker-library/haproxy/pull/262 from J0WI/alpine-3.24
- https://github.com/docker-library/haproxy/commit/992c9a8: Update Alpine to 3.24