### PR TITLE
Release SonarQube Server 2026.1.4

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -30,24 +30,24 @@ Directory: commercial-editions/datacenter/search
 GitCommit: 9f00ce57d8654a3737ae0b22997d7198f71660d8
 GitFetch: refs/heads/master
 
-Tags: 2026.1.3-developer, 2026.1-developer, 2026-lta-developer
+Tags: 2026.1.4-developer, 2026.1-developer, 2026-lta-developer
 Directory: commercial-editions/developer
-GitCommit: 21dbae3d7df8f96e641955104c459a18ad50c396
+GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2026.1.3-enterprise, 2026.1-enterprise, 2026-lta-enterprise
+Tags: 2026.1.4-enterprise, 2026.1-enterprise, 2026-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: 21dbae3d7df8f96e641955104c459a18ad50c396
+GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2026.1.3-datacenter-app, 2026.1-datacenter-app, 2026-lta-datacenter-app
+Tags: 2026.1.4-datacenter-app, 2026.1-datacenter-app, 2026-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: 21dbae3d7df8f96e641955104c459a18ad50c396
+GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2026.1.3-datacenter-search, 2026.1-datacenter-search, 2026-lta-datacenter-search
+Tags: 2026.1.4-datacenter-search, 2026.1-datacenter-search, 2026-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: 21dbae3d7df8f96e641955104c459a18ad50c396
+GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
 GitFetch: refs/heads/release/2026.1
 
 Tags: 2025.4.8-developer, 2025.4-developer, 2025.4-lta-developer


### PR DESCRIPTION
Dear team,

We want to release SonarQube Server LTA version 2026.1.4.
Can you please review the changes?

Thank you.