### PR TITLE
Odoo: update 17.0-19.0 to release 20260908

### DIFF
--- a/library/odoo
+++ b/library/odoo
@@ -1,16 +1,16 @@
 Maintainers: Christophe Monniez <moc@odoo.com> (@d-fence)
 GitRepo: https://github.com/odoo/docker
-GitCommit: 5930f757f9a968416ed835e59539197ada442956
+GitCommit: d9c2d8d50aa8eca1aadc186241bee3eac0e2d79e
 
-Tags: 19.0-20260817, 19.0, 19, latest
+Tags: 19.0-20260908, 19.0, 19, latest
 Architectures: amd64, arm64v8, ppc64le
 Directory: 19.0
 
-Tags: 18.0-20260817, 18.0, 18
+Tags: 18.0-20260908, 18.0, 18
 Architectures: amd64, arm64v8, ppc64le
 Directory: 18.0
 
-Tags: 17.0-20260817, 17.0, 17
+Tags: 17.0-20260908, 17.0, 17
 Architectures: amd64, arm64v8
 Directory: 17.0
 


### PR DESCRIPTION
Hello,

here are the usual updates of Odoo supported versions.

Thanks