### PR TITLE
archlinux: Release 20260802.0.566770

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260726.0.562117
-GitCommit: 8dc90695082262f4e8c0f31b6da0e8dc37c479b1
-GitFetch: refs/tags/v20260726.0.562117
+Tags: latest, base, base-20260802.0.566770
+GitCommit: ecb1fbdafe3d6f25ac05656f330fc839baa69099
+GitFetch: refs/tags/v20260802.0.566770
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260726.0.562117
-GitCommit: 8dc90695082262f4e8c0f31b6da0e8dc37c479b1
-GitFetch: refs/tags/v20260726.0.562117
+Tags: base-devel, base-devel-20260802.0.566770
+GitCommit: ecb1fbdafe3d6f25ac05656f330fc839baa69099
+GitFetch: refs/tags/v20260802.0.566770
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260726.0.562117
-GitCommit: 8dc90695082262f4e8c0f31b6da0e8dc37c479b1
-GitFetch: refs/tags/v20260726.0.562117
+Tags: multilib-devel, multilib-devel-20260802.0.566770
+GitCommit: ecb1fbdafe3d6f25ac05656f330fc839baa69099
+GitFetch: refs/tags/v20260802.0.566770
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks