### PR TITLE
Update memcached

### DIFF
--- a/library/memcached
+++ b/library/memcached
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/memcached.git
 
-Tags: 1.6.42, 1.6, 1, latest, 1.6.42-trixie, 1.6-trixie, 1-trixie, trixie
+Tags: 1.6.43, 1.6, 1, latest, 1.6.43-trixie, 1.6-trixie, 1-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ac84e05c54a4a00b15f252331e568f342de2c4c3
+GitCommit: b4548b2ac8062cccff5740449c8e555799c71bf8
 Directory: 1/debian
 
-Tags: 1.6.42-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.42-alpine3.24, 1.6-alpine3.24, 1-alpine3.24, alpine3.24
+Tags: 1.6.43-alpine, 1.6-alpine, 1-alpine, alpine, 1.6.43-alpine3.24, 1.6-alpine3.24, 1-alpine3.24, alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 933b8a9f8878586cc33dcbd5cb17d19000e8cce6
+GitCommit: b4548b2ac8062cccff5740449c8e555799c71bf8
 Directory: 1/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/memcached/commit/b4548b2: Update 1 to 1.6.43