### PR TITLE
Move rolling tags (latest, python3, r, scala, ...) to Spark 4.2.0

### DIFF
--- a/library/spark
+++ b/library/spark
@@ -6,17 +6,17 @@ Maintainers: Apache Spark Developers <dev@spark.apache.org> (@ApacheSpark),
              Yikun Jiang (@Yikun)
 GitRepo: https://github.com/apache/spark-docker.git
 
-Tags: 4.2.0-scala2.13-java21-python3-ubuntu, 4.2.0-java21-python3, 4.2.0-python3, 4.2.0
+Tags: 4.2.0-scala2.13-java21-python3-ubuntu, 4.2.0-java21-python3, 4.2.0-python3, 4.2.0, python3, latest
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java21-python3-ubuntu
 
-Tags: 4.2.0-scala2.13-java21-r-ubuntu, 4.2.0-java21-r, 4.2.0-r
+Tags: 4.2.0-scala2.13-java21-r-ubuntu, 4.2.0-java21-r, 4.2.0-r, r
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java21-r-ubuntu
 
-Tags: 4.2.0-scala2.13-java21-ubuntu, 4.2.0-java21-scala, 4.2.0-scala
+Tags: 4.2.0-scala2.13-java21-ubuntu, 4.2.0-java21-scala, 4.2.0-scala, scala
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java21-ubuntu
@@ -26,17 +26,17 @@ Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java21-python3-r-ubuntu
 
-Tags: 4.2.0-scala2.13-java17-python3-ubuntu, 4.2.0-java17
+Tags: 4.2.0-scala2.13-java17-python3-ubuntu, 4.2.0-java17, python3-java17
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java17-python3-ubuntu
 
-Tags: 4.2.0-scala2.13-java17-r-ubuntu, 4.2.0-java17-r
+Tags: 4.2.0-scala2.13-java17-r-ubuntu, 4.2.0-java17-r, r-java17
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java17-r-ubuntu
 
-Tags: 4.2.0-scala2.13-java17-ubuntu, 4.2.0-scala-java17
+Tags: 4.2.0-scala2.13-java17-ubuntu, 4.2.0-scala-java17, scala-java17
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java17-ubuntu
@@ -46,17 +46,17 @@ Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java17-python3-r-ubuntu
 
-Tags: 4.2.0-scala2.13-java25-python3-ubuntu, 4.2.0-java25
+Tags: 4.2.0-scala2.13-java25-python3-ubuntu, 4.2.0-java25, python3-java25
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java25-python3-ubuntu
 
-Tags: 4.2.0-scala2.13-java25-r-ubuntu, 4.2.0-java25-r
+Tags: 4.2.0-scala2.13-java25-r-ubuntu, 4.2.0-java25-r, r-java25
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java25-r-ubuntu
 
-Tags: 4.2.0-scala2.13-java25-ubuntu, 4.2.0-scala-java25
+Tags: 4.2.0-scala2.13-java25-ubuntu, 4.2.0-scala-java25, scala-java25
 Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java25-ubuntu
@@ -66,7 +66,7 @@ Architectures: amd64, arm64v8
 GitCommit: d3d8851fbbf64aa6f056d3a402eee1f4bf5781d0
 Directory: ./4.2.0/scala2.13-java25-python3-r-ubuntu
 
-Tags: 4.1.3-scala2.13-java21-python3-ubuntu, 4.1.3-java21-python3, 4.1.3-java21, python3, latest
+Tags: 4.1.3-scala2.13-java21-python3-ubuntu, 4.1.3-java21-python3, 4.1.3-java21
 Architectures: amd64, arm64v8
 GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
 Directory: ./4.1.3/scala2.13-java21-python3-ubuntu
@@ -86,17 +86,17 @@ Architectures: amd64, arm64v8
 GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
 Directory: ./4.1.3/scala2.13-java21-python3-r-ubuntu
 
-Tags: 4.1.3-scala2.13-java17-python3-ubuntu, 4.1.3-java17, 4.1.3-python3, 4.1.3, python3-java17
+Tags: 4.1.3-scala2.13-java17-python3-ubuntu, 4.1.3-java17, 4.1.3-python3, 4.1.3
 Architectures: amd64, arm64v8
 GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
 Directory: ./4.1.3/scala2.13-java17-python3-ubuntu
 
-Tags: 4.1.3-scala2.13-java17-r-ubuntu, 4.1.3-java17-r, 4.1.3-r, r-java17, r
+Tags: 4.1.3-scala2.13-java17-r-ubuntu, 4.1.3-java17-r, 4.1.3-r
 Architectures: amd64, arm64v8
 GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
 Directory: ./4.1.3/scala2.13-java17-r-ubuntu
 
-Tags: 4.1.3-scala2.13-java17-ubuntu, 4.1.3-scala-java17, scala-java17, 4.1.3-scala, scala
+Tags: 4.1.3-scala2.13-java17-ubuntu, 4.1.3-scala-java17, 4.1.3-scala
 Architectures: amd64, arm64v8
 GitCommit: 994aa3719a9d6f759d50d7d9d4ba5ad23f30cb7f
 Directory: ./4.1.3/scala2.13-java17-ubuntu


### PR DESCRIPTION
Follow-up to #22237. Since 4.2.0 is the newest Spark release (4.2.0 > 4.1.3),
this moves the rolling tags (latest, python3, r, scala, and the -java17/-java25
variants) from 4.1.3 onto 4.2.0, matching apache/spark-docker's versions.json.