### PR TITLE
Update oraclelinux-slim for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 8c0b15cfb10535ce5d00bd4b6d478ec15619c92b
+amd64-GitCommit: 9353e717fe50cc28aaad23d8a73210e8f6dedbab
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 74efe920ec188f591bc0f4d574931524c7b4c4ea
+arm64v8-GitCommit: daa80e6f50d815d08a486dcf620fa7fed7286427
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-42090](https://linux.oracle.com/errata/ELSA-2026-42090.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
