### PR TITLE
[security] Update golang

### DIFF
--- a/library/golang
+++ b/library/golang
@@ -6,161 +6,161 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/golang.git
 Builder: buildkit
 
-Tags: 1.27rc1-trixie, 1.27-rc-trixie
-SharedTags: 1.27rc1, 1.27-rc
+Tags: 1.27rc2-trixie, 1.27-rc-trixie
+SharedTags: 1.27rc2, 1.27-rc
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/trixie
 
-Tags: 1.27rc1-bookworm, 1.27-rc-bookworm
+Tags: 1.27rc2-bookworm, 1.27-rc-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/bookworm
 
-Tags: 1.27rc1-alpine3.24, 1.27-rc-alpine3.24, 1.27rc1-alpine, 1.27-rc-alpine
+Tags: 1.27rc2-alpine3.24, 1.27-rc-alpine3.24, 1.27rc2-alpine, 1.27-rc-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/alpine3.24
 
-Tags: 1.27rc1-alpine3.23, 1.27-rc-alpine3.23
+Tags: 1.27rc2-alpine3.23, 1.27-rc-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/alpine3.23
 
-Tags: 1.27rc1-windowsservercore-ltsc2025, 1.27-rc-windowsservercore-ltsc2025
-SharedTags: 1.27rc1-windowsservercore, 1.27-rc-windowsservercore, 1.27rc1, 1.27-rc
+Tags: 1.27rc2-windowsservercore-ltsc2025, 1.27-rc-windowsservercore-ltsc2025
+SharedTags: 1.27rc2-windowsservercore, 1.27-rc-windowsservercore, 1.27rc2, 1.27-rc
 Architectures: windows-amd64
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.27rc1-windowsservercore-ltsc2022, 1.27-rc-windowsservercore-ltsc2022
-SharedTags: 1.27rc1-windowsservercore, 1.27-rc-windowsservercore, 1.27rc1, 1.27-rc
+Tags: 1.27rc2-windowsservercore-ltsc2022, 1.27-rc-windowsservercore-ltsc2022
+SharedTags: 1.27rc2-windowsservercore, 1.27-rc-windowsservercore, 1.27rc2, 1.27-rc
 Architectures: windows-amd64
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.27rc1-nanoserver-ltsc2025, 1.27-rc-nanoserver-ltsc2025
-SharedTags: 1.27rc1-nanoserver, 1.27-rc-nanoserver
+Tags: 1.27rc2-nanoserver-ltsc2025, 1.27-rc-nanoserver-ltsc2025
+SharedTags: 1.27rc2-nanoserver, 1.27-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.27rc1-nanoserver-ltsc2022, 1.27-rc-nanoserver-ltsc2022
-SharedTags: 1.27rc1-nanoserver, 1.27-rc-nanoserver
+Tags: 1.27rc2-nanoserver-ltsc2022, 1.27-rc-nanoserver-ltsc2022
+SharedTags: 1.27rc2-nanoserver, 1.27-rc-nanoserver
 Architectures: windows-amd64
-GitCommit: 72507b24788ab7b475d25d5f358865809cba71c4
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.26.4-trixie, 1.26-trixie, 1-trixie, trixie
-SharedTags: 1.26.4, 1.26, 1, latest
+Tags: 1.26.5-trixie, 1.26-trixie, 1-trixie, trixie
+SharedTags: 1.26.5, 1.26, 1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/trixie
 
-Tags: 1.26.4-bookworm, 1.26-bookworm, 1-bookworm, bookworm
+Tags: 1.26.5-bookworm, 1.26-bookworm, 1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/bookworm
 
-Tags: 1.26.4-alpine3.24, 1.26-alpine3.24, 1-alpine3.24, alpine3.24, 1.26.4-alpine, 1.26-alpine, 1-alpine, alpine
+Tags: 1.26.5-alpine3.24, 1.26-alpine3.24, 1-alpine3.24, alpine3.24, 1.26.5-alpine, 1.26-alpine, 1-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34bfa3703c98a3f4e7dcc808a5b0a754faecb5ef
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/alpine3.24
 
-Tags: 1.26.4-alpine3.23, 1.26-alpine3.23, 1-alpine3.23, alpine3.23
+Tags: 1.26.5-alpine3.23, 1.26-alpine3.23, 1-alpine3.23, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/alpine3.23
 
-Tags: 1.26.4-windowsservercore-ltsc2025, 1.26-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 1.26.4-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.4, 1.26, 1, latest
+Tags: 1.26.5-windowsservercore-ltsc2025, 1.26-windowsservercore-ltsc2025, 1-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+SharedTags: 1.26.5-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.5, 1.26, 1, latest
 Architectures: windows-amd64
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.26.4-windowsservercore-ltsc2022, 1.26-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 1.26.4-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.4, 1.26, 1, latest
+Tags: 1.26.5-windowsservercore-ltsc2022, 1.26-windowsservercore-ltsc2022, 1-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 1.26.5-windowsservercore, 1.26-windowsservercore, 1-windowsservercore, windowsservercore, 1.26.5, 1.26, 1, latest
 Architectures: windows-amd64
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.26.4-nanoserver-ltsc2025, 1.26-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
-SharedTags: 1.26.4-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.26.5-nanoserver-ltsc2025, 1.26-nanoserver-ltsc2025, 1-nanoserver-ltsc2025, nanoserver-ltsc2025
+SharedTags: 1.26.5-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.26.4-nanoserver-ltsc2022, 1.26-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 1.26.4-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
+Tags: 1.26.5-nanoserver-ltsc2022, 1.26-nanoserver-ltsc2022, 1-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 1.26.5-nanoserver, 1.26-nanoserver, 1-nanoserver, nanoserver
 Architectures: windows-amd64
-GitCommit: 06d3b7744447bbfe4679ad0b53c8ddd260e04190
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 1.25.11-trixie, 1.25-trixie
-SharedTags: 1.25.11, 1.25
+Tags: 1.25.12-trixie, 1.25-trixie
+SharedTags: 1.25.12, 1.25
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/trixie
 
-Tags: 1.25.11-bookworm, 1.25-bookworm
+Tags: 1.25.12-bookworm, 1.25-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/bookworm
 
-Tags: 1.25.11-alpine3.24, 1.25-alpine3.24, 1.25.11-alpine, 1.25-alpine
+Tags: 1.25.12-alpine3.24, 1.25-alpine3.24, 1.25.12-alpine, 1.25-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 34bfa3703c98a3f4e7dcc808a5b0a754faecb5ef
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/alpine3.24
 
-Tags: 1.25.11-alpine3.23, 1.25-alpine3.23
+Tags: 1.25.12-alpine3.23, 1.25-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/alpine3.23
 
-Tags: 1.25.11-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025
-SharedTags: 1.25.11-windowsservercore, 1.25-windowsservercore, 1.25.11, 1.25
+Tags: 1.25.12-windowsservercore-ltsc2025, 1.25-windowsservercore-ltsc2025
+SharedTags: 1.25.12-windowsservercore, 1.25-windowsservercore, 1.25.12, 1.25
 Architectures: windows-amd64
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/windows/windowsservercore-ltsc2025
 Builder: classic
 Constraints: windowsservercore-ltsc2025
 
-Tags: 1.25.11-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022
-SharedTags: 1.25.11-windowsservercore, 1.25-windowsservercore, 1.25.11, 1.25
+Tags: 1.25.12-windowsservercore-ltsc2022, 1.25-windowsservercore-ltsc2022
+SharedTags: 1.25.12-windowsservercore, 1.25-windowsservercore, 1.25.12, 1.25
 Architectures: windows-amd64
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/windows/windowsservercore-ltsc2022
 Builder: classic
 Constraints: windowsservercore-ltsc2022
 
-Tags: 1.25.11-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025
-SharedTags: 1.25.11-nanoserver, 1.25-nanoserver
+Tags: 1.25.12-nanoserver-ltsc2025, 1.25-nanoserver-ltsc2025
+SharedTags: 1.25.12-nanoserver, 1.25-nanoserver
 Architectures: windows-amd64
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/windows/nanoserver-ltsc2025
 Builder: classic
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: 1.25.11-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022
-SharedTags: 1.25.11-nanoserver, 1.25-nanoserver
+Tags: 1.25.12-nanoserver-ltsc2022, 1.25-nanoserver-ltsc2022
+SharedTags: 1.25.12-nanoserver, 1.25-nanoserver
 Architectures: windows-amd64
-GitCommit: 0cacb947ea370f10d4d343bdfecf8de26333cabf
+GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/windows/nanoserver-ltsc2022
 Builder: classic
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/golang/commit/2940977: Update to 1.26.5, 1.25.12, and 1.27rc2