### PR TITLE
Update ELK images for 9.5.3

### DIFF
--- a/library/elasticsearch
+++ b/library/elasticsearch
@@ -13,7 +13,7 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.4
 GitCommit: 25fdea1109a231cedf9d1d3cf78bbb7fce488561
 
-Tags: 9.5.2
+Tags: 9.5.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.5
-GitCommit: 2f483686931c1a423f1a7a3efe79d2aa58bc8a42
+GitCommit: 18bba4670aa9212cd0c5e8aeff5aa2f23d7f652a

--- a/library/kibana
+++ b/library/kibana
@@ -13,7 +13,7 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.4
 GitCommit: 25fdea1109a231cedf9d1d3cf78bbb7fce488561
 
-Tags: 9.5.2
+Tags: 9.5.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.5
-GitCommit: 2f483686931c1a423f1a7a3efe79d2aa58bc8a42
+GitCommit: 18bba4670aa9212cd0c5e8aeff5aa2f23d7f652a

--- a/library/logstash
+++ b/library/logstash
@@ -13,7 +13,7 @@ Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.4
 GitCommit: 25fdea1109a231cedf9d1d3cf78bbb7fce488561
 
-Tags: 9.5.2
+Tags: 9.5.3
 Architectures: amd64, arm64v8
 GitFetch: refs/heads/9.5
-GitCommit: 2f483686931c1a423f1a7a3efe79d2aa58bc8a42
+GitCommit: 18bba4670aa9212cd0c5e8aeff5aa2f23d7f652a


### PR DESCRIPTION
Update Elasticsearch, Kibana, and Logstash official images to version 9.5.3.