### PR TITLE
add InfluxDB Enterprise 1.13.0 images

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,19 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 6191ef0ed95901f4ab7118579b0796cde37fa759
+GitCommit: b71413740b6b7d70f55fa630f9de872cbfe0a368
+
+Tags: 1.13-data, 1.13.0-data
+Directory: influxdb/1.13/data
+
+Tags: 1.13-data-alpine, 1.13.0-data-alpine
+Directory: influxdb/1.13/data/alpine
+
+Tags: 1.13-meta, 1.13.0-meta
+Directory: influxdb/1.13/meta
+
+Tags: 1.13-meta-alpine, 1.13.0-meta-alpine
+Directory: influxdb/1.13/meta/alpine
 
 Tags: 1.12, 1.12.4
 Architectures: amd64, arm64v8


### PR DESCRIPTION
- Add images for multi-node InfluxDB Enterprise 1.13.0 (1.13) images, specifically the data nodes and meta nodes.
- InfluxDB OSS 1.13.0 (1.13) single-node OSS images are not included at this time, but will be added in the near future.
- The data, data-alpine, meta, and meta-alpine tags have intentionally not been   moved from the 1.12 at this time. Users must specifically configure 1.13.
  images. The 1.13.0 images should not be the default
- Update 1.13 alpine images to alpine-3.23 from the 1.12 image's alpine-3.21.