### PR TITLE
Update 6 to 6.57.1

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,7 +2,7 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 4ef4edb001454acb616b1249373f2ae0cd8c9c96
+GitCommit: e0d59abf9fa19dbe42b6b4af9b86c5252a533357
 
 Tags: 6.57.1-bookworm, 6.57.1, 6.57-bookworm, 6.57, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm

--- a/library/ghost
+++ b/library/ghost
@@ -2,12 +2,12 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: bc5d011df043fce635b082c8fa43720ea5681a82
+GitCommit: 4ef4edb001454acb616b1249373f2ae0cd8c9c96
 
-Tags: 6.57.0-bookworm, 6.57.0, 6.57-bookworm, 6.57, 6-bookworm, 6, bookworm, latest
+Tags: 6.57.1-bookworm, 6.57.1, 6.57-bookworm, 6.57, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.57.0-alpine3.23, 6.57.0-alpine, 6.57-alpine3.23, 6.57-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.57.1-alpine3.23, 6.57.1-alpine, 6.57-alpine3.23, 6.57-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.57.1

Generated from https://github.com/TryGhost/docker-library-ghost/commit/4ef4edb001454acb616b1249373f2ae0cd8c9c96.