### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4.0, 3.4, latest, lts, 3.4.0-trixie, 3.4-trixie, trixie, lts-trixie
+Tags: 3.4.1, 3.4, latest, lts, 3.4.1-trixie, 3.4-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d38caa309841e22343e5e689ba738b6ea4f74aca
+GitCommit: b55e8717f90ff1aceae45152431f96bcd025759f
 Directory: 3.4
 
-Tags: 3.4.0-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.0-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
+Tags: 3.4.1-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.1-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: b55e8717f90ff1aceae45152431f96bcd025759f
 Directory: 3.4/alpine
 
 Tags: 3.3.10, 3.3, 3.3.10-trixie, 3.3-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b55e871: Update 3.4 to 3.4.1