### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.11.20260526.0
+Tags: 2023, latest, 2023.12.20260611.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 7a3381c4ef8fe16ab35a945953866e8e39076c34
+amd64-GitCommit: 155ddfdddc02656a3d6695f946bb80277e432d6e
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 217905a823d5e51a8c0e7ee8b01aec8ea1011905
+arm64v8-GitCommit: f21c34c153c99f17b2527e034ad7cfee7aeb5dc3
 
-Tags: 2, 2.0.20260526.0
+Tags: 2, 2.0.20260615.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0e6504b2ff6c0c49c2397bf7248ca28c35dc3ebe
+amd64-GitCommit: 0ee39270804fae19e26aea192fc7d8adce4f7dfa
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a76034b3fcc66f9f9aa39ad5c4493f10b82d853d
+arm64v8-GitCommit: 40c91041ac70ef649c2b389bcf7daea700dbb884
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- libssh2-1.4.3-12.amzn2.2.7

Packages addressing CVES:
- libssh2-1.4.3-12.amzn2.2.7
  - [CVE-2026-7598](https://alas.aws.amazon.com/cve/html/CVE-2026-7598.html)

Updated Packages for Amazon Linux 2023:
- python3-libs-3.9.25-1.amzn2023.0.6
- libsolv-0.7.22-1.amzn2023.0.4
- amazon-linux-repo-cdn-2023.12.20260611-0.amzn2023
- system-release-2023.12.20260611-0.amzn2023
- crypto-policies-20260224-1.gitea0f072.amzn2023.0.4
- python3-3.9.25-1.amzn2023.0.6

Packages addressing CVES:
- python3-libs-3.9.25-1.amzn2023.0.6, python3-3.9.25-1.amzn2023.0.6
  - [CVE-2026-6019](https://alas.aws.amazon.com/cve/html/CVE-2026-6019.html)
- libsolv-0.7.22-1.amzn2023.0.4
  - [CVE-2026-48863](https://alas.aws.amazon.com/cve/html/CVE-2026-48863.html)
  - [CVE-2026-48864](https://alas.aws.amazon.com/cve/html/CVE-2026-48864.html)
  - [CVE-2026-9149](https://alas.aws.amazon.com/cve/html/CVE-2026-9149.html)
  - [CVE-2026-9150](https://alas.aws.amazon.com/cve/html/CVE-2026-9150.html)