### PR TITLE
SapMachine August 2026 updates

### DIFF
--- a/library/sapmachine
+++ b/library/sapmachine
@@ -1,282 +1,282 @@
 Maintainers: Christoph Langer <sapmachine@sap.com> (@realclanger), Arno Zeller <sapmachine@sap.com> (@ArnoZeller)
 GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
-Tags: jre-headless, jre-headless-ubuntu, 26-jre-headless, 26-jre-headless-ubuntu, 26.0.2-jre-headless, 26.0.2-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 26-jre-headless-ubuntu-noble, 26-jre-headless-ubuntu-24.04, 26.0.2-jre-headless-ubuntu-noble, 26.0.2-jre-headless-ubuntu-24.04
+Tags: jre-headless, jre-headless-ubuntu, 26-jre-headless, 26-jre-headless-ubuntu, 26.0.2.1-jre-headless, 26.0.2.1-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 26-jre-headless-ubuntu-noble, 26-jre-headless-ubuntu-24.04, 26.0.2.1-jre-headless-ubuntu-noble, 26.0.2.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/24_04/jre-headless
 
-Tags: jre, jre-ubuntu, 26-jre, 26-jre-ubuntu, 26.0.2-jre, 26.0.2-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 26-jre-ubuntu-noble, 26-jre-ubuntu-24.04, 26.0.2-jre-ubuntu-noble, 26.0.2-jre-ubuntu-24.04
+Tags: jre, jre-ubuntu, 26-jre, 26-jre-ubuntu, 26.0.2.1-jre, 26.0.2.1-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 26-jre-ubuntu-noble, 26-jre-ubuntu-24.04, 26.0.2.1-jre-ubuntu-noble, 26.0.2.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/24_04/jre
 
-Tags: jdk-headless, jdk-headless-ubuntu, 26-jdk-headless, 26-jdk-headless-ubuntu, 26.0.2-jdk-headless, 26.0.2-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 26-jdk-headless-ubuntu-noble, 26-jdk-headless-ubuntu-24.04, 26.0.2-jdk-headless-ubuntu-noble, 26.0.2-jdk-headless-ubuntu-24.04
+Tags: jdk-headless, jdk-headless-ubuntu, 26-jdk-headless, 26-jdk-headless-ubuntu, 26.0.2.1-jdk-headless, 26.0.2.1-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 26-jdk-headless-ubuntu-noble, 26-jdk-headless-ubuntu-24.04, 26.0.2.1-jdk-headless-ubuntu-noble, 26.0.2.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/24_04/jdk-headless
 
-Tags: latest, ubuntu, jdk, jdk-ubuntu, 26, 26-ubuntu, 26.0.2, 26.0.2-ubuntu, 26-jdk, 26-jdk-ubuntu, 26.0.2-jdk, 26.0.2-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 26-ubuntu-noble, 26-ubuntu-24.04, 26-jdk-ubuntu-noble, 26-jdk-ubuntu-24.04, 26.0.2-ubuntu-noble, 26.0.2-ubuntu-24.04, 26.0.2-jdk-ubuntu-noble, 26.0.2-jdk-ubuntu-24.04
+Tags: latest, ubuntu, jdk, jdk-ubuntu, 26, 26-ubuntu, 26.0.2.1, 26.0.2.1-ubuntu, 26-jdk, 26-jdk-ubuntu, 26.0.2.1-jdk, 26.0.2.1-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 26-ubuntu-noble, 26-ubuntu-24.04, 26-jdk-ubuntu-noble, 26-jdk-ubuntu-24.04, 26.0.2.1-ubuntu-noble, 26.0.2.1-ubuntu-24.04, 26.0.2.1-jdk-ubuntu-noble, 26.0.2.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/24_04/jdk
 
-Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 26-jre-headless-ubuntu-jammy, 26-jre-headless-ubuntu-22.04, 26.0.2-jre-headless-ubuntu-jammy, 26.0.2-jre-headless-ubuntu-22.04
+Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 26-jre-headless-ubuntu-jammy, 26-jre-headless-ubuntu-22.04, 26.0.2.1-jre-headless-ubuntu-jammy, 26.0.2.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/22_04/jre-headless
 
-Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 26-jre-ubuntu-jammy, 26-jre-ubuntu-22.04, 26.0.2-jre-ubuntu-jammy, 26.0.2-jre-ubuntu-22.04
+Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 26-jre-ubuntu-jammy, 26-jre-ubuntu-22.04, 26.0.2.1-jre-ubuntu-jammy, 26.0.2.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/22_04/jre
 
-Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 26-jdk-headless-ubuntu-jammy, 26-jdk-headless-ubuntu-22.04, 26.0.2-jdk-headless-ubuntu-jammy, 26.0.2-jdk-headless-ubuntu-22.04
+Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 26-jdk-headless-ubuntu-jammy, 26-jdk-headless-ubuntu-22.04, 26.0.2.1-jdk-headless-ubuntu-jammy, 26.0.2.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/22_04/jdk-headless
 
-Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 26-ubuntu-jammy, 26-ubuntu-22.04, 26-jdk-ubuntu-jammy, 26-jdk-ubuntu-22.04, 26.0.2-ubuntu-jammy, 26.0.2-ubuntu-22.04, 26.0.2-jdk-ubuntu-jammy, 26.0.2-jdk-ubuntu-22.04
+Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 26-ubuntu-jammy, 26-ubuntu-22.04, 26-jdk-ubuntu-jammy, 26-jdk-ubuntu-22.04, 26.0.2.1-ubuntu-jammy, 26.0.2.1-ubuntu-22.04, 26.0.2.1-jdk-ubuntu-jammy, 26.0.2.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/ubuntu/22_04/jdk
 
-Tags: jre-alpine, 26-jre-alpine, 26.0.2-jre-alpine, jre-alpine-3.23, 26-jre-alpine-3.23, 26.0.2-jre-alpine-3.23
+Tags: jre-alpine, 26-jre-alpine, 26.0.2.1-jre-alpine, jre-alpine-3.23, 26-jre-alpine-3.23, 26.0.2.1-jre-alpine-3.23
 Architectures: amd64
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/alpine/3_23/jre
 
-Tags: alpine, jdk-alpine, 26-alpine, 26.0.2-alpine, 26-jdk-alpine, 26.0.2-jdk-alpine, alpine-3.23, jdk-alpine-3.23, 26-alpine-3.23, 26-jdk-alpine-3.23, 26.0.2-alpine-3.23, 26.0.2-jdk-alpine-3.23
+Tags: alpine, jdk-alpine, 26-alpine, 26.0.2.1-alpine, 26-jdk-alpine, 26.0.2.1-jdk-alpine, alpine-3.23, jdk-alpine-3.23, 26-alpine-3.23, 26-jdk-alpine-3.23, 26.0.2.1-alpine-3.23, 26.0.2.1-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/alpine/3_23/jdk
 
-Tags: jre-alpine-3.22, 26-jre-alpine-3.22, 26.0.2-jre-alpine-3.22
+Tags: jre-alpine-3.22, 26-jre-alpine-3.22, 26.0.2.1-jre-alpine-3.22
 Architectures: amd64
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/alpine/3_22/jre
 
-Tags: alpine-3.22, jdk-alpine-3.22, 26-alpine-3.22, 26-jdk-alpine-3.22, 26.0.2-alpine-3.22, 26.0.2-jdk-alpine-3.22
+Tags: alpine-3.22, jdk-alpine-3.22, 26-alpine-3.22, 26-jdk-alpine-3.22, 26.0.2.1-alpine-3.22, 26.0.2.1-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/alpine/3_22/jdk
 
-Tags: jre-alpine-3.21, 26-jre-alpine-3.21, 26.0.2-jre-alpine-3.21
+Tags: jre-alpine-3.21, 26-jre-alpine-3.21, 26.0.2.1-jre-alpine-3.21
 Architectures: amd64
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/alpine/3_21/jre
 
-Tags: alpine-3.21, jdk-alpine-3.21, 26-alpine-3.21, 26-jdk-alpine-3.21, 26.0.2-alpine-3.21, 26.0.2-jdk-alpine-3.21
+Tags: alpine-3.21, jdk-alpine-3.21, 26-alpine-3.21, 26-jdk-alpine-3.21, 26.0.2.1-alpine-3.21, 26.0.2.1-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: fabc98feee3aabe08a27ab080d567213faeb639c
+GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
 Directory: dockerfiles/26/alpine/3_21/jdk
 
-Tags: 25-jre-headless, 25-jre-headless-ubuntu, 25.0.4-jre-headless, 25.0.4-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.4-jre-headless-ubuntu-noble, 25.0.4-jre-headless-ubuntu-24.04
+Tags: 25-jre-headless, 25-jre-headless-ubuntu, 25.0.4.1-jre-headless, 25.0.4.1-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.4.1-jre-headless-ubuntu-noble, 25.0.4.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/24_04/jre-headless
 
-Tags: 25-jre, 25-jre-ubuntu, 25.0.4-jre, 25.0.4-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.4-jre-ubuntu-noble, 25.0.4-jre-ubuntu-24.04
+Tags: 25-jre, 25-jre-ubuntu, 25.0.4.1-jre, 25.0.4.1-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.4.1-jre-ubuntu-noble, 25.0.4.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/24_04/jre
 
-Tags: 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.4-jdk-headless, 25.0.4-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.4-jdk-headless-ubuntu-noble, 25.0.4-jdk-headless-ubuntu-24.04
+Tags: 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.4.1-jdk-headless, 25.0.4.1-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.4.1-jdk-headless-ubuntu-noble, 25.0.4.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/24_04/jdk-headless
 
-Tags: lts, lts-ubuntu, 25, 25-ubuntu, 25.0.4, 25.0.4-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.4-jdk, 25.0.4-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.4-ubuntu-noble, 25.0.4-ubuntu-24.04, 25.0.4-jdk-ubuntu-noble, 25.0.4-jdk-ubuntu-24.04
+Tags: lts, lts-ubuntu, 25, 25-ubuntu, 25.0.4.1, 25.0.4.1-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.4.1-jdk, 25.0.4.1-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.4.1-ubuntu-noble, 25.0.4.1-ubuntu-24.04, 25.0.4.1-jdk-ubuntu-noble, 25.0.4.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/24_04/jdk
 
-Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.4-jre-headless-ubuntu-jammy, 25.0.4-jre-headless-ubuntu-22.04
+Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.4.1-jre-headless-ubuntu-jammy, 25.0.4.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/22_04/jre-headless
 
-Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.4-jre-ubuntu-jammy, 25.0.4-jre-ubuntu-22.04
+Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.4.1-jre-ubuntu-jammy, 25.0.4.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/22_04/jre
 
-Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.4-jdk-headless-ubuntu-jammy, 25.0.4-jdk-headless-ubuntu-22.04
+Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.4.1-jdk-headless-ubuntu-jammy, 25.0.4.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/22_04/jdk-headless
 
-Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.4-ubuntu-jammy, 25.0.4-ubuntu-22.04, 25.0.4-jdk-ubuntu-jammy, 25.0.4-jdk-ubuntu-22.04
+Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.4.1-ubuntu-jammy, 25.0.4.1-ubuntu-22.04, 25.0.4.1-jdk-ubuntu-jammy, 25.0.4.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/ubuntu/22_04/jdk
 
-Tags: lts-jre-alpine, 25-jre-alpine, 25.0.4-jre-alpine, lts-jre-alpine-3.23, 25-jre-alpine-3.23, 25.0.4-jre-alpine-3.23
+Tags: lts-jre-alpine, 25-jre-alpine, 25.0.4.1-jre-alpine, lts-jre-alpine-3.23, 25-jre-alpine-3.23, 25.0.4.1-jre-alpine-3.23
 Architectures: amd64
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/alpine/3_23/jre
 
-Tags: lts-alpine, 25-alpine, 25.0.4-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.4-jdk-alpine, lts-alpine-3.23, lts-jdk-alpine-3.23, 25-alpine-3.23, 25-jdk-alpine-3.23, 25.0.4-alpine-3.23, 25.0.4-jdk-alpine-3.23
+Tags: lts-alpine, 25-alpine, 25.0.4.1-alpine, lts-jdk-alpine, 25-jdk-alpine, 25.0.4.1-jdk-alpine, lts-alpine-3.23, lts-jdk-alpine-3.23, 25-alpine-3.23, 25-jdk-alpine-3.23, 25.0.4.1-alpine-3.23, 25.0.4.1-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/alpine/3_23/jdk
 
-Tags: lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.4-jre-alpine-3.22
+Tags: lts-jre-alpine-3.22, 25-jre-alpine-3.22, 25.0.4.1-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/alpine/3_22/jre
 
-Tags: lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.4-alpine-3.22, 25.0.4-jdk-alpine-3.22
+Tags: lts-alpine-3.22, lts-jdk-alpine-3.22, 25-alpine-3.22, 25-jdk-alpine-3.22, 25.0.4.1-alpine-3.22, 25.0.4.1-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/alpine/3_22/jdk
 
-Tags: lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.4-jre-alpine-3.21
+Tags: lts-jre-alpine-3.21, 25-jre-alpine-3.21, 25.0.4.1-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/alpine/3_21/jre
 
-Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.4-alpine-3.21, 25.0.4-jdk-alpine-3.21
+Tags: lts-alpine-3.21, lts-jdk-alpine-3.21, 25-alpine-3.21, 25-jdk-alpine-3.21, 25.0.4.1-alpine-3.21, 25.0.4.1-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: 388387bc436968d8c0b6212a4a13e75a9a344c35
+GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
 Directory: dockerfiles/25/alpine/3_21/jdk
 
-Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.12-jre-headless, 21.0.12-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.12-jre-headless-ubuntu-noble, 21.0.12-jre-headless-ubuntu-24.04
+Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.12.1-jre-headless, 21.0.12.1-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.12.1-jre-headless-ubuntu-noble, 21.0.12.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
-Tags: 21-jre, 21-jre-ubuntu, 21.0.12-jre, 21.0.12-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.12-jre-ubuntu-noble, 21.0.12-jre-ubuntu-24.04
+Tags: 21-jre, 21-jre-ubuntu, 21.0.12.1-jre, 21.0.12.1-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.12.1-jre-ubuntu-noble, 21.0.12.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/24_04/jre
 
-Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.12-jdk-headless, 21.0.12-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.12-jdk-headless-ubuntu-noble, 21.0.12-jdk-headless-ubuntu-24.04
+Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.12.1-jdk-headless, 21.0.12.1-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.12.1-jdk-headless-ubuntu-noble, 21.0.12.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
-Tags: 21, 21-ubuntu, 21.0.12, 21.0.12-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.12-jdk, 21.0.12-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.12-ubuntu-noble, 21.0.12-ubuntu-24.04, 21.0.12-jdk-ubuntu-noble, 21.0.12-jdk-ubuntu-24.04
+Tags: 21, 21-ubuntu, 21.0.12.1, 21.0.12.1-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.12.1-jdk, 21.0.12.1-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.12.1-ubuntu-noble, 21.0.12.1-ubuntu-24.04, 21.0.12.1-jdk-ubuntu-noble, 21.0.12.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/24_04/jdk
 
-Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.12-jre-headless-ubuntu-jammy, 21.0.12-jre-headless-ubuntu-22.04
+Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.12.1-jre-headless-ubuntu-jammy, 21.0.12.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
-Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.12-jre-ubuntu-jammy, 21.0.12-jre-ubuntu-22.04
+Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.12.1-jre-ubuntu-jammy, 21.0.12.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/22_04/jre
 
-Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.12-jdk-headless-ubuntu-jammy, 21.0.12-jdk-headless-ubuntu-22.04
+Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.12.1-jdk-headless-ubuntu-jammy, 21.0.12.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
 
-Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.12-ubuntu-jammy, 21.0.12-ubuntu-22.04, 21.0.12-jdk-ubuntu-jammy, 21.0.12-jdk-ubuntu-22.04
+Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.12.1-ubuntu-jammy, 21.0.12.1-ubuntu-22.04, 21.0.12.1-jdk-ubuntu-jammy, 21.0.12.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/ubuntu/22_04/jdk
 
-Tags: 21-jre-alpine, 21.0.12-jre-alpine, 21-jre-alpine-3.23, 21.0.12-jre-alpine-3.23
+Tags: 21-jre-alpine, 21.0.12.1-jre-alpine, 21-jre-alpine-3.23, 21.0.12.1-jre-alpine-3.23
 Architectures: amd64
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/alpine/3_23/jre
 
-Tags: 21-alpine, 21.0.12-alpine, 21-jdk-alpine, 21.0.12-jdk-alpine, 21-alpine-3.23, 21-jdk-alpine-3.23, 21.0.12-alpine-3.23, 21.0.12-jdk-alpine-3.23
+Tags: 21-alpine, 21.0.12.1-alpine, 21-jdk-alpine, 21.0.12.1-jdk-alpine, 21-alpine-3.23, 21-jdk-alpine-3.23, 21.0.12.1-alpine-3.23, 21.0.12.1-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/alpine/3_23/jdk
 
-Tags: 21-jre-alpine-3.22, 21.0.12-jre-alpine-3.22
+Tags: 21-jre-alpine-3.22, 21.0.12.1-jre-alpine-3.22
 Architectures: amd64
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/alpine/3_22/jre
 
-Tags: 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.12-alpine-3.22, 21.0.12-jdk-alpine-3.22
+Tags: 21-alpine-3.22, 21-jdk-alpine-3.22, 21.0.12.1-alpine-3.22, 21.0.12.1-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/alpine/3_22/jdk
 
-Tags: 21-jre-alpine-3.21, 21.0.12-jre-alpine-3.21
+Tags: 21-jre-alpine-3.21, 21.0.12.1-jre-alpine-3.21
 Architectures: amd64
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/alpine/3_21/jre
 
-Tags: 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.12-alpine-3.21, 21.0.12-jdk-alpine-3.21
+Tags: 21-alpine-3.21, 21-jdk-alpine-3.21, 21.0.12.1-alpine-3.21, 21.0.12.1-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: df6fdf8f9b7bcfff1b73e78f6064087733f17bd2
+GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
 Directory: dockerfiles/21/alpine/3_21/jdk
 
-Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.20-jre-headless, 17.0.20-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.20-jre-headless-ubuntu-noble, 17.0.20-jre-headless-ubuntu-24.04
+Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.20.1-jre-headless, 17.0.20.1-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.20.1-jre-headless-ubuntu-noble, 17.0.20.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
-Tags: 17-jre, 17-jre-ubuntu, 17.0.20-jre, 17.0.20-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.20-jre-ubuntu-noble, 17.0.20-jre-ubuntu-24.04
+Tags: 17-jre, 17-jre-ubuntu, 17.0.20.1-jre, 17.0.20.1-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.20.1-jre-ubuntu-noble, 17.0.20.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/24_04/jre
 
-Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.20-jdk-headless, 17.0.20-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.20-jdk-headless-ubuntu-noble, 17.0.20-jdk-headless-ubuntu-24.04
+Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.20.1-jdk-headless, 17.0.20.1-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.20.1-jdk-headless-ubuntu-noble, 17.0.20.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
-Tags: 17, 17-ubuntu, 17.0.20, 17.0.20-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.20-jdk, 17.0.20-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.20-ubuntu-noble, 17.0.20-ubuntu-24.04, 17.0.20-jdk-ubuntu-noble, 17.0.20-jdk-ubuntu-24.04
+Tags: 17, 17-ubuntu, 17.0.20.1, 17.0.20.1-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.20.1-jdk, 17.0.20.1-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.20.1-ubuntu-noble, 17.0.20.1-ubuntu-24.04, 17.0.20.1-jdk-ubuntu-noble, 17.0.20.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/24_04/jdk
 
-Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.20-jre-headless-ubuntu-jammy, 17.0.20-jre-headless-ubuntu-22.04
+Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.20.1-jre-headless-ubuntu-jammy, 17.0.20.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
-Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.20-jre-ubuntu-jammy, 17.0.20-jre-ubuntu-22.04
+Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.20.1-jre-ubuntu-jammy, 17.0.20.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/22_04/jre
 
-Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.20-jdk-headless-ubuntu-jammy, 17.0.20-jdk-headless-ubuntu-22.04
+Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.20.1-jdk-headless-ubuntu-jammy, 17.0.20.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
 
-Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.20-ubuntu-jammy, 17.0.20-ubuntu-22.04, 17.0.20-jdk-ubuntu-jammy, 17.0.20-jdk-ubuntu-22.04
+Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.20.1-ubuntu-jammy, 17.0.20.1-ubuntu-22.04, 17.0.20.1-jdk-ubuntu-jammy, 17.0.20.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/ubuntu/22_04/jdk
 
-Tags: 17-jre-alpine, 17.0.20-jre-alpine, 17-jre-alpine-3.23, 17.0.20-jre-alpine-3.23
+Tags: 17-jre-alpine, 17.0.20.1-jre-alpine, 17-jre-alpine-3.23, 17.0.20.1-jre-alpine-3.23
 Architectures: amd64
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/alpine/3_23/jre
 
-Tags: 17-alpine, 17.0.20-alpine, 17-jdk-alpine, 17.0.20-jdk-alpine, 17-alpine-3.23, 17-jdk-alpine-3.23, 17.0.20-alpine-3.23, 17.0.20-jdk-alpine-3.23
+Tags: 17-alpine, 17.0.20.1-alpine, 17-jdk-alpine, 17.0.20.1-jdk-alpine, 17-alpine-3.23, 17-jdk-alpine-3.23, 17.0.20.1-alpine-3.23, 17.0.20.1-jdk-alpine-3.23
 Architectures: amd64
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/alpine/3_23/jdk
 
-Tags: 17-jre-alpine-3.22, 17.0.20-jre-alpine-3.22
+Tags: 17-jre-alpine-3.22, 17.0.20.1-jre-alpine-3.22
 Architectures: amd64
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/alpine/3_22/jre
 
-Tags: 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.20-alpine-3.22, 17.0.20-jdk-alpine-3.22
+Tags: 17-alpine-3.22, 17-jdk-alpine-3.22, 17.0.20.1-alpine-3.22, 17.0.20.1-jdk-alpine-3.22
 Architectures: amd64
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/alpine/3_22/jdk
 
-Tags: 17-jre-alpine-3.21, 17.0.20-jre-alpine-3.21
+Tags: 17-jre-alpine-3.21, 17.0.20.1-jre-alpine-3.21
 Architectures: amd64
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/alpine/3_21/jre
 
-Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.20-alpine-3.21, 17.0.20-jdk-alpine-3.21
+Tags: 17-alpine-3.21, 17-jdk-alpine-3.21, 17.0.20.1-alpine-3.21, 17.0.20.1-jdk-alpine-3.21
 Architectures: amd64
-GitCommit: 8849753c198ef4089dd70985c8efa446960bf8f1
+GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
 Directory: dockerfiles/17/alpine/3_21/jdk

--- a/library/sapmachine
+++ b/library/sapmachine
@@ -3,42 +3,42 @@ GitRepo: https://github.com/SAP/SapMachine-infrastructure.git
 
 Tags: jre-headless, jre-headless-ubuntu, 26-jre-headless, 26-jre-headless-ubuntu, 26.0.2.1-jre-headless, 26.0.2.1-jre-headless-ubuntu, jre-headless-ubuntu-noble, jre-headless-ubuntu-24.04, 26-jre-headless-ubuntu-noble, 26-jre-headless-ubuntu-24.04, 26.0.2.1-jre-headless-ubuntu-noble, 26.0.2.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/24_04/jre-headless
 
 Tags: jre, jre-ubuntu, 26-jre, 26-jre-ubuntu, 26.0.2.1-jre, 26.0.2.1-jre-ubuntu, jre-ubuntu-noble, jre-ubuntu-24.04, 26-jre-ubuntu-noble, 26-jre-ubuntu-24.04, 26.0.2.1-jre-ubuntu-noble, 26.0.2.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/24_04/jre
 
 Tags: jdk-headless, jdk-headless-ubuntu, 26-jdk-headless, 26-jdk-headless-ubuntu, 26.0.2.1-jdk-headless, 26.0.2.1-jdk-headless-ubuntu, jdk-headless-ubuntu-noble, jdk-headless-ubuntu-24.04, 26-jdk-headless-ubuntu-noble, 26-jdk-headless-ubuntu-24.04, 26.0.2.1-jdk-headless-ubuntu-noble, 26.0.2.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/24_04/jdk-headless
 
 Tags: latest, ubuntu, jdk, jdk-ubuntu, 26, 26-ubuntu, 26.0.2.1, 26.0.2.1-ubuntu, 26-jdk, 26-jdk-ubuntu, 26.0.2.1-jdk, 26.0.2.1-jdk-ubuntu, ubuntu-noble, ubuntu-24.04, jdk-ubuntu-noble, jdk-ubuntu-24.04, 26-ubuntu-noble, 26-ubuntu-24.04, 26-jdk-ubuntu-noble, 26-jdk-ubuntu-24.04, 26.0.2.1-ubuntu-noble, 26.0.2.1-ubuntu-24.04, 26.0.2.1-jdk-ubuntu-noble, 26.0.2.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/24_04/jdk
 
 Tags: jre-headless-ubuntu-jammy, jre-headless-ubuntu-22.04, 26-jre-headless-ubuntu-jammy, 26-jre-headless-ubuntu-22.04, 26.0.2.1-jre-headless-ubuntu-jammy, 26.0.2.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/22_04/jre-headless
 
 Tags: jre-ubuntu-jammy, jre-ubuntu-22.04, 26-jre-ubuntu-jammy, 26-jre-ubuntu-22.04, 26.0.2.1-jre-ubuntu-jammy, 26.0.2.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/22_04/jre
 
 Tags: jdk-headless-ubuntu-jammy, jdk-headless-ubuntu-22.04, 26-jdk-headless-ubuntu-jammy, 26-jdk-headless-ubuntu-22.04, 26.0.2.1-jdk-headless-ubuntu-jammy, 26.0.2.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/22_04/jdk-headless
 
 Tags: ubuntu-jammy, ubuntu-22.04, jdk-ubuntu-jammy, jdk-ubuntu-22.04, 26-ubuntu-jammy, 26-ubuntu-22.04, 26-jdk-ubuntu-jammy, 26-jdk-ubuntu-22.04, 26.0.2.1-ubuntu-jammy, 26.0.2.1-ubuntu-22.04, 26.0.2.1-jdk-ubuntu-jammy, 26.0.2.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 1d7f796c37bc0b2a8c9f61feae829af100ea71b6
+GitCommit: 2bd11e463d27599e812cb7260ab6234990e6a427
 Directory: dockerfiles/26/ubuntu/22_04/jdk
 
 Tags: jre-alpine, 26-jre-alpine, 26.0.2.1-jre-alpine, jre-alpine-3.23, 26-jre-alpine-3.23, 26.0.2.1-jre-alpine-3.23
@@ -73,42 +73,42 @@ Directory: dockerfiles/26/alpine/3_21/jdk
 
 Tags: 25-jre-headless, 25-jre-headless-ubuntu, 25.0.4.1-jre-headless, 25.0.4.1-jre-headless-ubuntu, lts-jre-headless-ubuntu, lts-jre-headless-ubuntu-noble, lts-jre-headless-ubuntu-24.04, 25-jre-headless-ubuntu-noble, 25-jre-headless-ubuntu-24.04, 25.0.4.1-jre-headless-ubuntu-noble, 25.0.4.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/24_04/jre-headless
 
 Tags: 25-jre, 25-jre-ubuntu, 25.0.4.1-jre, 25.0.4.1-jre-ubuntu, lts-jre-ubuntu, lts-jre-ubuntu-noble, lts-jre-ubuntu-24.04, 25-jre-ubuntu-noble, 25-jre-ubuntu-24.04, 25.0.4.1-jre-ubuntu-noble, 25.0.4.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/24_04/jre
 
 Tags: 25-jdk-headless, 25-jdk-headless-ubuntu, 25.0.4.1-jdk-headless, 25.0.4.1-jdk-headless-ubuntu, lts-jdk-headless-ubuntu, lts-jdk-headless-ubuntu-noble, lts-jdk-headless-ubuntu-24.04, 25-jdk-headless-ubuntu-noble, 25-jdk-headless-ubuntu-24.04, 25.0.4.1-jdk-headless-ubuntu-noble, 25.0.4.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/24_04/jdk-headless
 
 Tags: lts, lts-ubuntu, 25, 25-ubuntu, 25.0.4.1, 25.0.4.1-ubuntu, 25-jdk, 25-jdk-ubuntu, 25.0.4.1-jdk, 25.0.4.1-jdk-ubuntu, lts-jdk-ubuntu, lts-ubuntu-noble, lts-ubuntu-24.04, lts-jdk-ubuntu-noble, lts-jdk-ubuntu-24.04, 25-ubuntu-noble, 25-ubuntu-24.04, 25-jdk-ubuntu-noble, 25-jdk-ubuntu-24.04, 25.0.4.1-ubuntu-noble, 25.0.4.1-ubuntu-24.04, 25.0.4.1-jdk-ubuntu-noble, 25.0.4.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/24_04/jdk
 
 Tags: lts-jre-headless-ubuntu-jammy, lts-jre-headless-ubuntu-22.04, 25-jre-headless-ubuntu-jammy, 25-jre-headless-ubuntu-22.04, 25.0.4.1-jre-headless-ubuntu-jammy, 25.0.4.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/22_04/jre-headless
 
 Tags: lts-jre-ubuntu-jammy, lts-jre-ubuntu-22.04, 25-jre-ubuntu-jammy, 25-jre-ubuntu-22.04, 25.0.4.1-jre-ubuntu-jammy, 25.0.4.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/22_04/jre
 
 Tags: lts-jdk-headless-ubuntu-jammy, lts-jdk-headless-ubuntu-22.04, 25-jdk-headless-ubuntu-jammy, 25-jdk-headless-ubuntu-22.04, 25.0.4.1-jdk-headless-ubuntu-jammy, 25.0.4.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/22_04/jdk-headless
 
 Tags: lts-ubuntu-jammy, lts-ubuntu-22.04, lts-jdk-ubuntu-jammy, lts-jdk-ubuntu-22.04, 25-ubuntu-jammy, 25-ubuntu-22.04, 25-jdk-ubuntu-jammy, 25-jdk-ubuntu-22.04, 25.0.4.1-ubuntu-jammy, 25.0.4.1-ubuntu-22.04, 25.0.4.1-jdk-ubuntu-jammy, 25.0.4.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 8185e053cdacdbcf2f481b129e76f2e2d326f04b
+GitCommit: 1de6fbc9233ea4e095e314c2e58a3ccec1b9cf31
 Directory: dockerfiles/25/ubuntu/22_04/jdk
 
 Tags: lts-jre-alpine, 25-jre-alpine, 25.0.4.1-jre-alpine, lts-jre-alpine-3.23, 25-jre-alpine-3.23, 25.0.4.1-jre-alpine-3.23
@@ -143,42 +143,42 @@ Directory: dockerfiles/25/alpine/3_21/jdk
 
 Tags: 21-jre-headless, 21-jre-headless-ubuntu, 21.0.12.1-jre-headless, 21.0.12.1-jre-headless-ubuntu, 21-jre-headless-ubuntu-noble, 21-jre-headless-ubuntu-24.04, 21.0.12.1-jre-headless-ubuntu-noble, 21.0.12.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/24_04/jre-headless
 
 Tags: 21-jre, 21-jre-ubuntu, 21.0.12.1-jre, 21.0.12.1-jre-ubuntu, 21-jre-ubuntu-noble, 21-jre-ubuntu-24.04, 21.0.12.1-jre-ubuntu-noble, 21.0.12.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/24_04/jre
 
 Tags: 21-jdk-headless, 21-jdk-headless-ubuntu, 21.0.12.1-jdk-headless, 21.0.12.1-jdk-headless-ubuntu, 21-jdk-headless-ubuntu-noble, 21-jdk-headless-ubuntu-24.04, 21.0.12.1-jdk-headless-ubuntu-noble, 21.0.12.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/24_04/jdk-headless
 
 Tags: 21, 21-ubuntu, 21.0.12.1, 21.0.12.1-ubuntu, 21-jdk, 21-jdk-ubuntu, 21.0.12.1-jdk, 21.0.12.1-jdk-ubuntu, 21-ubuntu-noble, 21-ubuntu-24.04, 21-jdk-ubuntu-noble, 21-jdk-ubuntu-24.04, 21.0.12.1-ubuntu-noble, 21.0.12.1-ubuntu-24.04, 21.0.12.1-jdk-ubuntu-noble, 21.0.12.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/24_04/jdk
 
 Tags: 21-jre-headless-ubuntu-jammy, 21-jre-headless-ubuntu-22.04, 21.0.12.1-jre-headless-ubuntu-jammy, 21.0.12.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/22_04/jre-headless
 
 Tags: 21-jre-ubuntu-jammy, 21-jre-ubuntu-22.04, 21.0.12.1-jre-ubuntu-jammy, 21.0.12.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/22_04/jre
 
 Tags: 21-jdk-headless-ubuntu-jammy, 21-jdk-headless-ubuntu-22.04, 21.0.12.1-jdk-headless-ubuntu-jammy, 21.0.12.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/22_04/jdk-headless
 
 Tags: 21-ubuntu-jammy, 21-ubuntu-22.04, 21-jdk-ubuntu-jammy, 21-jdk-ubuntu-22.04, 21.0.12.1-ubuntu-jammy, 21.0.12.1-ubuntu-22.04, 21.0.12.1-jdk-ubuntu-jammy, 21.0.12.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 4ccd0cabc220d90c742f1944d1411a4023e44842
+GitCommit: 41b3799b91b259e01fab07e94f65292ce746f9d6
 Directory: dockerfiles/21/ubuntu/22_04/jdk
 
 Tags: 21-jre-alpine, 21.0.12.1-jre-alpine, 21-jre-alpine-3.23, 21.0.12.1-jre-alpine-3.23
@@ -213,42 +213,42 @@ Directory: dockerfiles/21/alpine/3_21/jdk
 
 Tags: 17-jre-headless, 17-jre-headless-ubuntu, 17.0.20.1-jre-headless, 17.0.20.1-jre-headless-ubuntu, 17-jre-headless-ubuntu-noble, 17-jre-headless-ubuntu-24.04, 17.0.20.1-jre-headless-ubuntu-noble, 17.0.20.1-jre-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/24_04/jre-headless
 
 Tags: 17-jre, 17-jre-ubuntu, 17.0.20.1-jre, 17.0.20.1-jre-ubuntu, 17-jre-ubuntu-noble, 17-jre-ubuntu-24.04, 17.0.20.1-jre-ubuntu-noble, 17.0.20.1-jre-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/24_04/jre
 
 Tags: 17-jdk-headless, 17-jdk-headless-ubuntu, 17.0.20.1-jdk-headless, 17.0.20.1-jdk-headless-ubuntu, 17-jdk-headless-ubuntu-noble, 17-jdk-headless-ubuntu-24.04, 17.0.20.1-jdk-headless-ubuntu-noble, 17.0.20.1-jdk-headless-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/24_04/jdk-headless
 
 Tags: 17, 17-ubuntu, 17.0.20.1, 17.0.20.1-ubuntu, 17-jdk, 17-jdk-ubuntu, 17.0.20.1-jdk, 17.0.20.1-jdk-ubuntu, 17-ubuntu-noble, 17-ubuntu-24.04, 17-jdk-ubuntu-noble, 17-jdk-ubuntu-24.04, 17.0.20.1-ubuntu-noble, 17.0.20.1-ubuntu-24.04, 17.0.20.1-jdk-ubuntu-noble, 17.0.20.1-jdk-ubuntu-24.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/24_04/jdk
 
 Tags: 17-jre-headless-ubuntu-jammy, 17-jre-headless-ubuntu-22.04, 17.0.20.1-jre-headless-ubuntu-jammy, 17.0.20.1-jre-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/22_04/jre-headless
 
 Tags: 17-jre-ubuntu-jammy, 17-jre-ubuntu-22.04, 17.0.20.1-jre-ubuntu-jammy, 17.0.20.1-jre-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/22_04/jre
 
 Tags: 17-jdk-headless-ubuntu-jammy, 17-jdk-headless-ubuntu-22.04, 17.0.20.1-jdk-headless-ubuntu-jammy, 17.0.20.1-jdk-headless-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/22_04/jdk-headless
 
 Tags: 17-ubuntu-jammy, 17-ubuntu-22.04, 17-jdk-ubuntu-jammy, 17-jdk-ubuntu-22.04, 17.0.20.1-ubuntu-jammy, 17.0.20.1-ubuntu-22.04, 17.0.20.1-jdk-ubuntu-jammy, 17.0.20.1-jdk-ubuntu-22.04
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 74cba1276f267b036f55a332cb2ebca11ec779f2
+GitCommit: c9ffd9f57f5f23f825cfc82ea2f9f6874c9e17df
 Directory: dockerfiles/17/ubuntu/22_04/jdk
 
 Tags: 17-jre-alpine, 17.0.20.1-jre-alpine, 17-jre-alpine-3.23, 17.0.20.1-jre-alpine-3.23


### PR DESCRIPTION
This updates the SapMachine docker images to the August 2026 releases