### PR TITLE
nats: Update to 2.14.6

### DIFF
--- a/library/nats
+++ b/library/nats
@@ -4,26 +4,26 @@ Maintainers: Derek Collison <derek@synadia.com> (@derekcollison),
              Neil Twigg <neil@synadia.com> (@neilalexander),
              Phil Pennock <pdp@synadia.com> (@philpennock)
 GitRepo: https://github.com/nats-io/nats-docker.git
-GitCommit: aa0caa57b71c01566a100b47b2ed94de6ef6cf80
+GitCommit: e55a3d1604e9fcd5b5b988b1ab68948d033a4708
 GitFetch: refs/heads/main
 
-Tags: 2.14.5-alpine3.22, 2.14-alpine3.22, 2-alpine3.22, alpine3.22, 2.14.5-alpine, 2.14-alpine, 2-alpine, alpine
+Tags: 2.14.6-alpine3.22, 2.14-alpine3.22, 2-alpine3.22, alpine3.22, 2.14.6-alpine, 2.14-alpine, 2-alpine, alpine
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.14.x/alpine3.22
 
-Tags: 2.14.5-scratch, 2.14-scratch, 2-scratch, scratch, 2.14.5-linux, 2.14-linux, 2-linux, linux
-SharedTags: 2.14.5, 2.14, 2, latest
+Tags: 2.14.6-scratch, 2.14-scratch, 2-scratch, scratch, 2.14.6-linux, 2.14-linux, 2-linux, linux
+SharedTags: 2.14.6, 2.14, 2, latest
 Architectures: amd64, arm32v6, arm32v7, arm64v8, s390x, ppc64le
 Directory: 2.14.x/scratch
 
-Tags: 2.14.5-windowsservercore-ltsc2022, 2.14-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
-SharedTags: 2.14.5-windowsservercore, 2.14-windowsservercore, 2-windowsservercore, windowsservercore
+Tags: 2.14.6-windowsservercore-ltsc2022, 2.14-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+SharedTags: 2.14.6-windowsservercore, 2.14-windowsservercore, 2-windowsservercore, windowsservercore
 Architectures: windows-amd64
 Directory: 2.14.x/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 2.14.5-nanoserver-ltsc2022, 2.14-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
-SharedTags: 2.14.5-nanoserver, 2.14-nanoserver, 2-nanoserver, nanoserver, 2.14.5, 2.14, 2, latest
+Tags: 2.14.6-nanoserver-ltsc2022, 2.14-nanoserver-ltsc2022, 2-nanoserver-ltsc2022, nanoserver-ltsc2022
+SharedTags: 2.14.6-nanoserver, 2.14-nanoserver, 2-nanoserver, nanoserver, 2.14.6, 2.14, 2, latest
 Architectures: windows-amd64
 Directory: 2.14.x/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022


### PR DESCRIPTION
Release info: https://github.com/nats-io/nats-server/releases/tag/v2.14.6