### PR TITLE
Updating to the latest release of Backdrop CMS 1.34.2

### DIFF
--- a/library/backdrop
+++ b/library/backdrop
@@ -4,12 +4,12 @@ Maintainers: Mike Pirog <mike@kalabox.io> (@pirog),
              Greg Netsas <greg@userfriendly.tech> (@klonos)
 GitRepo: https://github.com/backdrop-ops/backdrop-docker.git
 
-Tags: 1.33.0, 1.33, 1, 1.33.0-apache, 1.33-apache, 1-apache, apache, latest
+Tags: 1.34.2, 1.34, 1, 1.34.2-apache, 1.34-apache, 1-apache, apache, latest
 Architectures: amd64, arm64v8
-GitCommit: 7507205f204226257a3686d581f2a44efa4c998c
+GitCommit: 69d47cd9e593087cfe3de6029613606cdcabc047
 Directory: 1/apache
 
-Tags: 1.33.0-fpm, 1.33-fpm, 1-fpm, fpm
+Tags: 1.34.2-fpm, 1.34-fpm, 1-fpm, fpm
 Architectures: amd64, arm64v8
-GitCommit: 7507205f204226257a3686d581f2a44efa4c998c
+GitCommit: 69d47cd9e593087cfe3de6029613606cdcabc047
 Directory: 1/fpm


### PR DESCRIPTION
Update backdrop to 1.34.2

Here's the latest release of Backdrop:
https://github.com/backdrop/backdrop/releases/tag/1.34.2

Here's the latest commit to backdrop-docker repo
https://github.com/backdrop-ops/backdrop-docker/commits/master