### PR TITLE
Remove arm32v5 and s390x from bookworm images

### DIFF
--- a/library/buildpack-deps
+++ b/library/buildpack-deps
@@ -5,17 +5,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/buildpack-deps.git
 
 Tags: bookworm-curl, oldstable-curl
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 3e18c3af1f5dce6a48abf036857f9097b6bd79cc
 Directory: debian/bookworm/curl
 
 Tags: bookworm-scm, oldstable-scm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: debian/bookworm/scm
 
 Tags: bookworm, oldstable
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: d0ecd4b7313e9bc6b00d9a4fe62ad5787bc197ae
 Directory: debian/bookworm
 

--- a/library/cassandra
+++ b/library/cassandra
@@ -5,16 +5,16 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/cassandra.git
 
 Tags: 5.0.8, 5.0, 5, latest, 5.0.8-bookworm, 5.0-bookworm, 5-bookworm, bookworm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 7b9da8f4f58f48af79feb0fc2f7a1e2c639965f1
 Directory: 5.0
 
 Tags: 4.1.11, 4.1, 4, 4.1.11-bookworm, 4.1-bookworm, 4-bookworm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: f304ac2a02e00150b7e6629a40fcbd2891a0ba62
 Directory: 4.1
 
 Tags: 4.0.20, 4.0, 4.0.20-bookworm, 4.0-bookworm
-Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: a99c4aa59e96ab881db88b13ca0d4fd086b9a4dd
 Directory: 4.0

--- a/library/drupal
+++ b/library/drupal
@@ -15,12 +15,12 @@ GitCommit: 39e82484f1903eb2b223b61b4e9210568cd8cf48
 Directory: 11.4/php8.5/fpm-trixie
 
 Tags: 11.4.4-php8.5-apache-bookworm, 11.4-php8.5-apache-bookworm, 11-php8.5-apache-bookworm, php8.5-apache-bookworm, 11.4.4-apache-bookworm, 11.4-apache-bookworm, 11-apache-bookworm, apache-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 39e82484f1903eb2b223b61b4e9210568cd8cf48
 Directory: 11.4/php8.5/apache-bookworm
 
 Tags: 11.4.4-php8.5-fpm-bookworm, 11.4-php8.5-fpm-bookworm, 11-php8.5-fpm-bookworm, php8.5-fpm-bookworm, 11.4.4-fpm-bookworm, 11.4-fpm-bookworm, 11-fpm-bookworm, fpm-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 39e82484f1903eb2b223b61b4e9210568cd8cf48
 Directory: 11.4/php8.5/fpm-bookworm
 
@@ -45,12 +45,12 @@ GitCommit: 39e82484f1903eb2b223b61b4e9210568cd8cf48
 Directory: 11.4/php8.4/fpm-trixie
 
 Tags: 11.4.4-php8.4-apache-bookworm, 11.4-php8.4-apache-bookworm, 11-php8.4-apache-bookworm, php8.4-apache-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 39e82484f1903eb2b223b61b4e9210568cd8cf48
 Directory: 11.4/php8.4/apache-bookworm
 
 Tags: 11.4.4-php8.4-fpm-bookworm, 11.4-php8.4-fpm-bookworm, 11-php8.4-fpm-bookworm, php8.4-fpm-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 39e82484f1903eb2b223b61b4e9210568cd8cf48
 Directory: 11.4/php8.4/fpm-bookworm
 
@@ -75,12 +75,12 @@ GitCommit: 305e3e2acd5180ec2476d448fd97b4ccbcb0a55d
 Directory: 11.3/php8.5/fpm-trixie
 
 Tags: 11.3.16-php8.5-apache-bookworm, 11.3-php8.5-apache-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 305e3e2acd5180ec2476d448fd97b4ccbcb0a55d
 Directory: 11.3/php8.5/apache-bookworm
 
 Tags: 11.3.16-php8.5-fpm-bookworm, 11.3-php8.5-fpm-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 305e3e2acd5180ec2476d448fd97b4ccbcb0a55d
 Directory: 11.3/php8.5/fpm-bookworm
 
@@ -105,12 +105,12 @@ GitCommit: 305e3e2acd5180ec2476d448fd97b4ccbcb0a55d
 Directory: 11.3/php8.4/fpm-trixie
 
 Tags: 11.3.16-php8.4-apache-bookworm, 11.3-php8.4-apache-bookworm, 11.3.16-apache-bookworm, 11.3-apache-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 305e3e2acd5180ec2476d448fd97b4ccbcb0a55d
 Directory: 11.3/php8.4/apache-bookworm
 
 Tags: 11.3.16-php8.4-fpm-bookworm, 11.3-php8.4-fpm-bookworm, 11.3.16-fpm-bookworm, 11.3-fpm-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 305e3e2acd5180ec2476d448fd97b4ccbcb0a55d
 Directory: 11.3/php8.4/fpm-bookworm
 
@@ -135,12 +135,12 @@ GitCommit: a45e8fb9eda15287b07ed78448e76a2af3dcc837
 Directory: 10.6/php8.4/fpm-trixie
 
 Tags: 10.6.14-php8.4-apache-bookworm, 10.6-php8.4-apache-bookworm, 10-php8.4-apache-bookworm, 10.6.14-apache-bookworm, 10.6-apache-bookworm, 10-apache-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: a45e8fb9eda15287b07ed78448e76a2af3dcc837
 Directory: 10.6/php8.4/apache-bookworm
 
 Tags: 10.6.14-php8.4-fpm-bookworm, 10.6-php8.4-fpm-bookworm, 10-php8.4-fpm-bookworm, 10.6.14-fpm-bookworm, 10.6-fpm-bookworm, 10-fpm-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: a45e8fb9eda15287b07ed78448e76a2af3dcc837
 Directory: 10.6/php8.4/fpm-bookworm
 
@@ -165,12 +165,12 @@ GitCommit: a45e8fb9eda15287b07ed78448e76a2af3dcc837
 Directory: 10.6/php8.3/fpm-trixie
 
 Tags: 10.6.14-php8.3-apache-bookworm, 10.6-php8.3-apache-bookworm, 10-php8.3-apache-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: a45e8fb9eda15287b07ed78448e76a2af3dcc837
 Directory: 10.6/php8.3/apache-bookworm
 
 Tags: 10.6.14-php8.3-fpm-bookworm, 10.6-php8.3-fpm-bookworm, 10-php8.3-fpm-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: a45e8fb9eda15287b07ed78448e76a2af3dcc837
 Directory: 10.6/php8.3/fpm-bookworm
 

--- a/library/gcc
+++ b/library/gcc
@@ -27,14 +27,14 @@ Directory: 14
 
 # Last Modified: 2025-06-05
 Tags: 13.4.0, 13.4, 13, 13.4.0-bookworm, 13.4-bookworm, 13-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 118c07a8e6467baababb4634b6cfde14a67c24b0
 Directory: 13
 # Docker EOL: 2026-12-05
 
 # Last Modified: 2025-07-11
 Tags: 12.5.0, 12.5, 12, 12.5.0-bookworm, 12.5-bookworm, 12-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, ppc64le
 GitCommit: 7070981b23d22d3ca790f87bff26f13f3614dd4c
 Directory: 12
 # Docker EOL: 2027-01-11

--- a/library/golang
+++ b/library/golang
@@ -13,7 +13,7 @@ GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/trixie
 
 Tags: 1.27rc2-bookworm, 1.27-rc-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.27-rc/bookworm
 
@@ -66,7 +66,7 @@ GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/trixie
 
 Tags: 1.26.5-bookworm, 1.26-bookworm, 1-bookworm, bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.26/bookworm
 
@@ -119,7 +119,7 @@ GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/trixie
 
 Tags: 1.25.12-bookworm, 1.25-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 294097713ad2eaf9ee4c5e9dc57e040ac4b402d6
 Directory: 1.25/bookworm
 
@@ -172,7 +172,7 @@ GitCommit: 7e1ee164c303277ed2fcdea1f51f41a91c410a50
 Directory: tip/trixie
 
 Tags: tip-20260726-bookworm, tip-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 7e1ee164c303277ed2fcdea1f51f41a91c410a50
 Directory: tip/bookworm
 

--- a/library/hylang
+++ b/library/hylang
@@ -8,7 +8,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: latest/python3.15-rc-trixie
 
 Tags: 1.3.0-python3.15-rc-bookworm, 1.3-python3.15-rc-bookworm, 1-python3.15-rc-bookworm, python3.15-rc-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: latest/python3.15-rc-bookworm
 
 Tags: 1.3.0-python3.15-rc-alpine3.24, 1.3-python3.15-rc-alpine3.24, 1-python3.15-rc-alpine3.24, python3.15-rc-alpine3.24, 1.3.0-python3.15-rc-alpine, 1.3-python3.15-rc-alpine, 1-python3.15-rc-alpine, python3.15-rc-alpine
@@ -37,7 +37,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: latest/python3.14-trixie
 
 Tags: 1.3.0-python3.14-bookworm, 1.3-python3.14-bookworm, 1-python3.14-bookworm, python3.14-bookworm, 1.3.0-bookworm, 1.3-bookworm, 1-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: latest/python3.14-bookworm
 
 Tags: 1.3.0-python3.14-alpine3.24, 1.3-python3.14-alpine3.24, 1-python3.14-alpine3.24, python3.14-alpine3.24, 1.3.0-python3.14-alpine, 1.3-python3.14-alpine, 1-python3.14-alpine, python3.14-alpine, 1.3.0-alpine3.24, 1.3-alpine3.24, 1-alpine3.24, alpine3.24, 1.3.0-alpine, 1.3-alpine, 1-alpine, alpine
@@ -66,7 +66,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: latest/python3.13-trixie
 
 Tags: 1.3.0-python3.13-bookworm, 1.3-python3.13-bookworm, 1-python3.13-bookworm, python3.13-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: latest/python3.13-bookworm
 
 Tags: 1.3.0-python3.13-alpine3.24, 1.3-python3.13-alpine3.24, 1-python3.13-alpine3.24, python3.13-alpine3.24, 1.3.0-python3.13-alpine, 1.3-python3.13-alpine, 1-python3.13-alpine, python3.13-alpine
@@ -95,7 +95,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: latest/python3.12-trixie
 
 Tags: 1.3.0-python3.12-bookworm, 1.3-python3.12-bookworm, 1-python3.12-bookworm, python3.12-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: latest/python3.12-bookworm
 
 Tags: 1.3.0-python3.12-alpine3.24, 1.3-python3.12-alpine3.24, 1-python3.12-alpine3.24, python3.12-alpine3.24, 1.3.0-python3.12-alpine, 1.3-python3.12-alpine, 1-python3.12-alpine, python3.12-alpine
@@ -112,7 +112,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: latest/python3.11-trixie
 
 Tags: 1.3.0-python3.11-bookworm, 1.3-python3.11-bookworm, 1-python3.11-bookworm, python3.11-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: latest/python3.11-bookworm
 
 Tags: 1.3.0-python3.11-alpine3.24, 1.3-python3.11-alpine3.24, 1-python3.11-alpine3.24, python3.11-alpine3.24, 1.3.0-python3.11-alpine, 1.3-python3.11-alpine, 1-python3.11-alpine, python3.11-alpine
@@ -129,7 +129,7 @@ Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 Directory: latest/python3.10-trixie
 
 Tags: 1.3.0-python3.10-bookworm, 1.3-python3.10-bookworm, 1-python3.10-bookworm, python3.10-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 Directory: latest/python3.10-bookworm
 
 Tags: 1.3.0-python3.10-alpine3.24, 1.3-python3.10-alpine3.24, 1-python3.10-alpine3.24, python3.10-alpine3.24, 1.3.0-python3.10-alpine, 1.3-python3.10-alpine, 1-python3.10-alpine, python3.10-alpine

--- a/library/php
+++ b/library/php
@@ -25,22 +25,22 @@ GitCommit: c3638935a390c67c743fa1758d546413e3837600
 Directory: 8.6-rc/trixie/zts
 
 Tags: 8.6.0alpha3-cli-bookworm, 8.6-rc-cli-bookworm, 8.6.0alpha3-bookworm, 8.6-rc-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: c3638935a390c67c743fa1758d546413e3837600
 Directory: 8.6-rc/bookworm/cli
 
 Tags: 8.6.0alpha3-apache-bookworm, 8.6-rc-apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: c3638935a390c67c743fa1758d546413e3837600
 Directory: 8.6-rc/bookworm/apache
 
 Tags: 8.6.0alpha3-fpm-bookworm, 8.6-rc-fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: c3638935a390c67c743fa1758d546413e3837600
 Directory: 8.6-rc/bookworm/fpm
 
 Tags: 8.6.0alpha3-zts-bookworm, 8.6-rc-zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: c3638935a390c67c743fa1758d546413e3837600
 Directory: 8.6-rc/bookworm/zts
 
@@ -95,22 +95,22 @@ GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.5/trixie/zts
 
 Tags: 8.5.9-cli-bookworm, 8.5-cli-bookworm, 8-cli-bookworm, cli-bookworm, 8.5.9-bookworm, 8.5-bookworm, 8-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.5/bookworm/cli
 
 Tags: 8.5.9-apache-bookworm, 8.5-apache-bookworm, 8-apache-bookworm, apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.5/bookworm/apache
 
 Tags: 8.5.9-fpm-bookworm, 8.5-fpm-bookworm, 8-fpm-bookworm, fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.5/bookworm/fpm
 
 Tags: 8.5.9-zts-bookworm, 8.5-zts-bookworm, 8-zts-bookworm, zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.5/bookworm/zts
 
@@ -165,22 +165,22 @@ GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.4/trixie/zts
 
 Tags: 8.4.24-cli-bookworm, 8.4-cli-bookworm, 8.4.24-bookworm, 8.4-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.4/bookworm/cli
 
 Tags: 8.4.24-apache-bookworm, 8.4-apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.4/bookworm/apache
 
 Tags: 8.4.24-fpm-bookworm, 8.4-fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.4/bookworm/fpm
 
 Tags: 8.4.24-zts-bookworm, 8.4-zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.4/bookworm/zts
 
@@ -235,22 +235,22 @@ GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.3/trixie/zts
 
 Tags: 8.3.33-cli-bookworm, 8.3-cli-bookworm, 8.3.33-bookworm, 8.3-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.3/bookworm/cli
 
 Tags: 8.3.33-apache-bookworm, 8.3-apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.3/bookworm/apache
 
 Tags: 8.3.33-fpm-bookworm, 8.3-fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.3/bookworm/fpm
 
 Tags: 8.3.33-zts-bookworm, 8.3-zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.3/bookworm/zts
 
@@ -305,22 +305,22 @@ GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.2/trixie/zts
 
 Tags: 8.2.33-cli-bookworm, 8.2-cli-bookworm, 8.2.33-bookworm, 8.2-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.2/bookworm/cli
 
 Tags: 8.2.33-apache-bookworm, 8.2-apache-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.2/bookworm/apache
 
 Tags: 8.2.33-fpm-bookworm, 8.2-fpm-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.2/bookworm/fpm
 
 Tags: 8.2.33-zts-bookworm, 8.2-zts-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.2/bookworm/zts
 

--- a/library/postgres
+++ b/library/postgres
@@ -10,7 +10,7 @@ GitCommit: 62a714f93cc32220de46fd12235c9d509e3b1ad6
 Directory: 19/trixie
 
 Tags: 19beta2-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 62a714f93cc32220de46fd12235c9d509e3b1ad6
 Directory: 19/bookworm
 
@@ -30,7 +30,7 @@ GitCommit: d71f5241e97ebf5c6e6e37e3043ab542132550f2
 Directory: 18/trixie
 
 Tags: 18.4-bookworm, 18-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4f9ced003ba58a854656ba150d146243d27ae3ac
 Directory: 18/bookworm
 
@@ -50,7 +50,7 @@ GitCommit: 9e3449a57a973a64db74f4d773247d4c049bba68
 Directory: 17/trixie
 
 Tags: 17.10-bookworm, 17-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4f9ced003ba58a854656ba150d146243d27ae3ac
 Directory: 17/bookworm
 
@@ -70,7 +70,7 @@ GitCommit: f64ed48c36df300966bcbe72fee53af745045579
 Directory: 16/trixie
 
 Tags: 16.14-bookworm, 16-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4f9ced003ba58a854656ba150d146243d27ae3ac
 Directory: 16/bookworm
 
@@ -90,7 +90,7 @@ GitCommit: 4fd4a0af49c8eafd82e823b632515ca44c93c688
 Directory: 15/trixie
 
 Tags: 15.18-bookworm, 15-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4f9ced003ba58a854656ba150d146243d27ae3ac
 Directory: 15/bookworm
 
@@ -110,7 +110,7 @@ GitCommit: 7b2e3e89bb08d483b9d913986ec93c01a51edb39
 Directory: 14/trixie
 
 Tags: 14.23-bookworm, 14-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4f9ced003ba58a854656ba150d146243d27ae3ac
 Directory: 14/bookworm
 

--- a/library/python
+++ b/library/python
@@ -17,12 +17,12 @@ GitCommit: f3d4e7c4e6d553fa55e9a95871d8ee4bf9d814f8
 Directory: 3.15-rc/slim-trixie
 
 Tags: 3.15.0b4-bookworm, 3.15-rc-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: f3d4e7c4e6d553fa55e9a95871d8ee4bf9d814f8
 Directory: 3.15-rc/bookworm
 
 Tags: 3.15.0b4-slim-bookworm, 3.15-rc-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: f3d4e7c4e6d553fa55e9a95871d8ee4bf9d814f8
 Directory: 3.15-rc/slim-bookworm
 
@@ -64,12 +64,12 @@ GitCommit: 7914d06b7ddb34b99975318016ab5b9c18264015
 Directory: 3.14/slim-trixie
 
 Tags: 3.14.6-bookworm, 3.14-bookworm, 3-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 7914d06b7ddb34b99975318016ab5b9c18264015
 Directory: 3.14/bookworm
 
 Tags: 3.14.6-slim-bookworm, 3.14-slim-bookworm, 3-slim-bookworm, slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 7914d06b7ddb34b99975318016ab5b9c18264015
 Directory: 3.14/slim-bookworm
 
@@ -111,12 +111,12 @@ GitCommit: f79aea5b8f6b2d65b31ba2bb3f69c0c2083345c8
 Directory: 3.13/slim-trixie
 
 Tags: 3.13.14-bookworm, 3.13-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: f79aea5b8f6b2d65b31ba2bb3f69c0c2083345c8
 Directory: 3.13/bookworm
 
 Tags: 3.13.14-slim-bookworm, 3.13-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: f79aea5b8f6b2d65b31ba2bb3f69c0c2083345c8
 Directory: 3.13/slim-bookworm
 
@@ -158,12 +158,12 @@ GitCommit: 3362634339580d3232e65a66dd5a36c47ae7ff14
 Directory: 3.12/slim-trixie
 
 Tags: 3.12.13-bookworm, 3.12-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 3362634339580d3232e65a66dd5a36c47ae7ff14
 Directory: 3.12/bookworm
 
 Tags: 3.12.13-slim-bookworm, 3.12-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 3362634339580d3232e65a66dd5a36c47ae7ff14
 Directory: 3.12/slim-bookworm
 
@@ -189,12 +189,12 @@ GitCommit: 4d216ad3beb5b697c4049071c82fc375acb8abad
 Directory: 3.11/slim-trixie
 
 Tags: 3.11.15-bookworm, 3.11-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4d216ad3beb5b697c4049071c82fc375acb8abad
 Directory: 3.11/bookworm
 
 Tags: 3.11.15-slim-bookworm, 3.11-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4d216ad3beb5b697c4049071c82fc375acb8abad
 Directory: 3.11/slim-bookworm
 
@@ -220,12 +220,12 @@ GitCommit: 4d216ad3beb5b697c4049071c82fc375acb8abad
 Directory: 3.10/slim-trixie
 
 Tags: 3.10.20-bookworm, 3.10-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4d216ad3beb5b697c4049071c82fc375acb8abad
 Directory: 3.10/bookworm
 
 Tags: 3.10.20-slim-bookworm, 3.10-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4d216ad3beb5b697c4049071c82fc375acb8abad
 Directory: 3.10/slim-bookworm
 

--- a/library/redmine
+++ b/library/redmine
@@ -50,7 +50,7 @@ GitCommit: 4e7d7ad67b47d3a0d9d1d22379141a8be0fae2ee
 Directory: 6.0/trixie
 
 Tags: 6.0.10-bookworm, 6.0-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4e7d7ad67b47d3a0d9d1d22379141a8be0fae2ee
 Directory: 6.0/bookworm
 

--- a/library/ruby
+++ b/library/ruby
@@ -15,12 +15,12 @@ GitCommit: 887da016bf8e524ac6f1a96f079d1ba9628189f2
 Directory: 4.0/slim-trixie
 
 Tags: 4.0.6-bookworm, 4.0-bookworm, 4-bookworm, bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 887da016bf8e524ac6f1a96f079d1ba9628189f2
 Directory: 4.0/bookworm
 
 Tags: 4.0.6-slim-bookworm, 4.0-slim-bookworm, 4-slim-bookworm, slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 887da016bf8e524ac6f1a96f079d1ba9628189f2
 Directory: 4.0/slim-bookworm
 
@@ -45,12 +45,12 @@ GitCommit: 4ea2e7e222ba458994a266920e8815140bc2c901
 Directory: 3.4/slim-trixie
 
 Tags: 3.4.10-bookworm, 3.4-bookworm, 3-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4ea2e7e222ba458994a266920e8815140bc2c901
 Directory: 3.4/bookworm
 
 Tags: 3.4.10-slim-bookworm, 3.4-slim-bookworm, 3-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 4ea2e7e222ba458994a266920e8815140bc2c901
 Directory: 3.4/slim-bookworm
 
@@ -75,12 +75,12 @@ GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/slim-trixie
 
 Tags: 3.3.12-bookworm, 3.3-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/bookworm
 
 Tags: 3.3.12-slim-bookworm, 3.3-slim-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 31475ec8e3682c1b3d3d78e222f264f564657b25
 Directory: 3.3/slim-bookworm
 


### PR DESCRIPTION
The Debian LTS hammer cometh down (https://github.com/docker-library/official-images/pull/21977)