### PR TITLE
rust: Update Rust version to 1.96.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,53 +5,53 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.96-bullseye, 1.96.0-bullseye, bullseye
+Tags: 1-bullseye, 1.96-bullseye, 1.96.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.96-slim-bullseye, 1.96.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.96-slim-bullseye, 1.96.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.96-bookworm, 1.96.0-bookworm, bookworm
+Tags: 1-bookworm, 1.96-bookworm, 1.96.1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.96-slim-bookworm, 1.96.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.96-slim-bookworm, 1.96.1-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.96-trixie, 1.96.0-trixie, trixie, 1, 1.96, 1.96.0, latest
+Tags: 1-trixie, 1.96-trixie, 1.96.1-trixie, trixie, 1, 1.96, 1.96.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.96-slim-trixie, 1.96.0-slim-trixie, slim-trixie, 1-slim, 1.96-slim, 1.96.0-slim, slim
+Tags: 1-slim-trixie, 1.96-slim-trixie, 1.96.1-slim-trixie, slim-trixie, 1-slim, 1.96-slim, 1.96.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.21, 1.96-alpine3.21, 1.96.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.96-alpine3.21, 1.96.1-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.96-alpine3.22, 1.96.0-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.96-alpine3.22, 1.96.1-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.96-alpine3.23, 1.96.0-alpine3.23, alpine3.23
+Tags: 1-alpine3.23, 1.96-alpine3.23, 1.96.1-alpine3.23, alpine3.23
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7502a8239b3db41eda6017b17aa50067d140d2a7
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/alpine3.23
 
-Tags: 1-alpine3.24, 1.96-alpine3.24, 1.96.0-alpine3.24, alpine3.24, 1-alpine, 1.96-alpine, 1.96.0-alpine, alpine
+Tags: 1-alpine3.24, 1.96-alpine3.24, 1.96.1-alpine3.24, alpine3.24, 1-alpine, 1.96-alpine, 1.96.1-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 75656a9a1a93c5c8a537af4b9598580f5da9090e
+GitCommit: e40e5306e8f5197fb179b3aa10605f71e6cef670
 Directory: stable/alpine3.24
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.96.1
https://blog.rust-lang.org/2026/06/30/Rust-1.96.1/