### PR TITLE
influxdb: use INFLUXDB3_LOG_FILTER in 3.10 images

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: d58cf65256df87e716e9ae2be74665fb8bd0100b
+GitCommit: 2ac466229d7c615c795d9af5ec009614e0c5b73d
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8


### PR DESCRIPTION
## Summary

Bumps the pinned commit to pick up influxdata/influxdata-docker#896, which replaces the deprecated `LOG_FILTER` environment variable with `INFLUXDB3_LOG_FILTER` in the 3.10 core and enterprise images. Setting the deprecated name in the image caused a startup warning whenever the user also set `INFLUXDB3_LOG_FILTER`. No version changes; only the two 3.10 Dockerfiles differ between the old and new commit.