### PR TITLE
Update busybox

### DIFF
--- a/library/busybox
+++ b/library/busybox
@@ -1,38 +1,38 @@
-# this file is generated via https://github.com/docker-library/busybox/blob/7d88ac3f2be7fdef1fdcb0d11488f3adf615e2a1/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/busybox/blob/e7bf068f570ae5a3236675c3c6b22a576773e833/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/busybox.git
-GitCommit: 7d88ac3f2be7fdef1fdcb0d11488f3adf615e2a1
+GitCommit: e7bf068f570ae5a3236675c3c6b22a576773e833
 Builder: oci-import
 File: index.json
 # https://github.com/docker-library/busybox/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 71dbea6bedb4bb497581d61bb025f8558cc7833a
+amd64-GitCommit: 70ce0fb98bee360bbcce132660d727bf6ce55a99
 # https://github.com/docker-library/busybox/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 5fec30bd4375e5f8d5f399f635d8c01ddee548f7
+arm32v5-GitCommit: dcd2ccf75eb63960e476f723623dd6f4c89eb020
 # https://github.com/docker-library/busybox/tree/dist-arm32v6
 arm32v6-GitFetch: refs/heads/dist-arm32v6
-arm32v6-GitCommit: 73673f35a8b153f00120844f85a653f488e85793
+arm32v6-GitCommit: b3ae875e3aca1414fbc747afcf445931c59809c2
 # https://github.com/docker-library/busybox/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: a8c6f12d2a1c8011f706f4995b0ef10f3f901fcc
+arm32v7-GitCommit: 5e3d530c6dd8793d1976e4ed12cec362ef08c0b5
 # https://github.com/docker-library/busybox/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 0a49464ff90e706d47953a9aacc888cc80ddb62f
+arm64v8-GitCommit: 0436ae6a521e9e1bf3a524b0c3062a68d2af96e0
 # https://github.com/docker-library/busybox/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: 5d4c51cdbac3707680d85bc23b5f5bd8740e76dc
+i386-GitCommit: 7e6138892e25640c30b3278c334411e19bd554e8
 # https://github.com/docker-library/busybox/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 5b3724499baea9f0ff998d63feaccc786fff5ab3
+ppc64le-GitCommit: b59052fdba2469a70b4bec03730ab2ce76e20b7c
 # https://github.com/docker-library/busybox/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: d8f26a505ca1799feb33830218c6915f4087d8f5
+riscv64-GitCommit: 11771252466d121eef8fda1f6282ff0b2a6e9317
 # https://github.com/docker-library/busybox/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: f51c3009c496303f609e6d934d34d80b75db4fdd
+s390x-GitCommit: 729a0c071b5c666e84d7dc101468f6ac01fb8413
 
 Tags: 1.38.0-glibc, 1.38-glibc, 1-glibc, unstable-glibc, glibc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/busybox/commit/e7bf068: Update metadata for s390x
- https://github.com/docker-library/busybox/commit/fa8e8ca: Update metadata for riscv64
- https://github.com/docker-library/busybox/commit/85c8aa3: Update metadata for ppc64le
- https://github.com/docker-library/busybox/commit/de94732: Update metadata for arm64v8
- https://github.com/docker-library/busybox/commit/1ae9c53: Update metadata for arm32v7
- https://github.com/docker-library/busybox/commit/87701e4: Update metadata for arm32v6
- https://github.com/docker-library/busybox/commit/bbee275: Update metadata for arm32v5
- https://github.com/docker-library/busybox/commit/6b4f346: Merge pull request https://github.com/docker-library/busybox/pull/248 from infosiftr/buildroot-2026.05.1
- https://github.com/docker-library/busybox/commit/793924e: Update metadata for amd64 and i386
- https://github.com/docker-library/busybox/commit/1dbf724: Update buildroot to 2026.05.1