### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.12.20260706.1
+Tags: 2023, latest, 2023.12.20260710.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 9ae7e8f5ae855849261ffa5b014c86e9d94b08f0
+amd64-GitCommit: 2478dd3f94cea14d437682e817172d4b63c15e71
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 0010dc09d88635df46ae49440bdfe80d2715f906
+arm64v8-GitCommit: 5d31a103d559c9c2e39d9370e385a9bd91d5d5d3
 
-Tags: 2, 2.0.20260707.0
+Tags: 2, 2.0.20260710.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: e407484954ec851ac0545f16a386cabfd9c2c8e7
+amd64-GitCommit: edb8598c68888b180630a4e8b78be1ccb17a8684
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: a6d7f63771bbccd6207c47a6ad5ec859648e657e
+arm64v8-GitCommit: 6b6f8d2907bafc9f5cfc2f344205fdf2a5373567
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.12.20260710-0.amzn2023
- system-release-2023.12.20260710-0.amzn2023