### PR TITLE
archlinux: Release 20260705.0.552420

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260628.0.549485
-GitCommit: b1c9a9ff62e83926fb148b30ae6118da8af1023e
-GitFetch: refs/tags/v20260628.0.549485
+Tags: latest, base, base-20260705.0.552420
+GitCommit: 6fa6b70fb2433f63bfefbb0d209470921a849bda
+GitFetch: refs/tags/v20260705.0.552420
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260628.0.549485
-GitCommit: b1c9a9ff62e83926fb148b30ae6118da8af1023e
-GitFetch: refs/tags/v20260628.0.549485
+Tags: base-devel, base-devel-20260705.0.552420
+GitCommit: 6fa6b70fb2433f63bfefbb0d209470921a849bda
+GitFetch: refs/tags/v20260705.0.552420
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260628.0.549485
-GitCommit: b1c9a9ff62e83926fb148b30ae6118da8af1023e
-GitFetch: refs/tags/v20260628.0.549485
+Tags: multilib-devel, multilib-devel-20260705.0.552420
+GitCommit: 6fa6b70fb2433f63bfefbb0d209470921a849bda
+GitFetch: refs/tags/v20260705.0.552420
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks