### PR TITLE
Update Debian (notably, complete `mips64le` removal)

### DIFF
--- a/library/debian
+++ b/library/debian
@@ -7,69 +7,66 @@ GitRepo: https://github.com/debuerreotype/docker-debian-artifacts.git
 GitCommit: 7935fc7dd049cb343df42037c152f570069d274f
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 2b9b380c71ad8a3b6ce55c083c9ecfb901dabf71
+amd64-GitCommit: b09f23ad7aab0cafa864c696dfbf130128e5e452
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v5
 arm32v5-GitFetch: refs/heads/dist-arm32v5
-arm32v5-GitCommit: 8c4fa7179d1fff8b160cf9c2676708b2d230979f
+arm32v5-GitCommit: a2677ca23958951d6cf164871b1e669dc0013add
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm32v7
 arm32v7-GitFetch: refs/heads/dist-arm32v7
-arm32v7-GitCommit: e11403829ffe5cc336212fc63d1b80b93bb2375e
+arm32v7-GitCommit: 456c7b794635964924caeee1ff05f08a4ddd1aca
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: fb7215b47dab72bdbdd59204a7b7914311431d90
+arm64v8-GitCommit: 14d91d295c23da6cc04d4bfe8b3d74a8a6c54e5c
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-i386
 i386-GitFetch: refs/heads/dist-i386
-i386-GitCommit: e59de049d31e0388e384b2d6bd6c3a1235b43a60
-# https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-mips64le
-mips64le-GitFetch: refs/heads/dist-mips64le
-mips64le-GitCommit: 260556ad8990ae4fb249b3999f5bdb1b5f25ecdf
+i386-GitCommit: 6fed46af356c8b9395ea084f995292e9a5ff6447
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-ppc64le
 ppc64le-GitFetch: refs/heads/dist-ppc64le
-ppc64le-GitCommit: 4d0b3849971ef29d8fd5b6fe9708f87dd2e6867c
+ppc64le-GitCommit: a531630f39b669c0ab97f5f824506c632ab31091
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-riscv64
 riscv64-GitFetch: refs/heads/dist-riscv64
-riscv64-GitCommit: 281c7a5ed4438a7f5448698ac6eab0e37b950a28
+riscv64-GitCommit: 039121e5aaa185e97f4c884e99e6754ac19f12f8
 # https://github.com/debuerreotype/docker-debian-artifacts/tree/dist-s390x
 s390x-GitFetch: refs/heads/dist-s390x
-s390x-GitCommit: 1b131f0a7ff69541d9f7f276325c46f172f1aa35
+s390x-GitCommit: 16675ae12b09c5e400778ae3a4468cd692d67e3b
 
 # bookworm -- Debian 12.15 Released 11 July 2026
-Tags: bookworm, bookworm-20260713, 12.15, 12
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Tags: bookworm, bookworm-20260803, 12.15, 12
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Builder: oci-import
 Directory: bookworm/oci
 File: index.json
 
 Tags: bookworm-backports
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: bookworm/backports
 
-Tags: bookworm-slim, bookworm-20260713-slim, 12.15-slim, 12-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Tags: bookworm-slim, bookworm-20260803-slim, 12.15-slim, 12-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Builder: oci-import
 Directory: bookworm/slim/oci
 File: index.json
 
 # bullseye -- Debian 11.11 Released 31 August 2024
-Tags: bullseye, bullseye-20260713, 11.11, 11
+Tags: bullseye, bullseye-20260803, 11.11, 11
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: bullseye/oci
 File: index.json
 
-Tags: bullseye-slim, bullseye-20260713-slim, 11.11-slim, 11-slim
+Tags: bullseye-slim, bullseye-20260803-slim, 11.11-slim, 11-slim
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: bullseye/slim/oci
 File: index.json
 
 # experimental -- Experimental packages - not released; use at your own risk.
-Tags: experimental, experimental-20260713
+Tags: experimental, experimental-20260803
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: experimental
 
 # forky -- Debian x.y Testing distribution - Not Released
-Tags: forky, forky-20260713
+Tags: forky, forky-20260803
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: forky/oci
@@ -79,62 +76,62 @@ Tags: forky-backports
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: forky/backports
 
-Tags: forky-slim, forky-20260713-slim
+Tags: forky-slim, forky-20260803-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: forky/slim/oci
 File: index.json
 
 # oldoldstable -- Debian 11.11 Released 31 August 2024
-Tags: oldoldstable, oldoldstable-20260713
+Tags: oldoldstable, oldoldstable-20260803
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: oldoldstable/oci
 File: index.json
 
-Tags: oldoldstable-slim, oldoldstable-20260713-slim
+Tags: oldoldstable-slim, oldoldstable-20260803-slim
 Architectures: amd64, arm32v7, arm64v8, i386
 Builder: oci-import
 Directory: oldoldstable/slim/oci
 File: index.json
 
 # oldstable -- Debian 12.15 Released 11 July 2026
-Tags: oldstable, oldstable-20260713
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Tags: oldstable, oldstable-20260803
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Builder: oci-import
 Directory: oldstable/oci
 File: index.json
 
 Tags: oldstable-backports
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: oldstable/backports
 
-Tags: oldstable-slim, oldstable-20260713-slim
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Tags: oldstable-slim, oldstable-20260803-slim
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Builder: oci-import
 Directory: oldstable/slim/oci
 File: index.json
 
 # rc-buggy -- Experimental packages - not released; use at your own risk.
-Tags: rc-buggy, rc-buggy-20260713
+Tags: rc-buggy, rc-buggy-20260803
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: rc-buggy
 
 # sid -- Debian x.y Unstable - Not Released
-Tags: sid, sid-20260713
+Tags: sid, sid-20260803
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: sid/oci
 File: index.json
 
-Tags: sid-slim, sid-20260713-slim
+Tags: sid-slim, sid-20260803-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: sid/slim/oci
 File: index.json
 
 # stable -- Debian 13.6 Released 11 July 2026
-Tags: stable, stable-20260713
+Tags: stable, stable-20260803
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: stable/oci
@@ -144,14 +141,14 @@ Tags: stable-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: stable/backports
 
-Tags: stable-slim, stable-20260713-slim
+Tags: stable-slim, stable-20260803-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: stable/slim/oci
 File: index.json
 
 # testing -- Debian x.y Testing distribution - Not Released
-Tags: testing, testing-20260713
+Tags: testing, testing-20260803
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: testing/oci
@@ -161,14 +158,14 @@ Tags: testing-backports
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: testing/backports
 
-Tags: testing-slim, testing-20260713-slim
+Tags: testing-slim, testing-20260803-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: testing/slim/oci
 File: index.json
 
 # trixie -- Debian 13.6 Released 11 July 2026
-Tags: trixie, trixie-20260713, 13.6, 13, latest
+Tags: trixie, trixie-20260803, 13.6, 13, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: trixie/oci
@@ -178,20 +175,20 @@ Tags: trixie-backports
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: trixie/backports
 
-Tags: trixie-slim, trixie-20260713-slim, 13.6-slim, 13-slim
+Tags: trixie-slim, trixie-20260803-slim, 13.6-slim, 13-slim
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: trixie/slim/oci
 File: index.json
 
 # unstable -- Debian x.y Unstable - Not Released
-Tags: unstable, unstable-20260713
+Tags: unstable, unstable-20260803
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: unstable/oci
 File: index.json
 
-Tags: unstable-slim, unstable-20260713-slim
+Tags: unstable-slim, unstable-20260803-slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Builder: oci-import
 Directory: unstable/slim/oci


### PR DESCRIPTION
This contains the inevitable result of https://lists.debian.org/debian-devel-announce/2025/11/msg00001.html -- as bookworm is now LTS, mips64le is no longer supported, and has been officially dropped from the official Debian archives now, so there is no longer _any_ active suite with support for `mips64le`.

This also means the end of `mips64le` within DOI at large (as our primary build system is running Debian Bookworm and is thus affected by this as well, but also marks the end of any base image providing `mips64le` images -- it also couldn't come at a better time, given that our build server has been just barely limping along for ages now).