### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,54 +14,54 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b55e8717f90ff1aceae45152431f96bcd025759f
 Directory: 3.4/alpine
 
-Tags: 3.3.10, 3.3, 3.3.10-trixie, 3.3-trixie
+Tags: 3.3.11, 3.3, 3.3.11-trixie, 3.3-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 37598dc357dc2740f27aefecd2dd0e2554d3cf02
+GitCommit: fb10b7441a5a3d7b8144aac63e63651b9289376d
 Directory: 3.3
 
-Tags: 3.3.10-alpine, 3.3-alpine, 3.3.10-alpine3.24, 3.3-alpine3.24
+Tags: 3.3.11-alpine, 3.3-alpine, 3.3.11-alpine3.24, 3.3-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: fb10b7441a5a3d7b8144aac63e63651b9289376d
 Directory: 3.3/alpine
 
-Tags: 3.2.19, 3.2, 3.2.19-trixie, 3.2-trixie
+Tags: 3.2.20, 3.2, 3.2.20-trixie, 3.2-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: acd08ed24cd94cc7d8f89fa3f5cca7b7106ff0ca
+GitCommit: 53c0995b8339ba279d5a3615133d7a08ee298b5b
 Directory: 3.2
 
-Tags: 3.2.19-alpine, 3.2-alpine, 3.2.19-alpine3.24, 3.2-alpine3.24
+Tags: 3.2.20-alpine, 3.2-alpine, 3.2.20-alpine3.24, 3.2-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: 53c0995b8339ba279d5a3615133d7a08ee298b5b
 Directory: 3.2/alpine
 
-Tags: 3.0.23, 3.0, 3.0.23-trixie, 3.0-trixie
+Tags: 3.0.24, 3.0, 3.0.24-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 1fe6009a5f5b568ddac086d99a7d23809ea7f036
+GitCommit: 66a40fba9eb7f8d5c60435da9c9a89e89b2be5c0
 Directory: 3.0
 
-Tags: 3.0.23-alpine, 3.0-alpine, 3.0.23-alpine3.24, 3.0-alpine3.24
+Tags: 3.0.24-alpine, 3.0-alpine, 3.0.24-alpine3.24, 3.0-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: 66a40fba9eb7f8d5c60435da9c9a89e89b2be5c0
 Directory: 3.0/alpine
 
-Tags: 2.8.24, 2.8, 2.8.24-trixie, 2.8-trixie
+Tags: 2.8.25, 2.8, 2.8.25-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 288da6fb5e44d5fadc572917b3c2bcad8811875c
+GitCommit: c43ff9857804130b23c99fe33c7d2b34184d8a61
 Directory: 2.8
 
-Tags: 2.8.24-alpine, 2.8-alpine, 2.8.24-alpine3.24, 2.8-alpine3.24
+Tags: 2.8.25-alpine, 2.8-alpine, 2.8.25-alpine3.24, 2.8-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: c43ff9857804130b23c99fe33c7d2b34184d8a61
 Directory: 2.8/alpine
 
-Tags: 2.6.29, 2.6, 2.6.29-trixie, 2.6-trixie
+Tags: 2.6.30, 2.6, 2.6.30-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 669c5af611989a3396923ae0b655b0ca644f8a86
+GitCommit: 8503a6cd1800e447f9cde13857669e99c1fe25dd
 Directory: 2.6
 
-Tags: 2.6.29-alpine, 2.6-alpine, 2.6.29-alpine3.24, 2.6-alpine3.24
+Tags: 2.6.30-alpine, 2.6-alpine, 2.6.30-alpine3.24, 2.6-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: 8503a6cd1800e447f9cde13857669e99c1fe25dd
 Directory: 2.6/alpine
 
 Tags: 2.4.35, 2.4, 2.4.35-trixie, 2.4-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/c43ff98: Update 2.8 to 2.8.25
- https://github.com/docker-library/haproxy/commit/8503a6c: Update 2.6 to 2.6.30
- https://github.com/docker-library/haproxy/commit/fb10b74: Update 3.3 to 3.3.11
- https://github.com/docker-library/haproxy/commit/53c0995: Update 3.2 to 3.2.20
- https://github.com/docker-library/haproxy/commit/66a40fb: Update 3.0 to 3.0.24