### PR TITLE
Update oraclelinux for 9

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 059f29653473bf419ae5bfe2882b5f807ea77929
+amd64-GitCommit: c182f3c2adce2c7d89698c5346570b7ef6294e3a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a26ab49d441ea9e799d3c8d6b6f05daac56e85a3
+arm64v8-GitCommit: 8ac7a9ac4c4370096e49db719f08d2a4de52f6e7
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 9
- [ELSA-2026-25239](https://linux.oracle.com/errata/ELSA-2026-25239.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
