### PR TITLE
Updated nginx mainline to 1.31.3, nginx stable to 1.30.4.

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,72 +3,72 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.31.2, mainline, 1, 1.31, latest, 1.31.2-trixie, mainline-trixie, 1-trixie, 1.31-trixie, trixie
+Tags: 1.31.3, mainline, 1, 1.31, latest, 1.31.3-trixie, mainline-trixie, 1-trixie, 1.31-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/debian
 
-Tags: 1.31.2-perl, mainline-perl, 1-perl, 1.31-perl, perl, 1.31.2-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.31-trixie-perl, trixie-perl
+Tags: 1.31.3-perl, mainline-perl, 1-perl, 1.31-perl, perl, 1.31.3-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.31-trixie-perl, trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/debian-perl
 
-Tags: 1.31.2-otel, mainline-otel, 1-otel, 1.31-otel, otel, 1.31.2-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.31-trixie-otel, trixie-otel
+Tags: 1.31.3-otel, mainline-otel, 1-otel, 1.31-otel, otel, 1.31.3-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.31-trixie-otel, trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/debian-otel
 
-Tags: 1.31.2-alpine, mainline-alpine, 1-alpine, 1.31-alpine, alpine, 1.31.2-alpine3.23, mainline-alpine3.23, 1-alpine3.23, 1.31-alpine3.23, alpine3.23
+Tags: 1.31.3-alpine, mainline-alpine, 1-alpine, 1.31-alpine, alpine, 1.31.3-alpine3.24, mainline-alpine3.24, 1-alpine3.24, 1.31-alpine3.24, alpine3.24
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/alpine
 
-Tags: 1.31.2-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.31-alpine-perl, alpine-perl, 1.31.2-alpine3.23-perl, mainline-alpine3.23-perl, 1-alpine3.23-perl, 1.31-alpine3.23-perl, alpine3.23-perl
+Tags: 1.31.3-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.31-alpine-perl, alpine-perl, 1.31.3-alpine3.24-perl, mainline-alpine3.24-perl, 1-alpine3.24-perl, 1.31-alpine3.24-perl, alpine3.24-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/alpine-perl
 
-Tags: 1.31.2-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.31-alpine-slim, alpine-slim, 1.31.2-alpine3.23-slim, mainline-alpine3.23-slim, 1-alpine3.23-slim, 1.31-alpine3.23-slim, alpine3.23-slim
+Tags: 1.31.3-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.31-alpine-slim, alpine-slim, 1.31.3-alpine3.24-slim, mainline-alpine3.24-slim, 1-alpine3.24-slim, 1.31-alpine3.24-slim, alpine3.24-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/alpine-slim
 
-Tags: 1.31.2-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.31-alpine-otel, alpine-otel, 1.31.2-alpine3.23-otel, mainline-alpine3.23-otel, 1-alpine3.23-otel, 1.31-alpine3.23-otel, alpine3.23-otel
+Tags: 1.31.3-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.31-alpine-otel, alpine-otel, 1.31.3-alpine3.24-otel, mainline-alpine3.24-otel, 1-alpine3.24-otel, 1.31-alpine3.24-otel, alpine3.24-otel
 Architectures: amd64, arm64v8
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: mainline/alpine-otel
 
-Tags: 1.30.3, stable, 1.30, 1.30.3-trixie, stable-trixie, 1.30-trixie
+Tags: 1.30.4, stable, 1.30, 1.30.4-trixie, stable-trixie, 1.30-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/debian
 
-Tags: 1.30.3-perl, stable-perl, 1.30-perl, 1.30.3-trixie-perl, stable-trixie-perl, 1.30-trixie-perl
+Tags: 1.30.4-perl, stable-perl, 1.30-perl, 1.30.4-trixie-perl, stable-trixie-perl, 1.30-trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/debian-perl
 
-Tags: 1.30.3-otel, stable-otel, 1.30-otel, 1.30.3-trixie-otel, stable-trixie-otel, 1.30-trixie-otel
+Tags: 1.30.4-otel, stable-otel, 1.30-otel, 1.30.4-trixie-otel, stable-trixie-otel, 1.30-trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/debian-otel
 
-Tags: 1.30.3-alpine, stable-alpine, 1.30-alpine, 1.30.3-alpine3.23, stable-alpine3.23, 1.30-alpine3.23
+Tags: 1.30.4-alpine, stable-alpine, 1.30-alpine, 1.30.4-alpine3.24, stable-alpine3.24, 1.30-alpine3.24
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/alpine
 
-Tags: 1.30.3-alpine-perl, stable-alpine-perl, 1.30-alpine-perl, 1.30.3-alpine3.23-perl, stable-alpine3.23-perl, 1.30-alpine3.23-perl
+Tags: 1.30.4-alpine-perl, stable-alpine-perl, 1.30-alpine-perl, 1.30.4-alpine3.24-perl, stable-alpine3.24-perl, 1.30-alpine3.24-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/alpine-perl
 
-Tags: 1.30.3-alpine-slim, stable-alpine-slim, 1.30-alpine-slim, 1.30.3-alpine3.23-slim, stable-alpine3.23-slim, 1.30-alpine3.23-slim
+Tags: 1.30.4-alpine-slim, stable-alpine-slim, 1.30-alpine-slim, 1.30.4-alpine3.24-slim, stable-alpine3.24-slim, 1.30-alpine3.24-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/alpine-slim
 
-Tags: 1.30.3-alpine-otel, stable-alpine-otel, 1.30-alpine-otel, 1.30.3-alpine3.23-otel, stable-alpine3.23-otel, 1.30-alpine3.23-otel
+Tags: 1.30.4-alpine-otel, stable-alpine-otel, 1.30-alpine-otel, 1.30.4-alpine3.24-otel, stable-alpine3.24-otel, 1.30-alpine3.24-otel
 Architectures: amd64, arm64v8
-GitCommit: 00348041cc12284266751457dcfc10b15645476a
+GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
 Directory: stable/alpine-otel


### PR DESCRIPTION
While at it, alpine-based images get a bump to 3.24, and njs gets bumped to 1.0.0.