### PR TITLE
Release Neo4j 5.26.29

### DIFF
--- a/library/neo4j
+++ b/library/neo4j
@@ -27,25 +27,25 @@ Directory: 2026.06.0/ubi10/enterprise
 
 
 
-Tags: 5.26.28-community-trixie, 5.26-community-trixie, 5-community-trixie, 5.26.28-community, 5.26-community, 5-community, 5.26.28-trixie, 5.26-trixie, 5-trixie, 5.26.28, 5.26, 5
+Tags: 5.26.29-community-trixie, 5.26-community-trixie, 5-community-trixie, 5.26.29-community, 5.26-community, 5-community, 5.26.29-trixie, 5.26-trixie, 5-trixie, 5.26.29, 5.26, 5
 Architectures: amd64, arm64v8
-GitCommit: 6fa21e49ad7f4dc4b3f6808cd7e0d44a7fdd47d2
-Directory: 5.26.28/trixie/community
+GitCommit: c42f844d726db728d4156888657ed7a1a25bef26
+Directory: 5.26.29/trixie/community
 
-Tags: 5.26.28-enterprise-trixie, 5.26-enterprise-trixie, 5-enterprise-trixie, 5.26.28-enterprise, 5.26-enterprise, 5-enterprise
+Tags: 5.26.29-enterprise-trixie, 5.26-enterprise-trixie, 5-enterprise-trixie, 5.26.29-enterprise, 5.26-enterprise, 5-enterprise
 Architectures: amd64, arm64v8
-GitCommit: 6fa21e49ad7f4dc4b3f6808cd7e0d44a7fdd47d2
-Directory: 5.26.28/trixie/enterprise
+GitCommit: c42f844d726db728d4156888657ed7a1a25bef26
+Directory: 5.26.29/trixie/enterprise
 
-Tags: 5.26.28-community-ubi10, 5.26-community-ubi10, 5-community-ubi10, 5.26.28-ubi10, 5.26-ubi10, 5-ubi10
+Tags: 5.26.29-community-ubi10, 5.26-community-ubi10, 5-community-ubi10, 5.26.29-ubi10, 5.26-ubi10, 5-ubi10
 Architectures: amd64, arm64v8
-GitCommit: 6fa21e49ad7f4dc4b3f6808cd7e0d44a7fdd47d2
-Directory: 5.26.28/ubi10/community
+GitCommit: c42f844d726db728d4156888657ed7a1a25bef26
+Directory: 5.26.29/ubi10/community
 
-Tags: 5.26.28-enterprise-ubi10, 5.26-enterprise-ubi10, 5-enterprise-ubi10
+Tags: 5.26.29-enterprise-ubi10, 5.26-enterprise-ubi10, 5-enterprise-ubi10
 Architectures: amd64, arm64v8
-GitCommit: 6fa21e49ad7f4dc4b3f6808cd7e0d44a7fdd47d2
-Directory: 5.26.28/ubi10/enterprise
+GitCommit: c42f844d726db728d4156888657ed7a1a25bef26
+Directory: 5.26.29/ubi10/enterprise
 
 
 


### PR DESCRIPTION
This PR superseeds #21984 as a single clean commit.
Thank you!
