### PR TITLE
Update oraclelinux for 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 1a2a6d85aa8be9a1d63f0f87b7602b0ae559b6b2
+amd64-GitCommit: 9766598fb9c8865649300a3b8ebf48a7aea8626b
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: f0f5514b0141b6d4a001a65c0e1f1d6a2e89db7a
+arm64v8-GitCommit: 4e596a28fcedf2388473d8db67d45e9081313dc4
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-47757](https://linux.oracle.com/errata/ELSA-2026-47757.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
