### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -18,9 +18,9 @@ amd64-GitCommit: bdaec0a0c2b5f325aaabb4d80c13b54edb0ca41b
 arm64v8-GitFetch: refs/heads/al2023-arm64
 arm64v8-GitCommit: 252bddbcc2673e736f5690780c62a7f3aa9f965f
 
-Tags: 2, 2.0.20260817.0
+Tags: 2, 2.0.20260825.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: c3b7caf9f1aaab3a960049aa0a2064b5a3661cc7
+amd64-GitCommit: 2e18b8c24e61398cbc57ef9e4256c3e41c31109d
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: 4edbd4aab89b6762c9f0040d27c2e41623dbdbec
+arm64v8-GitCommit: ef2c940dc039d760a782b854fcfd721df9cf9a91


### PR DESCRIPTION
### Updated Packages for Amazon Linux 2:
- No update in this release