### PR TITLE
Update KrakenD to v2.13.9

### DIFF
--- a/library/krakend
+++ b/library/krakend
@@ -5,7 +5,7 @@ Maintainers: Daniel Ortiz <dortiz@krakend.io> (@taik0),
 GitRepo: https://github.com/krakend/docker-library.git
 
 # Alpine images
-Tags: 2.13.8, 2.13, 2, latest
+Tags: 2.13.9, 2.13, 2, latest
 Architectures: amd64, arm64v8
-GitCommit: 8b33f8b9315f0ee10f2db598b834b5341450420a
-Directory: 2.13.8
+GitCommit: 8e81c7f6c89afd51d662aec6d975789fe5bfc947
+Directory: 2.13.9


### PR DESCRIPTION
Security patches:
- CVE-2026-41178
- CVE-2026-56852
- CVE-2026-56865
- CVE-2026-56864
- CVE-2026-33818
- GHSA-hrxh-6v49-42gf
