### PR TITLE
archlinux: Release 20260712.0.555161

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260705.0.552420
-GitCommit: 6fa6b70fb2433f63bfefbb0d209470921a849bda
-GitFetch: refs/tags/v20260705.0.552420
+Tags: latest, base, base-20260712.0.555161
+GitCommit: cb78d7ca9477f37f5c7ce2d8f1e4ad1c827fb98c
+GitFetch: refs/tags/v20260712.0.555161
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260705.0.552420
-GitCommit: 6fa6b70fb2433f63bfefbb0d209470921a849bda
-GitFetch: refs/tags/v20260705.0.552420
+Tags: base-devel, base-devel-20260712.0.555161
+GitCommit: cb78d7ca9477f37f5c7ce2d8f1e4ad1c827fb98c
+GitFetch: refs/tags/v20260712.0.555161
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260705.0.552420
-GitCommit: 6fa6b70fb2433f63bfefbb0d209470921a849bda
-GitFetch: refs/tags/v20260705.0.552420
+Tags: multilib-devel, multilib-devel-20260712.0.555161
+GitCommit: cb78d7ca9477f37f5c7ce2d8f1e4ad1c827fb98c
+GitFetch: refs/tags/v20260712.0.555161
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks