### PR TITLE
Update oraclelinux-slim for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9497981f921007232f98432b0d7dc19565c38eef
+amd64-GitCommit: 570c54b548ff3bf22fa040e495f5dd2fa7f3b7e5
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: cc6dc1fc67912c0b1c79a9241be4499efb1f06ae
+arm64v8-GitCommit: b3537c830190681a423aecd6b2172a7af2343bd1
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-20587](https://linux.oracle.com/errata/ELSA-2026-20587.html)
- [ELSA-2026-20611](https://linux.oracle.com/errata/ELSA-2026-20611.html)
- [ELSA-2026-22721](https://linux.oracle.com/errata/ELSA-2026-22721.html)
- [ELSA-2026-22730](https://linux.oracle.com/errata/ELSA-2026-22730.html)
- [ELSA-2026-24339](https://linux.oracle.com/errata/ELSA-2026-24339.html)
- [ELSA-2026-26275](https://linux.oracle.com/errata/ELSA-2026-26275.html)
- [ELSA-2026-26354](https://linux.oracle.com/errata/ELSA-2026-26354.html)
- [ELSA-2026-28553](https://linux.oracle.com/errata/ELSA-2026-28553.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
