### PR TITLE
Update KrakenD to v2.13.8

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.7, 2.13, 2, latest
+Tags: 2.13.8, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 6384c602acef16436efffd7a6acc296b38ce5ecf
-Directory: 2.13.7
+GitCommit: 8b33f8b9315f0ee10f2db598b834b5341450420a
+Directory: 2.13.8


### PR DESCRIPTION
## Changes
Upgraded Go to 1.25.12, addressing several CVEs with disclosed descriptions
* [CVE-2026-39822](https://go.dev/issue/79005) `os`: Root escape via symlink plus trailing slash
* [CVE-2026-42505](https://go.dev/issue/79282) `crypto/tls`: Encrypted Client Hello privacy leak