### PR TITLE
Update 6 to 6.54.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,12 +2,12 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: aff074ca2b1fb1b2a7fc4d20a230e092f51d55e1
+GitCommit: e0307e330ad1e6ed788905c3003af79391124226
 
-Tags: 6.53.0-bookworm, 6.53.0, 6.53-bookworm, 6.53, 6-bookworm, 6, bookworm, latest
+Tags: 6.54.0-bookworm, 6.54.0, 6.54-bookworm, 6.54, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.53.0-alpine3.23, 6.53.0-alpine, 6.53-alpine3.23, 6.53-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.54.0-alpine3.23, 6.54.0-alpine, 6.54-alpine3.23, 6.54-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.54.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/e0307e330ad1e6ed788905c3003af79391124226.