### PR TITLE
archlinux: Release 20260628.0.549485

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260621.0.546891
-GitCommit: a2d95eaa190659feba8af28d69d0106bf2a3077e
-GitFetch: refs/tags/v20260621.0.546891
+Tags: latest, base, base-20260628.0.549485
+GitCommit: b1c9a9ff62e83926fb148b30ae6118da8af1023e
+GitFetch: refs/tags/v20260628.0.549485
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260621.0.546891
-GitCommit: a2d95eaa190659feba8af28d69d0106bf2a3077e
-GitFetch: refs/tags/v20260621.0.546891
+Tags: base-devel, base-devel-20260628.0.549485
+GitCommit: b1c9a9ff62e83926fb148b30ae6118da8af1023e
+GitFetch: refs/tags/v20260628.0.549485
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260621.0.546891
-GitCommit: a2d95eaa190659feba8af28d69d0106bf2a3077e
-GitFetch: refs/tags/v20260621.0.546891
+Tags: multilib-devel, multilib-devel-20260628.0.549485
+GitCommit: b1c9a9ff62e83926fb148b30ae6118da8af1023e
+GitFetch: refs/tags/v20260628.0.549485
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks