### PR TITLE
archlinux: Release 20260621.0.546891

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260614.0.544538
-GitCommit: 68cb260d0d6a46894542d8194b3fbcb9bb0a6e06
-GitFetch: refs/tags/v20260614.0.544538
+Tags: latest, base, base-20260621.0.546891
+GitCommit: a2d95eaa190659feba8af28d69d0106bf2a3077e
+GitFetch: refs/tags/v20260621.0.546891
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260614.0.544538
-GitCommit: 68cb260d0d6a46894542d8194b3fbcb9bb0a6e06
-GitFetch: refs/tags/v20260614.0.544538
+Tags: base-devel, base-devel-20260621.0.546891
+GitCommit: a2d95eaa190659feba8af28d69d0106bf2a3077e
+GitFetch: refs/tags/v20260621.0.546891
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260614.0.544538
-GitCommit: 68cb260d0d6a46894542d8194b3fbcb9bb0a6e06
-GitFetch: refs/tags/v20260614.0.544538
+Tags: multilib-devel, multilib-devel-20260621.0.546891
+GitCommit: a2d95eaa190659feba8af28d69d0106bf2a3077e
+GitFetch: refs/tags/v20260621.0.546891
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks