### PR TITLE
archlinux: Release 20260823.0.578598

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260816.0.574111
-GitCommit: 53772c74cb3aa87b0d4800ead6c6cba30ad35584
-GitFetch: refs/tags/v20260816.0.574111
+Tags: latest, base, base-20260823.0.578598
+GitCommit: edbfaa9363e61012cb4b73a97a0306b44291062f
+GitFetch: refs/tags/v20260823.0.578598
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260816.0.574111
-GitCommit: 53772c74cb3aa87b0d4800ead6c6cba30ad35584
-GitFetch: refs/tags/v20260816.0.574111
+Tags: base-devel, base-devel-20260823.0.578598
+GitCommit: edbfaa9363e61012cb4b73a97a0306b44291062f
+GitFetch: refs/tags/v20260823.0.578598
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260816.0.574111
-GitCommit: 53772c74cb3aa87b0d4800ead6c6cba30ad35584
-GitFetch: refs/tags/v20260816.0.574111
+Tags: multilib-devel, multilib-devel-20260823.0.578598
+GitCommit: edbfaa9363e61012cb4b73a97a0306b44291062f
+GitFetch: refs/tags/v20260823.0.578598
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks