### PR TITLE
Release SonarQube Community Build 26.8 and SonarQube Server 2026.1.5

### DIFF
--- a/library/sonarqube
+++ b/library/sonarqube
@@ -90,7 +90,7 @@ Directory: commercial-editions/datacenter/search
 GitCommit: 24038659701d0a53c0f494d57f09c4da67274020
 GitFetch: refs/heads/release/2025.1
 
-Tags: 26.7.0.124771-community, community, latest
+Tags: 26.8.0.126808-community, community, latest
 Directory: community-build
-GitCommit: 8de5d6138eb883e4225b6a264a5117a8ce117eb9
+GitCommit: 886f9480f4a9caf83de23784e11aa054cc3ad7f5
 GitFetch: refs/heads/master

--- a/library/sonarqube
+++ b/library/sonarqube
@@ -30,24 +30,24 @@ Directory: commercial-editions/datacenter/search
 GitCommit: 9f00ce57d8654a3737ae0b22997d7198f71660d8
 GitFetch: refs/heads/master
 
-Tags: 2026.1.4-developer, 2026.1-developer, 2026-lta-developer
+Tags: 2026.1.5-developer, 2026.1-developer, 2026-lta-developer
 Directory: commercial-editions/developer
-GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
+GitCommit: 40321754c341a8ee654678943fb924f32d825693
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2026.1.4-enterprise, 2026.1-enterprise, 2026-lta-enterprise
+Tags: 2026.1.5-enterprise, 2026.1-enterprise, 2026-lta-enterprise
 Directory: commercial-editions/enterprise
-GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
+GitCommit: 40321754c341a8ee654678943fb924f32d825693
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2026.1.4-datacenter-app, 2026.1-datacenter-app, 2026-lta-datacenter-app
+Tags: 2026.1.5-datacenter-app, 2026.1-datacenter-app, 2026-lta-datacenter-app
 Directory: commercial-editions/datacenter/app
-GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
+GitCommit: 40321754c341a8ee654678943fb924f32d825693
 GitFetch: refs/heads/release/2026.1
 
-Tags: 2026.1.4-datacenter-search, 2026.1-datacenter-search, 2026-lta-datacenter-search
+Tags: 2026.1.5-datacenter-search, 2026.1-datacenter-search, 2026-lta-datacenter-search
 Directory: commercial-editions/datacenter/search
-GitCommit: f4edb6723b4c9ec1ddf62e1f3a4b6fffda5eae52
+GitCommit: 40321754c341a8ee654678943fb924f32d825693
 GitFetch: refs/heads/release/2026.1
 
 Tags: 2025.4.8-developer, 2025.4-developer, 2025.4-lta-developer


### PR DESCRIPTION
Hi Team,

This is for releasing SonarQube Community Build 26.8 and SonarQube Server 2026.1.5

Thank you