### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -44,14 +44,14 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 3e679de0fb5d9e781f1aa313ab7464e270a809e3
 Directory: 3.2/alpine
 
-Tags: 3.0.25, 3.0, 3.0.25-trixie, 3.0-trixie
+Tags: 3.0.26, 3.0, 3.0.26-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 84fe98d090e7617a2d94e7ad7cfb16c14cd1a560
+GitCommit: 9dfb33f798390d8d9b64041834acd72f1591de48
 Directory: 3.0
 
-Tags: 3.0.25-alpine, 3.0-alpine, 3.0.25-alpine3.24, 3.0-alpine3.24
+Tags: 3.0.26-alpine, 3.0-alpine, 3.0.26-alpine3.24, 3.0-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 84fe98d090e7617a2d94e7ad7cfb16c14cd1a560
+GitCommit: 9dfb33f798390d8d9b64041834acd72f1591de48
 Directory: 3.0/alpine
 
 Tags: 2.8.27, 2.8, 2.8.27-trixie, 2.8-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/9dfb33f: Update 3.0 to 3.0.26