### PR TITLE
Bump Traefik to v3.7.8

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,37 +1,37 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.7-windowsservercore-ltsc2025, 3.7.7-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.7.8-windowsservercore-ltsc2025, 3.7.8-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3e9159616cbe83ef7ae5531555c899c95b5359
+GitCommit: 61ada8678aa88664f3eeeea0506d8f8e89001878
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.7-windowsservercore-ltsc2022, 3.7.7-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.7.8-windowsservercore-ltsc2022, 3.7.8-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3e9159616cbe83ef7ae5531555c899c95b5359
+GitCommit: 61ada8678aa88664f3eeeea0506d8f8e89001878
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.7-nanoserver-ltsc2025, 3.7.7-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.7.8-nanoserver-ltsc2025, 3.7.8-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3e9159616cbe83ef7ae5531555c899c95b5359
+GitCommit: 61ada8678aa88664f3eeeea0506d8f8e89001878
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.7-nanoserver-ltsc2022, 3.7.7-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.7.8-nanoserver-ltsc2022, 3.7.8-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3e9159616cbe83ef7ae5531555c899c95b5359
+GitCommit: 61ada8678aa88664f3eeeea0506d8f8e89001878
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.7, 3.7.7, v3.7, 3.7, langres, v3, 3, latest
+Tags: v3.7.8, 3.7.8, v3.7, 3.7, langres, v3, 3, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 9a3e9159616cbe83ef7ae5531555c899c95b5359
+GitCommit: 61ada8678aa88664f3eeeea0506d8f8e89001878
 Directory: v3.7/alpine
 
 Tags: v3.6.23-windowsservercore-ltsc2025, 3.6.23-windowsservercore-ltsc2025, v3.6-windowsservercore-ltsc2025, 3.6-windowsservercore-ltsc2025, ramequin-windowsservercore-ltsc2025


### PR DESCRIPTION

Hello,

This PR updates Traefik to [v3.7.8](https://github.com/traefik/traefik/releases/tag/v3.7.8).

/cc @mmatur @rtribotte @juliens

Cheers
