### PR TITLE
archlinux: Release 20260906.0.587075

### DIFF
--- a/library/archlinux
+++ b/library/archlinux
@@ -5,18 +5,18 @@ Maintainers: Santiago Torres-Arias <santiago@archlinux.org> (@SantiagoTorres),
              Justin Kromlinger <hashworks@archlinux.org> (@hashworks)
 GitRepo: https://gitlab.archlinux.org/archlinux/archlinux-docker.git
 
-Tags: latest, base, base-20260830.0.582275
-GitCommit: aa3a71ea6dc05d9c5028a4f92c0a4a16b265ee62
-GitFetch: refs/tags/v20260830.0.582275
+Tags: latest, base, base-20260906.0.587075
+GitCommit: 9b7cd5e184f371f7e5aecd406ff9d2f42c883b07
+GitFetch: refs/tags/v20260906.0.587075
 File: Dockerfile.base
 
-Tags: base-devel, base-devel-20260830.0.582275
-GitCommit: aa3a71ea6dc05d9c5028a4f92c0a4a16b265ee62
-GitFetch: refs/tags/v20260830.0.582275
+Tags: base-devel, base-devel-20260906.0.587075
+GitCommit: 9b7cd5e184f371f7e5aecd406ff9d2f42c883b07
+GitFetch: refs/tags/v20260906.0.587075
 File: Dockerfile.base-devel
 
-Tags: multilib-devel, multilib-devel-20260830.0.582275
-GitCommit: aa3a71ea6dc05d9c5028a4f92c0a4a16b265ee62
-GitFetch: refs/tags/v20260830.0.582275
+Tags: multilib-devel, multilib-devel-20260906.0.587075
+GitCommit: 9b7cd5e184f371f7e5aecd406ff9d2f42c883b07
+GitFetch: refs/tags/v20260906.0.587075
 File: Dockerfile.multilib-devel
 


### PR DESCRIPTION
This is an automated release [1].

[1] https://gitlab.archlinux.org/archlinux/archlinux-docker/-/blob/master/.gitlab-ci.yml

---

Maintainers: @SantiagoTorres @shibumi @hashworks