### PR TITLE
haskell: bump stack to 3.11.1

### DIFF
--- a/library/haskell
+++ b/library/haskell
@@ -4,60 +4,60 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.14.1-bookworm, 9.14-bookworm, 9-bookworm, bookworm, 9.14.1, 9.14, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.14/bookworm
 
 Tags: 9.14.1-slim-bookworm, 9.14-slim-bookworm, 9-slim-bookworm, slim-bookworm, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.14/slim-bookworm
 
 Tags: 9.12.4-bookworm, 9.12-bookworm, 9.12.4, 9.12
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.12/bookworm
 
 Tags: 9.12.4-slim-bookworm, 9.12-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.12/slim-bookworm
 
 Tags: 9.10.3-bookworm, 9.10-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.10/bookworm
 
 Tags: 9.10.3-slim-bookworm, 9.10-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.10/slim-bookworm
 
 Tags: 9.10.3-bullseye, 9.10-bullseye, 9-bullseye, bullseye, 9.10.3, 9.10
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.10/bullseye
 
 Tags: 9.10.3-slim-bullseye, 9.10-slim-bullseye, 9-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.10/slim-bullseye
 
 Tags: 9.8.4-bullseye, 9.8-bullseye, 9.8.4, 9.8
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.8/bullseye
 
 Tags: 9.8.4-slim-bullseye, 9.8-slim-bullseye, 9.8.4-slim, 9.8-slim
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.8/slim-bullseye
 
 Tags: 9.6.7-bullseye, 9.6-bullseye, 9.6.7, 9.6
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.6/bullseye
 
 Tags: 9.6.7-slim-bullseye, 9.6-slim-bullseye, 9.6.7-slim, 9.6-slim
 Architectures: amd64, arm64v8
-GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
+GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
 Directory: 9.6/slim-bullseye

--- a/library/haskell
+++ b/library/haskell
@@ -4,60 +4,60 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.14.1-bookworm, 9.14-bookworm, 9-bookworm, bookworm, 9.14.1, 9.14, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.14/bookworm
 
 Tags: 9.14.1-slim-bookworm, 9.14-slim-bookworm, 9-slim-bookworm, slim-bookworm, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.14/slim-bookworm
 
 Tags: 9.12.4-bookworm, 9.12-bookworm, 9.12.4, 9.12
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.12/bookworm
 
 Tags: 9.12.4-slim-bookworm, 9.12-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.12/slim-bookworm
 
 Tags: 9.10.3-bookworm, 9.10-bookworm
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.10/bookworm
 
 Tags: 9.10.3-slim-bookworm, 9.10-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.10/slim-bookworm
 
 Tags: 9.10.3-bullseye, 9.10-bullseye, 9-bullseye, bullseye, 9.10.3, 9.10
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.10/bullseye
 
 Tags: 9.10.3-slim-bullseye, 9.10-slim-bullseye, 9-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.10/slim-bullseye
 
 Tags: 9.8.4-bullseye, 9.8-bullseye, 9.8.4, 9.8
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.8/bullseye
 
 Tags: 9.8.4-slim-bullseye, 9.8-slim-bullseye, 9.8.4-slim, 9.8-slim
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.8/slim-bullseye
 
 Tags: 9.6.7-bullseye, 9.6-bullseye, 9.6.7, 9.6
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.6/bullseye
 
 Tags: 9.6.7-slim-bullseye, 9.6-slim-bullseye, 9.6.7-slim, 9.6-slim
 Architectures: amd64, arm64v8
-GitCommit: bff7ab9a0b05c06a8d35190d314f610758ce18c5
+GitCommit: 870b06856b1f4dfc09cd710ab9c680060d25e202
 Directory: 9.6/slim-bullseye

--- a/library/haskell
+++ b/library/haskell
@@ -4,60 +4,60 @@ GitRepo: https://github.com/haskell/docker-haskell
 
 Tags: 9.14.1-bookworm, 9.14-bookworm, 9-bookworm, bookworm, 9.14.1, 9.14, 9, latest
 Architectures: amd64, arm64v8
-GitCommit: 507dcd550c1eb050a5839572f74b908e3a3e306b
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.14/bookworm
 
 Tags: 9.14.1-slim-bookworm, 9.14-slim-bookworm, 9-slim-bookworm, slim-bookworm, 9-slim, slim
 Architectures: amd64, arm64v8
-GitCommit: 507dcd550c1eb050a5839572f74b908e3a3e306b
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.14/slim-bookworm
 
 Tags: 9.12.4-bookworm, 9.12-bookworm, 9.12.4, 9.12
 Architectures: amd64, arm64v8
-GitCommit: 653711c327934a0a48f59716103786a54deed063
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.12/bookworm
 
 Tags: 9.12.4-slim-bookworm, 9.12-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 653711c327934a0a48f59716103786a54deed063
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.12/slim-bookworm
 
 Tags: 9.10.3-bookworm, 9.10-bookworm
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.10/bookworm
 
 Tags: 9.10.3-slim-bookworm, 9.10-slim-bookworm
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.10/slim-bookworm
 
 Tags: 9.10.3-bullseye, 9.10-bullseye, 9-bullseye, bullseye, 9.10.3, 9.10
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.10/bullseye
 
 Tags: 9.10.3-slim-bullseye, 9.10-slim-bullseye, 9-slim-bullseye, slim-bullseye
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.10/slim-bullseye
 
 Tags: 9.8.4-bullseye, 9.8-bullseye, 9.8.4, 9.8
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.8/bullseye
 
 Tags: 9.8.4-slim-bullseye, 9.8-slim-bullseye, 9.8.4-slim, 9.8-slim
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.8/slim-bullseye
 
 Tags: 9.6.7-bullseye, 9.6-bullseye, 9.6.7, 9.6
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.6/bullseye
 
 Tags: 9.6.7-slim-bullseye, 9.6-slim-bullseye, 9.6.7-slim, 9.6-slim
 Architectures: amd64, arm64v8
-GitCommit: d478ceb8ff33f6208db87008e48cd084fd9747a1
+GitCommit: 371b24ac5fcf75c7d359c2c6d90daa4114ba6a53
 Directory: 9.6/slim-bullseye


### PR DESCRIPTION
This also brings in all the recent improvements from https://github.com/haskell/docker-haskell (docker files auto-generated by nickel, base image pins etc)