### PR TITLE
alpine: bump to 3.24.1

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -14,10 +14,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.24.0, 3.24, 3, latest
+Tags: 3.24.1, 3.24, 3, latest
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.24
-GitCommit: a60f0dddfb2941ccbac3107563aae1f1956392a9
+GitCommit: 398ff0c866d27e9f46f53e48184fe36c674b8897
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
security fixes in OpenSSL:

- CVE-2026-45447
- CVE-2026-34182
- CVE-2026-34183
- CVE-2026-42764
- CVE-2026-45445
- CVE-2026-7383
- CVE-2026-9076
- CVE-2026-34180
- CVE-2026-34181
- CVE-2026-42766
- CVE-2026-42767
- CVE-2026-42768
- CVE-2026-42769
- CVE-2026-42770
- CVE-2026-45446