### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,72 +4,72 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.4.1, 3.4, latest, lts, 3.4.1-trixie, 3.4-trixie, trixie, lts-trixie
+Tags: 3.4.2, 3.4, latest, lts, 3.4.2-trixie, 3.4-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b55e8717f90ff1aceae45152431f96bcd025759f
+GitCommit: 42313d5d1aaf525dcea1679909272dc8ba4c1c94
 Directory: 3.4
 
-Tags: 3.4.1-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.1-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
+Tags: 3.4.2-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.2-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b55e8717f90ff1aceae45152431f96bcd025759f
+GitCommit: 42313d5d1aaf525dcea1679909272dc8ba4c1c94
 Directory: 3.4/alpine
 
-Tags: 3.3.11, 3.3, 3.3.11-trixie, 3.3-trixie
+Tags: 3.3.12, 3.3, 3.3.12-trixie, 3.3-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fb10b7441a5a3d7b8144aac63e63651b9289376d
+GitCommit: 5336dec66c98b607f836b840e6c9f720baed666b
 Directory: 3.3
 
-Tags: 3.3.11-alpine, 3.3-alpine, 3.3.11-alpine3.24, 3.3-alpine3.24
+Tags: 3.3.12-alpine, 3.3-alpine, 3.3.12-alpine3.24, 3.3-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fb10b7441a5a3d7b8144aac63e63651b9289376d
+GitCommit: 5336dec66c98b607f836b840e6c9f720baed666b
 Directory: 3.3/alpine
 
-Tags: 3.2.20, 3.2, 3.2.20-trixie, 3.2-trixie
+Tags: 3.2.21, 3.2, 3.2.21-trixie, 3.2-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 53c0995b8339ba279d5a3615133d7a08ee298b5b
+GitCommit: 5f3b2c841ea8e0bce7bc5e753ce28327e629237d
 Directory: 3.2
 
-Tags: 3.2.20-alpine, 3.2-alpine, 3.2.20-alpine3.24, 3.2-alpine3.24
+Tags: 3.2.21-alpine, 3.2-alpine, 3.2.21-alpine3.24, 3.2-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 53c0995b8339ba279d5a3615133d7a08ee298b5b
+GitCommit: 5f3b2c841ea8e0bce7bc5e753ce28327e629237d
 Directory: 3.2/alpine
 
-Tags: 3.0.24, 3.0, 3.0.24-trixie, 3.0-trixie
+Tags: 3.0.25, 3.0, 3.0.25-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 66a40fba9eb7f8d5c60435da9c9a89e89b2be5c0
+GitCommit: 84fe98d090e7617a2d94e7ad7cfb16c14cd1a560
 Directory: 3.0
 
-Tags: 3.0.24-alpine, 3.0-alpine, 3.0.24-alpine3.24, 3.0-alpine3.24
+Tags: 3.0.25-alpine, 3.0-alpine, 3.0.25-alpine3.24, 3.0-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 66a40fba9eb7f8d5c60435da9c9a89e89b2be5c0
+GitCommit: 84fe98d090e7617a2d94e7ad7cfb16c14cd1a560
 Directory: 3.0/alpine
 
-Tags: 2.8.25, 2.8, 2.8.25-trixie, 2.8-trixie
+Tags: 2.8.26, 2.8, 2.8.26-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c43ff9857804130b23c99fe33c7d2b34184d8a61
+GitCommit: b034a68f85424edf4133c9c6b3c7eef4c12f03a8
 Directory: 2.8
 
-Tags: 2.8.25-alpine, 2.8-alpine, 2.8.25-alpine3.24, 2.8-alpine3.24
+Tags: 2.8.26-alpine, 2.8-alpine, 2.8.26-alpine3.24, 2.8-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c43ff9857804130b23c99fe33c7d2b34184d8a61
+GitCommit: b034a68f85424edf4133c9c6b3c7eef4c12f03a8
 Directory: 2.8/alpine
 
-Tags: 2.6.30, 2.6, 2.6.30-trixie, 2.6-trixie
+Tags: 2.6.31, 2.6, 2.6.31-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8503a6cd1800e447f9cde13857669e99c1fe25dd
+GitCommit: d41dc8229f8615343f080f84cd4ebb9f3500b98d
 Directory: 2.6
 
-Tags: 2.6.30-alpine, 2.6-alpine, 2.6.30-alpine3.24, 2.6-alpine3.24
+Tags: 2.6.31-alpine, 2.6-alpine, 2.6.31-alpine3.24, 2.6-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8503a6cd1800e447f9cde13857669e99c1fe25dd
+GitCommit: d41dc8229f8615343f080f84cd4ebb9f3500b98d
 Directory: 2.6/alpine
 
-Tags: 2.4.35, 2.4, 2.4.35-trixie, 2.4-trixie
+Tags: 2.4.36, 2.4, 2.4.36-trixie, 2.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 6eda5ce996d9ffb3f7a6ed352dd7f61580100a26
+GitCommit: ae7d6be4c656eaa0731b39802fe81ea34cd7ac19
 Directory: 2.4
 
-Tags: 2.4.35-alpine, 2.4-alpine, 2.4.35-alpine3.24, 2.4-alpine3.24
+Tags: 2.4.36-alpine, 2.4-alpine, 2.4.36-alpine3.24, 2.4-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 992c9a880168d47fc3a2ec0de8af682af5f0e028
+GitCommit: ae7d6be4c656eaa0731b39802fe81ea34cd7ac19
 Directory: 2.4/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/42313d5: Update 3.4 to 3.4.2
- https://github.com/docker-library/haproxy/commit/5336dec: Update 3.3 to 3.3.12
- https://github.com/docker-library/haproxy/commit/5f3b2c8: Update 3.2 to 3.2.21
- https://github.com/docker-library/haproxy/commit/84fe98d: Update 3.0 to 3.0.25
- https://github.com/docker-library/haproxy/commit/b034a68: Update 2.8 to 2.8.26
- https://github.com/docker-library/haproxy/commit/d41dc82: Update 2.6 to 2.6.31
- https://github.com/docker-library/haproxy/commit/ae7d6be: Update 2.4 to 2.4.36