### PR TITLE
Update Spark versions to 3.5.9, 4.0.4, 4.1.3

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -6,122 +6,122 @@ Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark),
              Yikun Jiang (@Yikun)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 4.1.2-scala2.13-java21-python3-ubuntu, 4.1.2-java21-python3, 4.1.2-java21, python3, latest
+Tags: 4.1.3-scala2.13-java21-python3-ubuntu, 4.1.3-java21-python3, 4.1.3-java21, python3, latest
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java21-python3-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java21-python3-ubuntu
 
-Tags: 4.1.2-scala2.13-java21-r-ubuntu, 4.1.2-java21-r
+Tags: 4.1.3-scala2.13-java21-r-ubuntu, 4.1.3-java21-r
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java21-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java21-r-ubuntu
 
-Tags: 4.1.2-scala2.13-java21-ubuntu, 4.1.2-java21-scala
+Tags: 4.1.3-scala2.13-java21-ubuntu, 4.1.3-java21-scala
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java21-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java21-ubuntu
 
-Tags: 4.1.2-scala2.13-java21-python3-r-ubuntu
+Tags: 4.1.3-scala2.13-java21-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java21-python3-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java21-python3-r-ubuntu
 
-Tags: 4.1.2-scala2.13-java17-python3-ubuntu, 4.1.2-java17, 4.1.2-python3, 4.1.2, python3-java17
+Tags: 4.1.3-scala2.13-java17-python3-ubuntu, 4.1.3-java17, 4.1.3-python3, 4.1.3, python3-java17
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java17-python3-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java17-python3-ubuntu
 
-Tags: 4.1.2-scala2.13-java17-r-ubuntu, 4.1.2-java17-r, 4.1.2-r, r-java17, r
+Tags: 4.1.3-scala2.13-java17-r-ubuntu, 4.1.3-java17-r, 4.1.3-r, r-java17, r
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java17-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java17-r-ubuntu
 
-Tags: 4.1.2-scala2.13-java17-ubuntu, 4.1.2-scala-java17, scala-java17, 4.1.2-scala, scala
+Tags: 4.1.3-scala2.13-java17-ubuntu, 4.1.3-scala-java17, scala-java17, 4.1.3-scala, scala
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java17-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java17-ubuntu
 
-Tags: 4.1.2-scala2.13-java17-python3-r-ubuntu
+Tags: 4.1.3-scala2.13-java17-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 593280202af9dd8ca71ae8afa39698800d5670bc
-Directory: ./4.1.2/scala2.13-java17-python3-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.1.3/scala2.13-java17-python3-r-ubuntu
 
-Tags: 4.0.2-scala2.13-java21-python3-ubuntu, 4.0.2-java21-python3, 4.0.2-java21
+Tags: 4.0.4-scala2.13-java21-python3-ubuntu, 4.0.4-java21-python3, 4.0.4-java21
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java21-python3-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java21-python3-ubuntu
 
-Tags: 4.0.2-scala2.13-java21-r-ubuntu, 4.0.2-java21-r
+Tags: 4.0.4-scala2.13-java21-r-ubuntu, 4.0.4-java21-r
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java21-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java21-r-ubuntu
 
-Tags: 4.0.2-scala2.13-java21-ubuntu, 4.0.2-java21-scala
+Tags: 4.0.4-scala2.13-java21-ubuntu, 4.0.4-java21-scala
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java21-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java21-ubuntu
 
-Tags: 4.0.2-scala2.13-java21-python3-r-ubuntu
+Tags: 4.0.4-scala2.13-java21-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java21-python3-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java21-python3-r-ubuntu
 
-Tags: 4.0.2-scala2.13-java17-python3-ubuntu, 4.0.2-python3, 4.0.2
+Tags: 4.0.4-scala2.13-java17-python3-ubuntu, 4.0.4-python3, 4.0.4
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java17-python3-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java17-python3-ubuntu
 
-Tags: 4.0.2-scala2.13-java17-r-ubuntu, 4.0.2-r
+Tags: 4.0.4-scala2.13-java17-r-ubuntu, 4.0.4-r
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java17-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java17-r-ubuntu
 
-Tags: 4.0.2-scala2.13-java17-ubuntu, 4.0.2-scala
+Tags: 4.0.4-scala2.13-java17-ubuntu, 4.0.4-scala
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java17-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java17-ubuntu
 
-Tags: 4.0.2-scala2.13-java17-python3-r-ubuntu
+Tags: 4.0.4-scala2.13-java17-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: 1e6fe4d2c19bd4ac1bfd3b1ec7c1f90ccd25cf12
-Directory: ./4.0.2/scala2.13-java17-python3-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./4.0.4/scala2.13-java17-python3-r-ubuntu
 
-Tags: 3.5.8-scala2.12-java17-python3-ubuntu, 3.5.8-java17-python3, 3.5.8-java17
+Tags: 3.5.9-scala2.12-java17-python3-ubuntu, 3.5.9-java17-python3, 3.5.9-java17
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java17-python3-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java17-python3-ubuntu
 
-Tags: 3.5.8-scala2.12-java17-r-ubuntu, 3.5.8-java17-r
+Tags: 3.5.9-scala2.12-java17-r-ubuntu, 3.5.9-java17-r
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java17-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java17-r-ubuntu
 
-Tags: 3.5.8-scala2.12-java17-ubuntu, 3.5.8-java17-scala
+Tags: 3.5.9-scala2.12-java17-ubuntu, 3.5.9-java17-scala
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java17-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java17-ubuntu
 
-Tags: 3.5.8-scala2.12-java17-python3-r-ubuntu
+Tags: 3.5.9-scala2.12-java17-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java17-python3-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java17-python3-r-ubuntu
 
-Tags: 3.5.8-scala2.12-java11-python3-ubuntu, 3.5.8-python3, 3.5.8
+Tags: 3.5.9-scala2.12-java11-python3-ubuntu, 3.5.9-python3, 3.5.9
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java11-python3-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java11-python3-ubuntu
 
-Tags: 3.5.8-scala2.12-java11-r-ubuntu, 3.5.8-r
+Tags: 3.5.9-scala2.12-java11-r-ubuntu, 3.5.9-r
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java11-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java11-r-ubuntu
 
-Tags: 3.5.8-scala2.12-java11-ubuntu, 3.5.8-scala
+Tags: 3.5.9-scala2.12-java11-ubuntu, 3.5.9-scala
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java11-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java11-ubuntu
 
-Tags: 3.5.8-scala2.12-java11-python3-r-ubuntu
+Tags: 3.5.9-scala2.12-java11-python3-r-ubuntu
 Architectures: amd64, arm64v8
-GitCommit: dd49d350dc0ee517299bd79f4be369f1e39fb9c2
-Directory: ./3.5.8/scala2.12-java11-python3-r-ubuntu
+GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
+Directory: ./3.5.9/scala2.12-java11-python3-r-ubuntu


### PR DESCRIPTION
This PR updates Spark images to the releases introduced by [apache/spark-docker#131](https://github.com/apache/spark-docker/pull/131):

- 3.5.8 -> 3.5.9
- 4.0.2 -> 4.0.4
- 4.1.2 -> 4.1.3

All entries reference the upstream commit [`994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f`](https://github.com/apache/spark-docker/commit/994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f).

The following 4.1.3 tags intentionally preserve the existing Java version discrepancies in `official-images` versus `spark-docker` following the same approach taken for `4.1.2` in [#21517](https://github.com/docker-library/official-images/pull/21517):

| Tag(s) | `official-images` target | `spark-docker` target |
| --- | --- | --- |
| `4.1.3`, `4.1.3-python3` | `scala2.13-java17-python3-ubuntu` | `scala2.13-java21-python3-ubuntu` |
| `4.1.3-r` | `scala2.13-java17-r-ubuntu` | `scala2.13-java21-r-ubuntu` |
| `4.1.3-scala` | `scala2.13-java17-ubuntu` | `scala2.13-java21-ubuntu` |

Tags for `3.5.9` and `4.0.4` use the same java versions as `spark-docker` with no discrepancies.