### PR TITLE
Update wordpress

### DIFF
--- a/library/wordpress
+++ b/library/wordpress
@@ -4,64 +4,64 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/wordpress.git
 
-Tags: 7.0.2-php8.2-apache, 7.0-php8.2-apache, 7-php8.2-apache, php8.2-apache, 7.0.2-php8.2, 7.0-php8.2, 7-php8.2, php8.2
+Tags: 7.0.3-php8.2-apache, 7.0-php8.2-apache, 7-php8.2-apache, php8.2-apache, 7.0.3-php8.2, 7.0-php8.2, 7-php8.2, php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.2/apache
 
-Tags: 7.0.2-php8.2-fpm, 7.0-php8.2-fpm, 7-php8.2-fpm, php8.2-fpm
+Tags: 7.0.3-php8.2-fpm, 7.0-php8.2-fpm, 7-php8.2-fpm, php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.2/fpm
 
-Tags: 7.0.2-php8.2-fpm-alpine, 7.0-php8.2-fpm-alpine, 7-php8.2-fpm-alpine, php8.2-fpm-alpine
+Tags: 7.0.3-php8.2-fpm-alpine, 7.0-php8.2-fpm-alpine, 7-php8.2-fpm-alpine, php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.2/fpm-alpine
 
-Tags: 7.0.2-apache, 7.0-apache, 7-apache, apache, 7.0.2, 7.0, 7, latest, 7.0.2-php8.3-apache, 7.0-php8.3-apache, 7-php8.3-apache, php8.3-apache, 7.0.2-php8.3, 7.0-php8.3, 7-php8.3, php8.3
+Tags: 7.0.3-apache, 7.0-apache, 7-apache, apache, 7.0.3, 7.0, 7, latest, 7.0.3-php8.3-apache, 7.0-php8.3-apache, 7-php8.3-apache, php8.3-apache, 7.0.3-php8.3, 7.0-php8.3, 7-php8.3, php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.3/apache
 
-Tags: 7.0.2-fpm, 7.0-fpm, 7-fpm, fpm, 7.0.2-php8.3-fpm, 7.0-php8.3-fpm, 7-php8.3-fpm, php8.3-fpm
+Tags: 7.0.3-fpm, 7.0-fpm, 7-fpm, fpm, 7.0.3-php8.3-fpm, 7.0-php8.3-fpm, 7-php8.3-fpm, php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.3/fpm
 
-Tags: 7.0.2-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine, 7.0.2-php8.3-fpm-alpine, 7.0-php8.3-fpm-alpine, 7-php8.3-fpm-alpine, php8.3-fpm-alpine
+Tags: 7.0.3-fpm-alpine, 7.0-fpm-alpine, 7-fpm-alpine, fpm-alpine, 7.0.3-php8.3-fpm-alpine, 7.0-php8.3-fpm-alpine, 7-php8.3-fpm-alpine, php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.3/fpm-alpine
 
-Tags: 7.0.2-php8.4-apache, 7.0-php8.4-apache, 7-php8.4-apache, php8.4-apache, 7.0.2-php8.4, 7.0-php8.4, 7-php8.4, php8.4
+Tags: 7.0.3-php8.4-apache, 7.0-php8.4-apache, 7-php8.4-apache, php8.4-apache, 7.0.3-php8.4, 7.0-php8.4, 7-php8.4, php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.4/apache
 
-Tags: 7.0.2-php8.4-fpm, 7.0-php8.4-fpm, 7-php8.4-fpm, php8.4-fpm
+Tags: 7.0.3-php8.4-fpm, 7.0-php8.4-fpm, 7-php8.4-fpm, php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.4/fpm
 
-Tags: 7.0.2-php8.4-fpm-alpine, 7.0-php8.4-fpm-alpine, 7-php8.4-fpm-alpine, php8.4-fpm-alpine
+Tags: 7.0.3-php8.4-fpm-alpine, 7.0-php8.4-fpm-alpine, 7-php8.4-fpm-alpine, php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.4/fpm-alpine
 
-Tags: 7.0.2-php8.5-apache, 7.0-php8.5-apache, 7-php8.5-apache, php8.5-apache, 7.0.2-php8.5, 7.0-php8.5, 7-php8.5, php8.5
+Tags: 7.0.3-php8.5-apache, 7.0-php8.5-apache, 7-php8.5-apache, php8.5-apache, 7.0.3-php8.5, 7.0-php8.5, 7-php8.5, php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.5/apache
 
-Tags: 7.0.2-php8.5-fpm, 7.0-php8.5-fpm, 7-php8.5-fpm, php8.5-fpm
+Tags: 7.0.3-php8.5-fpm, 7.0-php8.5-fpm, 7-php8.5-fpm, php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.5/fpm
 
-Tags: 7.0.2-php8.5-fpm-alpine, 7.0-php8.5-fpm-alpine, 7-php8.5-fpm-alpine, php8.5-fpm-alpine
+Tags: 7.0.3-php8.5-fpm-alpine, 7.0-php8.5-fpm-alpine, 7-php8.5-fpm-alpine, php8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 90eed6a6ad2acba838ec5c672dcc4b945e788f98
+GitCommit: f4cb99ee5e59ae4eccd18502b29d8f987b2455c7
 Directory: latest/php8.5/fpm-alpine
 
 Tags: cli-2.12.0-php8.2, cli-2.12-php8.2, cli-2-php8.2, cli-php8.2
@@ -84,62 +84,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: b962e97ba0d6cfd8784a521fb9d05fc89aa180a9
 Directory: cli/php8.5/alpine
 
-Tags: beta-7.1-RC1-php8.2-apache, beta-7.1-php8.2-apache, beta-7-php8.2-apache, beta-php8.2-apache, beta-7.1-RC1-php8.2, beta-7.1-php8.2, beta-7-php8.2, beta-php8.2
+Tags: beta-7.1-RC2-php8.2-apache, beta-7.1-php8.2-apache, beta-7-php8.2-apache, beta-php8.2-apache, beta-7.1-RC2-php8.2, beta-7.1-php8.2, beta-7-php8.2, beta-php8.2
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.2/apache
 
-Tags: beta-7.1-RC1-php8.2-fpm, beta-7.1-php8.2-fpm, beta-7-php8.2-fpm, beta-php8.2-fpm
+Tags: beta-7.1-RC2-php8.2-fpm, beta-7.1-php8.2-fpm, beta-7-php8.2-fpm, beta-php8.2-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.2/fpm
 
-Tags: beta-7.1-RC1-php8.2-fpm-alpine, beta-7.1-php8.2-fpm-alpine, beta-7-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
+Tags: beta-7.1-RC2-php8.2-fpm-alpine, beta-7.1-php8.2-fpm-alpine, beta-7-php8.2-fpm-alpine, beta-php8.2-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.2/fpm-alpine
 
-Tags: beta-7.1-RC1-apache, beta-7.1-apache, beta-7-apache, beta-apache, beta-7.1-RC1, beta-7.1, beta-7, beta, beta-7.1-RC1-php8.3-apache, beta-7.1-php8.3-apache, beta-7-php8.3-apache, beta-php8.3-apache, beta-7.1-RC1-php8.3, beta-7.1-php8.3, beta-7-php8.3, beta-php8.3
+Tags: beta-7.1-RC2-apache, beta-7.1-apache, beta-7-apache, beta-apache, beta-7.1-RC2, beta-7.1, beta-7, beta, beta-7.1-RC2-php8.3-apache, beta-7.1-php8.3-apache, beta-7-php8.3-apache, beta-php8.3-apache, beta-7.1-RC2-php8.3, beta-7.1-php8.3, beta-7-php8.3, beta-php8.3
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.3/apache
 
-Tags: beta-7.1-RC1-fpm, beta-7.1-fpm, beta-7-fpm, beta-fpm, beta-7.1-RC1-php8.3-fpm, beta-7.1-php8.3-fpm, beta-7-php8.3-fpm, beta-php8.3-fpm
+Tags: beta-7.1-RC2-fpm, beta-7.1-fpm, beta-7-fpm, beta-fpm, beta-7.1-RC2-php8.3-fpm, beta-7.1-php8.3-fpm, beta-7-php8.3-fpm, beta-php8.3-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.3/fpm
 
-Tags: beta-7.1-RC1-fpm-alpine, beta-7.1-fpm-alpine, beta-7-fpm-alpine, beta-fpm-alpine, beta-7.1-RC1-php8.3-fpm-alpine, beta-7.1-php8.3-fpm-alpine, beta-7-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
+Tags: beta-7.1-RC2-fpm-alpine, beta-7.1-fpm-alpine, beta-7-fpm-alpine, beta-fpm-alpine, beta-7.1-RC2-php8.3-fpm-alpine, beta-7.1-php8.3-fpm-alpine, beta-7-php8.3-fpm-alpine, beta-php8.3-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.3/fpm-alpine
 
-Tags: beta-7.1-RC1-php8.4-apache, beta-7.1-php8.4-apache, beta-7-php8.4-apache, beta-php8.4-apache, beta-7.1-RC1-php8.4, beta-7.1-php8.4, beta-7-php8.4, beta-php8.4
+Tags: beta-7.1-RC2-php8.4-apache, beta-7.1-php8.4-apache, beta-7-php8.4-apache, beta-php8.4-apache, beta-7.1-RC2-php8.4, beta-7.1-php8.4, beta-7-php8.4, beta-php8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.4/apache
 
-Tags: beta-7.1-RC1-php8.4-fpm, beta-7.1-php8.4-fpm, beta-7-php8.4-fpm, beta-php8.4-fpm
+Tags: beta-7.1-RC2-php8.4-fpm, beta-7.1-php8.4-fpm, beta-7-php8.4-fpm, beta-php8.4-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.4/fpm
 
-Tags: beta-7.1-RC1-php8.4-fpm-alpine, beta-7.1-php8.4-fpm-alpine, beta-7-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
+Tags: beta-7.1-RC2-php8.4-fpm-alpine, beta-7.1-php8.4-fpm-alpine, beta-7-php8.4-fpm-alpine, beta-php8.4-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.4/fpm-alpine
 
-Tags: beta-7.1-RC1-php8.5-apache, beta-7.1-php8.5-apache, beta-7-php8.5-apache, beta-php8.5-apache, beta-7.1-RC1-php8.5, beta-7.1-php8.5, beta-7-php8.5, beta-php8.5
+Tags: beta-7.1-RC2-php8.5-apache, beta-7.1-php8.5-apache, beta-7-php8.5-apache, beta-php8.5-apache, beta-7.1-RC2-php8.5, beta-7.1-php8.5, beta-7-php8.5, beta-php8.5
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.5/apache
 
-Tags: beta-7.1-RC1-php8.5-fpm, beta-7.1-php8.5-fpm, beta-7-php8.5-fpm, beta-php8.5-fpm
+Tags: beta-7.1-RC2-php8.5-fpm, beta-7.1-php8.5-fpm, beta-7-php8.5-fpm, beta-php8.5-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.5/fpm
 
-Tags: beta-7.1-RC1-php8.5-fpm-alpine, beta-7.1-php8.5-fpm-alpine, beta-7-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
+Tags: beta-7.1-RC2-php8.5-fpm-alpine, beta-7.1-php8.5-fpm-alpine, beta-7-php8.5-fpm-alpine, beta-php8.5-fpm-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 03d209cfc628a1c915e1f53a1b2a8b6541cfe48f
+GitCommit: fea35ca9fe01e657ea0a22f350cabaf229aa99d8
 Directory: beta/php8.5/fpm-alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/wordpress/commit/f4cb99e: Update latest to 7.0.3
- https://github.com/docker-library/wordpress/commit/fea35ca: Update beta to 7.1-RC2

Security update: https://www.ionsec.io/resources/xss2shell-wordpress-pre-auth-xss-to-rce/