### PR TITLE
[SECURITY] Redis follow-up for security release: missed 7.4.10

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -68,16 +68,16 @@ GitCommit: 11c8b131eb4c9a36110d70ceffedaa7397fb6cbf
 GitFetch: refs/tags/v8.10-rc2
 Directory: alpine
 
-Tags: 7.4.9, 7.4, 7, 7.4.9-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.10, 7.4, 7, 7.4.10-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
-GitCommit: 2b76f51f4af2f8586e137c49c55bfedb41d6751c
-GitFetch: refs/tags/v7.4.9
+GitCommit: 31c68732e7311d95e4c833b8fa50aa561ced577f
+GitFetch: refs/tags/v7.4.10
 Directory: debian
 
-Tags: 7.4.9-alpine, 7.4-alpine, 7-alpine, 7.4.9-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.10-alpine, 7.4-alpine, 7-alpine, 7.4.10-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2b76f51f4af2f8586e137c49c55bfedb41d6751c
-GitFetch: refs/tags/v7.4.9
+GitCommit: 31c68732e7311d95e4c833b8fa50aa561ced577f
+GitFetch: refs/tags/v7.4.10
 Directory: alpine
 
 Tags: 7.2.15, 7.2, 7.2.15-bookworm, 7.2-bookworm


### PR DESCRIPTION
Hi @yosifkit !
This is a follow-up for https://github.com/docker-library/official-images/pull/21922, adding missing 7.4.10 version