### PR TITLE
Update r-base to 4.6.1 released this morning

### DIFF
--- a/library/r-base
+++ b/library/r-base
@@ -2,8 +2,8 @@ Maintainers: Carl Boettiger <rocker-maintainers@eddelbuettel.com> (@cboettig),
              Dirk Eddelbuettel <rocker-maintainers@eddelbuettel.com> (@eddelbuettel)
 GitRepo: https://github.com/rocker-org/rocker.git
 
-Tags: 4.6.0, latest
+Tags: 4.6.1, latest
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 353d611b3ee5457b645f322f819eda32255a03ac
-Directory: r-base/4.6.0
+GitCommit: 869a1219d7251e433434279bda43b3ae62f68df8
+Directory: r-base/4.6.1
 


### PR DESCRIPTION
Standard update to the new R release made by upstream this morning, and using the Debian (unstable) package prepared earlier today as well.

No changes in the container setup or build besides the upgrade from R 4.6.0 to R 4.6.1, and with the commit in our repo correctly including referenced directory 4.6.1 as well as latest (with identical Dockerfiles).