### PR TITLE
Update Semeru versions with 26_03 u1 release

### DIFF
--- a/library/ibm-semeru-runtimes
+++ b/library/ibm-semeru-runtimes
@@ -5,235 +5,235 @@ GitRepo: https://github.com/ibmruntimes/semeru-containers.git
 GitFetch: refs/heads/ibm
 
 #-----------------------------openj9 v8 images---------------------------------
-Tags: open-8.0.502.0-jdk-jammy, open-8-jdk-jammy
+Tags: open-8.0.504.0-jdk-jammy, open-8-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 8/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8.0.502.0-jdk-noble, open-8-jdk-noble
+Tags: open-8.0.504.0-jdk-noble, open-8-jdk-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 8/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-8.0.502.0-jdk-resolute, open-8-jdk-resolute
-SharedTags: open-8.0.502.0-jdk, open-8-jdk
+Tags: open-8.0.504.0-jdk-resolute, open-8-jdk-resolute
+SharedTags: open-8.0.504.0-jdk, open-8-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 8/jdk/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
-Tags: open-8.0.502.0-jre-jammy, open-8-jre-jammy
+Tags: open-8.0.504.0-jre-jammy, open-8-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 8/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-8.0.502.0-jre-noble, open-8-jre-noble
+Tags: open-8.0.504.0-jre-noble, open-8-jre-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 8/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-8.0.502.0-jre-resolute, open-8-jre-resolute
-SharedTags: open-8.0.502.0-jre, open-8-jre
+Tags: open-8.0.504.0-jre-resolute, open-8-jre-resolute
+SharedTags: open-8.0.504.0-jre, open-8-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 8/jre/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v11 images---------------------------------
-Tags: open-11.0.32.0-jdk-jammy, open-11-jdk-jammy
+Tags: open-11.0.32.10-jdk-jammy, open-11-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 11/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.32.0-jdk-noble, open-11-jdk-noble
+Tags: open-11.0.32.10-jdk-noble, open-11-jdk-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 11/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.32.0-jdk-resolute, open-11-jdk-resolute
-SharedTags: open-11.0.32.0-jdk, open-11-jdk
+Tags: open-11.0.32.10-jdk-resolute, open-11-jdk-resolute
+SharedTags: open-11.0.32.10-jdk, open-11-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 11/jdk/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.32.0-jre-jammy, open-11-jre-jammy
+Tags: open-11.0.32.10-jre-jammy, open-11-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 11/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.32.0-jre-noble, open-11-jre-noble
+Tags: open-11.0.32.10-jre-noble, open-11-jre-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 11/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-11.0.32.0-jre-resolute, open-11-jre-resolute
-SharedTags: open-11.0.32.0-jre, open-11-jre
+Tags: open-11.0.32.10-jre-resolute, open-11-jre-resolute
+SharedTags: open-11.0.32.10-jre, open-11-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 11/jre/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v17 images---------------------------------
-Tags: open-17.0.20.0-jdk-jammy, open-17-jdk-jammy
+Tags: open-17.0.20.10-jdk-jammy, open-17-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 17/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.20.0-jdk-noble, open-17-jdk-noble
+Tags: open-17.0.20.10-jdk-noble, open-17-jdk-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 17/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.20.0-jdk-resolute, open-17-jdk-resolute
-SharedTags: open-17.0.20.0-jdk, open-17-jdk
+Tags: open-17.0.20.10-jdk-resolute, open-17-jdk-resolute
+SharedTags: open-17.0.20.10-jdk, open-17-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 17/jdk/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.20.0-jre-jammy, open-17-jre-jammy
+Tags: open-17.0.20.10-jre-jammy, open-17-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 17/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.20.0-jre-noble, open-17-jre-noble
+Tags: open-17.0.20.10-jre-noble, open-17-jre-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 17/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-17.0.20.0-jre-resolute, open-17-jre-resolute
-SharedTags: open-17.0.20.0-jre, open-17-jre
+Tags: open-17.0.20.10-jre-resolute, open-17-jre-resolute
+SharedTags: open-17.0.20.10-jre, open-17-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 17/jre/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v21 images---------------------------------
-Tags: open-21.0.12.0-jdk-jammy, open-21-jdk-jammy
+Tags: open-21.0.12.10-jdk-jammy, open-21-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 21/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.12.0-jdk-noble, open-21-jdk-noble
+Tags: open-21.0.12.10-jdk-noble, open-21-jdk-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 21/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.12.0-jdk-resolute, open-21-jdk-resolute
-SharedTags: open-21.0.12.0-jdk, open-21-jdk
+Tags: open-21.0.12.10-jdk-resolute, open-21-jdk-resolute
+SharedTags: open-21.0.12.10-jdk, open-21-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 21/jdk/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.12.0-jre-jammy, open-21-jre-jammy
+Tags: open-21.0.12.10-jre-jammy, open-21-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 21/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.12.0-jre-noble, open-21-jre-noble
+Tags: open-21.0.12.10-jre-noble, open-21-jre-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 21/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-21.0.12.0-jre-resolute, open-21-jre-resolute
-SharedTags: open-21.0.12.0-jre, open-21-jre
+Tags: open-21.0.12.10-jre-resolute, open-21-jre-resolute
+SharedTags: open-21.0.12.10-jre, open-21-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 21/jre/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v25 images---------------------------------
-Tags: open-jdk-25.0.4.0-jdk-jammy, open-25-jdk-jammy
+Tags: open-jdk-25.0.4.10-jdk-jammy, open-25-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 25/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.4.0-jdk-noble, open-25-jdk-noble
+Tags: open-jdk-25.0.4.10-jdk-noble, open-25-jdk-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 25/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.4.0-jdk-resolute, open-25-jdk-resolute
-SharedTags: open-jdk-25.0.4.0-jdk, open-25-jdk
+Tags: open-jdk-25.0.4.10-jdk-resolute, open-25-jdk-resolute
+SharedTags: open-jdk-25.0.4.10-jdk, open-25-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 25/jdk/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.4.0-jre-jammy, open-25-jre-jammy
+Tags: open-jdk-25.0.4.10-jre-jammy, open-25-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 25/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.4.0-jre-noble, open-25-jre-noble
+Tags: open-jdk-25.0.4.10-jre-noble, open-25-jre-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 25/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-jdk-25.0.4.0-jre-resolute, open-25-jre-resolute
-SharedTags: open-jdk-25.0.4.0-jre, open-25-jre
+Tags: open-jdk-25.0.4.10-jre-resolute, open-25-jre-resolute
+SharedTags: open-jdk-25.0.4.10-jre, open-25-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 25/jre/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
 #-----------------------------openj9 v26 images---------------------------------
-Tags: open-26.0.2.0-jdk-jammy, open-26-jdk-jammy
+Tags: open-26.0.2.10-jdk-jammy, open-26-jdk-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 26/jdk/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-26.0.2.0-jdk-noble, open-26-jdk-noble
+Tags: open-26.0.2.10-jdk-noble, open-26-jdk-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 26/jdk/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-26.0.2.0-jdk-resolute, open-26-jdk-resolute
-SharedTags: open-26.0.2.0-jdk, open-26-jdk
+Tags: open-26.0.2.10-jdk-resolute, open-26-jdk-resolute
+SharedTags: open-26.0.2.10-jdk, open-26-jdk
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 26/jdk/ubuntu/resolute
 File: Dockerfile.open.releases.full
 
-Tags: open-26.0.2.0-jre-jammy, open-26-jre-jammy
+Tags: open-26.0.2.10-jre-jammy, open-26-jre-jammy
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 26/jre/ubuntu/jammy
 File: Dockerfile.open.releases.full
 
-Tags: open-26.0.2.0-jre-noble, open-26-jre-noble
+Tags: open-26.0.2.10-jre-noble, open-26-jre-noble
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 26/jre/ubuntu/noble
 File: Dockerfile.open.releases.full
 
-Tags: open-26.0.2.0-jre-resolute, open-26-jre-resolute
-SharedTags: open-26.0.2.0-jre, open-26-jre
+Tags: open-26.0.2.10-jre-resolute, open-26-jre-resolute
+SharedTags: open-26.0.2.10-jre, open-26-jre
 Architectures: amd64, ppc64le, s390x, arm64v8
-GitCommit: 76f7f5a3258c82298f1a474606d44c450be73cc2
+GitCommit: 9cae183f9c91b85c7f28282fa5c69827b4028e0f
 Directory: 26/jre/ubuntu/resolute
 File: Dockerfile.open.releases.full


### PR DESCRIPTION
Updated OE and CE releases 8.0.504.0,11.0.32.10,17.0.20.10,21.0.12.10,25.0.4.10,26.0.2.10.