### PR TITLE
[SECURITY] Redis security release 2026-08-18

### DIFF
--- a/library/redis
+++ b/library/redis
@@ -8,98 +8,98 @@ Maintainers: Yossi Gottlieb <yossi@redis.com> (@yossigo),
              Gonen Goshen <gonen.goshen@redis.com> (@gonen-red)
 GitRepo: https://github.com/redis/docker-library-redis.git
 
-Tags: 8.10.0, 8.10, 8, 8.10.0-trixie, 8.10-trixie, 8-trixie, latest, trixie
+Tags: 8.10.1, 8.10, 8, 8.10.1-trixie, 8.10-trixie, 8-trixie, latest, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 0a24b09f88a6cb8feaf130d4eca7bd6b9b4c73a3
-GitFetch: refs/tags/v8.10.0
+GitCommit: 3b10654333bfc145b9eeed55c4bf495a81ac8ec0
+GitFetch: refs/tags/v8.10.1
 Directory: debian
 
-Tags: 8.10.0-alpine, 8.10-alpine, 8-alpine, 8.10.0-alpine3.23, 8.10-alpine3.23, 8-alpine3.23, alpine, alpine3.23
+Tags: 8.10.1-alpine, 8.10-alpine, 8-alpine, 8.10.1-alpine3.23, 8.10-alpine3.23, 8-alpine3.23, alpine, alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 0a24b09f88a6cb8feaf130d4eca7bd6b9b4c73a3
-GitFetch: refs/tags/v8.10.0
+GitCommit: 3b10654333bfc145b9eeed55c4bf495a81ac8ec0
+GitFetch: refs/tags/v8.10.1
 Directory: alpine
 
-Tags: 8.8.1, 8.8, 8.8.1-trixie, 8.8-trixie
+Tags: 8.8.2, 8.8, 8.8.2-trixie, 8.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: b675641c81d9f476e614aee4a6606365548bae41
-GitFetch: refs/tags/v8.8.1
+GitCommit: 52223e0e4f019209b83150a5d23de71536bf1341
+GitFetch: refs/tags/v8.8.2
 Directory: debian
 
-Tags: 8.8.1-alpine, 8.8-alpine, 8.8.1-alpine3.23, 8.8-alpine3.23
+Tags: 8.8.2-alpine, 8.8-alpine, 8.8.2-alpine3.23, 8.8-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b675641c81d9f476e614aee4a6606365548bae41
-GitFetch: refs/tags/v8.8.1
+GitCommit: 52223e0e4f019209b83150a5d23de71536bf1341
+GitFetch: refs/tags/v8.8.2
 Directory: alpine
 
-Tags: 8.6.5, 8.6, 8.6.5-trixie, 8.6-trixie
+Tags: 8.6.6, 8.6, 8.6.6-trixie, 8.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: 8bf384f30957c89ea17a1fd6e5f34ed31065f84b
-GitFetch: refs/tags/v8.6.5
+GitCommit: d573aa9142ef37e40e5ec71c0d8824497359accb
+GitFetch: refs/tags/v8.6.6
 Directory: debian
 
-Tags: 8.6.5-alpine, 8.6-alpine, 8.6.5-alpine3.23, 8.6-alpine3.23
+Tags: 8.6.6-alpine, 8.6-alpine, 8.6.6-alpine3.23, 8.6-alpine3.23
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 8bf384f30957c89ea17a1fd6e5f34ed31065f84b
-GitFetch: refs/tags/v8.6.5
+GitCommit: d573aa9142ef37e40e5ec71c0d8824497359accb
+GitFetch: refs/tags/v8.6.6
 Directory: alpine
 
-Tags: 8.4.5, 8.4, 8.4.5-trixie, 8.4-trixie
+Tags: 8.4.6, 8.4, 8.4.6-trixie, 8.4-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, riscv64, ppc64le, s390x
-GitCommit: cc3829e8d874f31c8d50ee1e7a81f283eaa9688a
-GitFetch: refs/tags/v8.4.5
+GitCommit: cfece209fac56577549c0c8c64b92bce1f2ae22d
+GitFetch: refs/tags/v8.4.6
 Directory: debian
 
-Tags: 8.4.5-alpine, 8.4-alpine, 8.4.5-alpine3.22, 8.4-alpine3.22
+Tags: 8.4.6-alpine, 8.4-alpine, 8.4.6-alpine3.22, 8.4-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: cc3829e8d874f31c8d50ee1e7a81f283eaa9688a
-GitFetch: refs/tags/v8.4.5
+GitCommit: cfece209fac56577549c0c8c64b92bce1f2ae22d
+GitFetch: refs/tags/v8.4.6
 Directory: alpine
 
-Tags: 8.2.8, 8.2, 8.2.8-bookworm, 8.2-bookworm
+Tags: 8.2.9, 8.2, 8.2.9-bookworm, 8.2-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 3769a841048d940966635f8f59471f3d350707bf
-GitFetch: refs/tags/v8.2.8
+GitCommit: 7dc061ece8b871fe66cc67fec22b9c5f23d5e9f1
+GitFetch: refs/tags/v8.2.9
 Directory: debian
 
-Tags: 8.2.8-alpine, 8.2-alpine, 8.2.8-alpine3.22, 8.2-alpine3.22
+Tags: 8.2.9-alpine, 8.2-alpine, 8.2.9-alpine3.22, 8.2-alpine3.22
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3769a841048d940966635f8f59471f3d350707bf
-GitFetch: refs/tags/v8.2.8
+GitCommit: 7dc061ece8b871fe66cc67fec22b9c5f23d5e9f1
+GitFetch: refs/tags/v8.2.9
 Directory: alpine
 
-Tags: 7.4.10, 7.4, 7, 7.4.10-bookworm, 7.4-bookworm, 7-bookworm
+Tags: 7.4.11, 7.4, 7, 7.4.11-bookworm, 7.4-bookworm, 7-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 31c68732e7311d95e4c833b8fa50aa561ced577f
-GitFetch: refs/tags/v7.4.10
+GitCommit: 74654c612ee06275377d483dc4e134e57b463e9e
+GitFetch: refs/tags/v7.4.11
 Directory: debian
 
-Tags: 7.4.10-alpine, 7.4-alpine, 7-alpine, 7.4.10-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
+Tags: 7.4.11-alpine, 7.4-alpine, 7-alpine, 7.4.11-alpine3.21, 7.4-alpine3.21, 7-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 31c68732e7311d95e4c833b8fa50aa561ced577f
-GitFetch: refs/tags/v7.4.10
+GitCommit: 74654c612ee06275377d483dc4e134e57b463e9e
+GitFetch: refs/tags/v7.4.11
 Directory: alpine
 
-Tags: 7.2.15, 7.2, 7.2.15-bookworm, 7.2-bookworm
+Tags: 7.2.16, 7.2, 7.2.16-bookworm, 7.2-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 976a7de4cd78b6a201b4a3a5ac49cd9c8e3e583f
-GitFetch: refs/tags/v7.2.15
+GitCommit: 09aa4e1a1bb278b1ad77bdeb43bde981fad64e49
+GitFetch: refs/tags/v7.2.16
 Directory: debian
 
-Tags: 7.2.15-alpine, 7.2-alpine, 7.2.15-alpine3.21, 7.2-alpine3.21
+Tags: 7.2.16-alpine, 7.2-alpine, 7.2.16-alpine3.21, 7.2-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 976a7de4cd78b6a201b4a3a5ac49cd9c8e3e583f
-GitFetch: refs/tags/v7.2.15
+GitCommit: 09aa4e1a1bb278b1ad77bdeb43bde981fad64e49
+GitFetch: refs/tags/v7.2.16
 Directory: alpine
 
-Tags: 6.2.23, 6.2, 6, 6.2.23-bookworm, 6.2-bookworm, 6-bookworm
+Tags: 6.2.24, 6.2, 6, 6.2.24-bookworm, 6.2-bookworm, 6-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 70d903a68609970bf9a66181cdc59d0fc1ebc885
-GitFetch: refs/tags/v6.2.23
+GitCommit: d452a755b3fa51c0a8d26e254f29a25bf2272e3c
+GitFetch: refs/tags/v6.2.24
 Directory: debian
 
-Tags: 6.2.23-alpine, 6.2-alpine, 6-alpine, 6.2.23-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
+Tags: 6.2.24-alpine, 6.2-alpine, 6-alpine, 6.2.24-alpine3.21, 6.2-alpine3.21, 6-alpine3.21
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 70d903a68609970bf9a66181cdc59d0fc1ebc885
-GitFetch: refs/tags/v6.2.23
+GitCommit: d452a755b3fa51c0a8d26e254f29a25bf2272e3c
+GitFetch: refs/tags/v6.2.24
 Directory: alpine


### PR DESCRIPTION
Hi Docker Team!

Please consider merging this security update for Redis. It includes several security fixes across all supported versions.

Apologies for the slight delay - we were impacted by yesterday's massive GitHub outage.