### PR TITLE
Update Rakudo-Star to 2026.07

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -4,17 +4,18 @@ Maintainers: Moritz Lenz <moritz.lenz@gmail.com> (@moritz),
              Anton Oks <anton.oks@gmx.de> (@AntonOks)
 GitRepo: https://github.com/rakudo/docker
 
-Tags: trixie, latest, 2026.06-trixie
+Tags: trixie, latest, 2026.07-trixie
 Architectures: amd64, arm64v8
-GitCommit: 606999aa1883485e18dbfe2c542814dcbbb5e643
-Directory: 2026.06/trixie
+GitCommit: e00facd818e1ba7fe4f7edc95cf392ed3e46efa2
+Directory: 2026.07/trixie
 
-Tags: bookworm, 2026.06-bookworm
+Tags: bookworm, 2026.07-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 606999aa1883485e18dbfe2c542814dcbbb5e643
-Directory: 2026.06/bookworm
+GitCommit: e00facd818e1ba7fe4f7edc95cf392ed3e46efa2
+Directory: 2026.07/bookworm
 
-Tags: alpine, 2026.06-alpine
+Tags: alpine, 2026.07-alpine
 Architectures: amd64, arm64v8
-GitCommit: 606999aa1883485e18dbfe2c542814dcbbb5e643
-Directory: 2026.06/alpine
+GitCommit: e00facd818e1ba7fe4f7edc95cf392ed3e46efa2
+Directory: 2026.07/alpine
+


### PR DESCRIPTION
Automated update from:

- Rakudo-Star version: 2026.07
- Docker commit: e00facd818e1ba7fe4f7edc95cf392ed3e46efa2

Generated by GitHub Actions.