### PR TITLE
Update influxdb 3.9 and 3.10 enterprise to 3.9.9 and 3.10.3

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 0b0552bd3ccd26316f601bd15194592afdb405dd
+GitCommit: d58cf65256df87e716e9ae2be74665fb8bd0100b
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -66,7 +66,7 @@ Tags: 3.9-core, 3.9.6-core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-core
 
-Tags: 3.9-enterprise, 3.9.7-enterprise
+Tags: 3.9-enterprise, 3.9.9-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-enterprise
 
@@ -74,6 +74,6 @@ Tags: 3-core, 3.10-core, 3.10.1-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-core
 
-Tags: 3-enterprise, 3.10-enterprise, 3.10.2-enterprise, enterprise
+Tags: 3-enterprise, 3.10-enterprise, 3.10.3-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-enterprise


### PR DESCRIPTION
Bumps the InfluxDB 3 enterprise images to the latest patch releases:

- `3.9-enterprise`, `3.9.9-enterprise`: 3.9.7 -> 3.9.9
- `3-enterprise`, `3.10-enterprise`, `3.10.3-enterprise`, `enterprise`: 3.10.2 -> 3.10.3

`GitCommit` is advanced to influxdata-docker `d58cf65` (influxdata/influxdata-docker#895), whose only `influxdb/` changes are the two enterprise Dockerfiles above. Core tags are unchanged (no new core release for these patches). Release artifacts are published on dl.influxdata.com.