### PR TITLE
influxdb: 3.9.13, 3.10.6, 3.11.4

### DIFF
--- a/library/influxdb
+++ b/library/influxdb
@@ -4,7 +4,7 @@ Maintainers: Brandon Pfeifer <bpfeifer@influxdata.com> (@bnpfeife),
              Praveenkumar Hemakumar <pkumar@influxdata.com> (@praveen-influx),
              Trevor Hilton <thilton@influxdata.com> (@hiltontj)
 GitRepo: https://github.com/influxdata/influxdata-docker
-GitCommit: 2f9040b54411d1fae3239a9c034d1ea023e43eaf
+GitCommit: c4978d4a9ebb34f1b8aebfabd1846d294b0f3852
 
 Tags: 1.13-data, 1.13.0-data
 Directory: influxdb/1.13/data
@@ -74,26 +74,26 @@ Tags: 2-alpine, 2.9-alpine, 2.9.1-alpine, alpine
 Architectures: amd64, arm64v8
 Directory: influxdb/2.9/alpine
 
-Tags: 3.9-core, 3.9.11-core
+Tags: 3.9-core, 3.9.13-core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-core
 
-Tags: 3.9-enterprise, 3.9.11-enterprise
+Tags: 3.9-enterprise, 3.9.13-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.9-enterprise
 
-Tags: 3.10-core, 3.10.5-core
+Tags: 3.10-core, 3.10.6-core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-core
 
-Tags: 3.10-enterprise, 3.10.5-enterprise
+Tags: 3.10-enterprise, 3.10.6-enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.10-enterprise
 
-Tags: 3-core, 3.11-core, 3.11.2-core, core
+Tags: 3-core, 3.11-core, 3.11.4-core, core
 Architectures: amd64, arm64v8
 Directory: influxdb/3.11-core
 
-Tags: 3-enterprise, 3.11-enterprise, 3.11.3-enterprise, enterprise
+Tags: 3-enterprise, 3.11-enterprise, 3.11.4-enterprise, enterprise
 Architectures: amd64, arm64v8
 Directory: influxdb/3.11-enterprise


### PR DESCRIPTION
Patch releases across the three supported InfluxDB 3 lines.

Changes: https://github.com/influxdata/influxdata-docker/compare/2f9040b54411d1fae3239a9c034d1ea023e43eaf...c4978d4a9ebb34f1b8aebfabd1846d294b0f3852