### PR TITLE
Update oraclelinux-slim for 9 and 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 570c54b548ff3bf22fa040e495f5dd2fa7f3b7e5
+amd64-GitCommit: 059f29653473bf419ae5bfe2882b5f807ea77929
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: b3537c830190681a423aecd6b2172a7af2343bd1
+arm64v8-GitCommit: a26ab49d441ea9e799d3c8d6b6f05daac56e85a3
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 9
- [ELSA-2026-19346](https://linux.oracle.com/errata/ELSA-2026-19346.html)
- [ELSA-2026-19357](https://linux.oracle.com/errata/ELSA-2026-19357.html)
- [ELSA-2026-19361](https://linux.oracle.com/errata/ELSA-2026-19361.html)
- [ELSA-2026-20597](https://linux.oracle.com/errata/ELSA-2026-20597.html)
- [ELSA-2026-20612](https://linux.oracle.com/errata/ELSA-2026-20612.html)
- [ELSA-2026-22312](https://linux.oracle.com/errata/ELSA-2026-22312.html)
- [ELSA-2026-22717](https://linux.oracle.com/errata/ELSA-2026-22717.html)
- [ELSA-2026-23230](https://linux.oracle.com/errata/ELSA-2026-23230.html)
- [ELSA-2026-28209](https://linux.oracle.com/errata/ELSA-2026-28209.html)
- [ELSA-2026-28253](https://linux.oracle.com/errata/ELSA-2026-28253.html)
- [ELSA-2026-28254](https://linux.oracle.com/errata/ELSA-2026-28254.html)
- [ELSA-2026-28911](https://linux.oracle.com/errata/ELSA-2026-28911.html)
- [ELSA-2026-33226](https://linux.oracle.com/errata/ELSA-2026-33226.html)

### Oracle Linux 8
- [ELSA-2026-36728](https://linux.oracle.com/errata/ELSA-2026-36728.html)
- [ELSA-2026-36730](https://linux.oracle.com/errata/ELSA-2026-36730.html)
- [ELSA-2026-36734](https://linux.oracle.com/errata/ELSA-2026-36734.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
