### PR TITLE
nginx updates

### DIFF
--- a/library/nginx
+++ b/library/nginx
@@ -3,72 +3,72 @@
 Maintainers: NGINX Docker Maintainers <docker-maint@nginx.com> (@nginx)
 GitRepo: https://github.com/nginx/docker-nginx.git
 
-Tags: 1.31.4, mainline, 1, 1.31, latest, 1.31.4-trixie, mainline-trixie, 1-trixie, 1.31-trixie, trixie
+Tags: 1.31.5, mainline, 1, 1.31, latest, 1.31.5-trixie, mainline-trixie, 1-trixie, 1.31-trixie, trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/debian
 
-Tags: 1.31.4-perl, mainline-perl, 1-perl, 1.31-perl, perl, 1.31.4-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.31-trixie-perl, trixie-perl
+Tags: 1.31.5-perl, mainline-perl, 1-perl, 1.31-perl, perl, 1.31.5-trixie-perl, mainline-trixie-perl, 1-trixie-perl, 1.31-trixie-perl, trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/debian-perl
 
-Tags: 1.31.4-otel, mainline-otel, 1-otel, 1.31-otel, otel, 1.31.4-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.31-trixie-otel, trixie-otel
+Tags: 1.31.5-otel, mainline-otel, 1-otel, 1.31-otel, otel, 1.31.5-trixie-otel, mainline-trixie-otel, 1-trixie-otel, 1.31-trixie-otel, trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/debian-otel
 
-Tags: 1.31.4-alpine, mainline-alpine, 1-alpine, 1.31-alpine, alpine, 1.31.4-alpine3.24, mainline-alpine3.24, 1-alpine3.24, 1.31-alpine3.24, alpine3.24
+Tags: 1.31.5-alpine, mainline-alpine, 1-alpine, 1.31-alpine, alpine, 1.31.5-alpine3.24, mainline-alpine3.24, 1-alpine3.24, 1.31-alpine3.24, alpine3.24
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/alpine
 
-Tags: 1.31.4-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.31-alpine-perl, alpine-perl, 1.31.4-alpine3.24-perl, mainline-alpine3.24-perl, 1-alpine3.24-perl, 1.31-alpine3.24-perl, alpine3.24-perl
+Tags: 1.31.5-alpine-perl, mainline-alpine-perl, 1-alpine-perl, 1.31-alpine-perl, alpine-perl, 1.31.5-alpine3.24-perl, mainline-alpine3.24-perl, 1-alpine3.24-perl, 1.31-alpine3.24-perl, alpine3.24-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/alpine-perl
 
-Tags: 1.31.4-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.31-alpine-slim, alpine-slim, 1.31.4-alpine3.24-slim, mainline-alpine3.24-slim, 1-alpine3.24-slim, 1.31-alpine3.24-slim, alpine3.24-slim
+Tags: 1.31.5-alpine-slim, mainline-alpine-slim, 1-alpine-slim, 1.31-alpine-slim, alpine-slim, 1.31.5-alpine3.24-slim, mainline-alpine3.24-slim, 1-alpine3.24-slim, 1.31-alpine3.24-slim, alpine3.24-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/alpine-slim
 
-Tags: 1.31.4-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.31-alpine-otel, alpine-otel, 1.31.4-alpine3.24-otel, mainline-alpine3.24-otel, 1-alpine3.24-otel, 1.31-alpine3.24-otel, alpine3.24-otel
+Tags: 1.31.5-alpine-otel, mainline-alpine-otel, 1-alpine-otel, 1.31-alpine-otel, alpine-otel, 1.31.5-alpine3.24-otel, mainline-alpine3.24-otel, 1-alpine3.24-otel, 1.31-alpine3.24-otel, alpine3.24-otel
 Architectures: amd64, arm64v8
-GitCommit: b8590bd36b4504b9b847fcf2e98a9111dcae85fa
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: mainline/alpine-otel
 
 Tags: 1.30.4, stable, 1.30, 1.30.4-trixie, stable-trixie, 1.30-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/debian
 
 Tags: 1.30.4-perl, stable-perl, 1.30-perl, 1.30.4-trixie-perl, stable-trixie-perl, 1.30-trixie-perl
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/debian-perl
 
 Tags: 1.30.4-otel, stable-otel, 1.30-otel, 1.30.4-trixie-otel, stable-trixie-otel, 1.30-trixie-otel
 Architectures: amd64, arm64v8
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/debian-otel
 
 Tags: 1.30.4-alpine, stable-alpine, 1.30-alpine, 1.30.4-alpine3.24, stable-alpine3.24, 1.30-alpine3.24
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/alpine
 
 Tags: 1.30.4-alpine-perl, stable-alpine-perl, 1.30-alpine-perl, 1.30.4-alpine3.24-perl, stable-alpine3.24-perl, 1.30-alpine3.24-perl
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/alpine-perl
 
 Tags: 1.30.4-alpine-slim, stable-alpine-slim, 1.30-alpine-slim, 1.30.4-alpine3.24-slim, stable-alpine3.24-slim, 1.30-alpine3.24-slim
 Architectures: arm64v8, arm32v6, arm32v7, ppc64le, s390x, i386, amd64, riscv64
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/alpine-slim
 
 Tags: 1.30.4-alpine-otel, stable-alpine-otel, 1.30-alpine-otel, 1.30.4-alpine3.24-otel, stable-alpine3.24-otel, 1.30-alpine3.24-otel
 Architectures: amd64, arm64v8
-GitCommit: ccdab6c99ae2e2fc53a144dc68d6b8f44163adf2
+GitCommit: c5b3ce398e37067d93ab1edf803e9b96a1116092
 Directory: stable/alpine-otel


### PR DESCRIPTION
- mainline nginx gets a bump to 1.31.5
- njs gets a bump to 1.0.1 for both mainline and stable