### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -11,12 +11,12 @@ GitCommit: 24fb071be01a0e6241fbbabd59a3dd07d31b80f5
 Directory: 16
 # Docker EOL: 2027-10-30
 
-# Last Modified: 2025-08-08
-Tags: 15.2.0, 15.2, 15, 15.2.0-trixie, 15.2-trixie, 15-trixie
+# Last Modified: 2026-06-12
+Tags: 15.3.0, 15.3, 15, 15.3.0-trixie, 15.3-trixie, 15-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 915af5ccbb6b09575e244f280c26925e77172039
+GitCommit: 3b87fe3e286f7aa21ed5d69fd5c39e1b4fb02057
 Directory: 15
-# Docker EOL: 2027-02-08
+# Docker EOL: 2027-12-12
 
 # Last Modified: 2025-05-23
 Tags: 14.3.0, 14.3, 14, 14.3.0-trixie, 14.3-trixie, 14-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/3b87fe3: Update 15 to 15.3.0
- https://github.com/docker-library/gcc/commit/89a8c2e: Merge pull request https://github.com/docker-library/gcc/pull/117 from pauldreik/fix_deprecated_node_warning