### PR TITLE
[SECURITY] Redis urgent security release for 6,7,8

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -8,52 +8,52 @@ Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
              Gonen Goshen <gonen.goshen@redis.com> (@gonen-red)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.8.0, 8.8, 8, 8.8.0-trixie, 8.8-trixie, 8-trixie, latest, trixie
+Tags: 8.8.1, 8.8, 8, 8.8.1-trixie, 8.8-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 40511fc518c300f3b48059daf43c7ac2ef97550b
-GitFetch: refs/tags/v8.8.0
+GitCommit: b675641c81d9f476e614aee4a6606365548bae41
+GitFetch: refs/tags/v8.8.1
 Directory: debian
 
-Tags: 8.8.0-alpine, 8.8-alpine, 8-alpine, 8.8.0-alpine3.23, 8.8-alpine3.23, 8-alpine3.23, alpine, alpine3.23
+Tags: 8.8.1-alpine, 8.8-alpine, 8-alpine, 8.8.1-alpine3.23, 8.8-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 40511fc518c300f3b48059daf43c7ac2ef97550b
-GitFetch: refs/tags/v8.8.0
+GitCommit: b675641c81d9f476e614aee4a6606365548bae41
+GitFetch: refs/tags/v8.8.1
 Directory: alpine
 
-Tags: 8.6.4, 8.6, 8.6.4-trixie, 8.6-trixie
+Tags: 8.6.5, 8.6, 8.6.5-trixie, 8.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 0076c90a8028d29b25313f7272fa2d1245c3be76
-GitFetch: refs/tags/v8.6.4
+GitCommit: 8bf384f30957c89ea17a1fd6e5f34ed31065f84b
+GitFetch: refs/tags/v8.6.5
 Directory: debian
 
-Tags: 8.6.4-alpine, 8.6-alpine, 8.6.4-alpine3.23, 8.6-alpine3.23
+Tags: 8.6.5-alpine, 8.6-alpine, 8.6.5-alpine3.23, 8.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0076c90a8028d29b25313f7272fa2d1245c3be76
-GitFetch: refs/tags/v8.6.4
+GitCommit: 8bf384f30957c89ea17a1fd6e5f34ed31065f84b
+GitFetch: refs/tags/v8.6.5
 Directory: alpine
 
-Tags: 8.4.4, 8.4, 8.4.4-trixie, 8.4-trixie
+Tags: 8.4.5, 8.4, 8.4.5-trixie, 8.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 75ad715d290fef57489d801696d4c75ceb97e1fe
-GitFetch: refs/tags/v8.4.4
+GitCommit: cc3829e8d874f31c8d50ee1e7a81f283eaa9688a
+GitFetch: refs/tags/v8.4.5
 Directory: debian
 
-Tags: 8.4.4-alpine, 8.4-alpine, 8.4.4-alpine3.22, 8.4-alpine3.22
+Tags: 8.4.5-alpine, 8.4-alpine, 8.4.5-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 75ad715d290fef57489d801696d4c75ceb97e1fe
-GitFetch: refs/tags/v8.4.4
+GitCommit: cc3829e8d874f31c8d50ee1e7a81f283eaa9688a
+GitFetch: refs/tags/v8.4.5
 Directory: alpine
 
-Tags: 8.2.7, 8.2, 8.2.7-bookworm, 8.2-bookworm
+Tags: 8.2.8, 8.2, 8.2.8-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 75cd859f27eb5b534583eac9f4c166a87160192a
-GitFetch: refs/tags/v8.2.7
+GitCommit: 3769a841048d940966635f8f59471f3d350707bf
+GitFetch: refs/tags/v8.2.8
 Directory: debian
 
-Tags: 8.2.7-alpine, 8.2-alpine, 8.2.7-alpine3.22, 8.2-alpine3.22
+Tags: 8.2.8-alpine, 8.2-alpine, 8.2.8-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 75cd859f27eb5b534583eac9f4c166a87160192a
-GitFetch: refs/tags/v8.2.7
+GitCommit: 3769a841048d940966635f8f59471f3d350707bf
+GitFetch: refs/tags/v8.2.8
 Directory: alpine
 
 Tags: 8.10-rc2, 8.10-rc2-trixie
@@ -80,26 +80,26 @@ GitCommit: 2b76f51f4af2f8586e137c49c55bfedb41d6751c
 GitFetch: refs/tags/v7.4.9
 Directory: alpine
 
-Tags: 7.2.14, 7.2, 7.2.14-bookworm, 7.2-bookworm
+Tags: 7.2.15, 7.2, 7.2.15-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 0a362f52c58445de1faf950919711fd1afab319a
-GitFetch: refs/tags/v7.2.14
+GitCommit: 976a7de4cd78b6a201b4a3a5ac49cd9c8e3e583f
+GitFetch: refs/tags/v7.2.15
 Directory: debian
 
-Tags: 7.2.14-alpine, 7.2-alpine, 7.2.14-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.15-alpine, 7.2-alpine, 7.2.15-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0a362f52c58445de1faf950919711fd1afab319a
-GitFetch: refs/tags/v7.2.14
+GitCommit: 976a7de4cd78b6a201b4a3a5ac49cd9c8e3e583f
+GitFetch: refs/tags/v7.2.15
 Directory: alpine
 
-Tags: 6.2.22, 6.2, 6, 6.2.22-bookworm, 6.2-bookworm, 6-bookworm
+Tags: 6.2.23, 6.2, 6, 6.2.23-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2598ca399aad20a20058ba8d043f4ac54207d994
-GitFetch: refs/tags/v6.2.22
+GitCommit: 70d903a68609970bf9a66181cdc59d0fc1ebc885
+GitFetch: refs/tags/v6.2.23
 Directory: debian
 
-Tags: 6.2.22-alpine, 6.2-alpine, 6-alpine, 6.2.22-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
+Tags: 6.2.23-alpine, 6.2-alpine, 6-alpine, 6.2.23-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2598ca399aad20a20058ba8d043f4ac54207d994
-GitFetch: refs/tags/v6.2.22
+GitCommit: 70d903a68609970bf9a66181cdc59d0fc1ebc885
+GitFetch: refs/tags/v6.2.23
 Directory: alpine


### PR DESCRIPTION
Dear Docker Team,

Redis has issued an urgent, unscheduled security release addressing serious vulnerabilities that may result in remote code execution.

All supported versions from 6 through 8 are affected.

Release notes:

https://github.com/redis/redis/releases#release-8.8.1
https://github.com/redis/redis/releases#release-8.6.5
https://github.com/redis/redis/releases#release-8.4.5
https://github.com/redis/redis/releases#release-8.2.8
https://github.com/redis/redis/releases#release-7.4.10
https://github.com/redis/redis/releases#release-7.2.15
https://github.com/redis/redis/releases#release-6.2.23