### PR TITLE
Update cassandra

### DIFF
--- a/library/cassandra
+++ b/library/cassandra
@@ -4,9 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/cassandra.git
 
-Tags: 5.0.9, 5.0, 5, latest, 5.0.9-bookworm, 5.0-bookworm, 5-bookworm, bookworm
-Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 49d4e7c3e500bab33230230d2dc5a286c0dfae4a
+Tags: 6.0-alpha2, 6.0, 6.0-alpha2-trixie, 6.0-trixie
+Architectures: amd64, arm64v8, ppc64le, s390x
+GitCommit: 929d3a1ab0aa656873dacdd915d8a86b85547776
+Directory: 6.0
+
+Tags: 5.0.9, 5.0, 5, latest, 5.0.9-trixie, 5.0-trixie, 5-trixie, trixie
+Architectures: amd64, arm32v7, arm64v8, ppc64le, s390x
+GitCommit: 929d3a1ab0aa656873dacdd915d8a86b85547776
 Directory: 5.0
 
 Tags: 4.1.12, 4.1, 4, 4.1.12-bookworm, 4.1-bookworm, 4-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/cassandra/commit/ef6e6bd: Merge pull request https://github.com/docker-library/cassandra/pull/293 from infosiftr/6.0-plus-trixie
- https://github.com/docker-library/cassandra/commit/929d3a1: add 6.0-rc; move 5.0 to trixie