### PR TITLE
Update rocket.chat to 8.8.1, 8.7.1, 8.6.2 (+5 more)

### DIFF
--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,10 +1,14 @@
-# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/f8019f94dfe743710de864045180bcf4ca357fa8/stackbrew.js
+# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/fb402decd269f2ba5252475c7e6a329a8f12b732/stackbrew.js
 
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 GitFetch: refs/heads/main
 
-Tags: 8.5.1, 8.5, 8, latest
+Tags: 8.6.0, 8.6, 8, latest
+GitCommit: 5f8d60841f68e7f2335b47892b3079dbb10344fa
+Directory: 8.6
+
+Tags: 8.5.1, 8.5
 GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
 Directory: 8.5
 
@@ -29,8 +33,16 @@ GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
 Directory: 8.0
 
 Tags: 7.13.9, 7.13, 7
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
+GitCommit: ab90642f634b4a480fdf33e020037a0974a76417
 Directory: 7.13
+
+Tags: 7.12.7, 7.12
+GitCommit: ab90642f634b4a480fdf33e020037a0974a76417
+Directory: 7.12
+
+Tags: 7.11.7, 7.11
+GitCommit: ab90642f634b4a480fdf33e020037a0974a76417
+Directory: 7.11
 
 Tags: 7.10.9, 7.10
 GitCommit: 2f4945d910dade78b5d1ad6e5b7a351b7d6ae939

--- a/library/rocket.chat
+++ b/library/rocket.chat
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/f8019f94dfe743710de864045180bcf4ca357fa8/stackbrew.js
+# this file is generated via https://github.com/RocketChat/Docker.Official.Image/blob/12a99a0c83e7854c6ccb4cc28e70e9e88fd6de4b/stackbrew.js
 
 Maintainers: Rocket.Chat Image Team <buildmaster@rocket.chat> (@RocketChat)
 GitRepo: https://github.com/RocketChat/Docker.Official.Image.git
 GitFetch: refs/heads/main
 
-Tags: 8.5.1, 8.5, 8, latest
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
+Tags: 8.8.1, 8.8, latest
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
+Directory: 8.8
+
+Tags: 8.7.1, 8.7
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
+Directory: 8.7
+
+Tags: 8.6.2, 8.6
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
+Directory: 8.6
+
+Tags: 8.5.3, 8.5
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
 Directory: 8.5
 
-Tags: 8.4.4, 8.4
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
+Tags: 8.4.6, 8.4
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
 Directory: 8.4
 
-Tags: 8.3.6, 8.3
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
+Tags: 8.3.8, 8.3
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
 Directory: 8.3
 
-Tags: 8.2.6, 8.2
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
+Tags: 8.2.8, 8.2
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
 Directory: 8.2
 
-Tags: 8.1.6, 8.1
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
-Directory: 8.1
-
-Tags: 8.0.7, 8.0
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
-Directory: 8.0
-
-Tags: 7.13.9, 7.13, 7
-GitCommit: 1c3e8bb69e9b09980e3129f201beaca6d65f756b
-Directory: 7.13
-
-Tags: 7.10.9, 7.10
-GitCommit: 2f4945d910dade78b5d1ad6e5b7a351b7d6ae939
+Tags: 7.10.15, 7.10
+GitCommit: 2ad8a4fc73ba9dceb1c18adf49f1510cf671e6aa
 Directory: 7.10
 


### PR DESCRIPTION
Source: https://github.com/RocketChat/Docker.Official.Image/pull/296

### New versions
- `8.8` → **8.8.1** — node:22-bookworm-slim, Deno 2.3.1
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.8.1
- `8.7` → **8.7.1** — node:22-bookworm-slim, Deno 2.3.1
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.7.1
- `8.6` → **8.6.2** — node:22-bookworm-slim, Deno 2.3.1
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.6.2
- `8.5` → **8.5.3** — node:22-bookworm-slim, Deno 2.3.1
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.5.3
- `8.4` → **8.4.6** — node:22-bookworm-slim, Deno 2.3.1
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.4.6
- `8.3` → **8.3.8** — node:22-bookworm-slim, Deno 1.43.5
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.3.8
- `8.2` → **8.2.8** — node:22-bookworm-slim, Deno 1.43.5
  https://github.com/RocketChat/Rocket.Chat/releases/tag/8.2.8
- `7.10` → **7.10.15** — node:22-bookworm-slim, Deno 1.43.5
  https://github.com/RocketChat/Rocket.Chat/releases/tag/7.10.15

### Removed
- `8.1` (was 8.1.6)
- `8.0` (was 8.0.7)
- `7.13` (was 7.13.9)