### PR TITLE
Remove EOL versions for CrateDB

### DIFF
--- a/library/crate
+++ b/library/crate
@@ -10,15 +10,3 @@ GitCommit: 6377f2e32b8fab296de491ad8778066b5d4ee74a
 Tags: 6.3.5, 6.3
 Architectures: amd64, arm64v8
 GitCommit: ccd9a41f0c3aa6591726561a984a26c29111c39e
-
-Tags: 6.2.11, 6.2
-Architectures: amd64, arm64v8
-GitCommit: 76ff6f9140b594332ece2d66c71c016fe2153699
-
-Tags: 6.1.6, 6.1
-Architectures: amd64, arm64v8
-GitCommit: 04e070dd4bb72d7e8a4f31950b8cf63f88605311
-
-Tags: 6.0.8, 6.0
-Architectures: amd64, arm64v8
-GitCommit: 6830c7f8fb59561f4937c763849ecb0140b1250c


### PR DESCRIPTION
Relates to https://github.com/docker-library/official-images/pull/21874#discussion_r3616780257