### PR TITLE
haxe: use ocaml 5.4.1 to compile haxe 5 on trixie

### DIFF
--- a/library/haxe
+++ b/library/haxe
@@ -50,7 +50,7 @@ Directory: 4.3/alpine3.21
 Tags: 5.0.0-preview.1-trixie, 5.0.0-trixie, 5.0-trixie
 SharedTags: 5.0.0-preview.1, 5.0.0, 5.0
 Architectures: amd64, arm32v7, arm64v8
-GitCommit: 2204a501180eac277a5c25375fdf2f8ee107ed3a
+GitCommit: aca4363c144c332aa3ab1905330d395d7f43a298
 Directory: 5.0/trixie
 
 Tags: 5.0.0-preview.1-bookworm, 5.0.0-bookworm, 5.0-bookworm


### PR DESCRIPTION
Re https://github.com/HaxeFoundation/docker-library-haxe/issues/15