### PR TITLE
[oraclelinux]: Release Oracle Linux 9 Update 8 for 9, 9-slim, 9-slim-fips

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 0218ab4ba2f820b1b978dcc5a76435040397a472
+amd64-GitCommit: 9497981f921007232f98432b0d7dc19565c38eef
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1793f77944bb75a34575d594c6ce680a4e6cbba0
+arm64v8-GitCommit: cc6dc1fc67912c0b1c79a9241be4499efb1f06ae
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
[oraclelinux]: Release Oracle Linux 9 Update 8

Oracle Linux 9 Update 8
https://docs.oracle.com/en/operating-systems/oracle-linux/9/relnotes9.8/

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
