### PR TITLE
influxdb3: bump patch release versions for influxdb3 enterprise

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 3a352072ae7f00a450957611c8f076fe2688b496
+GitCommit: 0b0552bd3ccd26316f601bd15194592afdb405dd
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -66,7 +66,7 @@ Tags: 3.9-core, 3.9.6-core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-core
 
-Tags: 3.9-enterprise, 3.9.6-enterprise
+Tags: 3.9-enterprise, 3.9.7-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-enterprise
 
@@ -74,6 +74,6 @@ Tags: 3-core, 3.10-core, 3.10.1-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-core
 
-Tags: 3-enterprise, 3.10-enterprise, 3.10.1-enterprise, enterprise
+Tags: 3-enterprise, 3.10-enterprise, 3.10.2-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-enterprise


### PR DESCRIPTION
- 3.9.7-enterprise
- 3.10.2-enterprise

(note: core is not part of this release)