### PR TITLE
Add 'latest' and '8' tags back to mongo shared tags

### DIFF
--- a/library/mongo
+++ b/library/mongo
@@ -5,7 +5,7 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
 GitRepo: https://github.com/docker-library/mongo.git
 
 Tags: 8.3.8-noble, 8.3-noble
-SharedTags: 8.3.8, 8.3
+SharedTags: 8.3.8, 8.3, 8, latest
 Architectures: amd64, arm64v8
 GitCommit: 353fa8d247cbd59779324d57e8cb8c4ce32a5308
 Directory: 8.3


### PR DESCRIPTION
Fixes https://github.com/docker-library/mongo/issues/768