### PR TITLE
Update oraclelinux-slim for 8, 10

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 6dee1d264675267a4422c27d5c9561e35544b425
+amd64-GitCommit: 9f179093056eb2df9386524bbc994c0f4a69d4e3
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: d5355b0decabdf250b54923108ed70f2a2ac81d5
+arm64v8-GitCommit: 588fe7c3bb5335d1609645c14130ccc0c3be5240
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 10
- [ELSA-2026-54650](https://linux.oracle.com/errata/ELSA-2026-54650.html)

### Oracle Linux 8
- [ELSA-2026-47755](https://linux.oracle.com/errata/ELSA-2026-47755.html)
- [ELSA-2026-48703](https://linux.oracle.com/errata/ELSA-2026-48703.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
