### PR TITLE
haxe: use ocaml 5.5.1 to compile haxe 5, remove bullseye

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -13,11 +13,6 @@ Architectures: amd64, arm32v7, arm64v8
 GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
 Directory: 4.3/bookworm
 
-Tags: 4.3.7-bullseye, 4.3-bullseye
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
-Directory: 4.3/bullseye
-
 Tags: 4.3.7-windowsservercore-ltsc2025, 4.3-windowsservercore-ltsc2025
 SharedTags: 4.3.7-windowsservercore, 4.3-windowsservercore, 4.3.7, 4.3, latest
 Architectures: windows-amd64
@@ -55,18 +50,13 @@ Directory: 4.3/alpine3.21
 Tags: 5.0.0-preview.1-trixie, 5.0.0-trixie, 5.0-trixie
 SharedTags: 5.0.0-preview.1, 5.0.0, 5.0
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2d4b15f59eb23f1f2232b1d247b1d4400f13db1f
+GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
 Directory: 5.0/trixie
 
 Tags: 5.0.0-preview.1-bookworm, 5.0.0-bookworm, 5.0-bookworm
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
+GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
 Directory: 5.0/bookworm
-
-Tags: 5.0.0-preview.1-bullseye, 5.0.0-bullseye, 5.0-bullseye
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
-Directory: 5.0/bullseye
 
 Tags: 5.0.0-preview.1-windowsservercore-ltsc2025, 5.0.0-windowsservercore-ltsc2025, 5.0-windowsservercore-ltsc2025
 SharedTags: 5.0.0-preview.1-windowsservercore, 5.0.0-windowsservercore, 5.0-windowsservercore, 5.0.0-preview.1, 5.0.0, 5.0
@@ -84,22 +74,22 @@ Constraints: windowsservercore-ltsc2022
 
 Tags: 5.0.0-preview.1-alpine3.24, 5.0.0-preview.1-alpine, 5.0.0-alpine3.24, 5.0-alpine3.24, 5.0.0-alpine, 5.0-alpine
 Architectures: amd64, arm64v8
-GitCommit: a6da5fc1fdee9a0fe1a35ab0a85f370071849112
+GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
 Directory: 5.0/alpine3.24
 
 Tags: 5.0.0-preview.1-alpine3.23, 5.0.0-alpine3.23, 5.0-alpine3.23
 Architectures: amd64, arm64v8
-GitCommit: b235f810bf048b25bc8fc70ef20915452a5a76f9
+GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
 Directory: 5.0/alpine3.23
 
 Tags: 5.0.0-preview.1-alpine3.22, 5.0.0-alpine3.22, 5.0-alpine3.22
 Architectures: amd64, arm64v8
-GitCommit: 29c1c10f60a3d5d96c92c23ed8d07f5393c962b5
+GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
 Directory: 5.0/alpine3.22
 
 Tags: 5.0.0-preview.1-alpine3.21, 5.0.0-alpine3.21, 5.0-alpine3.21
 Architectures: amd64, arm64v8
-GitCommit: 29c1c10f60a3d5d96c92c23ed8d07f5393c962b5
+GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
 Directory: 5.0/alpine3.21
 
 Tags: 4.2.5-bookworm, 4.2-bookworm
@@ -107,11 +97,6 @@ SharedTags: 4.2.5, 4.2
 Architectures: amd64, arm32v7, arm64v8
 GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
 Directory: 4.2/bookworm
-
-Tags: 4.2.5-bullseye, 4.2-bullseye
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
-Directory: 4.2/bullseye
 
 Tags: 4.2.5-windowsservercore-ltsc2025, 4.2-windowsservercore-ltsc2025
 SharedTags: 4.2.5-windowsservercore, 4.2-windowsservercore, 4.2.5, 4.2
@@ -127,12 +112,6 @@ GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.2/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
 
-Tags: 4.1.5-bullseye, 4.1-bullseye
-SharedTags: 4.1.5, 4.1
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
-Directory: 4.1/bullseye
-
 Tags: 4.1.5-windowsservercore-ltsc2025, 4.1-windowsservercore-ltsc2025
 SharedTags: 4.1.5-windowsservercore, 4.1-windowsservercore, 4.1.5, 4.1
 Architectures: windows-amd64
@@ -146,12 +125,6 @@ Architectures: windows-amd64
 GitCommit: c0367972017a7b87845bf33477e29b1fe64ccc4a
 Directory: 4.1/windowsservercore-ltsc2022
 Constraints: windowsservercore-ltsc2022
-
-Tags: 4.0.5-bullseye, 4.0-bullseye
-SharedTags: 4.0.5, 4.0
-Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2636eee6b67d0c99730e4ab1d0d752d66809e3fa
-Directory: 4.0/bullseye
 
 Tags: 4.0.5-windowsservercore-ltsc2025, 4.0-windowsservercore-ltsc2025
 SharedTags: 4.0.5-windowsservercore, 4.0-windowsservercore, 4.0.5, 4.0


### PR DESCRIPTION
 * Use ocaml 5.5.1 to compile haxe 5, re. https://github.com/HaxeFoundation/docker-library-haxe/issues/14
 * remove bullseye which the LTS reached EOL

