### PR TITLE
Update oraclelinux-slim for 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: a28fd64cea50c149190e6f517269a00eb165c9cd
+amd64-GitCommit: 2ca14f66baf690a9d98ae54e5a7237602243b269
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: aed455ed56cc42425c766d015ad8d805e576fce1
+arm64v8-GitCommit: 7b1ba4c4134d4e6e0e072939b11a3be65df18c47
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-22711](https://linux.oracle.com/errata/ELSA-2026-22711.html)
- [ELSA-2026-28234](https://linux.oracle.com/errata/ELSA-2026-28234.html)
- [ELSA-2026-39183](https://linux.oracle.com/errata/ELSA-2026-39183.html)
- [ELSA-2026-42739](https://linux.oracle.com/errata/ELSA-2026-42739.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
