### PR TITLE
Update for Corretto releases: 8.504.01.1, 11.0.32.10.1, 17.0.20.10.1, 21.0.12.9.1, 25.0.4.8.1, 26.0.2.11.1

### DIFF
--- a/library/amazoncorretto
+++ b/library/amazoncorretto
@@ -15,57 +15,57 @@ Maintainers: Amazon Corretto Team <corretto-team@amazon.com> (@corretto),
              Satyen Subramaniam <satyenme@amazon.com> (@satyenme)
 GitRepo: https://github.com/corretto/corretto-docker.git
 GitFetch: refs/heads/main
-GitCommit: a4a86adc91afa6ae78207899cd01bd88c9b46322
+GitCommit: 10edb080f80d1f4d9dfaa8bc8242d016c6676fd3
 
-Tags: 8-al2, 8u502-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u502-al2-generic, 8-al2-generic-jdk
+Tags: 8-al2, 8u504-al2, 8-al2-full, 8-al2-jdk, 8-al2-generic, 8u504-al2-generic, 8-al2-generic-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2-generic
 
-Tags: 8-al2023, 8u502-al2023, 8-al2023-jdk, 8, 8-jdk, 8u502, latest
+Tags: 8-al2023, 8u504-al2023, 8-al2023-jdk, 8, 8-jdk, 8u504, latest
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2023
 
-Tags: 8-al2023-jre, 8u502-al2023-jre, 8-jre
+Tags: 8-al2023-jre, 8u504-al2023-jre, 8-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2023
 
-Tags: 8-al2-native-jre, 8u502-al2-native-jre
+Tags: 8-al2-native-jre, 8u504-al2-native-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/al2
 
-Tags: 8-al2-native-jdk, 8u502-al2-native-jdk
+Tags: 8-al2-native-jdk, 8u504-al2-native-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/al2
 
-Tags: 8-alpine3.21, 8u502-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
+Tags: 8-alpine3.21, 8u504-alpine3.21, 8-alpine3.21-full, 8-alpine3.21-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.21
 
-Tags: 8-alpine3.21-jre, 8u502-alpine3.21-jre
+Tags: 8-alpine3.21-jre, 8u504-alpine3.21-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.21
 
-Tags: 8-alpine3.22, 8u502-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk
+Tags: 8-alpine3.22, 8u504-alpine3.22, 8-alpine3.22-full, 8-alpine3.22-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.22
 
-Tags: 8-alpine3.22-jre, 8u502-alpine3.22-jre
+Tags: 8-alpine3.22-jre, 8u504-alpine3.22-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.22
 
-Tags: 8-alpine3.23, 8u502-alpine3.23, 8-alpine3.23-full, 8-alpine3.23-jdk
+Tags: 8-alpine3.23, 8u504-alpine3.23, 8-alpine3.23-full, 8-alpine3.23-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.23
 
-Tags: 8-alpine3.23-jre, 8u502-alpine3.23-jre
+Tags: 8-alpine3.23-jre, 8u504-alpine3.23-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.23
 
-Tags: 8-alpine3.24, 8u502-alpine3.24, 8-alpine3.24-full, 8-alpine3.24-jdk, 8-alpine, 8u502-alpine, 8-alpine-full, 8-alpine-jdk
+Tags: 8-alpine3.24, 8u504-alpine3.24, 8-alpine3.24-full, 8-alpine3.24-jdk, 8-alpine, 8u504-alpine, 8-alpine-full, 8-alpine-jdk
 Architectures: amd64, arm64v8
 Directory: 8/jdk/alpine/3.24
 
-Tags: 8-alpine3.24-jre, 8u502-alpine3.24-jre, 8-alpine-jre, 8u502-alpine-jre
+Tags: 8-alpine3.24-jre, 8u504-alpine3.24-jre, 8-alpine-jre, 8u504-alpine-jre
 Architectures: amd64, arm64v8
 Directory: 8/jre/alpine/3.24
 


### PR DESCRIPTION
Update amazoncorretto for latest release. For more details, see the following:
* [corretto/corretto-docker repo](https://github.com/corretto/corretto-docker/commit/main)
* [corretto/corretto-8 release](https://github.com/corretto/corretto-8/releases/tag/8.504.01.1)
* [corretto/corretto-11 release](https://github.com/corretto/corretto-11/releases/tag/11.0.32.10.1)
* [corretto/corretto-17 release](https://github.com/corretto/corretto-17/releases/tag/17.0.20.10.1)
* [corretto/corretto-21 release](https://github.com/corretto/corretto-21/releases/tag/21.0.12.9.1)
* [corretto/corretto-25 release](https://github.com/corretto/corretto-25/releases/tag/25.0.4.8.1)
* [corretto/corretto-26 release](https://github.com/corretto/corretto-26/releases/tag/26.0.2.11.1)