### PR TITLE
Update oraclelinux-slim for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2ca14f66baf690a9d98ae54e5a7237602243b269
+amd64-GitCommit: 1a2a6d85aa8be9a1d63f0f87b7602b0ae559b6b2
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 7b1ba4c4134d4e6e0e072939b11a3be65df18c47
+arm64v8-GitCommit: f0f5514b0141b6d4a001a65c0e1f1d6a2e89db7a
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-42733](https://linux.oracle.com/errata/ELSA-2026-42733.html)
- [ELSA-2026-43420](https://linux.oracle.com/errata/ELSA-2026-43420.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
