### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 7.0.0-php8.2-apache, 7.0-php8.2-apache, 7-php8.2-apache, php8.2-apache, 7.0.0-php8.2, 7.0-php8.2, 7-php8.2, php8.2
+Tags: 7.0.1-php8.2-apache, 7.0-php8.2-apache, 7-php8.2-apache, php8.2-apache, 7.0.1-php8.2, 7.0-php8.2, 7-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.2/apache
 
-Tags: 7.0.0-php8.2-fpm, 7.0-php8.2-fpm, 7-php8.2-fpm, php8.2-fpm
+Tags: 7.0.1-php8.2-fpm, 7.0-php8.2-fpm, 7-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.2/fpm
 
-Tags: 7.0.0-php8.2-fpm-alpine, 7.0-php8.2-fpm-alpine, 7-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 7.0.1-php8.2-fpm-alpine, 7.0-php8.2-fpm-alpine, 7-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 7.0.0-apache, 7.0-apache, 7-apache, apache, 7.0.0, 7.0, 7, latest, 7.0.0-php8.3-apache, 7.0-php8.3-apache, 7-php8.3-apache, php8.3-apache, 7.0.0-php8.3, 7.0-php8.3, 7-php8.3, php8.3
+Tags: 7.0.1-apache, 7.0-apache, 7-apache, apache, 7.0.1, 7.0, 7, latest, 7.0.1-php8.3-apache, 7.0-php8.3-apache, 7-php8.3-apache, php8.3-apache, 7.0.1-php8.3, 7.0-php8.3, 7-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.3/apache
 
-Tags: 7.0.0-fpm, 7.0-fpm, 7-fpm, fpm, 7.0.0-php8.3-fpm, 7.0-php8.3-fpm, 7-php8.3-fpm, php8.3-fpm
+Tags: 7.0.1-fpm, 7.0-fpm, 7-fpm, fpm, 7.0.1-php8.3-fpm, 7.0-php8.3-fpm, 7-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.3/fpm
 
-Tags: 7.0.0-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine, 7.0.0-php8.3-fpm-alpine, 7.0-php8.3-fpm-alpine, 7-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 7.0.1-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine, 7.0.1-php8.3-fpm-alpine, 7.0-php8.3-fpm-alpine, 7-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.3/fpm-alpine
 
-Tags: 7.0.0-php8.4-apache, 7.0-php8.4-apache, 7-php8.4-apache, php8.4-apache, 7.0.0-php8.4, 7.0-php8.4, 7-php8.4, php8.4
+Tags: 7.0.1-php8.4-apache, 7.0-php8.4-apache, 7-php8.4-apache, php8.4-apache, 7.0.1-php8.4, 7.0-php8.4, 7-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.4/apache
 
-Tags: 7.0.0-php8.4-fpm, 7.0-php8.4-fpm, 7-php8.4-fpm, php8.4-fpm
+Tags: 7.0.1-php8.4-fpm, 7.0-php8.4-fpm, 7-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.4/fpm
 
-Tags: 7.0.0-php8.4-fpm-alpine, 7.0-php8.4-fpm-alpine, 7-php8.4-fpm-alpine, php8.4-fpm-alpine
+Tags: 7.0.1-php8.4-fpm-alpine, 7.0-php8.4-fpm-alpine, 7-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.4/fpm-alpine
 
-Tags: 7.0.0-php8.5-apache, 7.0-php8.5-apache, 7-php8.5-apache, php8.5-apache, 7.0.0-php8.5, 7.0-php8.5, 7-php8.5, php8.5
+Tags: 7.0.1-php8.5-apache, 7.0-php8.5-apache, 7-php8.5-apache, php8.5-apache, 7.0.1-php8.5, 7.0-php8.5, 7-php8.5, php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.5/apache
 
-Tags: 7.0.0-php8.5-fpm, 7.0-php8.5-fpm, 7-php8.5-fpm, php8.5-fpm
+Tags: 7.0.1-php8.5-fpm, 7.0-php8.5-fpm, 7-php8.5-fpm, php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.5/fpm
 
-Tags: 7.0.0-php8.5-fpm-alpine, 7.0-php8.5-fpm-alpine, 7-php8.5-fpm-alpine, php8.5-fpm-alpine
+Tags: 7.0.1-php8.5-fpm-alpine, 7.0-php8.5-fpm-alpine, 7-php8.5-fpm-alpine, php8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 862322ddbba563563ae63e1dcee31d477626eb8e
+GitCommit: abc2d453bf04d94816dc2fef3038e7a08a45dac0
 Directory: latest/php8.5/fpm-alpine
 
 Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
@@ -83,63 +83,3 @@ Tags: cli-2.12.0-php8.5, cli-2.12-php8.5, cli-2-php8.5, cli-php8.5
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.5/alpine
-
-Tags: beta-7.0.1-RC1-php8.2-apache, beta-7.0.1-php8.2-apache, beta-7.0-php8.2-apache, beta-7-php8.2-apache, beta-php8.2-apache, beta-7.0.1-RC1-php8.2, beta-7.0.1-php8.2, beta-7.0-php8.2, beta-7-php8.2, beta-php8.2
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.2/apache
-
-Tags: beta-7.0.1-RC1-php8.2-fpm, beta-7.0.1-php8.2-fpm, beta-7.0-php8.2-fpm, beta-7-php8.2-fpm, beta-php8.2-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.2/fpm
-
-Tags: beta-7.0.1-RC1-php8.2-fpm-alpine, beta-7.0.1-php8.2-fpm-alpine, beta-7.0-php8.2-fpm-alpine, beta-7-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.2/fpm-alpine
-
-Tags: beta-7.0.1-RC1-apache, beta-7.0.1-apache, beta-7.0-apache, beta-7-apache, beta-apache, beta-7.0.1-RC1, beta-7.0.1, beta-7.0, beta-7, beta, beta-7.0.1-RC1-php8.3-apache, beta-7.0.1-php8.3-apache, beta-7.0-php8.3-apache, beta-7-php8.3-apache, beta-php8.3-apache, beta-7.0.1-RC1-php8.3, beta-7.0.1-php8.3, beta-7.0-php8.3, beta-7-php8.3, beta-php8.3
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.3/apache
-
-Tags: beta-7.0.1-RC1-fpm, beta-7.0.1-fpm, beta-7.0-fpm, beta-7-fpm, beta-fpm, beta-7.0.1-RC1-php8.3-fpm, beta-7.0.1-php8.3-fpm, beta-7.0-php8.3-fpm, beta-7-php8.3-fpm, beta-php8.3-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.3/fpm
-
-Tags: beta-7.0.1-RC1-fpm-alpine, beta-7.0.1-fpm-alpine, beta-7.0-fpm-alpine, beta-7-fpm-alpine, beta-fpm-alpine, beta-7.0.1-RC1-php8.3-fpm-alpine, beta-7.0.1-php8.3-fpm-alpine, beta-7.0-php8.3-fpm-alpine, beta-7-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.3/fpm-alpine
-
-Tags: beta-7.0.1-RC1-php8.4-apache, beta-7.0.1-php8.4-apache, beta-7.0-php8.4-apache, beta-7-php8.4-apache, beta-php8.4-apache, beta-7.0.1-RC1-php8.4, beta-7.0.1-php8.4, beta-7.0-php8.4, beta-7-php8.4, beta-php8.4
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.4/apache
-
-Tags: beta-7.0.1-RC1-php8.4-fpm, beta-7.0.1-php8.4-fpm, beta-7.0-php8.4-fpm, beta-7-php8.4-fpm, beta-php8.4-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.4/fpm
-
-Tags: beta-7.0.1-RC1-php8.4-fpm-alpine, beta-7.0.1-php8.4-fpm-alpine, beta-7.0-php8.4-fpm-alpine, beta-7-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.4/fpm-alpine
-
-Tags: beta-7.0.1-RC1-php8.5-apache, beta-7.0.1-php8.5-apache, beta-7.0-php8.5-apache, beta-7-php8.5-apache, beta-php8.5-apache, beta-7.0.1-RC1-php8.5, beta-7.0.1-php8.5, beta-7.0-php8.5, beta-7-php8.5, beta-php8.5
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.5/apache
-
-Tags: beta-7.0.1-RC1-php8.5-fpm, beta-7.0.1-php8.5-fpm, beta-7.0-php8.5-fpm, beta-7-php8.5-fpm, beta-php8.5-fpm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.5/fpm
-
-Tags: beta-7.0.1-RC1-php8.5-fpm-alpine, beta-7.0.1-php8.5-fpm-alpine, beta-7.0-php8.5-fpm-alpine, beta-7-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
-Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: fa955bd3cb3d46a8488af00b883f6d52dd96a3f7
-Directory: beta/php8.5/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/abc2d45: Update latest to 7.0.1
- https://github.com/docker-library/wordpress/commit/1d0f3c0: Update beta to 7.0.1