### PR TITLE
Add spark 4.2.0

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -6,6 +6,66 @@ Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark),
              Yikun Jiang (@Yikun)
 GitRepo: https://github.com/apache/spark-docker.git
 
+Tags: 4.2.0-scala2.13-java21-python3-ubuntu, 4.2.0-java21-python3, 4.2.0-python3, 4.2.0
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java21-python3-ubuntu
+
+Tags: 4.2.0-scala2.13-java21-r-ubuntu, 4.2.0-java21-r, 4.2.0-r
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java21-r-ubuntu
+
+Tags: 4.2.0-scala2.13-java21-ubuntu, 4.2.0-java21-scala, 4.2.0-scala
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java21-ubuntu
+
+Tags: 4.2.0-scala2.13-java21-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java21-python3-r-ubuntu
+
+Tags: 4.2.0-scala2.13-java17-python3-ubuntu, 4.2.0-java17
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java17-python3-ubuntu
+
+Tags: 4.2.0-scala2.13-java17-r-ubuntu, 4.2.0-java17-r
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java17-r-ubuntu
+
+Tags: 4.2.0-scala2.13-java17-ubuntu, 4.2.0-scala-java17
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java17-ubuntu
+
+Tags: 4.2.0-scala2.13-java17-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java17-python3-r-ubuntu
+
+Tags: 4.2.0-scala2.13-java25-python3-ubuntu, 4.2.0-java25
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java25-python3-ubuntu
+
+Tags: 4.2.0-scala2.13-java25-r-ubuntu, 4.2.0-java25-r
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java25-r-ubuntu
+
+Tags: 4.2.0-scala2.13-java25-ubuntu, 4.2.0-scala-java25
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java25-ubuntu
+
+Tags: 4.2.0-scala2.13-java25-python3-r-ubuntu
+Architectures: amd64, arm64v8
+GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
+Directory: ./4.2.0/scala2.13-java25-python3-r-ubuntu
+
 Tags: 4.1.3-scala2.13-java21-python3-ubuntu, 4.1.3-java21-python3, 4.1.3-java21, python3, latest
 Architectures: amd64, arm64v8
 GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f


### PR DESCRIPTION
This PR adds Apache Spark 4.2.0 to the Docker Official Images, sourced from
[spark-docker](https://github.com/apache/spark-docker/pull/130).

It covers all 12 image variants (Scala 2.13 with Java 17, 21, and 25).

This change is purely additive: it only adds the 4.2.0 version-specific tags and
does not modify the shared rolling tags (`latest`, `python3`, `r`, `scala`, etc.),
which remain on 4.1.2.