### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.12.20260710.0
+Tags: 2023, latest, 2023.12.20260724.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 2478dd3f94cea14d437682e817172d4b63c15e71
+amd64-GitCommit: 5a0863340c247026a6912f2e76976294cb9bf836
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 5d31a103d559c9c2e39d9370e385a9bd91d5d5d3
+arm64v8-GitCommit: 8008e7cbda863c8599b8780f9cb8ccf4ded3d82a
 
-Tags: 2, 2.0.20260710.0
+Tags: 2, 2.0.20260720.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: edb8598c68888b180630a4e8b78be1ccb17a8684
+amd64-GitCommit: 2a1c5e64594d517a506c4fc73329ee10e4c81bda
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 6b6f8d2907bafc9f5cfc2f344205fdf2a5373567
+arm64v8-GitCommit: 95a0419d05495971eda7718cb0a7abbf1d526b70
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- krb5-libs-1.15.1-55.amzn2.2.10
- tzdata-2026c-1.amzn2.0.1
- python-libs-2.7.18-1.amzn2.0.21
- python-2.7.18-1.amzn2.0.21
- glib2-2.56.1-9.amzn2.0.14
- vim-minimal-9.0.2153-1.amzn2.0.8
- vim-data-9.0.2153-1.amzn2.0.8
- expat-2.1.0-15.amzn2.0.8
- libssh2-1.4.3-12.amzn2.2.8

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.12.20260724-0.amzn2023
- system-release-2023.12.20260724-0.amzn2023
- glibc-minimal-langpack-2.34-231.amzn2023.0.5
- glibc-2.34-231.amzn2023.0.5
- libacl-2.4.0-1.amzn2023.0.1
- libmount-2.37.4-1.amzn2023.0.6
- glib2-2.82.2-770.amzn2023
- python3-libs-3.9.25-1.amzn2023.0.8
- tzdata-2026c-1.amzn2023.0.1
- amazon-linux-repo-cdn-2023.12.20260720-0.amzn2023
- system-release-2023.12.20260720-0.amzn2023
- glibc-common-2.34-231.amzn2023.0.5
- libuuid-2.37.4-1.amzn2023.0.6
- libsmartcols-2.37.4-1.amzn2023.0.6
- libblkid-2.37.4-1.amzn2023.0.6
- krb5-libs-1.21.3-8.amzn2023.0.1
- python3-3.9.25-1.amzn2023.0.8