### PR TITLE
Mediawiki 1.43.9 / 1.44.6 / 1.45.4

### DIFF
--- a/library/mediawiki
+++ b/library/mediawiki
@@ -3,38 +3,38 @@ Maintainers: Kunal Mehta <legoktm@debian.org> (@legoktm),
              Christian Heusel <christian@heusel.eu> (@christian-heusel)
 GitRepo: https://github.com/wikimedia/mediawiki-docker.git
 GitFetch: refs/heads/main
-GitCommit: 3db09d3ce226d66390ffb868e3f555c471b16338
+GitCommit: a767602deb29a5dad3cc98531c3b86ec621a674e
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le
 
 # current stable version
-Tags: 1.45.3, 1.45, latest, stable
+Tags: 1.45.4, 1.45, latest, stable
 Directory: 1.45/apache
 
-Tags: 1.45.3-fpm, 1.45-fpm, stable-fpm
+Tags: 1.45.4-fpm, 1.45-fpm, stable-fpm
 Directory: 1.45/fpm
 
-Tags: 1.45.3-fpm-alpine, 1.45-fpm-alpine, stable-fpm-alpine
+Tags: 1.45.4-fpm-alpine, 1.45-fpm-alpine, stable-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.45/fpm-alpine
 
 # legacy stable version
-Tags: 1.44.5, 1.44
+Tags: 1.44.6, 1.44
 Directory: 1.44/apache
 
-Tags: 1.44.5-fpm, 1.44-fpm
+Tags: 1.44.6-fpm, 1.44-fpm
 Directory: 1.44/fpm
 
-Tags: 1.44.5-fpm-alpine, 1.44-fpm-alpine
+Tags: 1.44.6-fpm-alpine, 1.44-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.44/fpm-alpine
 
 # current lts version
-Tags: 1.43.8, 1.43, lts
+Tags: 1.43.9, 1.43, lts
 Directory: 1.43/apache
 
-Tags: 1.43.8-fpm, 1.43-fpm, lts-fpm
+Tags: 1.43.9-fpm, 1.43-fpm, lts-fpm
 Directory: 1.43/fpm
 
-Tags: 1.43.8-fpm-alpine, 1.43-fpm-alpine, lts-fpm-alpine
+Tags: 1.43.9-fpm-alpine, 1.43-fpm-alpine, lts-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le
 Directory: 1.43/fpm-alpine


### PR DESCRIPTION
See https://lists.wikimedia.org/hyperkitty/list/mediawiki-announce@lists.wikimedia.org/thread/6JITMBXZ6TXX3MW32BN33Z3JNHPJGJZS/

Related to https://github.com/wikimedia/mediawiki-docker/pull/167
