### PR TITLE
Redis: remove unsupported debian architectures 

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -9,7 +9,7 @@ Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
 GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.10.0, 8.10, 8, 8.10.0-trixie, 8.10-trixie, 8-trixie, latest, trixie
-Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
 GitCommit: 0a24b09f88a6cb8feaf130d4eca7bd6b9b4c73a3
 GitFetch: refs/tags/v8.10.0
 Directory: debian
@@ -21,7 +21,7 @@ GitFetch: refs/tags/v8.10.0
 Directory: alpine
 
 Tags: 8.8.1, 8.8, 8.8.1-trixie, 8.8-trixie
-Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
 GitCommit: b675641c81d9f476e614aee4a6606365548bae41
 GitFetch: refs/tags/v8.8.1
 Directory: debian
@@ -33,7 +33,7 @@ GitFetch: refs/tags/v8.8.1
 Directory: alpine
 
 Tags: 8.6.5, 8.6, 8.6.5-trixie, 8.6-trixie
-Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
 GitCommit: 8bf384f30957c89ea17a1fd6e5f34ed31065f84b
 GitFetch: refs/tags/v8.6.5
 Directory: debian
@@ -45,7 +45,7 @@ GitFetch: refs/tags/v8.6.5
 Directory: alpine
 
 Tags: 8.4.5, 8.4, 8.4.5-trixie, 8.4-trixie
-Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
 GitCommit: cc3829e8d874f31c8d50ee1e7a81f283eaa9688a
 GitFetch: refs/tags/v8.4.5
 Directory: debian

--- a/library/redis
+++ b/library/redis
@@ -9,7 +9,7 @@ Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
 GitRepo: https://github.com/redis/docker-library-redis.git
 
 Tags: 8.10.0, 8.10, 8, 8.10.0-trixie, 8.10-trixie, 8-trixie, latest, trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
 GitCommit: 0a24b09f88a6cb8feaf130d4eca7bd6b9b4c73a3
 GitFetch: refs/tags/v8.10.0
 Directory: debian
@@ -21,7 +21,7 @@ GitFetch: refs/tags/v8.10.0
 Directory: alpine
 
 Tags: 8.8.1, 8.8, 8.8.1-trixie, 8.8-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
 GitCommit: b675641c81d9f476e614aee4a6606365548bae41
 GitFetch: refs/tags/v8.8.1
 Directory: debian
@@ -33,7 +33,7 @@ GitFetch: refs/tags/v8.8.1
 Directory: alpine
 
 Tags: 8.6.5, 8.6, 8.6.5-trixie, 8.6-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
 GitCommit: 8bf384f30957c89ea17a1fd6e5f34ed31065f84b
 GitFetch: refs/tags/v8.6.5
 Directory: debian
@@ -45,7 +45,7 @@ GitFetch: refs/tags/v8.6.5
 Directory: alpine
 
 Tags: 8.4.5, 8.4, 8.4.5-trixie, 8.4-trixie
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, riscv64, ppc64le
 GitCommit: cc3829e8d874f31c8d50ee1e7a81f283eaa9688a
 GitFetch: refs/tags/v8.4.5
 Directory: debian
@@ -57,7 +57,7 @@ GitFetch: refs/tags/v8.4.5
 Directory: alpine
 
 Tags: 8.2.8, 8.2, 8.2.8-bookworm, 8.2-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 3769a841048d940966635f8f59471f3d350707bf
 GitFetch: refs/tags/v8.2.8
 Directory: debian
@@ -69,7 +69,7 @@ GitFetch: refs/tags/v8.2.8
 Directory: alpine
 
 Tags: 7.4.10, 7.4, 7, 7.4.10-bookworm, 7.4-bookworm, 7-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 31c68732e7311d95e4c833b8fa50aa561ced577f
 GitFetch: refs/tags/v7.4.10
 Directory: debian
@@ -81,7 +81,7 @@ GitFetch: refs/tags/v7.4.10
 Directory: alpine
 
 Tags: 7.2.15, 7.2, 7.2.15-bookworm, 7.2-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 976a7de4cd78b6a201b4a3a5ac49cd9c8e3e583f
 GitFetch: refs/tags/v7.2.15
 Directory: debian
@@ -93,7 +93,7 @@ GitFetch: refs/tags/v7.2.15
 Directory: alpine
 
 Tags: 6.2.23, 6.2, 6, 6.2.23-bookworm, 6.2-bookworm, 6-bookworm
-Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, mips64le, ppc64le, s390x
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
 GitCommit: 70d903a68609970bf9a66181cdc59d0fc1ebc885
 GitFetch: refs/tags/v6.2.23
 Directory: debian


### PR DESCRIPTION
Hi @tianon and Docker Team!

This is related to https://github.com/docker-library/official-images/pull/21977

Following the PR I removed the same architectures for versions based on bookworm, hasn't touched trixie based.