### PR TITLE
Increase cassandra test retries

### DIFF
--- a/test/tests/cassandra-basics/run.sh
+++ b/test/tests/cassandra-basics/run.sh
@@ -36,7 +36,8 @@ _status() {
 }
 
 # Make sure our container is up
-. "$dir/../../retry.sh" '_status'
+. "$dir/../../retry.sh" --tries 20 '_status'
+# (cassandra takes a long time to start up, even for responding to nodetool)
 
 cqlsh() {
 	docker run -i --rm \


### PR DESCRIPTION
because 6.0-alpha2 is even slower to start

This should hopefully fix the failing test on https://github.com/docker-library/cassandra/pull/293

```console
$ # (with link and cqlsh warnings removed)
$ time ./test/run.sh -t cassandra-basics cassandra:5.0-trixie
testing cassandra:5.0-trixie
        'cassandra-basics' [1/1].............passed
real    0m37.646s
user    0m0.226s
sys     0m0.412s

$ time ./test/run.sh -t cassandra-basics cassandra:6.0
testing cassandra:6.0
        'cassandra-basics' [1/1]..................passed
real    0m58.459s
user    0m0.320s
sys     0m0.504s
```