### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.5-dev2, 3.5-dev, 3.5-dev2-trixie, 3.5-dev-trixie
+Tags: 3.5-dev3, 3.5-dev, 3.5-dev3-trixie, 3.5-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3c156db21cda4f44e5308d5630ae119764b554e
+GitCommit: ec437dd2a3656610b10a42c08763d8fa1c591efe
 Directory: 3.5
 
-Tags: 3.5-dev2-alpine, 3.5-dev-alpine, 3.5-dev2-alpine3.24, 3.5-dev-alpine3.24
+Tags: 3.5-dev3-alpine, 3.5-dev-alpine, 3.5-dev3-alpine3.24, 3.5-dev-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3c156db21cda4f44e5308d5630ae119764b554e
+GitCommit: ec437dd2a3656610b10a42c08763d8fa1c591efe
 Directory: 3.5/alpine
 
 Tags: 3.4.2, 3.4, latest, lts, 3.4.2-trixie, 3.4-trixie, trixie, lts-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/ec437dd: Update 3.5 to 3.5-dev3