### PR TITLE
Update EspoCRM to v10.0.8

### DIFF
--- a/library/espocrm
+++ b/library/espocrm
@@ -3,17 +3,17 @@
 Maintainers: Taras Machyshyn <docker@espocrm.com> (@tmachyshyn)
 GitRepo: https://github.com/espocrm/espocrm-docker.git
 
-Tags: apache, apache-trixie, 10.0.7-apache, 10.0.7-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.7, 10.0, 10
+Tags: apache, apache-trixie, 10.0.8-apache, 10.0.8-apache-trixie, 10.0-apache, 10.0-apache-trixie, 10-apache, 10-apache-trixie, latest, 10.0.8, 10.0, 10
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: be0aa6944a9df2d4863b2186fe7c1e8173745257
+GitCommit: fd3d61ce1e3107b017863eb28b1595193efd59a5
 Directory: latest/apache
 
-Tags: fpm, fpm-trixie, 10.0.7-fpm, 10.0.7-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
+Tags: fpm, fpm-trixie, 10.0.8-fpm, 10.0.8-fpm-trixie, 10.0-fpm, 10.0-fpm-trixie, 10-fpm, 10-fpm-trixie
 Architectures: amd64, i386, arm32v5, arm32v7, arm64v8
-GitCommit: be0aa6944a9df2d4863b2186fe7c1e8173745257
+GitCommit: fd3d61ce1e3107b017863eb28b1595193efd59a5
 Directory: latest/fpm
 
-Tags: fpm-alpine, fpm-alpine3.23, 10.0.7-fpm-alpine, 10.0.7-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
+Tags: fpm-alpine, fpm-alpine3.23, 10.0.8-fpm-alpine, 10.0.8-fpm-alpine3.23, 10.0-fpm-alpine, 10.0-fpm-alpine3.23, 10-fpm-alpine, 10-fpm-alpine3.23
 Architectures: amd64, i386, arm32v6, arm32v7, arm64v8
-GitCommit: be0aa6944a9df2d4863b2186fe7c1e8173745257
+GitCommit: fd3d61ce1e3107b017863eb28b1595193efd59a5
 Directory: latest/fpm-alpine


### PR DESCRIPTION
This PR updates EspoCRM to the latest version, v10.0.8