### PR TITLE
Update oraclelinux-slim for 9

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 4dbbbdfa82c8e85018ca26d6101e36a0c1d274ac
+amd64-GitCommit: 8c0b15cfb10535ce5d00bd4b6d478ec15619c92b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: c988d5c947965d241a7d6dfa897d044043656f8b
+arm64v8-GitCommit: 74efe920ec188f591bc0f4d574931524c7b4c4ea
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 9
- [ELSA-2026-42736](https://linux.oracle.com/errata/ELSA-2026-42736.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
