### PR TITLE
Odoo: update 17.0-19.0 to release 20260803

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: f7f6765354127c8ca31c373f51a840d9ec79149d
+GitCommit: fdaf247fa3c97f91f0804e69ac2877c689d64168
 
-Tags: 19.0-20260723, 19.0, 19, latest
+Tags: 19.0-20260803, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20260723, 18.0, 18
+Tags: 18.0-20260803, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20260723, 17.0, 17
+Tags: 17.0-20260803, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the latest updates of Odoo supported versions.

Thanks