### PR TITLE
Update oraclelinux for 9 and 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: c182f3c2adce2c7d89698c5346570b7ef6294e3a
+amd64-GitCommit: 933e7860db994da27f3e7770dd22f231bf495e9d
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 8ac7a9ac4c4370096e49db719f08d2a4de52f6e7
+arm64v8-GitCommit: 620c06b1ee494209f03f09fdf35a11cd055677ac
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 9
- [ELSA-2026-38511](https://linux.oracle.com/errata/ELSA-2026-38511.html)

### Oracle Linux 8
- [ELSA-2026-33126](https://linux.oracle.com/errata/ELSA-2026-33126.html)
- [ELSA-2026-38503](https://linux.oracle.com/errata/ELSA-2026-38503.html)
- [ELSA-2026-38510](https://linux.oracle.com/errata/ELSA-2026-38510.html)
- [ELSA-2026-39320](https://linux.oracle.com/errata/ELSA-2026-39320.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
