### PR TITLE
Odoo: update 17.0-19.0 to release 20260716

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 6f3febcf4fc91b069d707b7b1bf93c77b019d0aa
+GitCommit: f7f6765354127c8ca31c373f51a840d9ec79149d
 
-Tags: 19.0-20260630, 19.0, 19, latest
+Tags: 19.0-20260723, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20260630, 18.0, 18
+Tags: 18.0-20260723, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20260630, 17.0, 17
+Tags: 17.0-20260723, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the latest updated of Odoo supported versions.
Also, npm was removed from the image in order to reclaim space.

Thks