### PR TITLE
[security] Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -4,6 +4,76 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
+Tags: 8.6.0alpha1-cli-trixie, 8.6-rc-cli-trixie, 8.6.0alpha1-trixie, 8.6-rc-trixie, 8.6.0alpha1-cli, 8.6-rc-cli, 8.6.0alpha1, 8.6-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/trixie/cli
+
+Tags: 8.6.0alpha1-apache-trixie, 8.6-rc-apache-trixie, 8.6.0alpha1-apache, 8.6-rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/trixie/apache
+
+Tags: 8.6.0alpha1-fpm-trixie, 8.6-rc-fpm-trixie, 8.6.0alpha1-fpm, 8.6-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/trixie/fpm
+
+Tags: 8.6.0alpha1-zts-trixie, 8.6-rc-zts-trixie, 8.6.0alpha1-zts, 8.6-rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/trixie/zts
+
+Tags: 8.6.0alpha1-cli-bookworm, 8.6-rc-cli-bookworm, 8.6.0alpha1-bookworm, 8.6-rc-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/bookworm/cli
+
+Tags: 8.6.0alpha1-apache-bookworm, 8.6-rc-apache-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/bookworm/apache
+
+Tags: 8.6.0alpha1-fpm-bookworm, 8.6-rc-fpm-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/bookworm/fpm
+
+Tags: 8.6.0alpha1-zts-bookworm, 8.6-rc-zts-bookworm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/bookworm/zts
+
+Tags: 8.6.0alpha1-cli-alpine3.24, 8.6-rc-cli-alpine3.24, 8.6.0alpha1-alpine3.24, 8.6-rc-alpine3.24, 8.6.0alpha1-cli-alpine, 8.6-rc-cli-alpine, 8.6.0alpha1-alpine, 8.6-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/alpine3.24/cli
+
+Tags: 8.6.0alpha1-fpm-alpine3.24, 8.6-rc-fpm-alpine3.24, 8.6.0alpha1-fpm-alpine, 8.6-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/alpine3.24/fpm
+
+Tags: 8.6.0alpha1-zts-alpine3.24, 8.6-rc-zts-alpine3.24, 8.6.0alpha1-zts-alpine, 8.6-rc-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/alpine3.24/zts
+
+Tags: 8.6.0alpha1-cli-alpine3.23, 8.6-rc-cli-alpine3.23, 8.6.0alpha1-alpine3.23, 8.6-rc-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/alpine3.23/cli
+
+Tags: 8.6.0alpha1-fpm-alpine3.23, 8.6-rc-fpm-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/alpine3.23/fpm
+
+Tags: 8.6.0alpha1-zts-alpine3.23, 8.6-rc-zts-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 2f6224c17e0b4481e1a7d495efaa3d4c0358fc84
+Directory: 8.6-rc/alpine3.23/zts
+
 Tags: 8.5.8RC1-cli-trixie, 8.5-rc-cli-trixie, 8.5.8RC1-trixie, 8.5-rc-trixie, 8.5.8RC1-cli, 8.5-rc-cli, 8.5.8RC1, 8.5-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3f76c8d02d363f364cb10df65769f9cd9658b275
@@ -144,282 +214,212 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: a2991ff649b8ce7571dfcc5c9a1c17ece6819ee9
 Directory: 8.5/alpine3.23/zts
 
-Tags: 8.4.23RC1-cli-trixie, 8.4-rc-cli-trixie, 8.4.23RC1-trixie, 8.4-rc-trixie, 8.4.23RC1-cli, 8.4-rc-cli, 8.4.23RC1, 8.4-rc
+Tags: 8.4.23-cli-trixie, 8.4-cli-trixie, 8.4.23-trixie, 8.4-trixie, 8.4.23-cli, 8.4-cli, 8.4.23, 8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/trixie/cli
-
-Tags: 8.4.23RC1-apache-trixie, 8.4-rc-apache-trixie, 8.4.23RC1-apache, 8.4-rc-apache
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/trixie/apache
-
-Tags: 8.4.23RC1-fpm-trixie, 8.4-rc-fpm-trixie, 8.4.23RC1-fpm, 8.4-rc-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/trixie/fpm
-
-Tags: 8.4.23RC1-zts-trixie, 8.4-rc-zts-trixie, 8.4.23RC1-zts, 8.4-rc-zts
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/trixie/zts
-
-Tags: 8.4.23RC1-cli-bookworm, 8.4-rc-cli-bookworm, 8.4.23RC1-bookworm, 8.4-rc-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/bookworm/cli
-
-Tags: 8.4.23RC1-apache-bookworm, 8.4-rc-apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/bookworm/apache
-
-Tags: 8.4.23RC1-fpm-bookworm, 8.4-rc-fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/bookworm/fpm
-
-Tags: 8.4.23RC1-zts-bookworm, 8.4-rc-zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/bookworm/zts
-
-Tags: 8.4.23RC1-cli-alpine3.24, 8.4-rc-cli-alpine3.24, 8.4.23RC1-alpine3.24, 8.4-rc-alpine3.24, 8.4.23RC1-cli-alpine, 8.4-rc-cli-alpine, 8.4.23RC1-alpine, 8.4-rc-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/alpine3.24/cli
-
-Tags: 8.4.23RC1-fpm-alpine3.24, 8.4-rc-fpm-alpine3.24, 8.4.23RC1-fpm-alpine, 8.4-rc-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/alpine3.24/fpm
-
-Tags: 8.4.23RC1-zts-alpine3.24, 8.4-rc-zts-alpine3.24, 8.4.23RC1-zts-alpine, 8.4-rc-zts-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/alpine3.24/zts
-
-Tags: 8.4.23RC1-cli-alpine3.23, 8.4-rc-cli-alpine3.23, 8.4.23RC1-alpine3.23, 8.4-rc-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/alpine3.23/cli
-
-Tags: 8.4.23RC1-fpm-alpine3.23, 8.4-rc-fpm-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/alpine3.23/fpm
-
-Tags: 8.4.23RC1-zts-alpine3.23, 8.4-rc-zts-alpine3.23
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 56a27a746dcfcd53bc043adec3fc00a22b5a8eb7
-Directory: 8.4-rc/alpine3.23/zts
-
-Tags: 8.4.22-cli-trixie, 8.4-cli-trixie, 8.4.22-trixie, 8.4-trixie, 8.4.22-cli, 8.4-cli, 8.4.22, 8.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/trixie/cli
 
-Tags: 8.4.22-apache-trixie, 8.4-apache-trixie, 8.4.22-apache, 8.4-apache
+Tags: 8.4.23-apache-trixie, 8.4-apache-trixie, 8.4.23-apache, 8.4-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/trixie/apache
 
-Tags: 8.4.22-fpm-trixie, 8.4-fpm-trixie, 8.4.22-fpm, 8.4-fpm
+Tags: 8.4.23-fpm-trixie, 8.4-fpm-trixie, 8.4.23-fpm, 8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/trixie/fpm
 
-Tags: 8.4.22-zts-trixie, 8.4-zts-trixie, 8.4.22-zts, 8.4-zts
+Tags: 8.4.23-zts-trixie, 8.4-zts-trixie, 8.4.23-zts, 8.4-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/trixie/zts
 
-Tags: 8.4.22-cli-bookworm, 8.4-cli-bookworm, 8.4.22-bookworm, 8.4-bookworm
+Tags: 8.4.23-cli-bookworm, 8.4-cli-bookworm, 8.4.23-bookworm, 8.4-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/bookworm/cli
 
-Tags: 8.4.22-apache-bookworm, 8.4-apache-bookworm
+Tags: 8.4.23-apache-bookworm, 8.4-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/bookworm/apache
 
-Tags: 8.4.22-fpm-bookworm, 8.4-fpm-bookworm
+Tags: 8.4.23-fpm-bookworm, 8.4-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/bookworm/fpm
 
-Tags: 8.4.22-zts-bookworm, 8.4-zts-bookworm
+Tags: 8.4.23-zts-bookworm, 8.4-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/bookworm/zts
 
-Tags: 8.4.22-cli-alpine3.24, 8.4-cli-alpine3.24, 8.4.22-alpine3.24, 8.4-alpine3.24, 8.4.22-cli-alpine, 8.4-cli-alpine, 8.4.22-alpine, 8.4-alpine
+Tags: 8.4.23-cli-alpine3.24, 8.4-cli-alpine3.24, 8.4.23-alpine3.24, 8.4-alpine3.24, 8.4.23-cli-alpine, 8.4-cli-alpine, 8.4.23-alpine, 8.4-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/alpine3.24/cli
 
-Tags: 8.4.22-fpm-alpine3.24, 8.4-fpm-alpine3.24, 8.4.22-fpm-alpine, 8.4-fpm-alpine
+Tags: 8.4.23-fpm-alpine3.24, 8.4-fpm-alpine3.24, 8.4.23-fpm-alpine, 8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/alpine3.24/fpm
 
-Tags: 8.4.22-zts-alpine3.24, 8.4-zts-alpine3.24, 8.4.22-zts-alpine, 8.4-zts-alpine
+Tags: 8.4.23-zts-alpine3.24, 8.4-zts-alpine3.24, 8.4.23-zts-alpine, 8.4-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/alpine3.24/zts
 
-Tags: 8.4.22-cli-alpine3.23, 8.4-cli-alpine3.23, 8.4.22-alpine3.23, 8.4-alpine3.23
+Tags: 8.4.23-cli-alpine3.23, 8.4-cli-alpine3.23, 8.4.23-alpine3.23, 8.4-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/alpine3.23/cli
 
-Tags: 8.4.22-fpm-alpine3.23, 8.4-fpm-alpine3.23
+Tags: 8.4.23-fpm-alpine3.23, 8.4-fpm-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/alpine3.23/fpm
 
-Tags: 8.4.22-zts-alpine3.23, 8.4-zts-alpine3.23
+Tags: 8.4.23-zts-alpine3.23, 8.4-zts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9df0b01226d18f08ce3741962999897e88e573d3
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.4/alpine3.23/zts
 
-Tags: 8.3.31-cli-trixie, 8.3-cli-trixie, 8.3.31-trixie, 8.3-trixie, 8.3.31-cli, 8.3-cli, 8.3.31, 8.3
+Tags: 8.3.32-cli-trixie, 8.3-cli-trixie, 8.3.32-trixie, 8.3-trixie, 8.3.32-cli, 8.3-cli, 8.3.32, 8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/trixie/cli
 
-Tags: 8.3.31-apache-trixie, 8.3-apache-trixie, 8.3.31-apache, 8.3-apache
+Tags: 8.3.32-apache-trixie, 8.3-apache-trixie, 8.3.32-apache, 8.3-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/trixie/apache
 
-Tags: 8.3.31-fpm-trixie, 8.3-fpm-trixie, 8.3.31-fpm, 8.3-fpm
+Tags: 8.3.32-fpm-trixie, 8.3-fpm-trixie, 8.3.32-fpm, 8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/trixie/fpm
 
-Tags: 8.3.31-zts-trixie, 8.3-zts-trixie, 8.3.31-zts, 8.3-zts
+Tags: 8.3.32-zts-trixie, 8.3-zts-trixie, 8.3.32-zts, 8.3-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/trixie/zts
 
-Tags: 8.3.31-cli-bookworm, 8.3-cli-bookworm, 8.3.31-bookworm, 8.3-bookworm
+Tags: 8.3.32-cli-bookworm, 8.3-cli-bookworm, 8.3.32-bookworm, 8.3-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/bookworm/cli
 
-Tags: 8.3.31-apache-bookworm, 8.3-apache-bookworm
+Tags: 8.3.32-apache-bookworm, 8.3-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/bookworm/apache
 
-Tags: 8.3.31-fpm-bookworm, 8.3-fpm-bookworm
+Tags: 8.3.32-fpm-bookworm, 8.3-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/bookworm/fpm
 
-Tags: 8.3.31-zts-bookworm, 8.3-zts-bookworm
+Tags: 8.3.32-zts-bookworm, 8.3-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/bookworm/zts
 
-Tags: 8.3.31-cli-alpine3.24, 8.3-cli-alpine3.24, 8.3.31-alpine3.24, 8.3-alpine3.24, 8.3.31-cli-alpine, 8.3-cli-alpine, 8.3.31-alpine, 8.3-alpine
+Tags: 8.3.32-cli-alpine3.24, 8.3-cli-alpine3.24, 8.3.32-alpine3.24, 8.3-alpine3.24, 8.3.32-cli-alpine, 8.3-cli-alpine, 8.3.32-alpine, 8.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/alpine3.24/cli
 
-Tags: 8.3.31-fpm-alpine3.24, 8.3-fpm-alpine3.24, 8.3.31-fpm-alpine, 8.3-fpm-alpine
+Tags: 8.3.32-fpm-alpine3.24, 8.3-fpm-alpine3.24, 8.3.32-fpm-alpine, 8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/alpine3.24/fpm
 
-Tags: 8.3.31-zts-alpine3.24, 8.3-zts-alpine3.24, 8.3.31-zts-alpine, 8.3-zts-alpine
+Tags: 8.3.32-zts-alpine3.24, 8.3-zts-alpine3.24, 8.3.32-zts-alpine, 8.3-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/alpine3.24/zts
 
-Tags: 8.3.31-cli-alpine3.23, 8.3-cli-alpine3.23, 8.3.31-alpine3.23, 8.3-alpine3.23
+Tags: 8.3.32-cli-alpine3.23, 8.3-cli-alpine3.23, 8.3.32-alpine3.23, 8.3-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/alpine3.23/cli
 
-Tags: 8.3.31-fpm-alpine3.23, 8.3-fpm-alpine3.23
+Tags: 8.3.32-fpm-alpine3.23, 8.3-fpm-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/alpine3.23/fpm
 
-Tags: 8.3.31-zts-alpine3.23, 8.3-zts-alpine3.23
+Tags: 8.3.32-zts-alpine3.23, 8.3-zts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.3/alpine3.23/zts
 
-Tags: 8.2.31-cli-trixie, 8.2-cli-trixie, 8.2.31-trixie, 8.2-trixie, 8.2.31-cli, 8.2-cli, 8.2.31, 8.2
+Tags: 8.2.32-cli-trixie, 8.2-cli-trixie, 8.2.32-trixie, 8.2-trixie, 8.2.32-cli, 8.2-cli, 8.2.32, 8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/trixie/cli
 
-Tags: 8.2.31-apache-trixie, 8.2-apache-trixie, 8.2.31-apache, 8.2-apache
+Tags: 8.2.32-apache-trixie, 8.2-apache-trixie, 8.2.32-apache, 8.2-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/trixie/apache
 
-Tags: 8.2.31-fpm-trixie, 8.2-fpm-trixie, 8.2.31-fpm, 8.2-fpm
+Tags: 8.2.32-fpm-trixie, 8.2-fpm-trixie, 8.2.32-fpm, 8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/trixie/fpm
 
-Tags: 8.2.31-zts-trixie, 8.2-zts-trixie, 8.2.31-zts, 8.2-zts
+Tags: 8.2.32-zts-trixie, 8.2-zts-trixie, 8.2.32-zts, 8.2-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/trixie/zts
 
-Tags: 8.2.31-cli-bookworm, 8.2-cli-bookworm, 8.2.31-bookworm, 8.2-bookworm
+Tags: 8.2.32-cli-bookworm, 8.2-cli-bookworm, 8.2.32-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/bookworm/cli
 
-Tags: 8.2.31-apache-bookworm, 8.2-apache-bookworm
+Tags: 8.2.32-apache-bookworm, 8.2-apache-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/bookworm/apache
 
-Tags: 8.2.31-fpm-bookworm, 8.2-fpm-bookworm
+Tags: 8.2.32-fpm-bookworm, 8.2-fpm-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/bookworm/fpm
 
-Tags: 8.2.31-zts-bookworm, 8.2-zts-bookworm
+Tags: 8.2.32-zts-bookworm, 8.2-zts-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/bookworm/zts
 
-Tags: 8.2.31-cli-alpine3.24, 8.2-cli-alpine3.24, 8.2.31-alpine3.24, 8.2-alpine3.24, 8.2.31-cli-alpine, 8.2-cli-alpine, 8.2.31-alpine, 8.2-alpine
+Tags: 8.2.32-cli-alpine3.24, 8.2-cli-alpine3.24, 8.2.32-alpine3.24, 8.2-alpine3.24, 8.2.32-cli-alpine, 8.2-cli-alpine, 8.2.32-alpine, 8.2-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/alpine3.24/cli
 
-Tags: 8.2.31-fpm-alpine3.24, 8.2-fpm-alpine3.24, 8.2.31-fpm-alpine, 8.2-fpm-alpine
+Tags: 8.2.32-fpm-alpine3.24, 8.2-fpm-alpine3.24, 8.2.32-fpm-alpine, 8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/alpine3.24/fpm
 
-Tags: 8.2.31-zts-alpine3.24, 8.2-zts-alpine3.24, 8.2.31-zts-alpine, 8.2-zts-alpine
+Tags: 8.2.32-zts-alpine3.24, 8.2-zts-alpine3.24, 8.2.32-zts-alpine, 8.2-zts-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 51f293de283bdf886127edddbcb79899c00f3ab1
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/alpine3.24/zts
 
-Tags: 8.2.31-cli-alpine3.23, 8.2-cli-alpine3.23, 8.2.31-alpine3.23, 8.2-alpine3.23
+Tags: 8.2.32-cli-alpine3.23, 8.2-cli-alpine3.23, 8.2.32-alpine3.23, 8.2-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/alpine3.23/cli
 
-Tags: 8.2.31-fpm-alpine3.23, 8.2-fpm-alpine3.23
+Tags: 8.2.32-fpm-alpine3.23, 8.2-fpm-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/alpine3.23/fpm
 
-Tags: 8.2.31-zts-alpine3.23, 8.2-zts-alpine3.23
+Tags: 8.2.32-zts-alpine3.23, 8.2-zts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: f4e930a76363da0b3b2f034d8ffc0532b1f8e61a
+GitCommit: 59c24e8d64b7d9d13f712503fa46305b84db3505
 Directory: 8.2/alpine3.23/zts


### PR DESCRIPTION
- https://github.com/docker-library/php/commit/59c24e8d64b7d9d13f712503fa46305b84db3505: Version bumps (https://github.com/docker-library/php/pull/1671)
  - Update 8.2 to 8.2.32
  - Update 8.3 to 8.3.32
  - Update 8.4 to 8.4.23
  - Update 8.4-rc
- https://github.com/docker-library/php/commit/2f6224c17e0b4481e1a7d495efaa3d4c0358fc84: Add 8.6 RC (https://github.com/docker-library/php/pull/1669)
- https://github.com/docker-library/php/commit/fdcffeaea4df2e31a3bb0e8a413cbba4cad7ad5f: Remove obsolete if in Dockerfile template (https://github.com/docker-library/php/pull/1670)
- https://github.com/docker-library/php/commit/536691f70ac79a1914026492f32e59e7339a9535: Drop `--with-pear` with PHP 8.6 (https://github.com/docker-library/php/pull/1654)