### PR TITLE
Update 6 to 6.51.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: f2dcba0b0e14654c5ad57934bdaf857f762b3edf
+GitCommit: b50dfc2e43e689f5bf8f4891fbc4cf38400a625b
 
-Tags: 6.50.0-bookworm, 6.50.0, 6.50-bookworm, 6.50, 6-bookworm, 6, bookworm, latest
+Tags: 6.51.0-bookworm, 6.51.0, 6.51-bookworm, 6.51, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8, s390x
 
-Tags: 6.50.0-alpine3.23, 6.50.0-alpine, 6.50-alpine3.23, 6.50-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.51.0-alpine3.23, 6.51.0-alpine, 6.51-alpine3.23, 6.51-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.51.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/b50dfc2e43e689f5bf8f4891fbc4cf38400a625b.