### PR TITLE
Nim: Update commit.

### DIFF
--- a/library/nim
+++ b/library/nim
@@ -1,6 +1,6 @@
 Maintainers: Constantine Molchanov (@moigagoo)
 GitRepo: https://github.com/nim-lang/docker-images.git
-GitCommit: 91d060a13836bd13fedc527e13ad9061752f235f
+GitCommit: 9b7d458808d9ab20f456f557a389e67a0b20e5dd
 
 Tags: 2.2.10, 2.2, 2, latest
 Architectures: amd64, arm64v8, i386, arm32v7


### PR DESCRIPTION
We had to switch to Bookworm base because Nim uses PCRE and Bookworm is the last Debian that has libpcre3.