### PR TITLE
Update Rust to 1.98.1, remove `bullseye` images

### DIFF
--- a/library/rust
+++ b/library/rust
@@ -5,53 +5,53 @@ Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
 
-Tags: 1-bullseye, 1.98-bullseye, 1.98.0-bullseye, bullseye
+Tags: 1-bullseye, 1.98-bullseye, 1.98.1-bullseye, bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/bullseye
 
-Tags: 1-slim-bullseye, 1.98-slim-bullseye, 1.98.0-slim-bullseye, slim-bullseye
+Tags: 1-slim-bullseye, 1.98-slim-bullseye, 1.98.1-slim-bullseye, slim-bullseye
 Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/bullseye/slim
 
-Tags: 1-bookworm, 1.98-bookworm, 1.98.0-bookworm, bookworm
+Tags: 1-bookworm, 1.98-bookworm, 1.98.1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/bookworm
 
-Tags: 1-slim-bookworm, 1.98-slim-bookworm, 1.98.0-slim-bookworm, slim-bookworm
+Tags: 1-slim-bookworm, 1.98-slim-bookworm, 1.98.1-slim-bookworm, slim-bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/bookworm/slim
 
-Tags: 1-trixie, 1.98-trixie, 1.98.0-trixie, trixie, 1, 1.98, 1.98.0, latest
+Tags: 1-trixie, 1.98-trixie, 1.98.1-trixie, trixie, 1, 1.98, 1.98.1, latest
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/trixie
 
-Tags: 1-slim-trixie, 1.98-slim-trixie, 1.98.0-slim-trixie, slim-trixie, 1-slim, 1.98-slim, 1.98.0-slim, slim
+Tags: 1-slim-trixie, 1.98-slim-trixie, 1.98.1-slim-trixie, slim-trixie, 1-slim, 1.98-slim, 1.98.1-slim, slim
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le, s390x, riscv64
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/trixie/slim
 
-Tags: 1-alpine3.21, 1.98-alpine3.21, 1.98.0-alpine3.21, alpine3.21
+Tags: 1-alpine3.21, 1.98-alpine3.21, 1.98.1-alpine3.21, alpine3.21
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/alpine3.21
 
-Tags: 1-alpine3.22, 1.98-alpine3.22, 1.98.0-alpine3.22, alpine3.22
+Tags: 1-alpine3.22, 1.98-alpine3.22, 1.98.1-alpine3.22, alpine3.22
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/alpine3.22
 
-Tags: 1-alpine3.23, 1.98-alpine3.23, 1.98.0-alpine3.23, alpine3.23
+Tags: 1-alpine3.23, 1.98-alpine3.23, 1.98.1-alpine3.23, alpine3.23
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/alpine3.23
 
-Tags: 1-alpine3.24, 1.98-alpine3.24, 1.98.0-alpine3.24, alpine3.24, 1-alpine, 1.98-alpine, 1.98.0-alpine, alpine
+Tags: 1-alpine3.24, 1.98-alpine3.24, 1.98.1-alpine3.24, alpine3.24, 1-alpine, 1.98-alpine, 1.98.1-alpine, alpine
 Architectures: amd64, arm64v8, ppc64le
-GitCommit: 7e8ce3f02e3f0292a54b9212ccad6204bde54289
+GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
 Directory: stable/alpine3.24
 

--- a/library/rust
+++ b/library/rust
@@ -1,19 +1,9 @@
-# this file is generated via https://github.com/rust-lang/docker-rust/blob/5ba8fc7544e1880d0fc5f56e9f11081082057dc2/x.py
+# this file is generated via https://github.com/rust-lang/docker-rust/blob/f7c674218ef70515d4ed95a0527baedaa066aceb/x.py
 
 Maintainers: Steven Fackler <sfackler@gmail.com> (@sfackler),
              Scott Schafer <schaferjscott@gmail.com> (@Muscraft),
              Jakub Beránek <berykubik@gmail.com> (@kobzol)
 GitRepo: https://github.com/rust-lang/docker-rust.git
-
-Tags: 1-bullseye, 1.98-bullseye, 1.98.1-bullseye, bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
-Directory: stable/bullseye
-
-Tags: 1-slim-bullseye, 1.98-slim-bullseye, 1.98.1-slim-bullseye, slim-bullseye
-Architectures: amd64, arm32v7, arm64v8, i386
-GitCommit: 0fc94fa4d5bac5532a9adf8e4f8b0fe6deca7d44
-Directory: stable/bullseye/slim
 
 Tags: 1-bookworm, 1.98-bookworm, 1.98.1-bookworm, bookworm
 Architectures: amd64, arm32v7, arm64v8, i386, ppc64le


### PR DESCRIPTION
https://github.com/rust-lang/rust/releases/tag/1.98.1
https://blog.rust-lang.org/2026/09/03/Rust-1.98.1/

This change also removes the `bullseye` images, as they are no longer supported. 

https://www.debian.org/News/2026/20260831