### PR TITLE
archlinux: Release 20260830.0.582275

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260823.0.578598
-GitCommit: edbfaa9363e61012cb4b73a97a0306b44291062f
-GitFetch: refs/tags/v20260823.0.578598
+Tags: latest, base, base-20260830.0.582275
+GitCommit: aa3a71ea6dc05d9c5028a4f92c0a4a16b265ee62
+GitFetch: refs/tags/v20260830.0.582275
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260823.0.578598
-GitCommit: edbfaa9363e61012cb4b73a97a0306b44291062f
-GitFetch: refs/tags/v20260823.0.578598
+Tags: base-devel, base-devel-20260830.0.582275
+GitCommit: aa3a71ea6dc05d9c5028a4f92c0a4a16b265ee62
+GitFetch: refs/tags/v20260830.0.582275
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260823.0.578598
-GitCommit: edbfaa9363e61012cb4b73a97a0306b44291062f
-GitFetch: refs/tags/v20260823.0.578598
+Tags: multilib-devel, multilib-devel-20260830.0.582275
+GitCommit: aa3a71ea6dc05d9c5028a4f92c0a4a16b265ee62
+GitFetch: refs/tags/v20260830.0.582275
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks