### PR TITLE
Update ELK images for 8.19.21 and 9.4.6

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -3,10 +3,10 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: elasticsearch
 Builder: buildkit
 
-Tags: 8.19.20
+Tags: 8.19.21
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
-GitCommit: 65e33330fd4152f5bc6c4f85c098de67401e1fa5
+GitCommit: ed80d28be98db297818205087153ff8ef01440f2
 
 Tags: 9.4.5
 Architectures: amd64, arm64v8

--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -8,10 +8,10 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
 GitCommit: ed80d28be98db297818205087153ff8ef01440f2
 
-Tags: 9.4.5
+Tags: 9.4.6
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.4
-GitCommit: f157a1e5cea700c6504440331c5cf9999062a98c
+GitCommit: 25fdea1109a231cedf9d1d3cf78bbb7fce488561
 
 Tags: 9.5.2
 Architectures: amd64, arm64v8

--- a/library/kibana
+++ b/library/kibana
@@ -8,10 +8,10 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
 GitCommit: ed80d28be98db297818205087153ff8ef01440f2
 
-Tags: 9.4.5
+Tags: 9.4.6
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.4
-GitCommit: f157a1e5cea700c6504440331c5cf9999062a98c
+GitCommit: 25fdea1109a231cedf9d1d3cf78bbb7fce488561
 
 Tags: 9.5.2
 Architectures: amd64, arm64v8

--- a/library/kibana
+++ b/library/kibana
@@ -3,10 +3,10 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: kibana
 Builder: buildkit
 
-Tags: 8.19.20
+Tags: 8.19.21
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
-GitCommit: 65e33330fd4152f5bc6c4f85c098de67401e1fa5
+GitCommit: ed80d28be98db297818205087153ff8ef01440f2
 
 Tags: 9.4.5
 Architectures: amd64, arm64v8

--- a/library/logstash
+++ b/library/logstash
@@ -8,10 +8,10 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
 GitCommit: ed80d28be98db297818205087153ff8ef01440f2
 
-Tags: 9.4.5
+Tags: 9.4.6
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.4
-GitCommit: f157a1e5cea700c6504440331c5cf9999062a98c
+GitCommit: 25fdea1109a231cedf9d1d3cf78bbb7fce488561
 
 Tags: 9.5.2
 Architectures: amd64, arm64v8

--- a/library/logstash
+++ b/library/logstash
@@ -3,10 +3,10 @@ GitRepo: https://github.com/elastic/dockerfiles.git
 Directory: logstash
 Builder: buildkit
 
-Tags: 8.19.20
+Tags: 8.19.21
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/8.19
-GitCommit: 65e33330fd4152f5bc6c4f85c098de67401e1fa5
+GitCommit: ed80d28be98db297818205087153ff8ef01440f2
 
 Tags: 9.4.5
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update ELK stack images for 8.19.21 and 9.4.6 releases.