### PR TITLE
Update oraclelinux-slim for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6dee1d264675267a4422c27d5c9561e35544b425
+amd64-GitCommit: 07bebc65c59880aeec0d51b4d549e773e32d1088
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d5355b0decabdf250b54923108ed70f2a2ac81d5
+arm64v8-GitCommit: 31580030c2086ddc0903ac5d570ed6add6a02db2
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-47755](https://linux.oracle.com/errata/ELSA-2026-47755.html)
- [ELSA-2026-48703](https://linux.oracle.com/errata/ELSA-2026-48703.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
