### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,34 +14,34 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: ec437dd2a3656610b10a42c08763d8fa1c591efe
 Directory: 3.5/alpine
 
-Tags: 3.4.2, 3.4, latest, lts, 3.4.2-trixie, 3.4-trixie, trixie, lts-trixie
+Tags: 3.4.3, 3.4, latest, lts, 3.4.3-trixie, 3.4-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 42313d5d1aaf525dcea1679909272dc8ba4c1c94
+GitCommit: 40955df2217f5cb77f861e709b239cedd43ff613
 Directory: 3.4
 
-Tags: 3.4.2-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.2-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
+Tags: 3.4.3-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.3-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 42313d5d1aaf525dcea1679909272dc8ba4c1c94
+GitCommit: 40955df2217f5cb77f861e709b239cedd43ff613
 Directory: 3.4/alpine
 
-Tags: 3.3.12, 3.3, 3.3.12-trixie, 3.3-trixie
+Tags: 3.3.13, 3.3, 3.3.13-trixie, 3.3-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5336dec66c98b607f836b840e6c9f720baed666b
+GitCommit: caa8282e7c19d57d87610ffb13560ee8ccbc263f
 Directory: 3.3
 
-Tags: 3.3.12-alpine, 3.3-alpine, 3.3.12-alpine3.24, 3.3-alpine3.24
+Tags: 3.3.13-alpine, 3.3-alpine, 3.3.13-alpine3.24, 3.3-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5336dec66c98b607f836b840e6c9f720baed666b
+GitCommit: caa8282e7c19d57d87610ffb13560ee8ccbc263f
 Directory: 3.3/alpine
 
-Tags: 3.2.21, 3.2, 3.2.21-trixie, 3.2-trixie
+Tags: 3.2.22, 3.2, 3.2.22-trixie, 3.2-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5f3b2c841ea8e0bce7bc5e753ce28327e629237d
+GitCommit: 3e679de0fb5d9e781f1aa313ab7464e270a809e3
 Directory: 3.2
 
-Tags: 3.2.21-alpine, 3.2-alpine, 3.2.21-alpine3.24, 3.2-alpine3.24
+Tags: 3.2.22-alpine, 3.2-alpine, 3.2.22-alpine3.24, 3.2-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 5f3b2c841ea8e0bce7bc5e753ce28327e629237d
+GitCommit: 3e679de0fb5d9e781f1aa313ab7464e270a809e3
 Directory: 3.2/alpine
 
 Tags: 3.0.25, 3.0, 3.0.25-trixie, 3.0-trixie
@@ -54,22 +54,22 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 84fe98d090e7617a2d94e7ad7cfb16c14cd1a560
 Directory: 3.0/alpine
 
-Tags: 2.8.26, 2.8, 2.8.26-trixie, 2.8-trixie
+Tags: 2.8.27, 2.8, 2.8.27-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b034a68f85424edf4133c9c6b3c7eef4c12f03a8
+GitCommit: 2ee81bd76371730aa58585c7f281acd89334f7bb
 Directory: 2.8
 
-Tags: 2.8.26-alpine, 2.8-alpine, 2.8.26-alpine3.24, 2.8-alpine3.24
+Tags: 2.8.27-alpine, 2.8-alpine, 2.8.27-alpine3.24, 2.8-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b034a68f85424edf4133c9c6b3c7eef4c12f03a8
+GitCommit: 2ee81bd76371730aa58585c7f281acd89334f7bb
 Directory: 2.8/alpine
 
-Tags: 2.6.31, 2.6, 2.6.31-trixie, 2.6-trixie
+Tags: 2.6.32, 2.6, 2.6.32-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d41dc8229f8615343f080f84cd4ebb9f3500b98d
+GitCommit: 32a1b4183b2b02c1dd8060bca6c706285ca1245f
 Directory: 2.6
 
-Tags: 2.6.31-alpine, 2.6-alpine, 2.6.31-alpine3.24, 2.6-alpine3.24
+Tags: 2.6.32-alpine, 2.6-alpine, 2.6.32-alpine3.24, 2.6-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: d41dc8229f8615343f080f84cd4ebb9f3500b98d
+GitCommit: 32a1b4183b2b02c1dd8060bca6c706285ca1245f
 Directory: 2.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/40955df: Update 3.4 to 3.4.3
- https://github.com/docker-library/haproxy/commit/caa8282: Update 3.3 to 3.3.13
- https://github.com/docker-library/haproxy/commit/3e679de: Update 3.2 to 3.2.22
- https://github.com/docker-library/haproxy/commit/2ee81bd: Update 2.8 to 2.8.27
- https://github.com/docker-library/haproxy/commit/32a1b41: Update 2.6 to 2.6.32