### PR TITLE
Update php

### DIFF
--- a/library/php
+++ b/library/php
@@ -1,78 +1,148 @@
-# this file is generated via https://github.com/docker-library/php/blob/319d5ab712cddbd8492c67fe70be2e1ead66bc67/generate-stackbrew-library.sh
+# this file is generated via https://github.com/docker-library/php/blob/e990b2ed2c33da795c1ab402e5eb47f528753159/generate-stackbrew-library.sh
 
 Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/php.git
 
-Tags: 8.6.0alpha3-cli-trixie, 8.6-rc-cli-trixie, 8.6.0alpha3-trixie, 8.6-rc-trixie, 8.6.0alpha3-cli, 8.6-rc-cli, 8.6.0alpha3, 8.6-rc
+Tags: 8.6.0beta1-cli-trixie, 8.6-rc-cli-trixie, 8.6.0beta1-trixie, 8.6-rc-trixie, 8.6.0beta1-cli, 8.6-rc-cli, 8.6.0beta1, 8.6-rc
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/trixie/cli
 
-Tags: 8.6.0alpha3-apache-trixie, 8.6-rc-apache-trixie, 8.6.0alpha3-apache, 8.6-rc-apache
+Tags: 8.6.0beta1-apache-trixie, 8.6-rc-apache-trixie, 8.6.0beta1-apache, 8.6-rc-apache
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/trixie/apache
 
-Tags: 8.6.0alpha3-fpm-trixie, 8.6-rc-fpm-trixie, 8.6.0alpha3-fpm, 8.6-rc-fpm
+Tags: 8.6.0beta1-fpm-trixie, 8.6-rc-fpm-trixie, 8.6.0beta1-fpm, 8.6-rc-fpm
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/trixie/fpm
 
-Tags: 8.6.0alpha3-zts-trixie, 8.6-rc-zts-trixie, 8.6.0alpha3-zts, 8.6-rc-zts
+Tags: 8.6.0beta1-zts-trixie, 8.6-rc-zts-trixie, 8.6.0beta1-zts, 8.6-rc-zts
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/trixie/zts
 
-Tags: 8.6.0alpha3-cli-bookworm, 8.6-rc-cli-bookworm, 8.6.0alpha3-bookworm, 8.6-rc-bookworm
+Tags: 8.6.0beta1-cli-bookworm, 8.6-rc-cli-bookworm, 8.6.0beta1-bookworm, 8.6-rc-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/bookworm/cli
 
-Tags: 8.6.0alpha3-apache-bookworm, 8.6-rc-apache-bookworm
+Tags: 8.6.0beta1-apache-bookworm, 8.6-rc-apache-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/bookworm/apache
 
-Tags: 8.6.0alpha3-fpm-bookworm, 8.6-rc-fpm-bookworm
+Tags: 8.6.0beta1-fpm-bookworm, 8.6-rc-fpm-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/bookworm/fpm
 
-Tags: 8.6.0alpha3-zts-bookworm, 8.6-rc-zts-bookworm
+Tags: 8.6.0beta1-zts-bookworm, 8.6-rc-zts-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/bookworm/zts
 
-Tags: 8.6.0alpha3-cli-alpine3.24, 8.6-rc-cli-alpine3.24, 8.6.0alpha3-alpine3.24, 8.6-rc-alpine3.24, 8.6.0alpha3-cli-alpine, 8.6-rc-cli-alpine, 8.6.0alpha3-alpine, 8.6-rc-alpine
+Tags: 8.6.0beta1-cli-alpine3.24, 8.6-rc-cli-alpine3.24, 8.6.0beta1-alpine3.24, 8.6-rc-alpine3.24, 8.6.0beta1-cli-alpine, 8.6-rc-cli-alpine, 8.6.0beta1-alpine, 8.6-rc-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/alpine3.24/cli
 
-Tags: 8.6.0alpha3-fpm-alpine3.24, 8.6-rc-fpm-alpine3.24, 8.6.0alpha3-fpm-alpine, 8.6-rc-fpm-alpine
+Tags: 8.6.0beta1-fpm-alpine3.24, 8.6-rc-fpm-alpine3.24, 8.6.0beta1-fpm-alpine, 8.6-rc-fpm-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/alpine3.24/fpm
 
-Tags: 8.6.0alpha3-zts-alpine3.24, 8.6-rc-zts-alpine3.24, 8.6.0alpha3-zts-alpine, 8.6-rc-zts-alpine
+Tags: 8.6.0beta1-zts-alpine3.24, 8.6-rc-zts-alpine3.24, 8.6.0beta1-zts-alpine, 8.6-rc-zts-alpine
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/alpine3.24/zts
 
-Tags: 8.6.0alpha3-cli-alpine3.23, 8.6-rc-cli-alpine3.23, 8.6.0alpha3-alpine3.23, 8.6-rc-alpine3.23
+Tags: 8.6.0beta1-cli-alpine3.23, 8.6-rc-cli-alpine3.23, 8.6.0beta1-alpine3.23, 8.6-rc-alpine3.23
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/alpine3.23/cli
 
-Tags: 8.6.0alpha3-fpm-alpine3.23, 8.6-rc-fpm-alpine3.23
+Tags: 8.6.0beta1-fpm-alpine3.23, 8.6-rc-fpm-alpine3.23
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/alpine3.23/fpm
 
-Tags: 8.6.0alpha3-zts-alpine3.23, 8.6-rc-zts-alpine3.23
+Tags: 8.6.0beta1-zts-alpine3.23, 8.6-rc-zts-alpine3.23
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: c3638935a390c67c743fa1758d546413e3837600
+GitCommit: 67f2b80d07d51a6b34a4cc238773a191aac1e29e
 Directory: 8.6-rc/alpine3.23/zts
+
+Tags: 8.5.10RC1-cli-trixie, 8.5-rc-cli-trixie, 8.5.10RC1-trixie, 8.5-rc-trixie, 8.5.10RC1-cli, 8.5-rc-cli, 8.5.10RC1, 8.5-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/trixie/cli
+
+Tags: 8.5.10RC1-apache-trixie, 8.5-rc-apache-trixie, 8.5.10RC1-apache, 8.5-rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/trixie/apache
+
+Tags: 8.5.10RC1-fpm-trixie, 8.5-rc-fpm-trixie, 8.5.10RC1-fpm, 8.5-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/trixie/fpm
+
+Tags: 8.5.10RC1-zts-trixie, 8.5-rc-zts-trixie, 8.5.10RC1-zts, 8.5-rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/trixie/zts
+
+Tags: 8.5.10RC1-cli-bookworm, 8.5-rc-cli-bookworm, 8.5.10RC1-bookworm, 8.5-rc-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/bookworm/cli
+
+Tags: 8.5.10RC1-apache-bookworm, 8.5-rc-apache-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/bookworm/apache
+
+Tags: 8.5.10RC1-fpm-bookworm, 8.5-rc-fpm-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/bookworm/fpm
+
+Tags: 8.5.10RC1-zts-bookworm, 8.5-rc-zts-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/bookworm/zts
+
+Tags: 8.5.10RC1-cli-alpine3.24, 8.5-rc-cli-alpine3.24, 8.5.10RC1-alpine3.24, 8.5-rc-alpine3.24, 8.5.10RC1-cli-alpine, 8.5-rc-cli-alpine, 8.5.10RC1-alpine, 8.5-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/alpine3.24/cli
+
+Tags: 8.5.10RC1-fpm-alpine3.24, 8.5-rc-fpm-alpine3.24, 8.5.10RC1-fpm-alpine, 8.5-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/alpine3.24/fpm
+
+Tags: 8.5.10RC1-zts-alpine3.24, 8.5-rc-zts-alpine3.24, 8.5.10RC1-zts-alpine, 8.5-rc-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/alpine3.24/zts
+
+Tags: 8.5.10RC1-cli-alpine3.23, 8.5-rc-cli-alpine3.23, 8.5.10RC1-alpine3.23, 8.5-rc-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/alpine3.23/cli
+
+Tags: 8.5.10RC1-fpm-alpine3.23, 8.5-rc-fpm-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/alpine3.23/fpm
+
+Tags: 8.5.10RC1-zts-alpine3.23, 8.5-rc-zts-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: a341eaa1fd19839ef080037214a3522a6b67dd68
+Directory: 8.5-rc/alpine3.23/zts
 
 Tags: 8.5.9-cli-trixie, 8.5-cli-trixie, 8-cli-trixie, cli-trixie, 8.5.9-trixie, 8.5-trixie, 8-trixie, trixie, 8.5.9-cli, 8.5-cli, 8-cli, cli, 8.5.9, 8.5, 8, latest
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
@@ -143,6 +213,76 @@ Tags: 8.5.9-zts-alpine3.23, 8.5-zts-alpine3.23, 8-zts-alpine3.23, zts-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 445bf414f1d5866f7aef715f1203eae043710070
 Directory: 8.5/alpine3.23/zts
+
+Tags: 8.4.25RC1-cli-trixie, 8.4-rc-cli-trixie, 8.4.25RC1-trixie, 8.4-rc-trixie, 8.4.25RC1-cli, 8.4-rc-cli, 8.4.25RC1, 8.4-rc
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/trixie/cli
+
+Tags: 8.4.25RC1-apache-trixie, 8.4-rc-apache-trixie, 8.4.25RC1-apache, 8.4-rc-apache
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/trixie/apache
+
+Tags: 8.4.25RC1-fpm-trixie, 8.4-rc-fpm-trixie, 8.4.25RC1-fpm, 8.4-rc-fpm
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/trixie/fpm
+
+Tags: 8.4.25RC1-zts-trixie, 8.4-rc-zts-trixie, 8.4.25RC1-zts, 8.4-rc-zts
+Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/trixie/zts
+
+Tags: 8.4.25RC1-cli-bookworm, 8.4-rc-cli-bookworm, 8.4.25RC1-bookworm, 8.4-rc-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/bookworm/cli
+
+Tags: 8.4.25RC1-apache-bookworm, 8.4-rc-apache-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/bookworm/apache
+
+Tags: 8.4.25RC1-fpm-bookworm, 8.4-rc-fpm-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/bookworm/fpm
+
+Tags: 8.4.25RC1-zts-bookworm, 8.4-rc-zts-bookworm
+Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/bookworm/zts
+
+Tags: 8.4.25RC1-cli-alpine3.24, 8.4-rc-cli-alpine3.24, 8.4.25RC1-alpine3.24, 8.4-rc-alpine3.24, 8.4.25RC1-cli-alpine, 8.4-rc-cli-alpine, 8.4.25RC1-alpine, 8.4-rc-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/alpine3.24/cli
+
+Tags: 8.4.25RC1-fpm-alpine3.24, 8.4-rc-fpm-alpine3.24, 8.4.25RC1-fpm-alpine, 8.4-rc-fpm-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/alpine3.24/fpm
+
+Tags: 8.4.25RC1-zts-alpine3.24, 8.4-rc-zts-alpine3.24, 8.4.25RC1-zts-alpine, 8.4-rc-zts-alpine
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/alpine3.24/zts
+
+Tags: 8.4.25RC1-cli-alpine3.23, 8.4-rc-cli-alpine3.23, 8.4.25RC1-alpine3.23, 8.4-rc-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/alpine3.23/cli
+
+Tags: 8.4.25RC1-fpm-alpine3.23, 8.4-rc-fpm-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/alpine3.23/fpm
+
+Tags: 8.4.25RC1-zts-alpine3.23, 8.4-rc-zts-alpine3.23
+Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
+GitCommit: 182c70e7e7aa18f56beea30516820c1c0d057ca9
+Directory: 8.4-rc/alpine3.23/zts
 
 Tags: 8.4.24-cli-trixie, 8.4-cli-trixie, 8.4.24-trixie, 8.4-trixie, 8.4.24-cli, 8.4-cli, 8.4.24, 8.4
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/php/commit/e990b2ed: Skip arm32v6 on 8.6.0beta (https://github.com/docker-library/php/pull/1679)
- https://github.com/docker-library/php/commit/67f2b80d: Update 8.6-rc to 8.6.0beta1
- https://github.com/docker-library/php/commit/a341eaa1: Update 8.5-rc to 8.5.10RC1
- https://github.com/docker-library/php/commit/182c70e7: Update 8.4-rc to 8.4.25RC1