### PR TITLE
[security] Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -4,110 +4,110 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mongo.git
 
-Tags: 8.3.3-noble, 8.3-noble
-SharedTags: 8.3.3, 8.3
+Tags: 8.3.4-noble, 8.3-noble
+SharedTags: 8.3.4, 8.3
 Architectures: amd64, arm64v8
-GitCommit: 53eaf619cf4f809a1deb11187216db82a4accf46
+GitCommit: 2c69a57b939afb99266e8f97258adb178e9559e0
 Directory: 8.3
 
-Tags: 8.3.3-windowsservercore-ltsc2025, 8.3-windowsservercore-ltsc2025
-SharedTags: 8.3.3-windowsservercore, 8.3-windowsservercore, 8.3.3, 8.3
+Tags: 8.3.4-windowsservercore-ltsc2025, 8.3-windowsservercore-ltsc2025
+SharedTags: 8.3.4-windowsservercore, 8.3-windowsservercore, 8.3.4, 8.3
 Architectures: windows-amd64
-GitCommit: 53eaf619cf4f809a1deb11187216db82a4accf46
+GitCommit: 2c69a57b939afb99266e8f97258adb178e9559e0
 Directory: 8.3/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8.3.3-windowsservercore-ltsc2022, 8.3-windowsservercore-ltsc2022
-SharedTags: 8.3.3-windowsservercore, 8.3-windowsservercore, 8.3.3, 8.3
+Tags: 8.3.4-windowsservercore-ltsc2022, 8.3-windowsservercore-ltsc2022
+SharedTags: 8.3.4-windowsservercore, 8.3-windowsservercore, 8.3.4, 8.3
 Architectures: windows-amd64
-GitCommit: 53eaf619cf4f809a1deb11187216db82a4accf46
+GitCommit: 2c69a57b939afb99266e8f97258adb178e9559e0
 Directory: 8.3/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8.3.3-nanoserver-ltsc2022, 8.3-nanoserver-ltsc2022
-SharedTags: 8.3.3-nanoserver, 8.3-nanoserver
+Tags: 8.3.4-nanoserver-ltsc2022, 8.3-nanoserver-ltsc2022
+SharedTags: 8.3.4-nanoserver, 8.3-nanoserver
 Architectures: windows-amd64
-GitCommit: 53eaf619cf4f809a1deb11187216db82a4accf46
+GitCommit: 2c69a57b939afb99266e8f97258adb178e9559e0
 Directory: 8.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8.2.10-noble, 8.2-noble, 8-noble, noble
-SharedTags: 8.2.10, 8.2, 8, latest
+Tags: 8.2.11-noble, 8.2-noble, 8-noble, noble
+SharedTags: 8.2.11, 8.2, 8, latest
 Architectures: amd64, arm64v8
-GitCommit: a7ed6548919e1d29303b99daabecf3ba6a26fd95
+GitCommit: a8cac75a3a6fedc2ce048069a862a9bcb07cd69f
 Directory: 8.2
 
-Tags: 8.2.10-windowsservercore-ltsc2025, 8.2-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 8.2.10-windowsservercore, 8.2-windowsservercore, 8-windowsservercore, windowsservercore, 8.2.10, 8.2, 8, latest
+Tags: 8.2.11-windowsservercore-ltsc2025, 8.2-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 8.2.11-windowsservercore, 8.2-windowsservercore, 8-windowsservercore, windowsservercore, 8.2.11, 8.2, 8, latest
 Architectures: windows-amd64
-GitCommit: a7ed6548919e1d29303b99daabecf3ba6a26fd95
+GitCommit: a8cac75a3a6fedc2ce048069a862a9bcb07cd69f
 Directory: 8.2/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8.2.10-windowsservercore-ltsc2022, 8.2-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 8.2.10-windowsservercore, 8.2-windowsservercore, 8-windowsservercore, windowsservercore, 8.2.10, 8.2, 8, latest
+Tags: 8.2.11-windowsservercore-ltsc2022, 8.2-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 8.2.11-windowsservercore, 8.2-windowsservercore, 8-windowsservercore, windowsservercore, 8.2.11, 8.2, 8, latest
 Architectures: windows-amd64
-GitCommit: a7ed6548919e1d29303b99daabecf3ba6a26fd95
+GitCommit: a8cac75a3a6fedc2ce048069a862a9bcb07cd69f
 Directory: 8.2/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8.2.10-nanoserver-ltsc2022, 8.2-nanoserver-ltsc2022, 8-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 8.2.10-nanoserver, 8.2-nanoserver, 8-nanoserver, nanoserver
+Tags: 8.2.11-nanoserver-ltsc2022, 8.2-nanoserver-ltsc2022, 8-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 8.2.11-nanoserver, 8.2-nanoserver, 8-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: a7ed6548919e1d29303b99daabecf3ba6a26fd95
+GitCommit: a8cac75a3a6fedc2ce048069a862a9bcb07cd69f
 Directory: 8.2/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8.0.24-noble, 8.0-noble
-SharedTags: 8.0.24, 8.0
+Tags: 8.0.26-noble, 8.0-noble
+SharedTags: 8.0.26, 8.0
 Architectures: amd64, arm64v8
-GitCommit: 32f61507832cad274a992b2ef44b7762279ca99b
+GitCommit: 962851fd9c12d66f75837dd2844c83369d4ed364
 Directory: 8.0
 
-Tags: 8.0.24-windowsservercore-ltsc2025, 8.0-windowsservercore-ltsc2025
-SharedTags: 8.0.24-windowsservercore, 8.0-windowsservercore, 8.0.24, 8.0
+Tags: 8.0.26-windowsservercore-ltsc2025, 8.0-windowsservercore-ltsc2025
+SharedTags: 8.0.26-windowsservercore, 8.0-windowsservercore, 8.0.26, 8.0
 Architectures: windows-amd64
-GitCommit: 32f61507832cad274a992b2ef44b7762279ca99b
+GitCommit: 962851fd9c12d66f75837dd2844c83369d4ed364
 Directory: 8.0/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 8.0.24-windowsservercore-ltsc2022, 8.0-windowsservercore-ltsc2022
-SharedTags: 8.0.24-windowsservercore, 8.0-windowsservercore, 8.0.24, 8.0
+Tags: 8.0.26-windowsservercore-ltsc2022, 8.0-windowsservercore-ltsc2022
+SharedTags: 8.0.26-windowsservercore, 8.0-windowsservercore, 8.0.26, 8.0
 Architectures: windows-amd64
-GitCommit: 32f61507832cad274a992b2ef44b7762279ca99b
+GitCommit: 962851fd9c12d66f75837dd2844c83369d4ed364
 Directory: 8.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 8.0.24-nanoserver-ltsc2022, 8.0-nanoserver-ltsc2022
-SharedTags: 8.0.24-nanoserver, 8.0-nanoserver
+Tags: 8.0.26-nanoserver-ltsc2022, 8.0-nanoserver-ltsc2022
+SharedTags: 8.0.26-nanoserver, 8.0-nanoserver
 Architectures: windows-amd64
-GitCommit: 32f61507832cad274a992b2ef44b7762279ca99b
+GitCommit: 962851fd9c12d66f75837dd2844c83369d4ed364
 Directory: 8.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 7.0.35-jammy, 7.0-jammy, 7-jammy
-SharedTags: 7.0.35, 7.0, 7
+Tags: 7.0.37-jammy, 7.0-jammy, 7-jammy
+SharedTags: 7.0.37, 7.0, 7
 Architectures: amd64, arm64v8
-GitCommit: afc4834dc3e4e3fc8a7d99f6f8da91e1135702a4
+GitCommit: b05f3db94d7c2ff82c00c93bc349c0e0e8107569
 Directory: 7.0
 
-Tags: 7.0.35-windowsservercore-ltsc2025, 7.0-windowsservercore-ltsc2025, 7-windowsservercore-ltsc2025
-SharedTags: 7.0.35-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.35, 7.0, 7
+Tags: 7.0.37-windowsservercore-ltsc2025, 7.0-windowsservercore-ltsc2025, 7-windowsservercore-ltsc2025
+SharedTags: 7.0.37-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.37, 7.0, 7
 Architectures: windows-amd64
-GitCommit: afc4834dc3e4e3fc8a7d99f6f8da91e1135702a4
+GitCommit: b05f3db94d7c2ff82c00c93bc349c0e0e8107569
 Directory: 7.0/windows/windowsservercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: 7.0.35-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022, 7-windowsservercore-ltsc2022
-SharedTags: 7.0.35-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.35, 7.0, 7
+Tags: 7.0.37-windowsservercore-ltsc2022, 7.0-windowsservercore-ltsc2022, 7-windowsservercore-ltsc2022
+SharedTags: 7.0.37-windowsservercore, 7.0-windowsservercore, 7-windowsservercore, 7.0.37, 7.0, 7
 Architectures: windows-amd64
-GitCommit: afc4834dc3e4e3fc8a7d99f6f8da91e1135702a4
+GitCommit: b05f3db94d7c2ff82c00c93bc349c0e0e8107569
 Directory: 7.0/windows/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 7.0.35-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7-nanoserver-ltsc2022
-SharedTags: 7.0.35-nanoserver, 7.0-nanoserver, 7-nanoserver
+Tags: 7.0.37-nanoserver-ltsc2022, 7.0-nanoserver-ltsc2022, 7-nanoserver-ltsc2022
+SharedTags: 7.0.37-nanoserver, 7.0-nanoserver, 7-nanoserver
 Architectures: windows-amd64
-GitCommit: afc4834dc3e4e3fc8a7d99f6f8da91e1135702a4
+GitCommit: b05f3db94d7c2ff82c00c93bc349c0e0e8107569
 Directory: 7.0/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/2c69a57: Update 8.3 to 8.3.4
- https://github.com/docker-library/mongo/commit/a8cac75: Update 8.2 to 8.2.11
- https://github.com/docker-library/mongo/commit/962851f: Update 8.0 to 8.0.26
- https://github.com/docker-library/mongo/commit/b05f3db: Update 7.0 to 7.0.37

MongoDB 8.3.4, 8.2.11, 8.0.26, and 7.0.37 contains a fix for [CVE-2026-11933](https://www.cve.org/CVERecord?id=CVE-2026-11933). See also https://www.mongodb.com/docs/manual/release-notes/