### PR TITLE
Redis: Update to 8.10-rc2

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -56,6 +56,18 @@ GitCommit: 75cd859f27eb5b534583eac9f4c166a87160192a
 GitFetch: refs/tags/v8.2.7
 Directory: alpine
 
+Tags: 8.10-rc2, 8.10-rc2-trixie
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+GitCommit: 11c8b131eb4c9a36110d70ceffedaa7397fb6cbf
+GitFetch: refs/tags/v8.10-rc2
+Directory: debian
+
+Tags: 8.10-rc2-alpine, 8.10-rc2-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 11c8b131eb4c9a36110d70ceffedaa7397fb6cbf
+GitFetch: refs/tags/v8.10-rc2
+Directory: alpine
+
 Tags: 7.4.9, 7.4, 7, 7.4.9-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
 GitCommit: 2b76f51f4af2f8586e137c49c55bfedb41d6751c


### PR DESCRIPTION
Hi Docker Team!

Please consider merging new Redis release `8.10-rc2`

The release includes changes from:
* https://github.com/redis/redis/releases/tag/8.10-rc1
* https://github.com/redis/redis/releases/tag/8.10-rc2

Release archive now contains all the modules, Dockefiles were modified accordingly to handle this change.