### PR TITLE
Update 6 to 6.57.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,12 +2,12 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 5699d26d74f7b97524c210d8bcbef8606fe242f9
+GitCommit: bc5d011df043fce635b082c8fa43720ea5681a82
 
-Tags: 6.56.0-bookworm, 6.56.0, 6.56-bookworm, 6.56, 6-bookworm, 6, bookworm, latest
+Tags: 6.57.0-bookworm, 6.57.0, 6.57-bookworm, 6.57, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.56.0-alpine3.23, 6.56.0-alpine, 6.56-alpine3.23, 6.56-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.57.0-alpine3.23, 6.57.0-alpine, 6.57-alpine3.23, 6.57-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.57.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/bc5d011df043fce635b082c8fa43720ea5681a82.