### PR TITLE
Apache CouchDB 3.5.2.1

### DIFF
--- a/library/couchdb
+++ b/library/couchdb
@@ -4,15 +4,15 @@
 Maintainers: Ronny Berndt <ronny@apache.org> (@big-r81), Jan Lehnardt <jan@apache.org> (@janl), Nick Vatamaniuc (@nickva)
 GitRepo: https://github.com/apache/couchdb-docker
 GitFetch: refs/heads/main
-GitCommit: adcb4f73e8a3c6fb0e901ab88cab50d71f02937a
+GitCommit: a76020b130d5d2e2a0e54f9437d90d35652b8707
 
-Tags: latest, 3.5.2, 3.5, 3
+Tags: latest, 3.5.2.1, 3.5.2, 3.5, 3
 Architectures: amd64, arm64v8
-Directory: 3.5.2
+Directory: 3.5.2.1
 
-Tags: 3.5.2-nouveau, 3.5-nouveau, 3-nouveau
+Tags: 3.5.2.1-nouveau, 3.5.2-nouveau, 3.5-nouveau, 3-nouveau
 Architectures: amd64, arm64v8
-Directory: 3.5.2-nouveau
+Directory: 3.5.2.1-nouveau
 
 Tags: 3.4.3, 3.4
 Architectures: amd64, arm64v8, s390x


### PR DESCRIPTION
This is packaging only update:

 * Erlang 26 update https://www.erlang.org/patches/OTP-26.2.5.21 which fixes a few CVEs (CVE-2026-42789, CVE-2026-42790)

 * Nouveau not starting fix systemd https://github.com/apache/couchdb/issues/6041