### PR TITLE
Update XWiki to 17.10.13

### DIFF
--- a/library/xwiki
+++ b/library/xwiki
@@ -34,20 +34,20 @@ Directory: 18.4/mariadb-tomcat
 GitCommit: 5aad8bafc1b80a41f4dc164233aa3492e764f5f1
 
 # LTS
-Tags: 17, 17.10, 17.10.12, 17-mysql-tomcat, 17.10-mysql-tomcat, 17.10.12-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
+Tags: 17, 17.10, 17.10.13, 17-mysql-tomcat, 17.10-mysql-tomcat, 17.10.13-mysql-tomcat, lts-mysql-tomcat, lts-mysql, lts
 Architectures: amd64, arm64v8
 Directory: 17/mysql-tomcat
-GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
+GitCommit: 61b809a2e6e5cd4dbdf62f6e1e1fa42e26697c6d
 
-Tags: 17-postgres-tomcat, 17.10-postgres-tomcat, 17.10.12-postgres-tomcat, lts-postgres-tomcat, lts-postgres
+Tags: 17-postgres-tomcat, 17.10-postgres-tomcat, 17.10.13-postgres-tomcat, lts-postgres-tomcat, lts-postgres
 Architectures: amd64, arm64v8
 Directory: 17/postgres-tomcat
-GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
+GitCommit: 61b809a2e6e5cd4dbdf62f6e1e1fa42e26697c6d
 
-Tags: 17-mariadb-tomcat, 17.10-mariadb-tomcat, 17.10.12-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
+Tags: 17-mariadb-tomcat, 17.10-mariadb-tomcat, 17.10.13-mariadb-tomcat, lts-mariadb-tomcat, lts-mariadb
 Architectures: amd64, arm64v8
 Directory: 17/mariadb-tomcat
-GitCommit: 08585fa0146021faf7da7e996f8d735bd3dcf727
+GitCommit: 61b809a2e6e5cd4dbdf62f6e1e1fa42e26697c6d
 
 # Previous LTS - Added back temporarily
 Tags: 16, 16.10, 16.10.18, 16-mysql-tomcat, 16.10-mysql-tomcat, 16.10.18-mysql-tomcat


### PR DESCRIPTION
Update the XWiki official images to the latest releases:

- `17` (LTS): 17.10.13
