### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,17 +4,17 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.8, 5.0, 5, latest, 5.0.8-bookworm, 5.0-bookworm, 5-bookworm, bookworm
+Tags: 5.0.9, 5.0, 5, latest, 5.0.9-bookworm, 5.0-bookworm, 5-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 7b9da8f4f58f48af79feb0fc2f7a1e2c639965f1
+GitCommit: 49d4e7c3e500bab33230230d2dc5a286c0dfae4a
 Directory: 5.0
 
-Tags: 4.1.11, 4.1, 4, 4.1.11-bookworm, 4.1-bookworm, 4-bookworm
+Tags: 4.1.12, 4.1, 4, 4.1.12-bookworm, 4.1-bookworm, 4-bookworm
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: f304ac2a02e00150b7e6629a40fcbd2891a0ba62
+GitCommit: 50bacaca78e08e488aebc7a9d11b4fd1f188770a
 Directory: 4.1
 
-Tags: 4.0.20, 4.0, 4.0.20-bookworm, 4.0-bookworm
+Tags: 4.0.21, 4.0, 4.0.21-bookworm, 4.0-bookworm
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: a99c4aa59e96ab881db88b13ca0d4fd086b9a4dd
+GitCommit: 7dc920047b2cc14d817e42d1f36b109e76ac4e7e
 Directory: 4.0


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/49d4e7c: Update 5.0 to 5.0.9
- https://github.com/docker-library/cassandra/commit/50bacac: Update 4.1 to 4.1.12
- https://github.com/docker-library/cassandra/commit/7dc9200: Update 4.0 to 4.0.21