### PR TITLE
Chronograf remove unsupported ARM32 variant for v1.11

### DIFF
--- a/library/chronograf
+++ b/library/chronograf
@@ -1,7 +1,7 @@
 Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Sven Rebhan <srebhan@influxdata.com> (@srebhan)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 5a147c30f9fe0d21692a884643000724171bb8a0
+GitCommit: 09594e6019ddabdb97327a2e353f3283dac76fc4
 
 Tags: 1.10, 1.10.9
 Architectures: amd64, arm32v7, arm64v8
@@ -11,7 +11,7 @@ Tags: 1.10-alpine, 1.10.9-alpine
 Directory: chronograf/1.10/alpine
 
 Tags: 1.11, 1.11.4, latest
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64, arm64v8
 Directory: chronograf/1.11
 
 Tags: 1.11-alpine, 1.11.4-alpine, alpine


### PR DESCRIPTION
The variant `arm32v7` is no longer built for Chronograf since version v1.11.0, therefore remove the architecture for the said version.