### PR TITLE
Release SonarQube Server 2025.4.8

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -50,24 +50,24 @@ Directory: commercial-editions/datacenter/search
 GitCommit: 21dbae3d7df8f96e641955104c459a18ad50c396
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2025.4.7-developer, 2025.4-developer, 2025.4-lta-developer
+Tags: 2025.4.8-developer, 2025.4-developer, 2025.4-lta-developer
 Directory: commercial-editions/developer
-GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
+GitCommit: 3e22fdcc697fe8b59b1289cd12e5a68c4290ec7d
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.7-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
+Tags: 2025.4.8-enterprise, 2025.4-enterprise, 2025.4-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
+GitCommit: 3e22fdcc697fe8b59b1289cd12e5a68c4290ec7d
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.7-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
+Tags: 2025.4.8-datacenter-app, 2025.4-datacenter-app, 2025.4-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
+GitCommit: 3e22fdcc697fe8b59b1289cd12e5a68c4290ec7d
 GitFetch: refs/heads/release/2025.4
 
-Tags: 2025.4.7-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
+Tags: 2025.4.8-datacenter-search, 2025.4-datacenter-search, 2025.4-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 6c3a0d72fca31c9fe49782f75c735e1df17ed637
+GitCommit: 3e22fdcc697fe8b59b1289cd12e5a68c4290ec7d
 GitFetch: refs/heads/release/2025.4
 
 Tags: 2025.1.8-developer, 2025.1-developer, 2025-lta-developer


### PR DESCRIPTION
Dear team,

We want to release SonarQube Server LTA version 2025.4.8.
Can you please review the changes?

Thank you.