### PR TITLE
Update influxdb 3.10 core to 3.10.3

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 2ac466229d7c615c795d9af5ec009614e0c5b73d
+GitCommit: 20a6a80079b50ec78170871b4bce420a38a9d0fa
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -70,7 +70,7 @@ Tags: 3.9-enterprise, 3.9.9-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-enterprise
 
-Tags: 3-core, 3.10-core, 3.10.1-core, core
+Tags: 3-core, 3.10-core, 3.10.3-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-core
 


### PR DESCRIPTION
Bumps the InfluxDB 3 core images to the latest patch release:

- `3-core`, `3.10-core`, `3.10.3-core`, `core`: 3.10.1 -> 3.10.3

`GitCommit` is advanced to influxdata-docker `20a6a80` (influxdata/influxdata-docker#905), whose only `influxdb/` change since the previous manifest commit is the `3.10-core/Dockerfile` version bump above -- so no other InfluxDB images rebuild. Enterprise and 3.9 tags are unchanged. Release artifacts (tarball, `.asc` signature, `.sha256`) are published on dl.influxdata.com for linux amd64/arm64.