### PR TITLE
Update 6 to 6.52.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -4,12 +4,12 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
              Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: b50dfc2e43e689f5bf8f4891fbc4cf38400a625b
+GitCommit: 2e666928621693be8331aaf9b7d7b42186053a6a
 
-Tags: 6.51.0-bookworm, 6.51.0, 6.51-bookworm, 6.51, 6-bookworm, 6, bookworm, latest
+Tags: 6.52.0-bookworm, 6.52.0, 6.52-bookworm, 6.52, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
-Architectures: amd64, arm32v7, arm64v8, s390x
+Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.51.0-alpine3.23, 6.51.0-alpine, 6.51-alpine3.23, 6.51-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.52.0-alpine3.23, 6.52.0-alpine, 6.52-alpine3.23, 6.52-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.52.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/2e666928621693be8331aaf9b7d7b42186053a6a.