### PR TITLE
MariaDB: 10.6.28 release

### DIFF
--- a/library/mariadb
+++ b/library/mariadb
@@ -56,12 +56,12 @@ Architectures: amd64, arm64v8, ppc64le, s390x
 GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
 Directory: 10.11
 
-Tags: 10.6.27-ubi9, 10.6-ubi9, 10.6.27-ubi, 10.6-ubi
+Tags: 10.6.28-ubi9, 10.6-ubi9, 10.6.28-ubi, 10.6-ubi
 Architectures: amd64, arm64v8, s390x, ppc64le
-GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
+GitCommit: 7252cf37a0c4357b6de41d52e90fcd4bf7374249
 Directory: 10.6-ubi
 
-Tags: 10.6.27-jammy, 10.6-jammy, 10.6.27, 10.6
+Tags: 10.6.28-jammy, 10.6-jammy, 10.6.28, 10.6
 Architectures: amd64, arm64v8, ppc64le, s390x
-GitCommit: 53935c78b82bff912b361357d59db11d7246ea96
+GitCommit: 7252cf37a0c4357b6de41d52e90fcd4bf7374249
 Directory: 10.6


### PR DESCRIPTION
Someone wanted the 10.6.28 early, so here it is.

The rest of the 2026q3 release is coming next week hopefully.