### PR TITLE
[security] Update ruby

### DIFF
--- a/library/ruby
+++ b/library/ruby
@@ -64,32 +64,32 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 4ea2e7e222ba458994a266920e8815140bc2c901
 Directory: 3.4/alpine3.23
 
-Tags: 3.3.11-trixie, 3.3-trixie, 3.3.11, 3.3
+Tags: 3.3.12-trixie, 3.3-trixie, 3.3.12, 3.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d7aaaf1227ccf244c72405748a9ca5e026e75c63
+GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/trixie
 
-Tags: 3.3.11-slim-trixie, 3.3-slim-trixie, 3.3.11-slim, 3.3-slim
+Tags: 3.3.12-slim-trixie, 3.3-slim-trixie, 3.3.12-slim, 3.3-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d7aaaf1227ccf244c72405748a9ca5e026e75c63
+GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/slim-trixie
 
-Tags: 3.3.11-bookworm, 3.3-bookworm
+Tags: 3.3.12-bookworm, 3.3-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d7aaaf1227ccf244c72405748a9ca5e026e75c63
+GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/bookworm
 
-Tags: 3.3.11-slim-bookworm, 3.3-slim-bookworm
+Tags: 3.3.12-slim-bookworm, 3.3-slim-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: d7aaaf1227ccf244c72405748a9ca5e026e75c63
+GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/slim-bookworm
 
-Tags: 3.3.11-alpine3.24, 3.3-alpine3.24, 3.3.11-alpine, 3.3-alpine
+Tags: 3.3.12-alpine3.24, 3.3-alpine3.24, 3.3.12-alpine, 3.3-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 722133125d0cacfafa3dc09e7f57087df2c76b0b
+GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/alpine3.24
 
-Tags: 3.3.11-alpine3.23, 3.3-alpine3.23
+Tags: 3.3.12-alpine3.23, 3.3-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d7aaaf1227ccf244c72405748a9ca5e026e75c63
+GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/alpine3.23


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/ruby/commit/31475ec: Update 3.3 to 3.3.12

https://www.ruby-lang.org/en/news/2026/07/16/ruby-3-3-12-released/