### PR TITLE
Update XWiki to 18.4.5

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -5,62 +5,62 @@ GitRepo: https://github.com/xwiki/xwiki-docker.git
 Tags: 18, 18.7, 18.7.0, 18-mysql-tomcat, 18.7-mysql-tomcat, 18.7.0-mysql-tomcat, mysql-tomcat, stable-mysql-tomcat, stable-mysql, stable, latest
 Architectures: amd64, arm64v8
 Directory: 18/mysql-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 Tags: 18-postgres-tomcat, 18.7-postgres-tomcat, 18.7.0-postgres-tomcat, postgres-tomcat, stable-postgres-tomcat, stable-postgres
 Architectures: amd64, arm64v8
 Directory: 18/postgres-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 Tags: 18-mariadb-tomcat, 18.7-mariadb-tomcat, 18.7.0-mariadb-tomcat, mariadb-tomcat, stable-mariadb-tomcat, stable-mariadb
 Architectures: amd64, arm64v8
 Directory: 18/mariadb-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 # Intermediate LTS
-Tags: 18.4, 18.4.4, 18.4-mysql-tomcat, 18.4.4-mysql-tomcat
+Tags: 18.4, 18.4.5, 18.4-mysql-tomcat, 18.4.5-mysql-tomcat
 Architectures: amd64, arm64v8
 Directory: 18.4/mysql-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 5aad8bafc1b80a41f4dc164233aa3492e764f5f1
 
-Tags: 18.4-postgres-tomcat, 18.4.4-postgres-tomcat
+Tags: 18.4-postgres-tomcat, 18.4.5-postgres-tomcat
 Architectures: amd64, arm64v8
 Directory: 18.4/postgres-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 5aad8bafc1b80a41f4dc164233aa3492e764f5f1
 
-Tags: 18.4-mariadb-tomcat, 18.4.4-mariadb-tomcat
+Tags: 18.4-mariadb-tomcat, 18.4.5-mariadb-tomcat
 Architectures: amd64, arm64v8
 Directory: 18.4/mariadb-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 5aad8bafc1b80a41f4dc164233aa3492e764f5f1
 
 # LTS
 Tags: 17, 17.10, 17.10.12, 17-mysql-tomcat, 17.10-mysql-tomcat, 17.10.12-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64, arm64v8
 Directory: 17/mysql-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 Tags: 17-postgres-tomcat, 17.10-postgres-tomcat, 17.10.12-postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 17/postgres-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 Tags: 17-mariadb-tomcat, 17.10-mariadb-tomcat, 17.10.12-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
 Architectures: amd64, arm64v8
 Directory: 17/mariadb-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 # Previous LTS - Added back temporarily
 Tags: 16, 16.10, 16.10.18, 16-mysql-tomcat, 16.10-mysql-tomcat, 16.10.18-mysql-tomcat
 Architectures: amd64, arm64v8
 Directory: 16/mysql-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 Tags: 16-postgres-tomcat, 16.10-postgres-tomcat, 16.10.18-postgres-tomcat
 Architectures: amd64, arm64v8
 Directory: 16/postgres-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
 
 Tags: 16-mariadb-tomcat, 16.10-mariadb-tomcat, 16.10.18-mariadb-tomcat
 Architectures: amd64, arm64v8
 Directory: 16/mariadb-tomcat
-GitCommit: c7085f91ebdbcce34bdfee2c1b2f001d31c81c2a
+GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727


### PR DESCRIPTION
Update the XWiki official images to the latest releases:

- `18` (stable): 18.7.0
- `18.4` (intermediate LTS): 18.4.5
- `17` (LTS): 17.10.12
- `16` (previous LTS): 16.10.18
