### PR TITLE
SapMachine July 2026 updates

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,282 +1,282 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Arno Zeller <sapmachine@sap.com> (@ArnoZeller)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: latest, ubuntu, jdk, jdk-ubuntu, 26, 26-ubuntu, 26.0.1, 26.0.1-ubuntu, 26-jdk, 26-jdk-ubuntu, 26.0.1-jdk, 26.0.1-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 26-ubuntu-noble, 26-ubuntu-24.04, 26-jdk-ubuntu-noble, 26-jdk-ubuntu-24.04, 26.0.1-ubuntu-noble, 26.0.1-ubuntu-24.04, 26.0.1-jdk-ubuntu-noble, 26.0.1-jdk-ubuntu-24.04
+Tags: jre-headless, jre-headless-ubuntu, 26-jre-headless, 26-jre-headless-ubuntu, 26.0.2-jre-headless, 26.0.2-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 26-jre-headless-ubuntu-noble, 26-jre-headless-ubuntu-24.04, 26.0.2-jre-headless-ubuntu-noble, 26.0.2-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/ubuntu/24_04/jdk
-
-Tags: jdk-headless, jdk-headless-ubuntu, 26-jdk-headless, 26-jdk-headless-ubuntu, 26.0.1-jdk-headless, 26.0.1-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 26-jdk-headless-ubuntu-noble, 26-jdk-headless-ubuntu-24.04, 26.0.1-jdk-headless-ubuntu-noble, 26.0.1-jdk-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/ubuntu/24_04/jdk-headless
-
-Tags: jre, jre-ubuntu, 26-jre, 26-jre-ubuntu, 26.0.1-jre, 26.0.1-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 26-jre-ubuntu-noble, 26-jre-ubuntu-24.04, 26.0.1-jre-ubuntu-noble, 26.0.1-jre-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/ubuntu/24_04/jre
-
-Tags: jre-headless, jre-headless-ubuntu, 26-jre-headless, 26-jre-headless-ubuntu, 26.0.1-jre-headless, 26.0.1-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 26-jre-headless-ubuntu-noble, 26-jre-headless-ubuntu-24.04, 26.0.1-jre-headless-ubuntu-noble, 26.0.1-jre-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
 Directory: dockerfiles/26/ubuntu/24_04/jre-headless
 
-Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 26-ubuntu-jammy, 26-ubuntu-22.04, 26-jdk-ubuntu-jammy, 26-jdk-ubuntu-22.04, 26.0.1-ubuntu-jammy, 26.0.1-ubuntu-22.04, 26.0.1-jdk-ubuntu-jammy, 26.0.1-jdk-ubuntu-22.04
+Tags: jre, jre-ubuntu, 26-jre, 26-jre-ubuntu, 26.0.2-jre, 26.0.2-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 26-jre-ubuntu-noble, 26-jre-ubuntu-24.04, 26.0.2-jre-ubuntu-noble, 26.0.2-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/ubuntu/22_04/jdk
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/ubuntu/24_04/jre
 
-Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 26-jdk-headless-ubuntu-jammy, 26-jdk-headless-ubuntu-22.04, 26.0.1-jdk-headless-ubuntu-jammy, 26.0.1-jdk-headless-ubuntu-22.04
+Tags: jdk-headless, jdk-headless-ubuntu, 26-jdk-headless, 26-jdk-headless-ubuntu, 26.0.2-jdk-headless, 26.0.2-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 26-jdk-headless-ubuntu-noble, 26-jdk-headless-ubuntu-24.04, 26.0.2-jdk-headless-ubuntu-noble, 26.0.2-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/ubuntu/22_04/jdk-headless
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/ubuntu/24_04/jdk-headless
 
-Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 26-jre-ubuntu-jammy, 26-jre-ubuntu-22.04, 26.0.1-jre-ubuntu-jammy, 26.0.1-jre-ubuntu-22.04
+Tags: latest, ubuntu, jdk, jdk-ubuntu, 26, 26-ubuntu, 26.0.2, 26.0.2-ubuntu, 26-jdk, 26-jdk-ubuntu, 26.0.2-jdk, 26.0.2-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 26-ubuntu-noble, 26-ubuntu-24.04, 26-jdk-ubuntu-noble, 26-jdk-ubuntu-24.04, 26.0.2-ubuntu-noble, 26.0.2-ubuntu-24.04, 26.0.2-jdk-ubuntu-noble, 26.0.2-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/ubuntu/22_04/jre
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/ubuntu/24_04/jdk
 
-Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 26-jre-headless-ubuntu-jammy, 26-jre-headless-ubuntu-22.04, 26.0.1-jre-headless-ubuntu-jammy, 26.0.1-jre-headless-ubuntu-22.04
+Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 26-jre-headless-ubuntu-jammy, 26-jre-headless-ubuntu-22.04, 26.0.2-jre-headless-ubuntu-jammy, 26.0.2-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
 Directory: dockerfiles/26/ubuntu/22_04/jre-headless
 
-Tags: alpine, jdk-alpine, 26-alpine, 26.0.1-alpine, 26-jdk-alpine, 26.0.1-jdk-alpine, alpine-3.23, jdk-alpine-3.23, 26-alpine-3.23, 26-jdk-alpine-3.23, 26.0.1-alpine-3.23, 26.0.1-jdk-alpine-3.23
-Architectures: amd64
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/alpine/3_23/jdk
+Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 26-jre-ubuntu-jammy, 26-jre-ubuntu-22.04, 26.0.2-jre-ubuntu-jammy, 26.0.2-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/ubuntu/22_04/jre
 
-Tags: jre-alpine, 26-jre-alpine, 26.0.1-jre-alpine, jre-alpine-3.23, 26-jre-alpine-3.23, 26.0.1-jre-alpine-3.23
+Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 26-jdk-headless-ubuntu-jammy, 26-jdk-headless-ubuntu-22.04, 26.0.2-jdk-headless-ubuntu-jammy, 26.0.2-jdk-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/ubuntu/22_04/jdk-headless
+
+Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 26-ubuntu-jammy, 26-ubuntu-22.04, 26-jdk-ubuntu-jammy, 26-jdk-ubuntu-22.04, 26.0.2-ubuntu-jammy, 26.0.2-ubuntu-22.04, 26.0.2-jdk-ubuntu-jammy, 26.0.2-jdk-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/ubuntu/22_04/jdk
+
+Tags: jre-alpine, 26-jre-alpine, 26.0.2-jre-alpine, jre-alpine-3.23, 26-jre-alpine-3.23, 26.0.2-jre-alpine-3.23
 Architectures: amd64
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
 Directory: dockerfiles/26/alpine/3_23/jre
 
-Tags: alpine-3.22, jdk-alpine-3.22, 26-alpine-3.22, 26-jdk-alpine-3.22, 26.0.1-alpine-3.22, 26.0.1-jdk-alpine-3.22
+Tags: alpine, jdk-alpine, 26-alpine, 26.0.2-alpine, 26-jdk-alpine, 26.0.2-jdk-alpine, alpine-3.23, jdk-alpine-3.23, 26-alpine-3.23, 26-jdk-alpine-3.23, 26.0.2-alpine-3.23, 26.0.2-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/alpine/3_22/jdk
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/alpine/3_23/jdk
 
-Tags: jre-alpine-3.22, 26-jre-alpine-3.22, 26.0.1-jre-alpine-3.22
+Tags: jre-alpine-3.22, 26-jre-alpine-3.22, 26.0.2-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
 Directory: dockerfiles/26/alpine/3_22/jre
 
-Tags: alpine-3.21, jdk-alpine-3.21, 26-alpine-3.21, 26-jdk-alpine-3.21, 26.0.1-alpine-3.21, 26.0.1-jdk-alpine-3.21
+Tags: alpine-3.22, jdk-alpine-3.22, 26-alpine-3.22, 26-jdk-alpine-3.22, 26.0.2-alpine-3.22, 26.0.2-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
-Directory: dockerfiles/26/alpine/3_21/jdk
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/alpine/3_22/jdk
 
-Tags: jre-alpine-3.21, 26-jre-alpine-3.21, 26.0.1-jre-alpine-3.21
+Tags: jre-alpine-3.21, 26-jre-alpine-3.21, 26.0.2-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 1f26335ea973ab72c80825cac4a24dcfbaaefb7f
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
 Directory: dockerfiles/26/alpine/3_21/jre
 
-Tags: lts, lts-ubuntu, 25, 25-ubuntu, 25.0.3, 25.0.3-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.3-jdk, 25.0.3-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.3-ubuntu-noble, 25.0.3-ubuntu-24.04, 25.0.3-jdk-ubuntu-noble, 25.0.3-jdk-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/ubuntu/24_04/jdk
+Tags: alpine-3.21, jdk-alpine-3.21, 26-alpine-3.21, 26-jdk-alpine-3.21, 26.0.2-alpine-3.21, 26.0.2-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+Directory: dockerfiles/26/alpine/3_21/jdk
 
-Tags: 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.3-jdk-headless, 25.0.3-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.3-jdk-headless-ubuntu-noble, 25.0.3-jdk-headless-ubuntu-24.04
+Tags: 25-jre-headless, 25-jre-headless-ubuntu, 25.0.4-jre-headless, 25.0.4-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.4-jre-headless-ubuntu-noble, 25.0.4-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/ubuntu/24_04/jdk-headless
-
-Tags: 25-jre, 25-jre-ubuntu, 25.0.3-jre, 25.0.3-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.3-jre-ubuntu-noble, 25.0.3-jre-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/ubuntu/24_04/jre
-
-Tags: 25-jre-headless, 25-jre-headless-ubuntu, 25.0.3-jre-headless, 25.0.3-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.3-jre-headless-ubuntu-noble, 25.0.3-jre-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
 Directory: dockerfiles/25/ubuntu/24_04/jre-headless
 
-Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.3-ubuntu-jammy, 25.0.3-ubuntu-22.04, 25.0.3-jdk-ubuntu-jammy, 25.0.3-jdk-ubuntu-22.04
+Tags: 25-jre, 25-jre-ubuntu, 25.0.4-jre, 25.0.4-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.4-jre-ubuntu-noble, 25.0.4-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/ubuntu/22_04/jdk
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/ubuntu/24_04/jre
 
-Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.3-jdk-headless-ubuntu-jammy, 25.0.3-jdk-headless-ubuntu-22.04
+Tags: 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.4-jdk-headless, 25.0.4-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.4-jdk-headless-ubuntu-noble, 25.0.4-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/ubuntu/22_04/jdk-headless
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/ubuntu/24_04/jdk-headless
 
-Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.3-jre-ubuntu-jammy, 25.0.3-jre-ubuntu-22.04
+Tags: lts, lts-ubuntu, 25, 25-ubuntu, 25.0.4, 25.0.4-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.4-jdk, 25.0.4-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.4-ubuntu-noble, 25.0.4-ubuntu-24.04, 25.0.4-jdk-ubuntu-noble, 25.0.4-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/ubuntu/22_04/jre
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/ubuntu/24_04/jdk
 
-Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.3-jre-headless-ubuntu-jammy, 25.0.3-jre-headless-ubuntu-22.04
+Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.4-jre-headless-ubuntu-jammy, 25.0.4-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
 Directory: dockerfiles/25/ubuntu/22_04/jre-headless
 
-Tags: lts-alpine, 25-alpine, 25.0.3-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.3-jdk-alpine, lts-alpine-3.23, lts-jdk-alpine-3.23, 25-alpine-3.23, 25-jdk-alpine-3.23, 25.0.3-alpine-3.23, 25.0.3-jdk-alpine-3.23
-Architectures: amd64
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/alpine/3_23/jdk
+Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.4-jre-ubuntu-jammy, 25.0.4-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/ubuntu/22_04/jre
 
-Tags: lts-jre-alpine, 25-jre-alpine, 25.0.3-jre-alpine, lts-jre-alpine-3.23, 25-jre-alpine-3.23, 25.0.3-jre-alpine-3.23
+Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.4-jdk-headless-ubuntu-jammy, 25.0.4-jdk-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/ubuntu/22_04/jdk-headless
+
+Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.4-ubuntu-jammy, 25.0.4-ubuntu-22.04, 25.0.4-jdk-ubuntu-jammy, 25.0.4-jdk-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/ubuntu/22_04/jdk
+
+Tags: lts-jre-alpine, 25-jre-alpine, 25.0.4-jre-alpine, lts-jre-alpine-3.23, 25-jre-alpine-3.23, 25.0.4-jre-alpine-3.23
 Architectures: amd64
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
 Directory: dockerfiles/25/alpine/3_23/jre
 
-Tags: lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.3-alpine-3.22, 25.0.3-jdk-alpine-3.22
+Tags: lts-alpine, 25-alpine, 25.0.4-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.4-jdk-alpine, lts-alpine-3.23, lts-jdk-alpine-3.23, 25-alpine-3.23, 25-jdk-alpine-3.23, 25.0.4-alpine-3.23, 25.0.4-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/alpine/3_22/jdk
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/alpine/3_23/jdk
 
-Tags: lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.3-jre-alpine-3.22
+Tags: lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.4-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
 Directory: dockerfiles/25/alpine/3_22/jre
 
-Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.3-alpine-3.21, 25.0.3-jdk-alpine-3.21
+Tags: lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.4-alpine-3.22, 25.0.4-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
-Directory: dockerfiles/25/alpine/3_21/jdk
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/alpine/3_22/jdk
 
-Tags: lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.3-jre-alpine-3.21
+Tags: lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.4-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 73134d1d0673ee093633e25170e31605389fb4de
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
 Directory: dockerfiles/25/alpine/3_21/jre
 
-Tags: 21, 21-ubuntu, 21.0.11, 21.0.11-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.11-jdk, 21.0.11-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.11-ubuntu-noble, 21.0.11-ubuntu-24.04, 21.0.11-jdk-ubuntu-noble, 21.0.11-jdk-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/ubuntu/24_04/jdk
+Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.4-alpine-3.21, 25.0.4-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+Directory: dockerfiles/25/alpine/3_21/jdk
 
-Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.11-jdk-headless, 21.0.11-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.11-jdk-headless-ubuntu-noble, 21.0.11-jdk-headless-ubuntu-24.04
+Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.12-jre-headless, 21.0.12-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.12-jre-headless-ubuntu-noble, 21.0.12-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
-
-Tags: 21-jre, 21-jre-ubuntu, 21.0.11-jre, 21.0.11-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.11-jre-ubuntu-noble, 21.0.11-jre-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/ubuntu/24_04/jre
-
-Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.11-jre-headless, 21.0.11-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.11-jre-headless-ubuntu-noble, 21.0.11-jre-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
-Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.11-ubuntu-jammy, 21.0.11-ubuntu-22.04, 21.0.11-jdk-ubuntu-jammy, 21.0.11-jdk-ubuntu-22.04
+Tags: 21-jre, 21-jre-ubuntu, 21.0.12-jre, 21.0.12-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.12-jre-ubuntu-noble, 21.0.12-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/ubuntu/22_04/jdk
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/ubuntu/24_04/jre
 
-Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.11-jdk-headless-ubuntu-jammy, 21.0.11-jdk-headless-ubuntu-22.04
+Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.12-jdk-headless, 21.0.12-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.12-jdk-headless-ubuntu-noble, 21.0.12-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
-Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.11-jre-ubuntu-jammy, 21.0.11-jre-ubuntu-22.04
+Tags: 21, 21-ubuntu, 21.0.12, 21.0.12-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.12-jdk, 21.0.12-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.12-ubuntu-noble, 21.0.12-ubuntu-24.04, 21.0.12-jdk-ubuntu-noble, 21.0.12-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/ubuntu/22_04/jre
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/ubuntu/24_04/jdk
 
-Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.11-jre-headless-ubuntu-jammy, 21.0.11-jre-headless-ubuntu-22.04
+Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.12-jre-headless-ubuntu-jammy, 21.0.12-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
-Tags: 21-alpine, 21.0.11-alpine, 21-jdk-alpine, 21.0.11-jdk-alpine, 21-alpine-3.23, 21-jdk-alpine-3.23, 21.0.11-alpine-3.23, 21.0.11-jdk-alpine-3.23
-Architectures: amd64
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/alpine/3_23/jdk
+Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.12-jre-ubuntu-jammy, 21.0.12-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/ubuntu/22_04/jre
 
-Tags: 21-jre-alpine, 21.0.11-jre-alpine, 21-jre-alpine-3.23, 21.0.11-jre-alpine-3.23
+Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.12-jdk-headless-ubuntu-jammy, 21.0.12-jdk-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
+
+Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.12-ubuntu-jammy, 21.0.12-ubuntu-22.04, 21.0.12-jdk-ubuntu-jammy, 21.0.12-jdk-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/ubuntu/22_04/jdk
+
+Tags: 21-jre-alpine, 21.0.12-jre-alpine, 21-jre-alpine-3.23, 21.0.12-jre-alpine-3.23
 Architectures: amd64
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
 Directory: dockerfiles/21/alpine/3_23/jre
 
-Tags: 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.11-alpine-3.22, 21.0.11-jdk-alpine-3.22
+Tags: 21-alpine, 21.0.12-alpine, 21-jdk-alpine, 21.0.12-jdk-alpine, 21-alpine-3.23, 21-jdk-alpine-3.23, 21.0.12-alpine-3.23, 21.0.12-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/alpine/3_22/jdk
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/alpine/3_23/jdk
 
-Tags: 21-jre-alpine-3.22, 21.0.11-jre-alpine-3.22
+Tags: 21-jre-alpine-3.22, 21.0.12-jre-alpine-3.22
 Architectures: amd64
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
 Directory: dockerfiles/21/alpine/3_22/jre
 
-Tags: 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.11-alpine-3.21, 21.0.11-jdk-alpine-3.21
+Tags: 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.12-alpine-3.22, 21.0.12-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
-Directory: dockerfiles/21/alpine/3_21/jdk
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/alpine/3_22/jdk
 
-Tags: 21-jre-alpine-3.21, 21.0.11-jre-alpine-3.21
+Tags: 21-jre-alpine-3.21, 21.0.12-jre-alpine-3.21
 Architectures: amd64
-GitCommit: b4834e4ac67a83161268945217d1cbfbc4619f65
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
 Directory: dockerfiles/21/alpine/3_21/jre
 
-Tags: 17, 17-ubuntu, 17.0.19, 17.0.19-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.19-jdk, 17.0.19-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.19-ubuntu-noble, 17.0.19-ubuntu-24.04, 17.0.19-jdk-ubuntu-noble, 17.0.19-jdk-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/ubuntu/24_04/jdk
+Tags: 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.12-alpine-3.21, 21.0.12-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+Directory: dockerfiles/21/alpine/3_21/jdk
 
-Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.19-jdk-headless, 17.0.19-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.19-jdk-headless-ubuntu-noble, 17.0.19-jdk-headless-ubuntu-24.04
+Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.20-jre-headless, 17.0.20-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.20-jre-headless-ubuntu-noble, 17.0.20-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
-
-Tags: 17-jre, 17-jre-ubuntu, 17.0.19-jre, 17.0.19-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.19-jre-ubuntu-noble, 17.0.19-jre-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/ubuntu/24_04/jre
-
-Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.19-jre-headless, 17.0.19-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.19-jre-headless-ubuntu-noble, 17.0.19-jre-headless-ubuntu-24.04
-Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
-Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.19-ubuntu-jammy, 17.0.19-ubuntu-22.04, 17.0.19-jdk-ubuntu-jammy, 17.0.19-jdk-ubuntu-22.04
+Tags: 17-jre, 17-jre-ubuntu, 17.0.20-jre, 17.0.20-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.20-jre-ubuntu-noble, 17.0.20-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/ubuntu/22_04/jdk
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/ubuntu/24_04/jre
 
-Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.19-jdk-headless-ubuntu-jammy, 17.0.19-jdk-headless-ubuntu-22.04
+Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.20-jdk-headless, 17.0.20-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.20-jdk-headless-ubuntu-noble, 17.0.20-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
-Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.19-jre-ubuntu-jammy, 17.0.19-jre-ubuntu-22.04
+Tags: 17, 17-ubuntu, 17.0.20, 17.0.20-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.20-jdk, 17.0.20-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.20-ubuntu-noble, 17.0.20-ubuntu-24.04, 17.0.20-jdk-ubuntu-noble, 17.0.20-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/ubuntu/22_04/jre
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/ubuntu/24_04/jdk
 
-Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.19-jre-headless-ubuntu-jammy, 17.0.19-jre-headless-ubuntu-22.04
+Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.20-jre-headless-ubuntu-jammy, 17.0.20-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
-Tags: 17-alpine, 17.0.19-alpine, 17-jdk-alpine, 17.0.19-jdk-alpine, 17-alpine-3.23, 17-jdk-alpine-3.23, 17.0.19-alpine-3.23, 17.0.19-jdk-alpine-3.23
-Architectures: amd64
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/alpine/3_23/jdk
+Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.20-jre-ubuntu-jammy, 17.0.20-jre-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/ubuntu/22_04/jre
 
-Tags: 17-jre-alpine, 17.0.19-jre-alpine, 17-jre-alpine-3.23, 17.0.19-jre-alpine-3.23
+Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.20-jdk-headless-ubuntu-jammy, 17.0.20-jdk-headless-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
+
+Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.20-ubuntu-jammy, 17.0.20-ubuntu-22.04, 17.0.20-jdk-ubuntu-jammy, 17.0.20-jdk-ubuntu-22.04
+Architectures: amd64, arm64v8, ppc64le
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/ubuntu/22_04/jdk
+
+Tags: 17-jre-alpine, 17.0.20-jre-alpine, 17-jre-alpine-3.23, 17.0.20-jre-alpine-3.23
 Architectures: amd64
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
 Directory: dockerfiles/17/alpine/3_23/jre
 
-Tags: 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.19-alpine-3.22, 17.0.19-jdk-alpine-3.22
+Tags: 17-alpine, 17.0.20-alpine, 17-jdk-alpine, 17.0.20-jdk-alpine, 17-alpine-3.23, 17-jdk-alpine-3.23, 17.0.20-alpine-3.23, 17.0.20-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/alpine/3_22/jdk
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/alpine/3_23/jdk
 
-Tags: 17-jre-alpine-3.22, 17.0.19-jre-alpine-3.22
+Tags: 17-jre-alpine-3.22, 17.0.20-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
 Directory: dockerfiles/17/alpine/3_22/jre
 
-Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.19-alpine-3.21, 17.0.19-jdk-alpine-3.21
+Tags: 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.20-alpine-3.22, 17.0.20-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
-Directory: dockerfiles/17/alpine/3_21/jdk
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/alpine/3_22/jdk
 
-Tags: 17-jre-alpine-3.21, 17.0.19-jre-alpine-3.21
+Tags: 17-jre-alpine-3.21, 17.0.20-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 7ec104476583410abc8a50c8fb1e0851dfee4d36
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
 Directory: dockerfiles/17/alpine/3_21/jre
+
+Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.20-alpine-3.21, 17.0.20-jdk-alpine-3.21
+Architectures: amd64
+GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+Directory: dockerfiles/17/alpine/3_21/jdk


### PR DESCRIPTION
This updates the SapMachine docker images to the July 2026 releases