### PR TITLE
Update 6 to 6.63.0, Update 6 to CLI 1.32.4, Update 6-next to 6.63.0

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,20 +2,20 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: aa41ad81c41b2594a77125c9311f84ddbcd727ee
+GitCommit: 5deb5f61ead677a9d4acb3007289071ae2b7f558
 
-Tags: 6.62.0-bookworm, 6.62.0, 6.62-bookworm, 6.62, 6-bookworm, 6, bookworm, latest
+Tags: 6.63.0-bookworm, 6.63.0, 6.63-bookworm, 6.63, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.62.0-alpine3.23, 6.62.0-alpine, 6.62-alpine3.23, 6.62-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
+Tags: 6.63.0-alpine3.23, 6.63.0-alpine, 6.63-alpine3.23, 6.63-alpine, 6-alpine3.23, 6-alpine, alpine3.23, alpine
 Directory: 6/alpine3.23
 Architectures: amd64, arm64v8
 
-Tags: 6.62.0-next-bookworm, 6.62.0-next, 6.62-next-bookworm, 6.62-next, 6-next-bookworm, 6-next, next-bookworm, next
+Tags: 6.63.0-next-bookworm, 6.63.0-next, 6.63-next-bookworm, 6.63-next, 6-next-bookworm, 6-next, next-bookworm, next
 Directory: 6-next/bookworm
 Architectures: amd64, arm32v7, arm64v8
 
-Tags: 6.62.0-next-alpine3.23, 6.62.0-next-alpine, 6.62-next-alpine3.23, 6.62-next-alpine, 6-next-alpine3.23, 6-next-alpine, next-alpine3.23, next-alpine
+Tags: 6.63.0-next-alpine3.23, 6.63.0-next-alpine, 6.63-next-alpine3.23, 6.63-next-alpine, 6-next-alpine3.23, 6-next-alpine, next-alpine3.23, next-alpine
 Directory: 6-next/alpine3.23
 Architectures: amd64, arm64v8


### PR DESCRIPTION
Update 6 to 6.63.0, Update 6 to CLI 1.32.4, Update 6-next to 6.63.0

Generated from https://github.com/TryGhost/docker-library-ghost/commit/5deb5f61ead677a9d4acb3007289071ae2b7f558.