### PR TITLE
Remove s390x from Rust's Debian Bookworm

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -1,4 +1,4 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/75656a9a1a93c5c8a537af4b9598580f5da9090e/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/5ba8fc7544e1880d0fc5f56e9f11081082057dc2/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft),
@@ -16,13 +16,13 @@ GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
 Directory: stable/bullseye/slim
 
 Tags: 1-bookworm, 1.97-bookworm, 1.97.1-bookworm, bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 5ba8fc7544e1880d0fc5f56e9f11081082057dc2
 Directory: stable/bookworm
 
 Tags: 1-slim-bookworm, 1.97-slim-bookworm, 1.97.1-slim-bookworm, slim-bookworm
-Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x
-GitCommit: 40acf7919e2e27dc706918e42758a6f1c21e806b
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 5ba8fc7544e1880d0fc5f56e9f11081082057dc2
 Directory: stable/bookworm/slim
 
 Tags: 1-trixie, 1.97-trixie, 1.97.1-trixie, trixie, 1, 1.97, 1.97.1, latest


### PR DESCRIPTION
`rust` was [listed as affected](https://github.com/docker-library/official-images/pull/21977#issuecomment-5172421111) by the removal of `s390x` from bookworm / oldstable, which this PR resolves.