### PR TITLE
Update 6 to 6.62.0, Update 6-next to 6.62.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,22 +2,20 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 653aed98404d4e3428aa09a77347a2d3d7d775f2
+GitCommit: aa41ad81c41b2594a77125c9311f84ddbcd727ee
 
-Tags: 6.61.0-bookworm, 6.61.0, 6.61-bookworm, 6.61, 6-bookworm, 6, bookworm, latest
+Tags: 6.62.0-bookworm, 6.62.0, 6.62-bookworm, 6.62, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.61.0-alpine3.23, 6.61.0-alpine, 6.61-alpine3.23, 6.61-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.62.0-alpine3.23, 6.62.0-alpine, 6.62-alpine3.23, 6.62-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8
 
-Tags: 6.61.0-next-bookworm, 6.61.0-next, 6.61-next-bookworm, 6.61-next, 6-next-bookworm, 6-next, next-bookworm, next
+Tags: 6.62.0-next-bookworm, 6.62.0-next, 6.62-next-bookworm, 6.62-next, 6-next-bookworm, 6-next, next-bookworm, next
 Directory: 6-next/bookworm
 Architectures: amd64, arm32v7, arm64v8
-Builder: buildkit
 
-Tags: 6.61.0-next-alpine3.23, 6.61.0-next-alpine, 6.61-next-alpine3.23, 6.61-next-alpine, 6-next-alpine3.23, 6-next-alpine, next-alpine3.23, next-alpine
+Tags: 6.62.0-next-alpine3.23, 6.62.0-next-alpine, 6.62-next-alpine3.23, 6.62-next-alpine, 6-next-alpine3.23, 6-next-alpine, next-alpine3.23, next-alpine
 Directory: 6-next/alpine3.23
 Architectures: amd64, arm64v8
-Builder: buildkit


### PR DESCRIPTION
Update 6 to 6.62.0, Update 6-next to 6.62.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/aa41ad81c41b2594a77125c9311f84ddbcd727ee.