### PR TITLE
Update oraclelinux-slim for 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 933e7860db994da27f3e7770dd22f231bf495e9d
+amd64-GitCommit: 4dbbbdfa82c8e85018ca26d6101e36a0c1d274ac
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 620c06b1ee494209f03f09fdf35a11cd055677ac
+arm64v8-GitCommit: c988d5c947965d241a7d6dfa897d044043656f8b
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-18139](https://linux.oracle.com/errata/ELSA-2026-18139.html)
- [ELSA-2026-19130](https://linux.oracle.com/errata/ELSA-2026-19130.html)
- [ELSA-2026-19145](https://linux.oracle.com/errata/ELSA-2026-19145.html)
- [ELSA-2026-19148](https://linux.oracle.com/errata/ELSA-2026-19148.html)
- [ELSA-2026-22715](https://linux.oracle.com/errata/ELSA-2026-22715.html)
- [ELSA-2026-28235](https://linux.oracle.com/errata/ELSA-2026-28235.html)
- [ELSA-2026-28236](https://linux.oracle.com/errata/ELSA-2026-28236.html)
- [ELSA-2026-33124](https://linux.oracle.com/errata/ELSA-2026-33124.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
