### PR TITLE
Update amazonlinux: remove AL1 tags (EOL), add 20260817 releases, remove inactive maintainer

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -1,7 +1,6 @@
 Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
              Frédérick Lefebvre (@fred-lefebvre),
              Stewart Smith (@stewartsmith),
-             Christopher Miller (@mysteriouspants),
              Sumit Tomer (@sktomer),
              Jason Jiannuo Pei (@peijiannuo),
              Michael Mammo (@MichaelAbebaw),
@@ -12,21 +11,16 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.12.20260727.0
+Tags: 2023, latest, 2023.12.20260817.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: 0c02d87a58138cbd40c56c00ca144091415cdce7
+amd64-GitCommit: bdaec0a0c2b5f325aaabb4d80c13b54edb0ca41b
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 6d8dc6e6b1ffe58e25ce27ab58820ef62f7931ef
+arm64v8-GitCommit: 252bddbcc2673e736f5690780c62a7f3aa9f965f
 
-Tags: 2, 2.0.20260727.0
+Tags: 2, 2.0.20260817.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 37997cdea2a520726c1d6d8c89696dd27426661e
+amd64-GitCommit: c3b7caf9f1aaab3a960049aa0a2064b5a3661cc7
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 0fda7faf95a4aae5c353564f2c9a2cec44731771
-
-Tags: 1, 2018.03, 2018.03.0.20231218.0
-Architectures: amd64
-amd64-GitFetch: refs/heads/2018.03
-amd64-GitCommit: cfb41ad1c7624786ea10f60c15ce9c117c4da3b6
+arm64v8-GitCommit: 4edbd4aab89b6762c9f0040d27c2e41623dbdbec


### PR DESCRIPTION
Changes:
- Remove Amazon Linux 1 (AL1) tags: 1, 2018.03, 2018.03.0.20231218.0 AL1 reached end of life on December 31, 2023. https://aws.amazon.com/amazon-linux-ami/

- Update AL2023 to 2023.12.20260817.0
- Update AL2 to 2.0.20260817.0

- Remove Christopher Miller (@mysteriouspants) from Maintainers (no longer active at Amazon)

Updated Packages for Amazon Linux 2:
- libssh2-1.4.3-12.amzn2.2.9

Updated Packages for Amazon Linux 2023:
- amazon-linux-repo-cdn-2023.12.20260817-0.amzn2023
- system-release-2023.12.20260817-0.amzn2023