### PR TITLE
Add amazonlinux releases

### DIFF
--- a/library/amazonlinux
+++ b/library/amazonlinux
@@ -11,16 +11,23 @@ Maintainers: Amazon Linux <amazon-linux@amazon.com> (@amazonlinux),
 GitRepo: https://github.com/amazonlinux/container-images.git
 GitCommit: cc7a1876866f4056fa73a789a5b758358151c189
 
-Tags: 2023, latest, 2023.12.20260817.0
+Tags: 2023, latest, 2023.12.20260831.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/al2023
-amd64-GitCommit: bdaec0a0c2b5f325aaabb4d80c13b54edb0ca41b
+amd64-GitCommit: b8bc4d92c50ce09a7fc7c9e383305ce6f5f5ac55
 arm64v8-GitFetch: refs/heads/al2023-arm64
-arm64v8-GitCommit: 252bddbcc2673e736f5690780c62a7f3aa9f965f
+arm64v8-GitCommit: 9b29d37c934a985b589bbdccb84553ceed9d2f53
 
-Tags: 2, 2.0.20260825.0
+Tags: 2, 2.0.20260831.0
 Architectures: amd64, arm64v8
 amd64-GitFetch: refs/heads/amzn2
-amd64-GitCommit: 2e18b8c24e61398cbc57ef9e4256c3e41c31109d
+amd64-GitCommit: 02547aa61f35c92969df4d63db6de49e7f83a444
 arm64v8-GitFetch: refs/heads/amzn2-arm64
-arm64v8-GitCommit: ef2c940dc039d760a782b854fcfd721df9cf9a91
+arm64v8-GitCommit: 65d37573062b30ebb68ab11e4340e9a02e3db4ab
+
+Tags: 2027, 2027.0.20260903.0
+Architectures: amd64, arm64v8
+amd64-GitFetch: refs/heads/al2027
+amd64-GitCommit: aefc00b1e0db0a7ef1f5c89bbfaa300d1072eec3
+arm64v8-GitFetch: refs/heads/al2027-arm64
+arm64v8-GitCommit: 9251c1fce0017819a9fc6c81344f6d181cbd18a2


### PR DESCRIPTION
Updated Packages for Amazon Linux 2:
- vim-minimal-9.0.2153-1.amzn2.0.11
- vim-data-9.0.2153-1.amzn2.0.11

Updated Packages for Amazon Linux 2023:
- openssl-fips-provider-latest-3.5.7-2.amzn2023.0.2
- amazon-linux-repo-cdn-2023.12.20260831-0.amzn2023
- system-release-2023.12.20260831-0.amzn2023
- openssl-libs-3.5.7-2.amzn2023.0.2
- python3-pip-wheel-21.3.1-2.amzn2023.0.21