### PR TITLE
influxdb3: release 3.9.11, 3.10.5, 3.11.0 core and enterprise

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 20a6a80079b50ec78170871b4bce420a38a9d0fa
+GitCommit: 956738144f87def2c889ff590d9f3e6619220482
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -62,18 +62,26 @@ Tags: 2-alpine, 2.9-alpine, 2.9.1-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.9/alpine
 
-Tags: 3.9-core, 3.9.6-core
+Tags: 3.9-core, 3.9.11-core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-core
 
-Tags: 3.9-enterprise, 3.9.9-enterprise
+Tags: 3.9-enterprise, 3.9.11-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-enterprise
 
-Tags: 3-core, 3.10-core, 3.10.3-core, core
+Tags: 3.10-core, 3.10.5-core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-core
 
-Tags: 3-enterprise, 3.10-enterprise, 3.10.3-enterprise, enterprise
+Tags: 3.10-enterprise, 3.10.5-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-enterprise
+
+Tags: 3-core, 3.11-core, 3.11.0-core, core
+Architectures: amd64, arm64v8
+Directory: influxdb/3.11-core
+
+Tags: 3-enterprise, 3.11-enterprise, 3.11.0-enterprise, enterprise
+Architectures: amd64, arm64v8
+Directory: influxdb/3.11-enterprise


### PR DESCRIPTION
Following are the updates,

- 3.9
    - core: 3.9.11
    - enterprise: 3.9.11
- 3.10
    - core: 3.10.5
    - enterprise: 3.10.5
- 3.11 (newly added)
    - core: 3.11.0
    - enterprise: 3.11.0 
    
 Supersedes #21887