### PR TITLE
Update Jetty versions to 12.0.38 & 12.1.12

### DIFF
--- a/library/jetty
+++ b/library/jetty
@@ -1,160 +1,144 @@
-Maintainers: Greg Wilkins <gregw@webtide.com> (@gregw),
-             Lachlan Roberts <lachlan@webtide.com> (@lachlan-roberts),
+Maintainers: Lachlan Roberts <lachlan@webtide.com> (@lachlan-roberts),
              Olivier Lamy <olamy@webtide.com> (@olamy),
              Joakim Erdfelt <joakim@webtide.com> (@joakime)
 GitRepo: https://github.com/eclipse/jetty.docker.git
 
-Tags: 12.1.11-jdk25-alpine, 12.1-jdk25-alpine, 12-jdk25-alpine, 12.1.11-jdk25-alpine-eclipse-temurin, 12.1-jdk25-alpine-eclipse-temurin, 12-jdk25-alpine-eclipse-temurin
+Tags: 12.1.12-jdk25-alpine, 12.1-jdk25-alpine, 12-jdk25-alpine, 12.1.12-jdk25-alpine-eclipse-temurin, 12.1-jdk25-alpine-eclipse-temurin, 12-jdk25-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk25-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11, 12.1, 12, 12.1.11-jdk25, 12.1-jdk25, 12-jdk25, 12.1.11-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.11-jdk25-eclipse-temurin, 12.1-jdk25-eclipse-temurin, 12-jdk25-eclipse-temurin, latest, jdk25
+Tags: 12.1.12, 12.1, 12, 12.1.12-jdk25, 12.1-jdk25, 12-jdk25, 12.1.12-eclipse-temurin, 12.1-eclipse-temurin, 12-eclipse-temurin, 12.1.12-jdk25-eclipse-temurin, 12.1-jdk25-eclipse-temurin, 12-jdk25-eclipse-temurin, latest, jdk25
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk25
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.11-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
+Tags: 12.1.12-jdk21-alpine, 12.1-jdk21-alpine, 12-jdk21-alpine, 12.1.12-jdk21-alpine-eclipse-temurin, 12.1-jdk21-alpine-eclipse-temurin, 12-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk21-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk21, 12.1-jdk21, 12-jdk21, 12.1.11-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, jdk21
+Tags: 12.1.12-jdk21, 12.1-jdk21, 12-jdk21, 12.1.12-jdk21-eclipse-temurin, 12.1-jdk21-eclipse-temurin, 12-jdk21-eclipse-temurin, jdk21
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk21
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.11-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
+Tags: 12.1.12-jdk17-alpine, 12.1-jdk17-alpine, 12-jdk17-alpine, 12.1.12-jdk17-alpine-eclipse-temurin, 12.1-jdk17-alpine-eclipse-temurin, 12-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.1/jdk17-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk17, 12.1-jdk17, 12-jdk17, 12.1.11-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
+Tags: 12.1.12-jdk17, 12.1-jdk17, 12-jdk17, 12.1.12-jdk17-eclipse-temurin, 12.1-jdk17-eclipse-temurin, 12-jdk17-eclipse-temurin, jdk17
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.1/jdk17
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jre21-alpine, 12.0-jre21-alpine, 12.0.37-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
+Tags: 12.0.38-jre21-alpine, 12.0-jre21-alpine, 12.0.38-jre21-alpine-eclipse-temurin, 12.0-jre21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre21-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jre21, 12.0-jre21, 12.0.37-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
+Tags: 12.0.38-jre21, 12.0-jre21, 12.0.38-jre21-eclipse-temurin, 12.0-jre21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre21
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jre17-alpine, 12.0-jre17-alpine, 12.0.37-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
+Tags: 12.0.38-jre17-alpine, 12.0-jre17-alpine, 12.0.38-jre17-alpine-eclipse-temurin, 12.0-jre17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jre17-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jre17, 12.0-jre17, 12.0.37-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
+Tags: 12.0.38-jre17, 12.0-jre17, 12.0.38-jre17-eclipse-temurin, 12.0-jre17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jre17
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk25-alpine, 12.0-jdk25-alpine, 12.0.37-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
+Tags: 12.0.38-jdk25-alpine, 12.0-jdk25-alpine, 12.0.38-jdk25-alpine-eclipse-temurin, 12.0-jdk25-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk25-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37, 12.0, 12.0.37-jdk25, 12.0-jdk25, 12.0.37-eclipse-temurin, 12.0-eclipse-temurin, 12.0.37-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
+Tags: 12.0.38, 12.0, 12.0.38-jdk25, 12.0-jdk25, 12.0.38-eclipse-temurin, 12.0-eclipse-temurin, 12.0.38-jdk25-eclipse-temurin, 12.0-jdk25-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk25
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk21-alpine, 12.0-jdk21-alpine, 12.0.37-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
+Tags: 12.0.38-jdk21-alpine, 12.0-jdk21-alpine, 12.0.38-jdk21-alpine-eclipse-temurin, 12.0-jdk21-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk21-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk21, 12.0-jdk21, 12.0.37-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
+Tags: 12.0.38-jdk21, 12.0-jdk21, 12.0.38-jdk21-eclipse-temurin, 12.0-jdk21-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk21
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk17-alpine, 12.0-jdk17-alpine, 12.0.37-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
+Tags: 12.0.38-jdk17-alpine, 12.0-jdk17-alpine, 12.0.38-jdk17-alpine-eclipse-temurin, 12.0-jdk17-alpine-eclipse-temurin
 Architectures: amd64
 Directory: eclipse-temurin/12.0/jdk17-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk17, 12.0-jdk17, 12.0.37-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
+Tags: 12.0.38-jdk17, 12.0-jdk17, 12.0.38-jdk17-eclipse-temurin, 12.0-jdk17-eclipse-temurin
 Architectures: amd64, arm64v8
 Directory: eclipse-temurin/12.0/jdk17
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk25-alpine-amazoncorretto, 12.1-jdk25-alpine-amazoncorretto, 12-jdk25-alpine-amazoncorretto
+Tags: 12.1.12-jdk25-alpine-amazoncorretto, 12.1-jdk25-alpine-amazoncorretto, 12-jdk25-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk25-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-amazoncorretto, 12.1-amazoncorretto, 12-amazoncorretto, 12.1.11-jdk25-amazoncorretto, 12.1-jdk25-amazoncorretto, 12-jdk25-amazoncorretto
+Tags: 12.1.12-amazoncorretto, 12.1.12-al2023-amazoncorretto, 12.1-amazoncorretto, 12.1-al2023-amazoncorretto, 12-amazoncorretto, 12-al2023-amazoncorretto, 12.1.12-jdk25-amazoncorretto, 12.1.12-jdk25-al2023-amazoncorretto, 12.1-jdk25-amazoncorretto, 12.1-jdk25-al2023-amazoncorretto, 12-jdk25-amazoncorretto, 12-jdk25-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk25
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 9578065cf06deeb24b08aa851c6038fa5bf41f2d
 
-Tags: 12.1.11-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
+Tags: 12.1.12-jdk21-alpine-amazoncorretto, 12.1-jdk21-alpine-amazoncorretto, 12-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk21-al2023-amazoncorretto, 12.1-jdk21-al2023-amazoncorretto, 12-jdk21-al2023-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/12.1/jdk21-al2023
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
-
-Tags: 12.1.11-jdk21-amazoncorretto, 12.1-jdk21-amazoncorretto, 12-jdk21-amazoncorretto
+Tags: 12.1.12-jdk21-amazoncorretto, 12.1.12-jdk21-al2023-amazoncorretto, 12.1-jdk21-amazoncorretto, 12.1-jdk21-al2023-amazoncorretto, 12-jdk21-amazoncorretto, 12-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk21
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 9578065cf06deeb24b08aa851c6038fa5bf41f2d
 
-Tags: 12.1.11-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
+Tags: 12.1.12-jdk17-alpine-amazoncorretto, 12.1-jdk17-alpine-amazoncorretto, 12-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.1.11-jdk17-al2023-amazoncorretto, 12.1-jdk17-al2023-amazoncorretto, 12-jdk17-al2023-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/12.1/jdk17-al2023
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
-
-Tags: 12.1.11-jdk17-amazoncorretto, 12.1-jdk17-amazoncorretto, 12-jdk17-amazoncorretto
+Tags: 12.1.12-jdk17-amazoncorretto, 12.1.12-jdk17-al2023-amazoncorretto, 12.1-jdk17-amazoncorretto, 12.1-jdk17-al2023-amazoncorretto, 12-jdk17-amazoncorretto, 12-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.1/jdk17
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 9578065cf06deeb24b08aa851c6038fa5bf41f2d
 
-Tags: 12.0.37-jdk25-al2023-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto, 12.0-amazoncorretto, 12.0-jdk25-amazoncorretto
+Tags: 12.0.38-jdk25-alpine-amazoncorretto, 12.0-jdk25-alpine-amazoncorretto
 Architectures: amd64, arm64v8
-Directory: amazoncorretto/12.0/jdk25-al2023
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+Directory: amazoncorretto/12.0/jdk25-alpine
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
+Tags: 12.0.38-amazoncorretto, 12.0.38-al2023-amazoncorretto, 12.0-amazoncorretto, 12.0-al2023-amazoncorretto, 12.0.38-jdk25-amazoncorretto, 12.0.38-jdk25-al2023-amazoncorretto, 12.0-jdk25-amazoncorretto, 12.0-jdk25-al2023-amazoncorretto
+Architectures: amd64, arm64v8
+Directory: amazoncorretto/12.0/jdk25
+GitCommit: 9578065cf06deeb24b08aa851c6038fa5bf41f2d
+
+Tags: 12.0.38-jdk21-alpine-amazoncorretto, 12.0-jdk21-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk21-al2023-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/12.0/jdk21-al2023
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
-
-Tags: 12.0.37-jdk21-amazoncorretto, 12.0-jdk21-amazoncorretto
+Tags: 12.0.38-jdk21-amazoncorretto, 12.0.38-jdk21-al2023-amazoncorretto, 12.0-jdk21-amazoncorretto, 12.0-jdk21-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk21
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 9578065cf06deeb24b08aa851c6038fa5bf41f2d
 
-Tags: 12.0.37-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
+Tags: 12.0.38-jdk17-alpine-amazoncorretto, 12.0-jdk17-alpine-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17-alpine
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 32d8ba2e3a02a53e0bd29ac3618bae089b701c6a
 
-Tags: 12.0.37-jdk17-al2023-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
-Architectures: amd64, arm64v8
-Directory: amazoncorretto/12.0/jdk17-al2023
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
-
-Tags: 12.0.37-jdk17-amazoncorretto, 12.0-jdk17-amazoncorretto
+Tags: 12.0.38-jdk17-amazoncorretto, 12.0.38-jdk17-al2023-amazoncorretto, 12.0-jdk17-amazoncorretto, 12.0-jdk17-al2023-amazoncorretto
 Architectures: amd64, arm64v8
 Directory: amazoncorretto/12.0/jdk17
-GitCommit: ecf7d1c2fe812e4edbfa1aef4ff9f515e7e23e04
+GitCommit: 9578065cf06deeb24b08aa851c6038fa5bf41f2d


### PR DESCRIPTION
- Update Jetty versions to `12.0.38` & `12.1.12`
- Drop dedicated base images for al2023 now that al2 is EOL.