### PR TITLE
lightstreamer: matrix refactor + -base variant

### DIFF
--- a/library/lightstreamer
+++ b/library/lightstreamer
@@ -3,322 +3,162 @@ Maintainers: Lightstreamer Server Development Team <support@lightstreamer.com> (
              Gianluca Finocchiaro <gianluca.finocchiaro@lightstreamer.com> (@gfinocchiaro)
 GitRepo: https://github.com/Lightstreamer/Docker.git
 
-Tags: 6.0.3-jdk8-temurin-jammy-base, 6.0-jdk8-temurin-jammy-base
+Tags: 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.0/jdk8
 
-Tags: 6.0.3-jdk8-temurin-jammy, 6.0-jdk8-temurin-jammy
+Tags: 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.0/jdk8-base
 
-Tags: 6.0.3-jdk8-temurin-noble-base, 6.0-jdk8-temurin-noble-base, 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
+Tags: 6.1.0-jdk8, 6.1-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8, 6-jdk8-temurin, 6.1.0, 6.1, 6
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.1/jdk8
 
-Tags: 6.0.3-jdk8-temurin-noble, 6.0-jdk8-temurin-noble, 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
+Tags: 6.1.0-jdk8-base, 6.1-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.0/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 6.1/jdk8-base
 
-Tags: 6.1.0-jdk8-temurin-jammy-base, 6.1-jdk8-temurin-jammy-base, 6-jdk8-temurin-jammy-base
+Tags: 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk8
 
-Tags: 6.1.0-jdk8-temurin-jammy, 6.1-jdk8-temurin-jammy, 6-jdk8-temurin-jammy
+Tags: 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk8-base
 
-Tags: 6.1.0-jdk8-temurin-noble-base, 6.1-jdk8-temurin-noble-base, 6-jdk8-temurin-noble-base, 6.1.0-jdk8-base, 6.1-jdk8-base, 6-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
+Tags: 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk11
 
-Tags: 6.1.0-jdk8-temurin-noble, 6.1-jdk8-temurin-noble, 6-jdk8-temurin-noble, 6.1.0-jdk8, 6.1-jdk8, 6-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8-temurin, 6.1.0, 6.1, 6
+Tags: 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 6.1/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.0/jdk11-base
 
-Tags: 7.0.3-jdk11-temurin-jammy-base, 7.0-jdk11-temurin-jammy-base
+Tags: 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk8
 
-Tags: 7.0.3-jdk11-temurin-jammy, 7.0-jdk11-temurin-jammy
+Tags: 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk8-base
 
-Tags: 7.0.3-jdk11-temurin-noble-base, 7.0-jdk11-temurin-noble-base, 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
+Tags: 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk11
 
-Tags: 7.0.3-jdk11-temurin-noble, 7.0-jdk11-temurin-noble, 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
+Tags: 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk11/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.1/jdk11-base
 
-Tags: 7.0.3-jdk8-temurin-jammy-base, 7.0-jdk8-temurin-jammy-base
+Tags: 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk8
 
-Tags: 7.0.3-jdk8-temurin-jammy, 7.0-jdk8-temurin-jammy
+Tags: 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk8-base
 
-Tags: 7.0.3-jdk8-temurin-noble-base, 7.0-jdk8-temurin-noble-base, 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
+Tags: 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk11
 
-Tags: 7.0.3-jdk8-temurin-noble, 7.0-jdk8-temurin-noble, 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
+Tags: 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.0/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.2/jdk11-base
 
-Tags: 7.1.3-jdk11-temurin-jammy-base, 7.1-jdk11-temurin-jammy-base
+Tags: 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk8
 
-Tags: 7.1.3-jdk11-temurin-jammy, 7.1-jdk11-temurin-jammy
+Tags: 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk8-base
 
-Tags: 7.1.3-jdk11-temurin-noble-base, 7.1-jdk11-temurin-noble-base, 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
+Tags: 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk11
 
-Tags: 7.1.3-jdk11-temurin-noble, 7.1-jdk11-temurin-noble, 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
+Tags: 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk11/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk11-base
 
-Tags: 7.1.3-jdk8-temurin-jammy-base, 7.1-jdk8-temurin-jammy-base
+Tags: 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk17
 
-Tags: 7.1.3-jdk8-temurin-jammy, 7.1-jdk8-temurin-jammy
+Tags: 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.3/jdk17-base
 
-Tags: 7.1.3-jdk8-temurin-noble-base, 7.1-jdk8-temurin-noble-base, 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
+Tags: 7.4.8-jdk8, 7.4-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8, 7-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk8
 
-Tags: 7.1.3-jdk8-temurin-noble, 7.1-jdk8-temurin-noble, 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
+Tags: 7.4.8-jdk8-base, 7.4-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-base, 7-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.1/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk8-base
 
-Tags: 7.2.2-jdk11-temurin-jammy-base, 7.2-jdk11-temurin-jammy-base
+Tags: 7.4.8-jdk11, 7.4-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11, 7-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk11
 
-Tags: 7.2.2-jdk11-temurin-jammy, 7.2-jdk11-temurin-jammy
+Tags: 7.4.8-jdk11-base, 7.4-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-base, 7-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk11-base
 
-Tags: 7.2.2-jdk11-temurin-noble-base, 7.2-jdk11-temurin-noble-base, 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
+Tags: 7.4.8-jdk17, 7.4-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17, 7-jdk17-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk17
 
-Tags: 7.2.2-jdk11-temurin-noble, 7.2-jdk11-temurin-noble, 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
+Tags: 7.4.8-jdk17-base, 7.4-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-base, 7-jdk17-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk11/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk17-base
 
-Tags: 7.2.2-jdk8-temurin-jammy-base, 7.2-jdk8-temurin-jammy-base
+Tags: 7.4.8-jdk21, 7.4-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21, 7-jdk21-temurin
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-jammy-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk21
 
-Tags: 7.2.2-jdk8-temurin-jammy, 7.2-jdk8-temurin-jammy
+Tags: 7.4.8-jdk21-base, 7.4-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-base, 7-jdk21-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-jammy
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk21-base
 
-Tags: 7.2.2-jdk8-temurin-noble-base, 7.2-jdk8-temurin-noble-base, 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
+Tags: 7.4.8-jdk25, 7.4-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-noble-base
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk25
 
-Tags: 7.2.2-jdk8-temurin-noble, 7.2-jdk8-temurin-noble, 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
+Tags: 7.4.8-jdk25-base, 7.4-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
 Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.2/jdk8/temurin-noble
-
-Tags: 7.3.3-jdk11-temurin-jammy-base, 7.3-jdk11-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-jammy-base
-
-Tags: 7.3.3-jdk11-temurin-jammy, 7.3-jdk11-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-jammy
-
-Tags: 7.3.3-jdk11-temurin-noble-base, 7.3-jdk11-temurin-noble-base, 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-noble-base
-
-Tags: 7.3.3-jdk11-temurin-noble, 7.3-jdk11-temurin-noble, 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk11/temurin-noble
-
-Tags: 7.3.3-jdk17-temurin-jammy-base, 7.3-jdk17-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-jammy-base
-
-Tags: 7.3.3-jdk17-temurin-jammy, 7.3-jdk17-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-jammy
-
-Tags: 7.3.3-jdk17-temurin-noble-base, 7.3-jdk17-temurin-noble-base, 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-noble-base
-
-Tags: 7.3.3-jdk17-temurin-noble, 7.3-jdk17-temurin-noble, 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk17/temurin-noble
-
-Tags: 7.3.3-jdk8-temurin-jammy-base, 7.3-jdk8-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-jammy-base
-
-Tags: 7.3.3-jdk8-temurin-jammy, 7.3-jdk8-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-jammy
-
-Tags: 7.3.3-jdk8-temurin-noble-base, 7.3-jdk8-temurin-noble-base, 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-noble-base
-
-Tags: 7.3.3-jdk8-temurin-noble, 7.3-jdk8-temurin-noble, 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.3/jdk8/temurin-noble
-
-Tags: 7.4.8-jdk11-temurin-jammy-base, 7.4-jdk11-temurin-jammy-base, 7-jdk11-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-jammy-base
-
-Tags: 7.4.8-jdk11-temurin-jammy, 7.4-jdk11-temurin-jammy, 7-jdk11-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-jammy
-
-Tags: 7.4.8-jdk11-temurin-noble-base, 7.4-jdk11-temurin-noble-base, 7-jdk11-temurin-noble-base, 7.4.8-jdk11-base, 7.4-jdk11-base, 7-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-noble-base
-
-Tags: 7.4.8-jdk11-temurin-noble, 7.4-jdk11-temurin-noble, 7-jdk11-temurin-noble, 7.4.8-jdk11, 7.4-jdk11, 7-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk11/temurin-noble
-
-Tags: 7.4.8-jdk17-temurin-jammy-base, 7.4-jdk17-temurin-jammy-base, 7-jdk17-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-jammy-base
-
-Tags: 7.4.8-jdk17-temurin-jammy, 7.4-jdk17-temurin-jammy, 7-jdk17-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-jammy
-
-Tags: 7.4.8-jdk17-temurin-noble-base, 7.4-jdk17-temurin-noble-base, 7-jdk17-temurin-noble-base, 7.4.8-jdk17-base, 7.4-jdk17-base, 7-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-noble-base
-
-Tags: 7.4.8-jdk17-temurin-noble, 7.4-jdk17-temurin-noble, 7-jdk17-temurin-noble, 7.4.8-jdk17, 7.4-jdk17, 7-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk17/temurin-noble
-
-Tags: 7.4.8-jdk21-temurin-jammy-base, 7.4-jdk21-temurin-jammy-base, 7-jdk21-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-jammy-base
-
-Tags: 7.4.8-jdk21-temurin-jammy, 7.4-jdk21-temurin-jammy, 7-jdk21-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-jammy
-
-Tags: 7.4.8-jdk21-temurin-noble-base, 7.4-jdk21-temurin-noble-base, 7-jdk21-temurin-noble-base, 7.4.8-jdk21-base, 7.4-jdk21-base, 7-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-noble-base
-
-Tags: 7.4.8-jdk21-temurin-noble, 7.4-jdk21-temurin-noble, 7-jdk21-temurin-noble, 7.4.8-jdk21, 7.4-jdk21, 7-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk21/temurin-noble
-
-Tags: 7.4.8-jdk25-temurin-jammy-base, 7.4-jdk25-temurin-jammy-base, 7-jdk25-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-jammy-base
-
-Tags: 7.4.8-jdk25-temurin-jammy, 7.4-jdk25-temurin-jammy, 7-jdk25-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-jammy
-
-Tags: 7.4.8-jdk25-temurin-noble-base, 7.4-jdk25-temurin-noble-base, 7-jdk25-temurin-noble-base, 7.4.8-jdk25-base, 7.4-jdk25-base, 7-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-noble-base
-
-Tags: 7.4.8-jdk25-temurin-noble, 7.4-jdk25-temurin-noble, 7-jdk25-temurin-noble, 7.4.8-jdk25, 7.4-jdk25, 7-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk25/temurin-noble
-
-Tags: 7.4.8-jdk8-temurin-jammy-base, 7.4-jdk8-temurin-jammy-base, 7-jdk8-temurin-jammy-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-jammy-base
-
-Tags: 7.4.8-jdk8-temurin-jammy, 7.4-jdk8-temurin-jammy, 7-jdk8-temurin-jammy
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-jammy
-
-Tags: 7.4.8-jdk8-temurin-noble-base, 7.4-jdk8-temurin-noble-base, 7-jdk8-temurin-noble-base, 7.4.8-jdk8-base, 7.4-jdk8-base, 7-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-temurin-base
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-noble-base
-
-Tags: 7.4.8-jdk8-temurin-noble, 7.4-jdk8-temurin-noble, 7-jdk8-temurin-noble, 7.4.8-jdk8, 7.4-jdk8, 7-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8-temurin
-Architectures: amd64, arm64v8
-GitCommit: 156c401231708a23043ac9a06238569e10a3d406
-Directory: 7.4/jdk8/temurin-noble
+GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+Directory: 7.4/jdk25-base

--- a/library/lightstreamer
+++ b/library/lightstreamer
@@ -1,84 +1,324 @@
 Maintainers: Lightstreamer Server Development Team <support@lightstreamer.com> (@lightstreamer),
-             Dario Crivelli <dario.crivelli@lightstreamer.com> (@dario-weswit)
+             Dario Crivelli <dario.crivelli@lightstreamer.com> (@dario-weswit),
+             Gianluca Finocchiaro <gianluca.finocchiaro@lightstreamer.com> (@gfinocchiaro)
 GitRepo: https://github.com/Lightstreamer/Docker.git
 
-Tags: 6.0.3, 6.0
+Tags: 6.0.3-jdk8-temurin-jammy-base, 6.0-jdk8-temurin-jammy-base
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 6.0
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.0/jdk8/temurin-jammy-base
 
-Tags: 6.1.0, 6.1, 6
+Tags: 6.0.3-jdk8-temurin-jammy, 6.0-jdk8-temurin-jammy
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 6.1
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.0/jdk8/temurin-jammy
 
-Tags: 7.0.3-jdk8-temurin, 7.0-jdk8-temurin, 7.0.3-jdk8, 7.0-jdk8
+Tags: 6.0.3-jdk8-temurin-noble-base, 6.0-jdk8-temurin-noble-base, 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.0/jdk8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.0/jdk8/temurin-noble-base
 
-Tags: 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3-jdk11, 7.0-jdk11, 7.0.3, 7.0
+Tags: 6.0.3-jdk8-temurin-noble, 6.0-jdk8-temurin-noble, 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.0/jdk11
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.0/jdk8/temurin-noble
 
-Tags: 7.1.3-jdk8-temurin, 7.1-jdk8-temurin, 7.1.3-jdk8, 7.1-jdk8
+Tags: 6.1.0-jdk8-temurin-jammy-base, 6.1-jdk8-temurin-jammy-base, 6-jdk8-temurin-jammy-base
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.1/jdk8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.1/jdk8/temurin-jammy-base
 
-Tags: 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3-jdk11, 7.1-jdk11, 7.1.3, 7.1
+Tags: 6.1.0-jdk8-temurin-jammy, 6.1-jdk8-temurin-jammy, 6-jdk8-temurin-jammy
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.1/jdk11
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.1/jdk8/temurin-jammy
 
-Tags: 7.2.2-jdk8-temurin, 7.2-jdk8-temurin, 7.2.2-jdk8, 7.2-jdk8
+Tags: 6.1.0-jdk8-temurin-noble-base, 6.1-jdk8-temurin-noble-base, 6-jdk8-temurin-noble-base, 6.1.0-jdk8-base, 6.1-jdk8-base, 6-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.2/jdk8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.1/jdk8/temurin-noble-base
 
-Tags: 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2-jdk11, 7.2-jdk11, 7.2.2, 7.2
+Tags: 6.1.0-jdk8-temurin-noble, 6.1-jdk8-temurin-noble, 6-jdk8-temurin-noble, 6.1.0-jdk8, 6.1-jdk8, 6-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8-temurin, 6.1.0, 6.1, 6
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.2/jdk11
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 6.1/jdk8/temurin-noble
 
-Tags: 7.3.3-jdk8-temurin, 7.3-jdk8-temurin, 7.3.3-jdk8, 7.3-jdk8
+Tags: 7.0.3-jdk11-temurin-jammy-base, 7.0-jdk11-temurin-jammy-base
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.3/jdk8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk11/temurin-jammy-base
 
-Tags: 7.3.3-jdk11-temurin, 7.3-jdk11-temurin, 7.3.3-jdk11, 7.3-jdk11
+Tags: 7.0.3-jdk11-temurin-jammy, 7.0-jdk11-temurin-jammy
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.3/jdk11
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk11/temurin-jammy
 
-Tags: 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3-jdk17, 7.3-jdk17, 7.3.3, 7.3
+Tags: 7.0.3-jdk11-temurin-noble-base, 7.0-jdk11-temurin-noble-base, 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
 Architectures: amd64, arm64v8
-GitCommit: b6c4a87af3e78b53887f311bdf2404f4f9956796
-Directory: 7.3/jdk17
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk11/temurin-noble-base
 
-Tags: 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8-temurin, 7.4.8-jdk8, 7.4-jdk8, 7-jdk8
+Tags: 7.0.3-jdk11-temurin-noble, 7.0-jdk11-temurin-noble, 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
 Architectures: amd64, arm64v8
-GitCommit: e9f661a11fd775edfe188bb2e4f9ada8e8dad2cb
-Directory: 7.4/jdk8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk11/temurin-noble
 
-Tags: 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11-temurin, 7.4.8-jdk11, 7.4-jdk11, 7-jdk11
+Tags: 7.0.3-jdk8-temurin-jammy-base, 7.0-jdk8-temurin-jammy-base
 Architectures: amd64, arm64v8
-GitCommit: e9f661a11fd775edfe188bb2e4f9ada8e8dad2cb
-Directory: 7.4/jdk11
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk8/temurin-jammy-base
 
-Tags: 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17-temurin, 7.4.8-jdk17, 7.4-jdk17, 7-jdk17
+Tags: 7.0.3-jdk8-temurin-jammy, 7.0-jdk8-temurin-jammy
 Architectures: amd64, arm64v8
-GitCommit: e9f661a11fd775edfe188bb2e4f9ada8e8dad2cb
-Directory: 7.4/jdk17
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk8/temurin-jammy
 
-Tags: 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21-temurin, 7.4.8-jdk21, 7.4-jdk21, 7-jdk21
+Tags: 7.0.3-jdk8-temurin-noble-base, 7.0-jdk8-temurin-noble-base, 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: e9f661a11fd775edfe188bb2e4f9ada8e8dad2cb
-Directory: 7.4/jdk21
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk8/temurin-noble-base
 
-Tags: 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25-temurin, 7.4.8-jdk25, 7.4-jdk25, 7-jdk25, 7.4.8, 7.4, 7, latest
+Tags: 7.0.3-jdk8-temurin-noble, 7.0-jdk8-temurin-noble, 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: e9f661a11fd775edfe188bb2e4f9ada8e8dad2cb
-Directory: 7.4/jdk25
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.0/jdk8/temurin-noble
 
+Tags: 7.1.3-jdk11-temurin-jammy-base, 7.1-jdk11-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk11/temurin-jammy-base
+
+Tags: 7.1.3-jdk11-temurin-jammy, 7.1-jdk11-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk11/temurin-jammy
+
+Tags: 7.1.3-jdk11-temurin-noble-base, 7.1-jdk11-temurin-noble-base, 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk11/temurin-noble-base
+
+Tags: 7.1.3-jdk11-temurin-noble, 7.1-jdk11-temurin-noble, 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk11/temurin-noble
+
+Tags: 7.1.3-jdk8-temurin-jammy-base, 7.1-jdk8-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk8/temurin-jammy-base
+
+Tags: 7.1.3-jdk8-temurin-jammy, 7.1-jdk8-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk8/temurin-jammy
+
+Tags: 7.1.3-jdk8-temurin-noble-base, 7.1-jdk8-temurin-noble-base, 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk8/temurin-noble-base
+
+Tags: 7.1.3-jdk8-temurin-noble, 7.1-jdk8-temurin-noble, 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.1/jdk8/temurin-noble
+
+Tags: 7.2.2-jdk11-temurin-jammy-base, 7.2-jdk11-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk11/temurin-jammy-base
+
+Tags: 7.2.2-jdk11-temurin-jammy, 7.2-jdk11-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk11/temurin-jammy
+
+Tags: 7.2.2-jdk11-temurin-noble-base, 7.2-jdk11-temurin-noble-base, 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk11/temurin-noble-base
+
+Tags: 7.2.2-jdk11-temurin-noble, 7.2-jdk11-temurin-noble, 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk11/temurin-noble
+
+Tags: 7.2.2-jdk8-temurin-jammy-base, 7.2-jdk8-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk8/temurin-jammy-base
+
+Tags: 7.2.2-jdk8-temurin-jammy, 7.2-jdk8-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk8/temurin-jammy
+
+Tags: 7.2.2-jdk8-temurin-noble-base, 7.2-jdk8-temurin-noble-base, 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk8/temurin-noble-base
+
+Tags: 7.2.2-jdk8-temurin-noble, 7.2-jdk8-temurin-noble, 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.2/jdk8/temurin-noble
+
+Tags: 7.3.3-jdk11-temurin-jammy-base, 7.3-jdk11-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk11/temurin-jammy-base
+
+Tags: 7.3.3-jdk11-temurin-jammy, 7.3-jdk11-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk11/temurin-jammy
+
+Tags: 7.3.3-jdk11-temurin-noble-base, 7.3-jdk11-temurin-noble-base, 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk11/temurin-noble-base
+
+Tags: 7.3.3-jdk11-temurin-noble, 7.3-jdk11-temurin-noble, 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk11/temurin-noble
+
+Tags: 7.3.3-jdk17-temurin-jammy-base, 7.3-jdk17-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk17/temurin-jammy-base
+
+Tags: 7.3.3-jdk17-temurin-jammy, 7.3-jdk17-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk17/temurin-jammy
+
+Tags: 7.3.3-jdk17-temurin-noble-base, 7.3-jdk17-temurin-noble-base, 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk17/temurin-noble-base
+
+Tags: 7.3.3-jdk17-temurin-noble, 7.3-jdk17-temurin-noble, 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk17/temurin-noble
+
+Tags: 7.3.3-jdk8-temurin-jammy-base, 7.3-jdk8-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk8/temurin-jammy-base
+
+Tags: 7.3.3-jdk8-temurin-jammy, 7.3-jdk8-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk8/temurin-jammy
+
+Tags: 7.3.3-jdk8-temurin-noble-base, 7.3-jdk8-temurin-noble-base, 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk8/temurin-noble-base
+
+Tags: 7.3.3-jdk8-temurin-noble, 7.3-jdk8-temurin-noble, 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.3/jdk8/temurin-noble
+
+Tags: 7.4.8-jdk11-temurin-jammy-base, 7.4-jdk11-temurin-jammy-base, 7-jdk11-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk11/temurin-jammy-base
+
+Tags: 7.4.8-jdk11-temurin-jammy, 7.4-jdk11-temurin-jammy, 7-jdk11-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk11/temurin-jammy
+
+Tags: 7.4.8-jdk11-temurin-noble-base, 7.4-jdk11-temurin-noble-base, 7-jdk11-temurin-noble-base, 7.4.8-jdk11-base, 7.4-jdk11-base, 7-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk11/temurin-noble-base
+
+Tags: 7.4.8-jdk11-temurin-noble, 7.4-jdk11-temurin-noble, 7-jdk11-temurin-noble, 7.4.8-jdk11, 7.4-jdk11, 7-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk11/temurin-noble
+
+Tags: 7.4.8-jdk17-temurin-jammy-base, 7.4-jdk17-temurin-jammy-base, 7-jdk17-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk17/temurin-jammy-base
+
+Tags: 7.4.8-jdk17-temurin-jammy, 7.4-jdk17-temurin-jammy, 7-jdk17-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk17/temurin-jammy
+
+Tags: 7.4.8-jdk17-temurin-noble-base, 7.4-jdk17-temurin-noble-base, 7-jdk17-temurin-noble-base, 7.4.8-jdk17-base, 7.4-jdk17-base, 7-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk17/temurin-noble-base
+
+Tags: 7.4.8-jdk17-temurin-noble, 7.4-jdk17-temurin-noble, 7-jdk17-temurin-noble, 7.4.8-jdk17, 7.4-jdk17, 7-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk17/temurin-noble
+
+Tags: 7.4.8-jdk21-temurin-jammy-base, 7.4-jdk21-temurin-jammy-base, 7-jdk21-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk21/temurin-jammy-base
+
+Tags: 7.4.8-jdk21-temurin-jammy, 7.4-jdk21-temurin-jammy, 7-jdk21-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk21/temurin-jammy
+
+Tags: 7.4.8-jdk21-temurin-noble-base, 7.4-jdk21-temurin-noble-base, 7-jdk21-temurin-noble-base, 7.4.8-jdk21-base, 7.4-jdk21-base, 7-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk21/temurin-noble-base
+
+Tags: 7.4.8-jdk21-temurin-noble, 7.4-jdk21-temurin-noble, 7-jdk21-temurin-noble, 7.4.8-jdk21, 7.4-jdk21, 7-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk21/temurin-noble
+
+Tags: 7.4.8-jdk25-temurin-jammy-base, 7.4-jdk25-temurin-jammy-base, 7-jdk25-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk25/temurin-jammy-base
+
+Tags: 7.4.8-jdk25-temurin-jammy, 7.4-jdk25-temurin-jammy, 7-jdk25-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk25/temurin-jammy
+
+Tags: 7.4.8-jdk25-temurin-noble-base, 7.4-jdk25-temurin-noble-base, 7-jdk25-temurin-noble-base, 7.4.8-jdk25-base, 7.4-jdk25-base, 7-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk25/temurin-noble-base
+
+Tags: 7.4.8-jdk25-temurin-noble, 7.4-jdk25-temurin-noble, 7-jdk25-temurin-noble, 7.4.8-jdk25, 7.4-jdk25, 7-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk25/temurin-noble
+
+Tags: 7.4.8-jdk8-temurin-jammy-base, 7.4-jdk8-temurin-jammy-base, 7-jdk8-temurin-jammy-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk8/temurin-jammy-base
+
+Tags: 7.4.8-jdk8-temurin-jammy, 7.4-jdk8-temurin-jammy, 7-jdk8-temurin-jammy
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk8/temurin-jammy
+
+Tags: 7.4.8-jdk8-temurin-noble-base, 7.4-jdk8-temurin-noble-base, 7-jdk8-temurin-noble-base, 7.4.8-jdk8-base, 7.4-jdk8-base, 7-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-temurin-base
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk8/temurin-noble-base
+
+Tags: 7.4.8-jdk8-temurin-noble, 7.4-jdk8-temurin-noble, 7-jdk8-temurin-noble, 7.4.8-jdk8, 7.4-jdk8, 7-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8-temurin
+Architectures: amd64, arm64v8
+GitCommit: 156c401231708a23043ac9a06238569e10a3d406
+Directory: 7.4/jdk8/temurin-noble

--- a/library/lightstreamer
+++ b/library/lightstreamer
@@ -5,160 +5,160 @@ GitRepo: https://github.com/Lightstreamer/Docker.git
 
 Tags: 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 6.0/jdk8
 
 Tags: 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 6.0/jdk8-base
 
 Tags: 6.1.0-jdk8, 6.1-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8, 6-jdk8-temurin, 6.1.0, 6.1, 6
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 6.1/jdk8
 
 Tags: 6.1.0-jdk8-base, 6.1-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 6.1/jdk8-base
 
 Tags: 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.0/jdk8
 
 Tags: 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.0/jdk8-base
 
 Tags: 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.0/jdk11
 
 Tags: 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.0/jdk11-base
 
 Tags: 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.1/jdk8
 
 Tags: 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.1/jdk8-base
 
 Tags: 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.1/jdk11
 
 Tags: 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.1/jdk11-base
 
 Tags: 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.2/jdk8
 
 Tags: 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.2/jdk8-base
 
 Tags: 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.2/jdk11
 
 Tags: 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.2/jdk11-base
 
 Tags: 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.3/jdk8
 
 Tags: 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.3/jdk8-base
 
 Tags: 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.3/jdk11
 
 Tags: 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.3/jdk11-base
 
 Tags: 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.3/jdk17
 
 Tags: 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.3/jdk17-base
 
 Tags: 7.4.8-jdk8, 7.4-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8, 7-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk8
 
 Tags: 7.4.8-jdk8-base, 7.4-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-base, 7-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk8-base
 
 Tags: 7.4.8-jdk11, 7.4-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11, 7-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk11
 
 Tags: 7.4.8-jdk11-base, 7.4-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-base, 7-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk11-base
 
 Tags: 7.4.8-jdk17, 7.4-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17, 7-jdk17-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk17
 
 Tags: 7.4.8-jdk17-base, 7.4-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-base, 7-jdk17-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk17-base
 
 Tags: 7.4.8-jdk21, 7.4-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21, 7-jdk21-temurin
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk21
 
 Tags: 7.4.8-jdk21-base, 7.4-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-base, 7-jdk21-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk21-base
 
 Tags: 7.4.8-jdk25, 7.4-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk25
 
 Tags: 7.4.8-jdk25-base, 7.4-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
 Architectures: amd64, arm64v8
-GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
+GitCommit: 52bdda2121071588ab5cb36be7bc5a01eaf89e6e
 Directory: 7.4/jdk25-base

--- a/library/lightstreamer
+++ b/library/lightstreamer
@@ -5,160 +5,160 @@ GitRepo: https://github.com/Lightstreamer/Docker.git
 
 Tags: 6.0.3-jdk8, 6.0-jdk8, 6.0.3-jdk8-temurin, 6.0-jdk8-temurin, 6.0.3, 6.0
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 6.0/jdk8
 
 Tags: 6.0.3-jdk8-base, 6.0-jdk8-base, 6.0.3-jdk8-temurin-base, 6.0-jdk8-temurin-base, 6.0.3-base, 6.0-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 6.0/jdk8-base
 
 Tags: 6.1.0-jdk8, 6.1-jdk8, 6.1.0-jdk8-temurin, 6.1-jdk8-temurin, 6-jdk8, 6-jdk8-temurin, 6.1.0, 6.1, 6
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 6.1/jdk8
 
 Tags: 6.1.0-jdk8-base, 6.1-jdk8-base, 6.1.0-jdk8-temurin-base, 6.1-jdk8-temurin-base, 6-jdk8-base, 6-jdk8-temurin-base, 6.1.0-base, 6.1-base, 6-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 6.1/jdk8-base
 
 Tags: 7.0.3-jdk8, 7.0-jdk8, 7.0.3-jdk8-temurin, 7.0-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.0/jdk8
 
 Tags: 7.0.3-jdk8-base, 7.0-jdk8-base, 7.0.3-jdk8-temurin-base, 7.0-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.0/jdk8-base
 
 Tags: 7.0.3-jdk11, 7.0-jdk11, 7.0.3-jdk11-temurin, 7.0-jdk11-temurin, 7.0.3, 7.0
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.0/jdk11
 
 Tags: 7.0.3-jdk11-base, 7.0-jdk11-base, 7.0.3-jdk11-temurin-base, 7.0-jdk11-temurin-base, 7.0.3-base, 7.0-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.0/jdk11-base
 
 Tags: 7.1.3-jdk8, 7.1-jdk8, 7.1.3-jdk8-temurin, 7.1-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.1/jdk8
 
 Tags: 7.1.3-jdk8-base, 7.1-jdk8-base, 7.1.3-jdk8-temurin-base, 7.1-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.1/jdk8-base
 
 Tags: 7.1.3-jdk11, 7.1-jdk11, 7.1.3-jdk11-temurin, 7.1-jdk11-temurin, 7.1.3, 7.1
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.1/jdk11
 
 Tags: 7.1.3-jdk11-base, 7.1-jdk11-base, 7.1.3-jdk11-temurin-base, 7.1-jdk11-temurin-base, 7.1.3-base, 7.1-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.1/jdk11-base
 
 Tags: 7.2.2-jdk8, 7.2-jdk8, 7.2.2-jdk8-temurin, 7.2-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.2/jdk8
 
 Tags: 7.2.2-jdk8-base, 7.2-jdk8-base, 7.2.2-jdk8-temurin-base, 7.2-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.2/jdk8-base
 
 Tags: 7.2.2-jdk11, 7.2-jdk11, 7.2.2-jdk11-temurin, 7.2-jdk11-temurin, 7.2.2, 7.2
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.2/jdk11
 
 Tags: 7.2.2-jdk11-base, 7.2-jdk11-base, 7.2.2-jdk11-temurin-base, 7.2-jdk11-temurin-base, 7.2.2-base, 7.2-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.2/jdk11-base
 
 Tags: 7.3.3-jdk8, 7.3-jdk8, 7.3.3-jdk8-temurin, 7.3-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.3/jdk8
 
 Tags: 7.3.3-jdk8-base, 7.3-jdk8-base, 7.3.3-jdk8-temurin-base, 7.3-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.3/jdk8-base
 
 Tags: 7.3.3-jdk11, 7.3-jdk11, 7.3.3-jdk11-temurin, 7.3-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.3/jdk11
 
 Tags: 7.3.3-jdk11-base, 7.3-jdk11-base, 7.3.3-jdk11-temurin-base, 7.3-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.3/jdk11-base
 
 Tags: 7.3.3-jdk17, 7.3-jdk17, 7.3.3-jdk17-temurin, 7.3-jdk17-temurin, 7.3.3, 7.3
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.3/jdk17
 
 Tags: 7.3.3-jdk17-base, 7.3-jdk17-base, 7.3.3-jdk17-temurin-base, 7.3-jdk17-temurin-base, 7.3.3-base, 7.3-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.3/jdk17-base
 
 Tags: 7.4.8-jdk8, 7.4-jdk8, 7.4.8-jdk8-temurin, 7.4-jdk8-temurin, 7-jdk8, 7-jdk8-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk8
 
 Tags: 7.4.8-jdk8-base, 7.4-jdk8-base, 7.4.8-jdk8-temurin-base, 7.4-jdk8-temurin-base, 7-jdk8-base, 7-jdk8-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk8-base
 
 Tags: 7.4.8-jdk11, 7.4-jdk11, 7.4.8-jdk11-temurin, 7.4-jdk11-temurin, 7-jdk11, 7-jdk11-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk11
 
 Tags: 7.4.8-jdk11-base, 7.4-jdk11-base, 7.4.8-jdk11-temurin-base, 7.4-jdk11-temurin-base, 7-jdk11-base, 7-jdk11-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk11-base
 
 Tags: 7.4.8-jdk17, 7.4-jdk17, 7.4.8-jdk17-temurin, 7.4-jdk17-temurin, 7-jdk17, 7-jdk17-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk17
 
 Tags: 7.4.8-jdk17-base, 7.4-jdk17-base, 7.4.8-jdk17-temurin-base, 7.4-jdk17-temurin-base, 7-jdk17-base, 7-jdk17-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk17-base
 
 Tags: 7.4.8-jdk21, 7.4-jdk21, 7.4.8-jdk21-temurin, 7.4-jdk21-temurin, 7-jdk21, 7-jdk21-temurin
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk21
 
 Tags: 7.4.8-jdk21-base, 7.4-jdk21-base, 7.4.8-jdk21-temurin-base, 7.4-jdk21-temurin-base, 7-jdk21-base, 7-jdk21-temurin-base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk21-base
 
 Tags: 7.4.8-jdk25, 7.4-jdk25, 7.4.8-jdk25-temurin, 7.4-jdk25-temurin, 7-jdk25, 7-jdk25-temurin, 7.4.8, 7.4, 7, latest
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk25
 
 Tags: 7.4.8-jdk25-base, 7.4-jdk25-base, 7.4.8-jdk25-temurin-base, 7.4-jdk25-temurin-base, 7-jdk25-base, 7-jdk25-temurin-base, 7.4.8-base, 7.4-base, 7-base, base
 Architectures: amd64, arm64v8
-GitCommit: ca38a7d50a3c1a6e50fdc2cfb53e480673f356f9
+GitCommit: 8f15c7f4051c1d0b9ee1894095efa9bafd8e7677
 Directory: 7.4/jdk25-base


### PR DESCRIPTION
Refactor of the entire matrix. Highlights:

- All previously-published tag names remain valid — no `docker pull` will 404.
- Every previously-published tag continues to use Eclipse Temurin as its JDK.
- Directory layout changed to `<mm>/<runtime>/temurin-<os>/`, which lets us publish explicit-OS tag variants (`-noble`, `-jammy`) instead of relying on Temurin's floating default.
- All pre-existing tags now resolve to `temurin-noble` (previously they used Temurin's unpinned base). Same JDK, forward-compatible OS pin.
- New `-base` edition (`base`, `<ver>-<runtime>-temurin-<os>-base`, etc.) provides a minimal image with factory config stripped, intended for downstream to layer their own conf/adapters.
- Retains the `-temurin` (no-OS) alias family for backwards compatibility.
 - Adds Gianluca Finocchiaro (@gfinocchiaro) to the `Maintainers:` list.