### PR TITLE
Update 6 to 6.55.0, Update 6 to CLI 1.30.1

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,12 +2,12 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 1e0c9b7e9dcd75744b8bf2099c4d78cdc32843b2
+GitCommit: e7e2193c3aad24a4a46092943585dc4ccd23e7cc
 
-Tags: 6.54.1-bookworm, 6.54.1, 6.54-bookworm, 6.54, 6-bookworm, 6, bookworm, latest
+Tags: 6.55.0-bookworm, 6.55.0, 6.55-bookworm, 6.55, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.54.1-alpine3.23, 6.54.1-alpine, 6.54-alpine3.23, 6.54-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.55.0-alpine3.23, 6.55.0-alpine, 6.55-alpine3.23, 6.55-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.55.0, Update 6 to CLI 1.30.1

Generated from https://github.com/TryGhost/docker-library-ghost/commit/e7e2193c3aad24a4a46092943585dc4ccd23e7cc.