### PR TITLE
archlinux: Release 20260726.0.562117

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260719.0.558177
-GitCommit: adcd8fd3c6825b191e7aae4792403be31a7dea77
-GitFetch: refs/tags/v20260719.0.558177
+Tags: latest, base, base-20260726.0.562117
+GitCommit: 8dc90695082262f4e8c0f31b6da0e8dc37c479b1
+GitFetch: refs/tags/v20260726.0.562117
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260719.0.558177
-GitCommit: adcd8fd3c6825b191e7aae4792403be31a7dea77
-GitFetch: refs/tags/v20260719.0.558177
+Tags: base-devel, base-devel-20260726.0.562117
+GitCommit: 8dc90695082262f4e8c0f31b6da0e8dc37c479b1
+GitFetch: refs/tags/v20260726.0.562117
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260719.0.558177
-GitCommit: adcd8fd3c6825b191e7aae4792403be31a7dea77
-GitFetch: refs/tags/v20260719.0.558177
+Tags: multilib-devel, multilib-devel-20260726.0.562117
+GitCommit: 8dc90695082262f4e8c0f31b6da0e8dc37c479b1
+GitFetch: refs/tags/v20260726.0.562117
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks