### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -14,62 +14,62 @@ Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
 GitCommit: 9c550cab84dacefb80a7fdde0dc5241d473ff554
 Directory: 3.5/alpine
 
-Tags: 3.4.3, 3.4, latest, lts, 3.4.3-trixie, 3.4-trixie, trixie, lts-trixie
+Tags: 3.4.4, 3.4, latest, lts, 3.4.4-trixie, 3.4-trixie, trixie, lts-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 40955df2217f5cb77f861e709b239cedd43ff613
+GitCommit: b71e05460e819fb232782af4ececabefcb13dcfc
 Directory: 3.4
 
-Tags: 3.4.3-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.3-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
+Tags: 3.4.4-alpine, 3.4-alpine, alpine, lts-alpine, 3.4.4-alpine3.24, 3.4-alpine3.24, alpine3.24, lts-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 40955df2217f5cb77f861e709b239cedd43ff613
+GitCommit: b71e05460e819fb232782af4ececabefcb13dcfc
 Directory: 3.4/alpine
 
-Tags: 3.3.13, 3.3, 3.3.13-trixie, 3.3-trixie
+Tags: 3.3.14, 3.3, 3.3.14-trixie, 3.3-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: caa8282e7c19d57d87610ffb13560ee8ccbc263f
+GitCommit: be82c5967740b4b0bfbf40dcf4d8d8e4c37a2035
 Directory: 3.3
 
-Tags: 3.3.13-alpine, 3.3-alpine, 3.3.13-alpine3.24, 3.3-alpine3.24
+Tags: 3.3.14-alpine, 3.3-alpine, 3.3.14-alpine3.24, 3.3-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: caa8282e7c19d57d87610ffb13560ee8ccbc263f
+GitCommit: be82c5967740b4b0bfbf40dcf4d8d8e4c37a2035
 Directory: 3.3/alpine
 
-Tags: 3.2.22, 3.2, 3.2.22-trixie, 3.2-trixie
+Tags: 3.2.23, 3.2, 3.2.23-trixie, 3.2-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e679de0fb5d9e781f1aa313ab7464e270a809e3
+GitCommit: 7a5c202cde713867a737033dca56e7a211a8b8df
 Directory: 3.2
 
-Tags: 3.2.22-alpine, 3.2-alpine, 3.2.22-alpine3.24, 3.2-alpine3.24
+Tags: 3.2.23-alpine, 3.2-alpine, 3.2.23-alpine3.24, 3.2-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 3e679de0fb5d9e781f1aa313ab7464e270a809e3
+GitCommit: 7a5c202cde713867a737033dca56e7a211a8b8df
 Directory: 3.2/alpine
 
-Tags: 3.0.26, 3.0, 3.0.26-trixie, 3.0-trixie
+Tags: 3.0.27, 3.0, 3.0.27-trixie, 3.0-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9dfb33f798390d8d9b64041834acd72f1591de48
+GitCommit: 35f3a33fa2f01c68ac27b704a79185070f9ead6d
 Directory: 3.0
 
-Tags: 3.0.26-alpine, 3.0-alpine, 3.0.26-alpine3.24, 3.0-alpine3.24
+Tags: 3.0.27-alpine, 3.0-alpine, 3.0.27-alpine3.24, 3.0-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9dfb33f798390d8d9b64041834acd72f1591de48
+GitCommit: 35f3a33fa2f01c68ac27b704a79185070f9ead6d
 Directory: 3.0/alpine
 
-Tags: 2.8.27, 2.8, 2.8.27-trixie, 2.8-trixie
+Tags: 2.8.28, 2.8, 2.8.28-trixie, 2.8-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ee81bd76371730aa58585c7f281acd89334f7bb
+GitCommit: 4d2c2c31a112dc9ef3b48021fd0565e8a7403179
 Directory: 2.8
 
-Tags: 2.8.27-alpine, 2.8-alpine, 2.8.27-alpine3.24, 2.8-alpine3.24
+Tags: 2.8.28-alpine, 2.8-alpine, 2.8.28-alpine3.24, 2.8-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 2ee81bd76371730aa58585c7f281acd89334f7bb
+GitCommit: 4d2c2c31a112dc9ef3b48021fd0565e8a7403179
 Directory: 2.8/alpine
 
-Tags: 2.6.32, 2.6, 2.6.32-trixie, 2.6-trixie
+Tags: 2.6.33, 2.6, 2.6.33-trixie, 2.6-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 32a1b4183b2b02c1dd8060bca6c706285ca1245f
+GitCommit: b3b97708ca92b17023049d15da7eaf6a0d614593
 Directory: 2.6
 
-Tags: 2.6.32-alpine, 2.6-alpine, 2.6.32-alpine3.24, 2.6-alpine3.24
+Tags: 2.6.33-alpine, 2.6-alpine, 2.6.33-alpine3.24, 2.6-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 32a1b4183b2b02c1dd8060bca6c706285ca1245f
+GitCommit: b3b97708ca92b17023049d15da7eaf6a0d614593
 Directory: 2.6/alpine


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/b71e054: Update 3.4 to 3.4.4
- https://github.com/docker-library/haproxy/commit/be82c59: Update 3.3 to 3.3.14
- https://github.com/docker-library/haproxy/commit/7a5c202: Update 3.2 to 3.2.23
- https://github.com/docker-library/haproxy/commit/35f3a33: Update 3.0 to 3.0.27
- https://github.com/docker-library/haproxy/commit/4d2c2c3: Update 2.8 to 2.8.28
- https://github.com/docker-library/haproxy/commit/b3b9770: Update 2.6 to 2.6.33