### PR TITLE
Update oraclelinux-slim for 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: f0f0a74c889ee20ab5b7bf2ed613d5898f4714a2
+amd64-GitCommit: facb59ab7a0cd1d951f934a0398908a103ab583a
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: a9557dc2e6d5a042d0c8bd994b4d7e5628bff4af
+arm64v8-GitCommit: 96e9b3a0f8bea609c72c3b342393470ba072422d
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-49668](https://linux.oracle.com/errata/ELSA-2026-49668.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
