### PR TITLE
influxdb: 3.9.11 + 3.10.5 (core + enterprise)

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -62,18 +62,22 @@ Tags: 2-alpine, 2.9-alpine, 2.9.1-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.9/alpine
 
-Tags: 3.9-core, 3.9.6-core
+Tags: 3.9-core, 3.9.11-core
 Architectures: amd64, arm64v8
+GitCommit: 4935f4eb6b374869721872ecd7ef3e01bd228cf4
 Directory: influxdb/3.9-core
 
-Tags: 3.9-enterprise, 3.9.9-enterprise
+Tags: 3.9-enterprise, 3.9.11-enterprise
 Architectures: amd64, arm64v8
+GitCommit: 4935f4eb6b374869721872ecd7ef3e01bd228cf4
 Directory: influxdb/3.9-enterprise
 
-Tags: 3-core, 3.10-core, 3.10.3-core, core
+Tags: 3-core, 3.10-core, 3.10.5-core, core
 Architectures: amd64, arm64v8
+GitCommit: 4935f4eb6b374869721872ecd7ef3e01bd228cf4
 Directory: influxdb/3.10-core
 
-Tags: 3-enterprise, 3.10-enterprise, 3.10.3-enterprise, enterprise
+Tags: 3-enterprise, 3.10-enterprise, 3.10.5-enterprise, enterprise
 Architectures: amd64, arm64v8
+GitCommit: 4935f4eb6b374869721872ecd7ef3e01bd228cf4
 Directory: influxdb/3.10-enterprise


### PR DESCRIPTION
Updates the influxdb3 core and enterprise images to the latest patch releases:

- `3.9-core`: 3.9.6 -> **3.9.11**
- `3.9-enterprise`: 3.9.9 -> **3.9.11**
- `3.10-core` (`core`): 3.10.3 -> **3.10.5**
- `3.10-enterprise` (`enterprise`): 3.10.3 -> **3.10.5**

GitCommit `4935f4eb6b374869721872ecd7ef3e01bd228cf4` (influxdata/influxdata-docker master). Release tarballs and detached signatures for all four are published on dl.influxdata.com and verified.