### PR TITLE
Update oraclelinux-slim for 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 813af9e87a37594d8df23916f0284aded17cb1b2
+amd64-GitCommit: 6dee1d264675267a4422c27d5c9561e35544b425
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 6be180393b742705e7580dab747fdbde2b89638a
+arm64v8-GitCommit: d5355b0decabdf250b54923108ed70f2a2ac81d5
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-52675](https://linux.oracle.com/errata/ELSA-2026-52675.html)

Signed-off-by: Kevin Lyons <>
