### PR TITLE
Bump IBM Java version to 8.0.8.70

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -6,16 +6,16 @@ GitFetch: refs/heads/main
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, ppc64le, s390x
-GitCommit: b0fe612dc5069a4db167cf208f03cc9950d00842
+GitCommit: d909a041f0e0736b779516cac5a9612101d0eff5
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-sfj, sfj
 Architectures: amd64, ppc64le, s390x
-GitCommit: b0fe612dc5069a4db167cf208f03cc9950d00842
+GitCommit: d909a041f0e0736b779516cac5a9612101d0eff5
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sdk, sdk
 Architectures: amd64, ppc64le, s390x
-GitCommit: b0fe612dc5069a4db167cf208f03cc9950d00842
+GitCommit: d909a041f0e0736b779516cac5a9612101d0eff5
 Directory: ibmjava/8/sdk/ubuntu
 


### PR DESCRIPTION
Updated java8 docker files with 8.0.8.70 release.