### PR TITLE
Update redmine

### DIFF
--- a/library/redmine
+++ b/library/redmine
@@ -4,42 +4,42 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/redmine.git
 
-Tags: 6.1.2, 6.1, 6, latest, 6.1.2-trixie, 6.1-trixie, 6-trixie, trixie
+Tags: 6.1.3, 6.1, 6, latest, 6.1.3-trixie, 6.1-trixie, 6-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
+GitCommit: 4e7d7ad67b47d3a0d9d1d22379141a8be0fae2ee
 Directory: 6.1/trixie
 
-Tags: 6.1.2-bookworm, 6.1-bookworm, 6-bookworm, bookworm
+Tags: 6.1.3-bookworm, 6.1-bookworm, 6-bookworm, bookworm
 Architectures: amd64, arm64v8
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
+GitCommit: 4e7d7ad67b47d3a0d9d1d22379141a8be0fae2ee
 Directory: 6.1/bookworm
 
-Tags: 6.1.2-alpine3.23, 6.1-alpine3.23, 6-alpine3.23, alpine3.23, 6.1.2-alpine, 6.1-alpine, 6-alpine, alpine
+Tags: 6.1.3-alpine3.24, 6.1-alpine3.24, 6-alpine3.24, alpine3.24, 6.1.3-alpine, 6.1-alpine, 6-alpine, alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
+GitCommit: cd64642854837245a4d8e0125e85c9ec9f33bf01
+Directory: 6.1/alpine3.24
+
+Tags: 6.1.3-alpine3.23, 6.1-alpine3.23, 6-alpine3.23, alpine3.23
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: cd64642854837245a4d8e0125e85c9ec9f33bf01
 Directory: 6.1/alpine3.23
 
-Tags: 6.1.2-alpine3.22, 6.1-alpine3.22, 6-alpine3.22, alpine3.22
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
-Directory: 6.1/alpine3.22
-
-Tags: 6.0.9, 6.0, 6.0.9-trixie, 6.0-trixie
+Tags: 6.0.10, 6.0, 6.0.10-trixie, 6.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
+GitCommit: 4e7d7ad67b47d3a0d9d1d22379141a8be0fae2ee
 Directory: 6.0/trixie
 
-Tags: 6.0.9-bookworm, 6.0-bookworm
+Tags: 6.0.10-bookworm, 6.0-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
+GitCommit: 4e7d7ad67b47d3a0d9d1d22379141a8be0fae2ee
 Directory: 6.0/bookworm
 
-Tags: 6.0.9-alpine3.23, 6.0-alpine3.23, 6.0.9-alpine, 6.0-alpine
+Tags: 6.0.10-alpine3.24, 6.0-alpine3.24, 6.0.10-alpine, 6.0-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
-Directory: 6.0/alpine3.23
+GitCommit: cd64642854837245a4d8e0125e85c9ec9f33bf01
+Directory: 6.0/alpine3.24
 
-Tags: 6.0.9-alpine3.22, 6.0-alpine3.22
+Tags: 6.0.10-alpine3.23, 6.0-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0b2add6effd42b4c132ebe726aa4e1fb6a6e8991
-Directory: 6.0/alpine3.22
+GitCommit: cd64642854837245a4d8e0125e85c9ec9f33bf01
+Directory: 6.0/alpine3.23


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/redmine/commit/4e7d7ad: Fix failing arm32v5 builds (https://github.com/docker-library/redmine/pull/419)
- https://github.com/docker-library/redmine/commit/52417b1: Merge pull request https://github.com/docker-library/redmine/pull/420 from infosiftr/alpine
- https://github.com/docker-library/redmine/commit/cd64642: Update to Alpine 3.24