### PR TITLE
Update 6 to 6.60.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,12 +2,12 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 0da6924c7edbdd0d7294909e7cedb043661b202e
+GitCommit: 4a9626af1d9f6a8f903ab6246fda29e56dcf106f
 
-Tags: 6.59.0-bookworm, 6.59.0, 6.59-bookworm, 6.59, 6-bookworm, 6, bookworm, latest
+Tags: 6.60.0-bookworm, 6.60.0, 6.60-bookworm, 6.60, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.59.0-alpine3.23, 6.59.0-alpine, 6.59-alpine3.23, 6.59-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.60.0-alpine3.23, 6.60.0-alpine, 6.60-alpine3.23, 6.60-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.60.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/4a9626af1d9f6a8f903ab6246fda29e56dcf106f.