### PR TITLE
Update Rakudo-Star to 2026.08

### DIFF
--- a/library/rakudo-star
+++ b/library/rakudo-star
@@ -4,17 +4,18 @@ Maintainers: Moritz Lenz <moritz.lenz@gmail.com> (@moritz),
              Anton Oks <anton.oks@gmx.de> (@AntonOks)
 GitRepo: https://github.com/rakudo/docker
 
-Tags: trixie, latest, 2026.06-trixie
+Tags: trixie, latest, 2026.08-trixie
 Architectures: amd64, arm64v8
-GitCommit: 606999aa1883485e18dbfe2c542814dcbbb5e643
-Directory: 2026.06/trixie
+GitCommit: 03c5add3d4d6950c365da222446f2f64509e451f
+Directory: 2026.08/trixie
 
-Tags: bookworm, 2026.06-bookworm
+Tags: bookworm, 2026.08-bookworm
 Architectures: amd64, arm64v8
-GitCommit: 606999aa1883485e18dbfe2c542814dcbbb5e643
-Directory: 2026.06/bookworm
+GitCommit: 03c5add3d4d6950c365da222446f2f64509e451f
+Directory: 2026.08/bookworm
 
-Tags: alpine, 2026.06-alpine
+Tags: alpine, 2026.08-alpine
 Architectures: amd64, arm64v8
-GitCommit: 606999aa1883485e18dbfe2c542814dcbbb5e643
-Directory: 2026.06/alpine
+GitCommit: 03c5add3d4d6950c365da222446f2f64509e451f
+Directory: 2026.08/alpine
+


### PR DESCRIPTION
Automated update from:

- Rakudo-Star version: 2026.08
- Docker commit: 03c5add3d4d6950c365da222446f2f64509e451f

Generated by GitHub Actions.