### PR TITLE
archlinux: Release 20260614.0.544538

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260607.0.541780
-GitCommit: 042993c2d1b622a2fe40e4305e545d012118b47c
-GitFetch: refs/tags/v20260607.0.541780
+Tags: latest, base, base-20260614.0.544538
+GitCommit: 68cb260d0d6a46894542d8194b3fbcb9bb0a6e06
+GitFetch: refs/tags/v20260614.0.544538
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260607.0.541780
-GitCommit: 042993c2d1b622a2fe40e4305e545d012118b47c
-GitFetch: refs/tags/v20260607.0.541780
+Tags: base-devel, base-devel-20260614.0.544538
+GitCommit: 68cb260d0d6a46894542d8194b3fbcb9bb0a6e06
+GitFetch: refs/tags/v20260614.0.544538
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260607.0.541780
-GitCommit: 042993c2d1b622a2fe40e4305e545d012118b47c
-GitFetch: refs/tags/v20260607.0.541780
+Tags: multilib-devel, multilib-devel-20260614.0.544538
+GitCommit: 68cb260d0d6a46894542d8194b3fbcb9bb0a6e06
+GitFetch: refs/tags/v20260614.0.544538
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks