### PR TITLE
Update GeoNetwork to 4.2.17 and 4.4.12

### DIFF
--- a/library/geonetwork
+++ b/library/geonetwork
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/4941b6a2f4f16c44bf0fe219feadc36bc4f3aea9/generate-stackbrew-library.sh
+# this file is generated via https://github.com/geonetwork/docker-geonetwork/blob/2951781f87c63b1a69a1def46c8b3605de843870/generate-stackbrew-library.sh
 
 Maintainers: Joana Simoes <jo@doublebyte.net> (@doublebyte1),
          Juan Luis Rodriguez <juanluisrp@geocat.net> (@juanluisrp),
@@ -16,12 +16,12 @@ Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 17278beab34080c90454c0b7059bd6b49701f979
 Directory: 3.12.12/postgres
 
-Tags: 4.2.16, 4.2
+Tags: 4.2.17, 4.2
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 4941b6a2f4f16c44bf0fe219feadc36bc4f3aea9
-Directory: 4.2.16
+GitCommit: e9f63f420e69b4652657811fbbda2bd08250d3cb
+Directory: 4.2.17
 
-Tags: 4.4.11, 4.4, 4, latest
+Tags: 4.4.12, 4.4, 4, latest
 Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 491f3faf9465394003e24fba6f74fb51b9e24069
-Directory: 4.4.11
+GitCommit: 2951781f87c63b1a69a1def46c8b3605de843870
+Directory: 4.4.12


### PR DESCRIPTION
Update GeoNetwork images:

- 4.2.17 (patch release of the 4.2.x series)
- 4.4.12 (patch release of the 4.4.x series, tagged as `4.4`, `4`, `latest`)