### PR TITLE
alpine: security bump 3.22.5 and 3.23.5

### DIFF
--- a/library/alpine
+++ b/library/alpine
@@ -27,10 +27,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.23.4, 3.23
+Tags: 3.23.5, 3.23
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.23
-GitCommit: c68e08480b8fb053591ade7dbaffa2ea67db2f56
+GitCommit: 4ad948cca27e7a605aa63ae1c59c22081a2c6d13
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/
@@ -40,10 +40,10 @@ s390x-Directory: s390x/
 i386-Directory: x86/
 amd64-Directory: x86_64/
 
-Tags: 3.22.4, 3.22
+Tags: 3.22.5, 3.22
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, riscv64, s390x, i386, amd64
 GitFetch: refs/heads/v3.22
-GitCommit: ce1b9f141bbd2d604064cae6a3f5309b4a2a40b9
+GitCommit: aff8a4cfde38012a59285f21c8820777acd6033b
 arm64v8-Directory: aarch64/
 arm32v6-Directory: armhf/
 arm32v7-Directory: armv7/


### PR DESCRIPTION
Fixes OpenSSL:

- CVE-2026-34180
- CVE-2026-34181
- CVE-2026-34182
- CVE-2026-34183
- CVE-2026-42764
- CVE-2026-42766
- CVE-2026-42767
- CVE-2026-42768
- CVE-2026-42769
- CVE-2026-42770
- CVE-2026-45445
- CVE-2026-45446
- CVE-2026-45447
- CVE-2026-7383
- CVE-2026-9076