### PR TITLE
Update haproxy

### DIFF
--- a/library/haproxy
+++ b/library/haproxy
@@ -4,14 +4,14 @@ Maintainers: Tianon Gravi <admwiggin@gmail.com> (@tianon),
              Joseph Ferguson <yosifkit@gmail.com> (@yosifkit)
 GitRepo: https://github.com/docker-library/haproxy.git
 
-Tags: 3.5-dev5, 3.5-dev, 3.5-dev5-trixie, 3.5-dev-trixie
+Tags: 3.5-dev6, 3.5-dev, 3.5-dev6-trixie, 3.5-dev-trixie
 Architectures: amd64, arm32v5, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9c550cab84dacefb80a7fdde0dc5241d473ff554
+GitCommit: efe5fe70213c9d19e9f13e21c8c7160fa6648e30
 Directory: 3.5
 
-Tags: 3.5-dev5-alpine, 3.5-dev-alpine, 3.5-dev5-alpine3.24, 3.5-dev-alpine3.24
+Tags: 3.5-dev6-alpine, 3.5-dev-alpine, 3.5-dev6-alpine3.24, 3.5-dev-alpine3.24
 Architectures: amd64, arm32v6, arm32v7, arm64v8, i386, ppc64le, riscv64, s390x
-GitCommit: 9c550cab84dacefb80a7fdde0dc5241d473ff554
+GitCommit: efe5fe70213c9d19e9f13e21c8c7160fa6648e30
 Directory: 3.5/alpine
 
 Tags: 3.4.4, 3.4, latest, lts, 3.4.4-trixie, 3.4-trixie, trixie, lts-trixie


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/haproxy/commit/efe5fe7: Update 3.5 to 3.5-dev6