### PR TITLE
Update for Corretto releases: 8.504.01.1, 11.0.32.10.1, 17.0.20.10.1, 21.0.12.9.1, 25.0.4.8.1, 26.0.2.11.1

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,7 +15,7 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: a4a86adc91afa6ae78207899cd01bd88c9b46322
+GitCommit: 7f7e4d70baf93e386f5f8483f9041da85dc837c0
 
 Tags: 8-al2, 8u502-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u502-al2-generic, 8-al2-generic-jdk
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update amazoncorretto for latest release. For more details, see the following:
* [corretto/corretto-docker repo](https://github.com/corretto/corretto-docker/commit/main)
* [corretto/corretto-8 release](https://github.com/corretto/corretto-8/releases/tag/8.504.01.1)
* [corretto/corretto-11 release](https://github.com/corretto/corretto-11/releases/tag/11.0.32.10.1)
* [corretto/corretto-17 release](https://github.com/corretto/corretto-17/releases/tag/17.0.20.10.1)
* [corretto/corretto-21 release](https://github.com/corretto/corretto-21/releases/tag/21.0.12.9.1)
* [corretto/corretto-25 release](https://github.com/corretto/corretto-25/releases/tag/25.0.4.8.1)
* [corretto/corretto-26 release](https://github.com/corretto/corretto-26/releases/tag/26.0.2.11.1)