### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.12.20260611.0
+Tags: 2023, latest, 2023.12.20260706.1
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 155ddfdddc02656a3d6695f946bb80277e432d6e
+amd64-GitCommit: 9ae7e8f5ae855849261ffa5b014c86e9d94b08f0
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: f21c34c153c99f17b2527e034ad7cfee7aeb5dc3
+arm64v8-GitCommit: 0010dc09d88635df46ae49440bdfe80d2715f906
 
-Tags: 2, 2.0.20260615.0
+Tags: 2, 2.0.20260707.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 0ee39270804fae19e26aea192fc7d8adce4f7dfa
+amd64-GitCommit: e407484954ec851ac0545f16a386cabfd9c2c8e7
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 40c91041ac70ef649c2b389bcf7daea700dbb884
+arm64v8-GitCommit: a6d7f63771bbccd6207c47a6ad5ec859648e657e
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- libblkid-2.30.2-2.amzn2.0.14
- libxml2-2.9.1-6.amzn2.5.25
- libmount-2.30.2-2.amzn2.0.14
- system-release-2-18.amzn2
- libuuid-2.30.2-2.amzn2.0.14
- expat-2.1.0-15.amzn2.0.7

Updated Packages for Amazon Linux 2023:
- libxml2-2.10.4-1.amzn2023.0.19
- libuuid-2.37.4-1.amzn2023.0.5
- expat-2.6.3-1.amzn2023.0.6
- libsmartcols-2.37.4-1.amzn2023.0.5
- libmount-2.37.4-1.amzn2023.0.5
- python3-libs-3.9.25-1.amzn2023.0.7
- gnupg2-minimal-2.3.7-1.amzn2023.0.9
- amazon-linux-repo-cdn-2023.12.20260706-1.amzn2023
- system-release-2023.12.20260706-1.amzn2023
- sqlite-libs-3.40.0-1.amzn2023.0.8
- libblkid-2.37.4-1.amzn2023.0.5
- python3-3.9.25-1.amzn2023.0.7