### PR TITLE
Update influxdb3 to 3.10

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: e44695c822e78059d0dfbaf6c5c25840f37488d1
+GitCommit: ddd58c7ba3c15041c5909d54efcf11db322d8250
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -62,10 +62,10 @@ Tags: 2-alpine, 2.9-alpine, 2.9.1-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.9/alpine
 
-Tags: 3-core, 3.9-core, 3.9.3-core, core
+Tags: 3-core, 3.10-core, 3.10.0-core, core
 Architectures: amd64, arm64v8
-Directory: influxdb/3.9-core
+Directory: influxdb/3.10-core
 
-Tags: 3-enterprise, 3.9-enterprise, 3.9.3-enterprise, enterprise
+Tags: 3-enterprise, 3.10-enterprise, 3.10.0-enterprise, enterprise
 Architectures: amd64, arm64v8
-Directory: influxdb/3.9-enterprise
+Directory: influxdb/3.10-enterprise


### PR DESCRIPTION
Updates the `influxdb3` core and enterprise images to `3.10.0`.

- `GitCommit` bumped to `ddd58c7ba3c15041c5909d54efcf11db322d8250` (influxdata/influxdata-docker), which adds the `influxdb/3.10-core` and `influxdb/3.10-enterprise` directories and bumps the `1.11-alpine`, `1.11-data-alpine`, and `1.11-meta-alpine` images to base off of `alpine:3.21`.
- `3-core`/`core` and `3-enterprise`/`enterprise` tags now point at 3.10.0.