### PR TITLE
Update oraclelinux for 10 and 9

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 9766598fb9c8865649300a3b8ebf48a7aea8626b
+amd64-GitCommit: f0f0a74c889ee20ab5b7bf2ed613d5898f4714a2
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 4e596a28fcedf2388473d8db67d45e9081313dc4
+arm64v8-GitCommit: a9557dc2e6d5a042d0c8bd994b4d7e5628bff4af
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-48650](https://linux.oracle.com/errata/ELSA-2026-48650.html)

### Oracle Linux 9
- [ELSA-2026-47982](https://linux.oracle.com/errata/ELSA-2026-47982.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
