### PR TITLE
Update mysql

### DIFF
--- a/library/mysql
+++ b/library/mysql
@@ -4,14 +4,20 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/mysql.git
 
-Tags: 9.7.1, 9.7, 9, lts, latest, 9.7.1-oraclelinux9, 9.7-oraclelinux9, 9-oraclelinux9, lts-oraclelinux9, oraclelinux9, 9.7.1-oracle, 9.7-oracle, 9-oracle, lts-oracle, oracle
+Tags: 26.7.0, 26.7, 26, innovation, latest, 26.7.0-oraclelinux9, 26.7-oraclelinux9, 26-oraclelinux9, innovation-oraclelinux9, oraclelinux9, 26.7.0-oracle, 26.7-oracle, 26-oracle, innovation-oracle, oracle
 Architectures: amd64, arm64v8
-GitCommit: 7f30fdb0738041fc5125e8218e393e0a891243e9
+GitCommit: 288e46ff450920468d5a1fcb618d359068704c3d
+Directory: innovation
+File: Dockerfile.oracle
+
+Tags: 9.7.2, 9.7, 9, lts, 9.7.2-oraclelinux9, 9.7-oraclelinux9, 9-oraclelinux9, lts-oraclelinux9, 9.7.2-oracle, 9.7-oracle, 9-oracle, lts-oracle
+Architectures: amd64, arm64v8
+GitCommit: 55e1d05e12ac954be18a3114d7c177ad957e435b
 Directory: 9.7
 File: Dockerfile.oracle
 
-Tags: 8.4.10, 8.4, 8, 8.4.10-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, 8.4.10-oracle, 8.4-oracle, 8-oracle
+Tags: 8.4.11, 8.4, 8, 8.4.11-oraclelinux9, 8.4-oraclelinux9, 8-oraclelinux9, 8.4.11-oracle, 8.4-oracle, 8-oracle
 Architectures: amd64, arm64v8
-GitCommit: 99f090f89830dbd679771884e723c0f74bec0b29
+GitCommit: 01f90d87012e46cd174073bba02d64e9fc693ed3
 Directory: 8.4
 File: Dockerfile.oracle


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mysql/commit/288e46f: Update innovation to 26.7.0, oracle 26.7.0-1.el9, mysql-shell 26.7.0-1.el9
- https://github.com/docker-library/mysql/commit/55e1d05: Update 9.7 to 9.7.2, oracle 9.7.2-1.el9, mysql-shell 9.7.1-1.el9
- https://github.com/docker-library/mysql/commit/01f90d8: Update 8.4 to 8.4.11, oracle 8.4.11-1.el9, mysql-shell 8.4.10-1.el9

https://blogs.oracle.com/mysql/a-more-predictable-mysql-release-model-calendar-versions-lts-and-innovation