### PR TITLE
Bump IBM Java version to 8.0.8.71

### DIFF
--- a/library/ibmjava
+++ b/library/ibmjava
@@ -6,16 +6,16 @@ GitFetch: refs/heads/main
 
 Tags: 8-jre, jre, 8, latest
 Architectures: amd64, ppc64le, s390x
-GitCommit: d909a041f0e0736b779516cac5a9612101d0eff5
+GitCommit: 49d2961216408b39f2bef2adb8a258a7c6ae94cf
 Directory: ibmjava/8/jre/ubuntu
 
 Tags: 8-sfj, sfj
 Architectures: amd64, ppc64le, s390x
-GitCommit: d909a041f0e0736b779516cac5a9612101d0eff5
+GitCommit: 49d2961216408b39f2bef2adb8a258a7c6ae94cf
 Directory: ibmjava/8/sfj/ubuntu
 
 Tags: 8-sdk, sdk
 Architectures: amd64, ppc64le, s390x
-GitCommit: d909a041f0e0736b779516cac5a9612101d0eff5
+GitCommit: 49d2961216408b39f2bef2adb8a258a7c6ae94cf
 Directory: ibmjava/8/sdk/ubuntu
 


### PR DESCRIPTION
Updated java8 docker files with 8.0.8.71 release.