### PR TITLE
Update Fluentd to v1.19.3

### DIFF
--- a/library/fluentd
+++ b/library/fluentd
@@ -3,7 +3,7 @@ Maintainers: Masahiro Nakagawa <repeatedly@gmail.com> (@repeatedly),
 GitRepo: https://github.com/fluent/fluentd-docker-image.git
 
 # Debian images
-Tags: v1.19.2-debian-1.0, v1.19-debian-1, v1.19.2-1.0, v1.19-1, latest
+Tags: v1.19.3-debian-1.0, v1.19-debian-1, v1.19.3-1.0, v1.19-1, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 162a49598542a981bbf73470f0bba815dc4dbf0e
+GitCommit: 4df4b2131322b81e39ae41a30a2d6231a385fda4
 Directory: v1.19/debian


### PR DESCRIPTION
See https://www.fluentd.org/blog/fluentd-v1.19.3-has-been-released/