### PR TITLE
Update oraclelinux for 8

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 288c184f8f29d88996e96b8cef7962204dec49ed
+amd64-GitCommit: 5ad3832349ccc1657d2a16920d941ab0a8386c87
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: e31bad913d7425811f3851026d79d8748bb16492
+arm64v8-GitCommit: 33ee11226f7127f817be166b8238bc385dc07157
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
This PR ships the following advisories:

### Oracle Linux 8
- [ELSA-2026-54654](https://linux.oracle.com/errata/ELSA-2026-54654.html)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
