### PR TITLE
Update gcc

### DIFF
--- a/library/gcc
+++ b/library/gcc
@@ -25,12 +25,12 @@ GitCommit: 5719f2f1af9000a4129748ce85656c7964b76c31
 Directory: 14
 # Docker EOL: 2027-12-26
 
-# Last Modified: 2025-06-05
-Tags: 13.4.0, 13.4, 13, 13.4.0-bookworm, 13.4-bookworm, 13-bookworm
+# Last Modified: 2026-09-11
+Tags: 13.5.0, 13.5, 13, 13.5.0-bookworm, 13.5-bookworm, 13-bookworm
 Architectures: amd64, arm32v7, arm64v8, ppc64le
-GitCommit: 5719f2f1af9000a4129748ce85656c7964b76c31
+GitCommit: cf5c03c266c89d12e1760b78b4914ad8b6c1e868
 Directory: 13
-# Docker EOL: 2026-12-05
+# Docker EOL: 2028-03-11
 
 # Last Modified: 2025-07-11
 Tags: 12.5.0, 12.5, 12, 12.5.0-bookworm, 12.5-bookworm, 12-bookworm


### PR DESCRIPTION
Changes:

- https://github.com/docker-library/gcc/commit/cf5c03c: Update 13 to 13.5.0