### PR TITLE
Update Oracle Linux 8 (8) and Oracle Linux 9 (9-slim, 9-slim-fips, 9)

### DIFF
--- a/library/oraclelinux
+++ b/library/oraclelinux
@@ -4,10 +4,10 @@ GitCommit: 5c8a1c296acd6e90487cd261d16cf85fd6bcb73f
 GitFetch: refs/heads/master
 # https://github.com/oracle/container-images/tree/dist-amd64
 amd64-GitFetch: refs/heads/dist-amd64
-amd64-GitCommit: 5e03281193225ed31795ca9d99677f71950c29f8
+amd64-GitCommit: a2ac8f4693e67083491e7eb8a2fe1605cda8e588
 # https://github.com/oracle/container-images/tree/dist-arm64v8
 arm64v8-GitFetch: refs/heads/dist-arm64v8
-arm64v8-GitCommit: 1c1391d34ed581df35df7d21ec8ed22b1d1ad38e
+arm64v8-GitCommit: 7d9d6b83b473d7882631ca5800979206f73fef6a
 
 Tags: 10
 Architectures: amd64, arm64v8


### PR DESCRIPTION
## 2026-09-11
* Update Oracle Linux 8 for `amd64` and `arm64v8`:
  * [ELSA-2026-64809 - ELSA-2026-64809-0 Moderate: expat security update](https://linux.oracle.com/errata/ELSA-2026-64809.html)
    * [CVE-2026-50219](https://nvd.nist.gov/vuln/detail/CVE-2026-50219)
    * [CVE-2026-56132](https://nvd.nist.gov/vuln/detail/CVE-2026-56132)
  * [ELSA-2026-65998 - ELSA-2026-65998-0 Moderate: gzip security update](https://linux.oracle.com/errata/ELSA-2026-65998.html)
    * [CVE-2026-41991](https://nvd.nist.gov/vuln/detail/CVE-2026-41991)
    * [CVE-2026-41992](https://nvd.nist.gov/vuln/detail/CVE-2026-41992)
  * [ELSA-2026-66451 - ELSA-2026-66451-0 Moderate: glib2 security update](https://linux.oracle.com/errata/ELSA-2026-66451.html)
    * [CVE-2026-16118](https://nvd.nist.gov/vuln/detail/CVE-2026-16118)
  * [ELSA-2026-66348 - ELSA-2026-66348-0 Important: vim security update](https://linux.oracle.com/errata/ELSA-2026-66348.html)
    * [CVE-2026-28420](https://nvd.nist.gov/vuln/detail/CVE-2026-28420)
    * [CVE-2026-52859](https://nvd.nist.gov/vuln/detail/CVE-2026-52859)
    * [CVE-2026-55892](https://nvd.nist.gov/vuln/detail/CVE-2026-55892)
    * [CVE-2026-59857](https://nvd.nist.gov/vuln/detail/CVE-2026-59857)
    * [CVE-2026-73072](https://nvd.nist.gov/vuln/detail/CVE-2026-73072)
    * [CVE-2026-73076](https://nvd.nist.gov/vuln/detail/CVE-2026-73076)
    * [CVE-2026-73078](https://nvd.nist.gov/vuln/detail/CVE-2026-73078)
* Update Oracle Linux 9 slim, Oracle Linux 9 slim FIPS, and Oracle Linux 9 for `amd64` and `arm64v8`:
  * [ELSA-2026-64812 - ELSA-2026-64812-0 Moderate: expat security update](https://linux.oracle.com/errata/ELSA-2026-64812.html)
    * [CVE-2026-50219](https://nvd.nist.gov/vuln/detail/CVE-2026-50219)
    * [CVE-2026-56132](https://nvd.nist.gov/vuln/detail/CVE-2026-56132)
  * [ELSA-2026-64800 - ELSA-2026-64800-0 Moderate: glib2 security update](https://linux.oracle.com/errata/ELSA-2026-64800.html)
    * [CVE-2026-16118](https://nvd.nist.gov/vuln/detail/CVE-2026-16118)

Signed-off-by: Kevin Lyons <kevin.x.lyons@oracle.com>
