### PR TITLE
Updated ghost to fix armv7 build

### DIFF
--- a/library/ghost
+++ b/library/ghost
@@ -2,7 +2,7 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: 5deb5f61ead677a9d4acb3007289071ae2b7f558
+GitCommit: c6bb661a0a9d20e13444545c19e627ad16daf83a
 
 Tags: 6.63.0-bookworm, 6.63.0, 6.63-bookworm, 6.63, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm

--- a/library/ghost
+++ b/library/ghost
@@ -2,7 +2,7 @@
 
 Maintainers: Austin Burdine <austin@ghost.org> (@acburdine)
 GitRepo: https://github.com/TryGhost/docker-library-ghost.git
-GitCommit: c6bb661a0a9d20e13444545c19e627ad16daf83a
+GitCommit: bf283c39f99329242ea095b56ab886dcc978d150
 
 Tags: 6.63.0-bookworm, 6.63.0, 6.63-bookworm, 6.63, 6-bookworm, 6, bookworm, latest
 Directory: 6/bookworm
@@ -14,7 +14,7 @@ Architectures: amd64, arm64v8
 
 Tags: 6.63.0-next-bookworm, 6.63.0-next, 6.63-next-bookworm, 6.63-next, 6-next-bookworm, 6-next, next-bookworm, next
 Directory: 6-next/bookworm
-Architectures: amd64, arm32v7, arm64v8
+Architectures: amd64, arm64v8
 
 Tags: 6.63.0-next-alpine3.23, 6.63.0-next-alpine, 6.63-next-alpine3.23, 6.63-next-alpine, 6-next-alpine3.23, 6-next-alpine, next-alpine3.23, next-alpine
 Directory: 6-next/alpine3.23


### PR DESCRIPTION
Fixed the armv7 build in the Ghost image - see https://github.com/TryGhost/docker-library-ghost/pull/486