### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -1,15 +1,15 @@
-# this file is generated via https://github.com/docker-library/gcc/blob/24fb071be01a0e6241fbbabd59a3dd07d31b80f5/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/gcc/blob/ade82435010cf820e826fb74d89a4c3a7e9e6fb3/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/gcc.git
 
-# Last Modified: 2026-04-30
-Tags: 16.1.0, 16.1, 16, latest, 16.1.0-trixie, 16.1-trixie, 16-trixie, trixie
+# Last Modified: 2026-08-07
+Tags: 16.2.0, 16.2, 16, latest, 16.2.0-trixie, 16.2-trixie, 16-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, ppc64le, s390x
-GitCommit: 24fb071be01a0e6241fbbabd59a3dd07d31b80f5
+GitCommit: ec9b92635140e2869eb3aad9b7a921b47ec54e50
 Directory: 16
-# Docker EOL: 2027-10-30
+# Docker EOL: 2028-02-07
 
 # Last Modified: 2026-06-12
 Tags: 15.3.0, 15.3, 15, 15.3.0-trixie, 15.3-trixie, 15-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/ec9b926: Update 16 to 16.2.0
- https://github.com/docker-library/gcc/commit/ade8243: Remove mips64le special case (no longer supported) (https://github.com/docker-library/gcc/pull/118)