### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -12,19 +12,19 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.12.20260724.0
+Tags: 2023, latest, 2023.12.20260727.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 5a0863340c247026a6912f2e76976294cb9bf836
+amd64-GitCommit: 0c02d87a58138cbd40c56c00ca144091415cdce7
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 8008e7cbda863c8599b8780f9cb8ccf4ded3d82a
+arm64v8-GitCommit: 6d8dc6e6b1ffe58e25ce27ab58820ef62f7931ef
 
-Tags: 2, 2.0.20260720.0
+Tags: 2, 2.0.20260727.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 2a1c5e64594d517a506c4fc73329ee10e4c81bda
+amd64-GitCommit: 37997cdea2a520726c1d6d8c89696dd27426661e
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 95a0419d05495971eda7718cb0a7abbf1d526b70
+arm64v8-GitCommit: 0fda7faf95a4aae5c353564f2c9a2cec44731771
 
 Tags: 1, 2018.03, 2018.03.0.20231218.0
 Architectures: amd64


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.12.20260727-0.amzn2023
- system-release-2023.12.20260727-0.amzn2023