### PR TITLE
nats: Update to v2.14.5, v2.12.15

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,47 +4,47 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: 2240af2a7067772eaa6453e3aa801c2c28657440
+GitCommit: aa0caa57b71c01566a100b47b2ed94de6ef6cf80
 GitFetch: refs/heads/main
 
-Tags: 2.14.4-alpine3.22, 2.14-alpine3.22, 2-alpine3.22, alpine3.22, 2.14.4-alpine, 2.14-alpine, 2-alpine, alpine
+Tags: 2.14.5-alpine3.22, 2.14-alpine3.22, 2-alpine3.22, alpine3.22, 2.14.5-alpine, 2.14-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.14.x/alpine3.22
 
-Tags: 2.14.4-scratch, 2.14-scratch, 2-scratch, scratch, 2.14.4-linux, 2.14-linux, 2-linux, linux
-SharedTags: 2.14.4, 2.14, 2, latest
+Tags: 2.14.5-scratch, 2.14-scratch, 2-scratch, scratch, 2.14.5-linux, 2.14-linux, 2-linux, linux
+SharedTags: 2.14.5, 2.14, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.14.x/scratch
 
-Tags: 2.14.4-windowsservercore-ltsc2022, 2.14-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.14.4-windowsservercore, 2.14-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.14.5-windowsservercore-ltsc2022, 2.14-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.14.5-windowsservercore, 2.14-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.14.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.14.4-nanoserver-ltsc2022, 2.14-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.14.4-nanoserver, 2.14-nanoserver, 2-nanoserver, nanoserver, 2.14.4, 2.14, 2, latest
+Tags: 2.14.5-nanoserver-ltsc2022, 2.14-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.14.5-nanoserver, 2.14-nanoserver, 2-nanoserver, nanoserver, 2.14.5, 2.14, 2, latest
 Architectures: windows-amd64
 Directory: 2.14.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: 2.12.14-alpine3.22, 2.12-alpine3.22, 2.12.14-alpine, 2.12-alpine
+Tags: 2.12.15-alpine3.22, 2.12-alpine3.22, 2.12.15-alpine, 2.12-alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/alpine3.22
 
-Tags: 2.12.14-scratch, 2.12-scratch, 2.12.14-linux, 2.12-linux
-SharedTags: 2.12.14, 2.12
+Tags: 2.12.15-scratch, 2.12-scratch, 2.12.15-linux, 2.12-linux
+SharedTags: 2.12.15, 2.12
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.12.x/scratch
 
-Tags: 2.12.14-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022
-SharedTags: 2.12.14-windowsservercore, 2.12-windowsservercore
+Tags: 2.12.15-windowsservercore-ltsc2022, 2.12-windowsservercore-ltsc2022
+SharedTags: 2.12.15-windowsservercore, 2.12-windowsservercore
 Architectures: windows-amd64
 Directory: 2.12.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.12.14-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022
-SharedTags: 2.12.14-nanoserver, 2.12-nanoserver, 2.12.14, 2.12
+Tags: 2.12.15-nanoserver-ltsc2022, 2.12-nanoserver-ltsc2022
+SharedTags: 2.12.15-nanoserver, 2.12-nanoserver, 2.12.15, 2.12
 Architectures: windows-amd64
 Directory: 2.12.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
More information here:

- https://github.com/nats-io/nats-server/releases/tag/v2.14.5
- https://github.com/nats-io/nats-server/releases/tag/v2.12.15