### PR TITLE
influxdb3: release 3.11.1 core and enterprise

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 956738144f87def2c889ff590d9f3e6619220482
+GitCommit: a2353390bbaca5b5b987453c2fe10fe38d2d8aab
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8
@@ -78,10 +78,10 @@ Tags: 3.10-enterprise, 3.10.5-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-enterprise
 
-Tags: 3-core, 3.11-core, 3.11.0-core, core
+Tags: 3-core, 3.11-core, 3.11.1-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.11-core
 
-Tags: 3-enterprise, 3.11-enterprise, 3.11.0-enterprise, enterprise
+Tags: 3-enterprise, 3.11-enterprise, 3.11.1-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.11-enterprise


### PR DESCRIPTION
Following are the updates,

- 3.11
    - core: 3.11.1
    - enterprise: 3.11.1

`GitCommit` points at influxdata/influxdata-docker@a2353390bbaca5b5b987453c2fe10fe38d2d8aab, the current tip of that repo's default branch.