### PR TITLE
Update 6 to 6.53.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -1,15 +1,13 @@
-# this file is generated via https://github.com/TryGhost/docker-library-ghost/blob/9fb421959252801fdf17f77fb323e339201c9974/generate-stackbrew-library.sh
+# this file is generated via https://github.com/TryGhost/docker-library-ghost/blob/33bc5a970d63ea9461fbfda72a7299aacdd83465/generate-stackbrew-library.sh
 
-Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
-             Joseph Ferguson <yosifkit@gmail.com> (@yosifkit),
-             Austin Burdine <austin@ghost.org> (@acburdine)
+Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 6678c7b0b3609acb363578ee4b718a4fa9960ee2
+GitCommit: aff074ca2b1fb1b2a7fc4d20a230e092f51d55e1
 
-Tags: 6.52.1-bookworm, 6.52.1, 6.52-bookworm, 6.52, 6-bookworm, 6, bookworm, latest
+Tags: 6.53.0-bookworm, 6.53.0, 6.53-bookworm, 6.53, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.52.1-alpine3.23, 6.52.1-alpine, 6.52-alpine3.23, 6.52-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.53.0-alpine3.23, 6.53.0-alpine, 6.53-alpine3.23, 6.53-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.53.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/aff074ca2b1fb1b2a7fc4d20a230e092f51d55e1.