### PR TITLE
Bump Traefik to v3.7.13, v2.11.57

### DIFF
--- a/library/traefik
+++ b/library/traefik
@@ -1,69 +1,69 @@
 Maintainers: Julien Salleyron <julien@traefik.io> (@juliens), Romain Tribotté <romain.tribotte@traefik.io> (@rtribotte), Michael Matur <michael@traefik.io> (@mmatur), Kevin Pollet <kevin.pollet@traefik.io> (@kevinpollet), Tom Moulard <tom.moulard@traefik.io> (@tommoulard)
 
-Tags: v3.7.12-windowsservercore-ltsc2025, 3.7.12-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
+Tags: v3.7.13-windowsservercore-ltsc2025, 3.7.13-windowsservercore-ltsc2025, v3.7-windowsservercore-ltsc2025, 3.7-windowsservercore-ltsc2025, langres-windowsservercore-ltsc2025, v3-windowsservercore-ltsc2025, 3-windowsservercore-ltsc2025, windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6154367ea1927cc5cee06f8d0feac3e33aa8771e
+GitCommit: 06814bb30ce37fe65a09268ea792eec6e037dff5
 Directory: v3.7/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v3.7.12-windowsservercore-ltsc2022, 3.7.12-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
+Tags: v3.7.13-windowsservercore-ltsc2022, 3.7.13-windowsservercore-ltsc2022, v3.7-windowsservercore-ltsc2022, 3.7-windowsservercore-ltsc2022, langres-windowsservercore-ltsc2022, v3-windowsservercore-ltsc2022, 3-windowsservercore-ltsc2022, windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6154367ea1927cc5cee06f8d0feac3e33aa8771e
+GitCommit: 06814bb30ce37fe65a09268ea792eec6e037dff5
 Directory: v3.7/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v3.7.12-nanoserver-ltsc2025, 3.7.12-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
+Tags: v3.7.13-nanoserver-ltsc2025, 3.7.13-nanoserver-ltsc2025, v3.7-nanoserver-ltsc2025, 3.7-nanoserver-ltsc2025, langres-nanoserver-ltsc2025, v3-nanoserver-ltsc2025, 3-nanoserver-ltsc2025, nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6154367ea1927cc5cee06f8d0feac3e33aa8771e
+GitCommit: 06814bb30ce37fe65a09268ea792eec6e037dff5
 Directory: v3.7/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v3.7.12-nanoserver-ltsc2022, 3.7.12-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
+Tags: v3.7.13-nanoserver-ltsc2022, 3.7.13-nanoserver-ltsc2022, v3.7-nanoserver-ltsc2022, 3.7-nanoserver-ltsc2022, langres-nanoserver-ltsc2022, v3-nanoserver-ltsc2022, 3-nanoserver-ltsc2022, nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6154367ea1927cc5cee06f8d0feac3e33aa8771e
+GitCommit: 06814bb30ce37fe65a09268ea792eec6e037dff5
 Directory: v3.7/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v3.7.12, 3.7.12, v3.7, 3.7, langres, v3, 3, latest
+Tags: v3.7.13, 3.7.13, v3.7, 3.7, langres, v3, 3, latest
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: 6154367ea1927cc5cee06f8d0feac3e33aa8771e
+GitCommit: 06814bb30ce37fe65a09268ea792eec6e037dff5
 Directory: v3.7/alpine
 
-Tags: v2.11.56-windowsservercore-ltsc2025, 2.11.56-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025
+Tags: v2.11.57-windowsservercore-ltsc2025, 2.11.57-windowsservercore-ltsc2025, v2.11-windowsservercore-ltsc2025, 2.11-windowsservercore-ltsc2025, mimolette-windowsservercore-ltsc2025, v2-windowsservercore-ltsc2025, 2-windowsservercore-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e1a2d657cbaf082450c091fbc653cf2e413e0a5c
+GitCommit: eb04607952dc3fca148cae1469c32845970182e1
 Directory: v2.11/windows/servercore-ltsc2025
 Constraints: windowsservercore-ltsc2025
 
-Tags: v2.11.56-windowsservercore-ltsc2022, 2.11.56-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
+Tags: v2.11.57-windowsservercore-ltsc2022, 2.11.57-windowsservercore-ltsc2022, v2.11-windowsservercore-ltsc2022, 2.11-windowsservercore-ltsc2022, mimolette-windowsservercore-ltsc2022, v2-windowsservercore-ltsc2022, 2-windowsservercore-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e1a2d657cbaf082450c091fbc653cf2e413e0a5c
+GitCommit: eb04607952dc3fca148cae1469c32845970182e1
 Directory: v2.11/windows/servercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: v2.11.56-nanoserver-ltsc2025, 2.11.56-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025
+Tags: v2.11.57-nanoserver-ltsc2025, 2.11.57-nanoserver-ltsc2025, v2.11-nanoserver-ltsc2025, 2.11-nanoserver-ltsc2025, mimolette-nanoserver-ltsc2025, v2-nanoserver-ltsc2025, 2-nanoserver-ltsc2025
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e1a2d657cbaf082450c091fbc653cf2e413e0a5c
+GitCommit: eb04607952dc3fca148cae1469c32845970182e1
 Directory: v2.11/windows/nanoserver-ltsc2025
 Constraints: nanoserver-ltsc2025, windowsservercore-ltsc2025
 
-Tags: v2.11.56-nanoserver-ltsc2022, 2.11.56-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
+Tags: v2.11.57-nanoserver-ltsc2022, 2.11.57-nanoserver-ltsc2022, v2.11-nanoserver-ltsc2022, 2.11-nanoserver-ltsc2022, mimolette-nanoserver-ltsc2022, v2-nanoserver-ltsc2022, 2-nanoserver-ltsc2022
 Architectures: windows-amd64
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e1a2d657cbaf082450c091fbc653cf2e413e0a5c
+GitCommit: eb04607952dc3fca148cae1469c32845970182e1
 Directory: v2.11/windows/nanoserver-ltsc2022
 Constraints: nanoserver-ltsc2022, windowsservercore-ltsc2022
 
-Tags: v2.11.56, 2.11.56, v2.11, 2.11, mimolette, v2, 2
+Tags: v2.11.57, 2.11.57, v2.11, 2.11, mimolette, v2, 2
 Architectures: amd64, arm32v6, arm64v8, ppc64le, riscv64, s390x
 GitRepo: https://github.com/traefik/traefik-library-image.git
-GitCommit: e1a2d657cbaf082450c091fbc653cf2e413e0a5c
+GitCommit: eb04607952dc3fca148cae1469c32845970182e1
 Directory: v2.11/alpine


### PR DESCRIPTION

Hello,

This PR updates Traefik to:
- [v3.7.13](https://github.com/traefik/traefik/releases/tag/v3.7.13)
- [v2.11.57](https://github.com/traefik/traefik/releases/tag/v2.11.57)

/cc @mmatur @rtribotte @nmengin

Cheers
