### PR TITLE
influxdb3: release 3.11.3 enterprise

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: b71413740b6b7d70f55fa630f9de872cbfe0a368
+GitCommit: 2f9040b54411d1fae3239a9c034d1ea023e43eaf
 
 Tags: 1.13-data, 1.13.0-data
 Directory: influxdb/1.13/data
@@ -94,6 +94,6 @@ Tags: 3-core, 3.11-core, 3.11.2-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.11-core
 
-Tags: 3-enterprise, 3.11-enterprise, 3.11.2-enterprise, enterprise
+Tags: 3-enterprise, 3.11-enterprise, 3.11.3-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.11-enterprise


### PR DESCRIPTION
InfluxDB 3 Enterprise 3.11.3 (patch release).

- GitCommit -> influxdata/influxdata-docker@2f9040b54411d1fae3239a9c034d1ea023e43eaf (influxdata/influxdata-docker#915)
- influxdb/3.11-enterprise: 3.11.2 -> 3.11.3; tags 3-enterprise, 3.11-enterprise, 3.11.3-enterprise, enterprise
- influxdb/3.11-core unchanged at 3.11.2 (Enterprise-only patch; no Core 3.11.3)

Release: https://github.com/influxdata/influxdb/releases/tag/v3.11.3 (draft pending publication).