### PR TITLE
rust: Update Rust to 1.97.1

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,53 +5,53 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.97-bullseye, 1.97.0-bullseye, bullseye
+Tags: 1-bullseye, 1.97-bullseye, 1.97.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.97-slim-bullseye, 1.97.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.97-slim-bullseye, 1.97.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.97-bookworm, 1.97.0-bookworm, bookworm
+Tags: 1-bookworm, 1.97-bookworm, 1.97.1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.97-slim-bookworm, 1.97.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.97-slim-bookworm, 1.97.1-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.97-trixie, 1.97.0-trixie, trixie, 1, 1.97, 1.97.0, latest
+Tags: 1-trixie, 1.97-trixie, 1.97.1-trixie, trixie, 1, 1.97, 1.97.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.97-slim-trixie, 1.97.0-slim-trixie, slim-trixie, 1-slim, 1.97-slim, 1.97.0-slim, slim
+Tags: 1-slim-trixie, 1.97-slim-trixie, 1.97.1-slim-trixie, slim-trixie, 1-slim, 1.97-slim, 1.97.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.21, 1.97-alpine3.21, 1.97.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.97-alpine3.21, 1.97.1-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.97-alpine3.22, 1.97.0-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.97-alpine3.22, 1.97.1-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.97-alpine3.23, 1.97.0-alpine3.23, alpine3.23
+Tags: 1-alpine3.23, 1.97-alpine3.23, 1.97.1-alpine3.23, alpine3.23
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/alpine3.23
 
-Tags: 1-alpine3.24, 1.97-alpine3.24, 1.97.0-alpine3.24, alpine3.24, 1-alpine, 1.97-alpine, 1.97.0-alpine, alpine
+Tags: 1-alpine3.24, 1.97-alpine3.24, 1.97.1-alpine3.24, alpine3.24, 1-alpine, 1.97-alpine, 1.97.1-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ed5becd64c545a35d43519984f537f43d098cff
+GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/alpine3.24
 


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.97.1
https://blog.rust-lang.org/2026/07/16/Rust-1.97.1/