### PR TITLE
Update 6 to 6.58.0, Update 6 to CLI 1.32.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,12 +2,12 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: e0d59abf9fa19dbe42b6b4af9b86c5252a533357
+GitCommit: d8c8404852b1d63eb9776e7b373cc0584fae7bc1
 
-Tags: 6.57.1-bookworm, 6.57.1, 6.57-bookworm, 6.57, 6-bookworm, 6, bookworm, latest
+Tags: 6.58.0-bookworm, 6.58.0, 6.58-bookworm, 6.58, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.57.1-alpine3.23, 6.57.1-alpine, 6.57-alpine3.23, 6.57-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.58.0-alpine3.23, 6.58.0-alpine, 6.58-alpine3.23, 6.58-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.58.0, Update 6 to CLI 1.32.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/d8c8404852b1d63eb9776e7b373cc0584fae7bc1.