### PR TITLE
Release SonarQube Server 2026.4.0

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -10,24 +10,24 @@ GitRepo: https://github.com/SonarSource/docker-sonarqube.git
 Architectures: amd64, arm64v8
 Builder: buildkit
 
-Tags: 2026.3.1-developer, 2026.3-developer, developer
+Tags: 2026.4.0-developer, 2026.4-developer, developer
 Directory: commercial-editions/developer
-GitCommit: 824ea0f883def7b7f1b35cfa9b87a6a20f616167
+GitCommit: 9f00ce57d8654a3737ae0b22997d7198f71660d8
 GitFetch: refs/heads/master
 
-Tags: 2026.3.1-enterprise, 2026.3-enterprise, enterprise
+Tags: 2026.4.0-enterprise, 2026.4-enterprise, enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 824ea0f883def7b7f1b35cfa9b87a6a20f616167
+GitCommit: 9f00ce57d8654a3737ae0b22997d7198f71660d8
 GitFetch: refs/heads/master
 
-Tags: 2026.3.1-datacenter-app, 2026.3-datacenter-app, datacenter-app
+Tags: 2026.4.0-datacenter-app, 2026.4-datacenter-app, datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 824ea0f883def7b7f1b35cfa9b87a6a20f616167
+GitCommit: 9f00ce57d8654a3737ae0b22997d7198f71660d8
 GitFetch: refs/heads/master
 
-Tags: 2026.3.1-datacenter-search, 2026.3-datacenter-search, datacenter-search
+Tags: 2026.4.0-datacenter-search, 2026.4-datacenter-search, datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 824ea0f883def7b7f1b35cfa9b87a6a20f616167
+GitCommit: 9f00ce57d8654a3737ae0b22997d7198f71660d8
 GitFetch: refs/heads/master
 
 Tags: 2026.1.3-developer, 2026.1-developer, 2026-lta-developer


### PR DESCRIPTION
Dear team,

We want to release SonarQube Server version 2026.4.0.
Can you please review the changes?

Thank you.