### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -18,12 +18,12 @@ GitCommit: 3b87fe3e286f7aa21ed5d69fd5c39e1b4fb02057
 Directory: 15
 # Docker EOL: 2027-12-12
 
-# Last Modified: 2025-05-23
-Tags: 14.3.0, 14.3, 14, 14.3.0-trixie, 14.3-trixie, 14-trixie
+# Last Modified: 2026-06-26
+Tags: 14.4.0, 14.4, 14, 14.4.0-trixie, 14.4-trixie, 14-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 280306a58a2ff0c21a95ed8abe882ac483d03c8b
+GitCommit: d0fb67beca5c8248b88c7e5271ab34b4fdb279a0
 Directory: 14
-# Docker EOL: 2026-11-23
+# Docker EOL: 2027-12-26
 
 # Last Modified: 2025-06-05
 Tags: 13.4.0, 13.4, 13, 13.4.0-bookworm, 13.4-bookworm, 13-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/d0fb67b: Update 14 to 14.4.0