### PR TITLE
Update mongo

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -31,33 +31,6 @@ GitCommit: cb9ffa8b5a41abc772a49abb8517142bc558f55a
 Directory: 8.3/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 8.2.12-noble, 8.2-noble, 8-noble, noble
-SharedTags: 8.2.12, 8.2, 8, latest
-Architectures: amd64, arm64v8
-GitCommit: 390701f7482e927179a2917c178b6c5eadd2c2d9
-Directory: 8.2
-
-Tags: 8.2.12-windowsservercore-ltsc2025, 8.2-windowsservercore-ltsc2025, 8-windowsservercore-ltsc2025, windowsservercore-ltsc2025
-SharedTags: 8.2.12-windowsservercore, 8.2-windowsservercore, 8-windowsservercore, windowsservercore, 8.2.12, 8.2, 8, latest
-Architectures: windows-amd64
-GitCommit: 390701f7482e927179a2917c178b6c5eadd2c2d9
-Directory: 8.2/windows/windowsservercore-ltsc2025
-Constraints: windowsservercore-ltsc2025
-
-Tags: 8.2.12-windowsservercore-ltsc2022, 8.2-windowsservercore-ltsc2022, 8-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 8.2.12-windowsservercore, 8.2-windowsservercore, 8-windowsservercore, windowsservercore, 8.2.12, 8.2, 8, latest
-Architectures: windows-amd64
-GitCommit: 390701f7482e927179a2917c178b6c5eadd2c2d9
-Directory: 8.2/windows/windowsservercore-ltsc2022
-Constraints: windowsservercore-ltsc2022
-
-Tags: 8.2.12-nanoserver-ltsc2022, 8.2-nanoserver-ltsc2022, 8-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 8.2.12-nanoserver, 8.2-nanoserver, 8-nanoserver, nanoserver
-Architectures: windows-amd64
-GitCommit: 390701f7482e927179a2917c178b6c5eadd2c2d9
-Directory: 8.2/windows/nanoserver-ltsc2022
-Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
-
 Tags: 8.0.28-noble, 8.0-noble
 SharedTags: 8.0.28, 8.0
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/mongo/commit/1533435: Update 8.2

It is "end of life", but this is MongoDB and they have a history this past year of re-releasing EOL software (https://github.com/docker-library/mongo/pull/744, https://github.com/docker-library/mongo/pull/756, https://github.com/docker-library/mongo/issues/761). I don't think waiting to remove it will matter since they've released things over 2 years after end of life.